### PR TITLE
feat(planningops): enforce worker attempt budget in local loop runtime

### DIFF
--- a/planningops/contracts/attempt-budget-contract.md
+++ b/planningops/contracts/attempt-budget-contract.md
@@ -26,3 +26,4 @@ If omitted, defaults are used:
 
 ## Reference
 - parser/validator implementation: `planningops/scripts/issue_loop_runner.py` (`parse_attempt_budget`)
+- runtime enforcement: `planningops/scripts/ralph_loop_local.py` + `planningops/scripts/worker_executor.py`

--- a/planningops/contracts/failure-taxonomy-and-retry-policy.md
+++ b/planningops/contracts/failure-taxonomy-and-retry-policy.md
@@ -8,6 +8,9 @@
 - `feedback_failed`: issue/project update failed
 - `idempotency_conflict`: duplicate key or replay mismatch
 - `runtime_error`: unexpected local execution error
+- `attempt_budget_exhausted`: worker attempt cap reached
+- `runtime_timeout_retries_exhausted`: timed out across allowed retries
+- `runtime_error_retries_exhausted`: non-timeout runtime failures exhausted retries
 
 ## Adapter Reason Mapping Standard
 Adapter hook reason families are constrained to:
@@ -35,6 +38,9 @@ Feedback failure handling rule:
 - `feedback_failed`: up to 3 retries with exponential backoff (5s, 15s, 45s)
 - `idempotency_conflict`: retry once in read-only mode, then stop
 - `runtime_error`: up to 2 retries, then mark `inconclusive`
+- `attempt_budget_exhausted`: no retry until budget is raised or issue is split/replanned
+- `runtime_timeout_retries_exhausted`: same as `runtime_error` with timeout root-cause annotation
+- `runtime_error_retries_exhausted`: same as `runtime_error` with retry-exhausted annotation
 
 ## Escalation Rules
 - same `reason_code` repeated 3 times for same issue => create follow-up issue

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -7,6 +7,7 @@ Host executable runners, validators, and contract tests for planningops loops.
 - Runtime runners:
   - `issue_loop_runner.py` (`--pec-preflight-mode legacy|hybrid|strict-pec`)
   - `ralph_loop_local.py`
+  - `worker_executor.py`
   - `meta_plan_orchestrator.py`
   - `github_sync_adapter.py`
   - `repo_execution_adapters.py`
@@ -36,6 +37,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_meta_plan_graph_schema_contract.sh`
   - `test_verify_plan_projection_contract.sh`
   - `test_ralph_loop_local_worker_policy.sh`
+  - `test_worker_executor_contract.sh`
   - `test_*.sh`
 
 ## Change Rules

--- a/planningops/scripts/issue_loop_runner.py
+++ b/planningops/scripts/issue_loop_runner.py
@@ -377,6 +377,13 @@ def evaluate_worker_task_pack_preflight(runtime_profile_file, selected, mode, lo
         "--strict",
     ]
     rc, out, err = run(cmd)
+    report_doc = {}
+    if report_path.exists():
+        try:
+            report_doc = load_json(report_path, {})
+        except Exception:  # noqa: BLE001
+            report_doc = {}
+    worker_task_pack = report_doc.get("worker_task_pack") if isinstance(report_doc, dict) else None
     return {
         "status": "pass" if rc == 0 else "fail",
         "reason_code": "worker_task_pack_ok" if rc == 0 else "worker_task_pack_invalid",
@@ -384,6 +391,8 @@ def evaluate_worker_task_pack_preflight(runtime_profile_file, selected, mode, lo
         "rc": rc,
         "stdout": out[-2000:],
         "stderr": err[-2000:],
+        "worker_task_pack": worker_task_pack,
+        "validation_errors": report_doc.get("validation_errors", []) if isinstance(report_doc, dict) else [],
     }
 
 
@@ -895,6 +904,37 @@ def main():
         )
         return 6
 
+    selected_attempt_budget = selected.get("attempt_budget", dict(DEFAULT_ATTEMPT_BUDGET))
+    max_attempts = int(selected_attempt_budget.get("max_attempts", DEFAULT_ATTEMPT_BUDGET["max_attempts"]))
+    if max_attempts <= 0:
+        print(
+            json.dumps(
+                {
+                    "result": "attempt_budget_invalid",
+                    "issue_number": selected.get("number"),
+                    "issue_repo": selected.get("issue_repo"),
+                    "plan_item_id": selected.get("plan_item_id"),
+                    "attempt_budget": selected_attempt_budget,
+                    "selection_trace": selection_trace,
+                },
+                ensure_ascii=True,
+            )
+        )
+        return 7
+
+    worker_pack = worker_task_pack_preflight.get("worker_task_pack") or {}
+    retry_policy = worker_pack.get("retry_policy") if isinstance(worker_pack, dict) else {}
+    max_retries = int((retry_policy or {}).get("max_retries", 0))
+    retry_cap_attempts = max_retries + 1
+    enforced_attempts = min(max_attempts, retry_cap_attempts)
+    selection_trace["attempt_budget_guard"] = {
+        "attempt_budget": selected_attempt_budget,
+        "max_attempts": max_attempts,
+        "max_retries": max_retries,
+        "retry_cap_attempts": retry_cap_attempts,
+        "enforced_worker_attempts": enforced_attempts,
+    }
+
     issue_num = selected["number"]
     lock_owner_id = f"issue-loop-runner-{os.getpid()}-{int(datetime.now(timezone.utc).timestamp())}"
     lock_acquired, lock_doc, stale_lock_recovered = acquire_issue_lock(issue_num, lock_owner_id, args.lease_ttl_seconds)
@@ -967,7 +1007,8 @@ def main():
             "selected_workflow_state": selected.get("workflow_state"),
             "selected_loop_profile": selected_loop_profile,
             "selected_plan_item_id": selected.get("plan_item_id"),
-            "attempt_budget": selected.get("attempt_budget", dict(DEFAULT_ATTEMPT_BUDGET)),
+            "attempt_budget": selected_attempt_budget,
+            "attempt_budget_guard": selection_trace.get("attempt_budget_guard", {}),
             "pec_preflight": pec_preflight,
             "adapter_pre_hook": pre_hook_result,
         },
@@ -1023,6 +1064,10 @@ def main():
                 args.runtime_profile_file,
                 "--task-key",
                 f"issue-{issue_num}",
+                "--max-attempts",
+                str(max_attempts),
+                "--worker-task-pack-report",
+                str(worker_task_pack_preflight.get("report_path")),
             ]
         )
 
@@ -1445,6 +1490,8 @@ def main():
             "selected_workflow_state": selected.get("workflow_state"),
             "selected_loop_profile": selected_loop_profile,
             "selected_plan_item_id": selected.get("plan_item_id"),
+            "attempt_budget": selected_attempt_budget,
+            "attempt_budget_guard": selection_trace.get("attempt_budget_guard", {}),
             "final_loop_profile": final_loop_profile,
             "lock_owner_id": lock_owner_id,
             "watchdog_report": str(watchdog_path),
@@ -1530,7 +1577,8 @@ def main():
         "selected_workflow_state": selected.get("workflow_state"),
         "selected_loop_profile": selected_loop_profile,
         "selected_plan_item_id": selected.get("plan_item_id"),
-        "attempt_budget": selected.get("attempt_budget", dict(DEFAULT_ATTEMPT_BUDGET)),
+        "attempt_budget": selected_attempt_budget,
+        "attempt_budget_guard": selection_trace.get("attempt_budget_guard", {}),
         "checkpoint_resumed": bool(args.resume_from_checkpoint and resume_checkpoint),
         "checkpoint_stage_at_start": resume_stage,
         "lock_owner_id": lock_owner_id,

--- a/planningops/scripts/ralph_loop_local.py
+++ b/planningops/scripts/ralph_loop_local.py
@@ -3,9 +3,14 @@
 import argparse
 import json
 from pathlib import Path
-import subprocess
 import sys
 from datetime import datetime, timezone
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from worker_executor import WorkerExecutionPolicy, execute_worker_command
 
 
 def utc_now():
@@ -21,11 +26,6 @@ def append_ndjson(path: Path, data: dict):
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(data, ensure_ascii=True) + "\n")
-
-
-def run_cmd(args):
-    completed = subprocess.run(args, capture_output=True, text=True)
-    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
 
 
 def render_template(value: str, context: dict):
@@ -116,6 +116,60 @@ def load_runtime_context(profile_file: Path, task_key: str):
     }
 
 
+def parse_int(value, field_name: str, minimum: int):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be integer") from exc
+    if parsed < minimum:
+        if minimum == 0:
+            raise ValueError(f"{field_name} must be >= 0")
+        raise ValueError(f"{field_name} must be positive integer")
+    return parsed
+
+
+def load_worker_task_pack_report(report_path: str | None):
+    if not report_path:
+        return {}
+    doc_path = Path(report_path)
+    if not doc_path.exists():
+        raise ValueError(f"worker task-pack report not found: {doc_path}")
+    doc = json.loads(doc_path.read_text(encoding="utf-8"))
+    if not isinstance(doc, dict):
+        raise ValueError("worker task-pack report must be object")
+    return doc
+
+
+def resolve_worker_execution_policy(runtime_ctx: dict, max_attempts: int, worker_task_pack_report: str | None):
+    provider_policy = runtime_ctx.get("provider_policy") or {}
+    max_retries = parse_int(provider_policy.get("max_retries", 0), "provider_policy.max_retries", 0)
+    timeout_ms = parse_int(provider_policy.get("timeout_ms", 60000), "provider_policy.timeout_ms", 1)
+    source = "runtime_context.provider_policy"
+
+    report_doc = load_worker_task_pack_report(worker_task_pack_report)
+    if report_doc:
+        worker_pack = report_doc.get("worker_task_pack")
+        if not isinstance(worker_pack, dict):
+            raise ValueError("worker task-pack report missing worker_task_pack object")
+        retry_policy = worker_pack.get("retry_policy")
+        if not isinstance(retry_policy, dict):
+            raise ValueError("worker task-pack missing retry_policy object")
+        max_retries = parse_int(retry_policy.get("max_retries"), "worker_task_pack.retry_policy.max_retries", 0)
+        timeout_ms = parse_int(worker_pack.get("timeout_ms"), "worker_task_pack.timeout_ms", 1)
+        source = "worker_task_pack.report"
+
+    policy = WorkerExecutionPolicy(
+        max_retries=max_retries,
+        timeout_ms=timeout_ms,
+        max_attempts=parse_int(max_attempts, "max_attempts", 0),
+    )
+    policy.validate()
+    return {
+        "policy": policy,
+        "source": source,
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Local Ralph Loop harness")
     parser.add_argument("--issue-number", type=int, required=True)
@@ -134,6 +188,17 @@ def main():
         "--task-key",
         default=None,
         help="Task key for per-task runtime override (default: issue-<issue-number>)",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=3,
+        help="Attempt-budget cap for this worker execution.",
+    )
+    parser.add_argument(
+        "--worker-task-pack-report",
+        default=None,
+        help="Optional validated worker task-pack report path (takes priority over runtime provider policy).",
     )
     args = parser.parse_args()
 
@@ -215,6 +280,45 @@ def main():
         print(f"loop failed at runtime context: {exc}")
         return 1
 
+    try:
+        execution_policy_doc = resolve_worker_execution_policy(
+            runtime_ctx=runtime_ctx,
+            max_attempts=args.max_attempts,
+            worker_task_pack_report=args.worker_task_pack_report,
+        )
+    except ValueError as exc:
+        reason = "missing_input"
+        write_json(
+            verification_path,
+            {
+                "issue_number": args.issue_number,
+                "loop_id": loop_id,
+                "verdict": "fail",
+                "reason_code": reason,
+                "stage": "execution_policy",
+                "error": str(exc),
+                "executed_at_utc": now.isoformat(),
+            },
+        )
+        append_ndjson(
+            transition_log_path,
+            {
+                "transition_id": f"{loop_id}-execution-policy-fail",
+                "run_id": loop_id,
+                "card_id": args.issue_number,
+                "from_state": "Todo",
+                "to_state": "Blocked",
+                "transition_reason": "context.invalid_execution_policy",
+                "actor_type": "agent",
+                "actor_id": "ralph-loop-local",
+                "decided_at_utc": now.isoformat(),
+                "replanning_flag": True,
+            },
+        )
+        print(f"loop failed at execution policy: {exc}")
+        return 1
+
+    policy = execution_policy_doc["policy"]
     write_json(
         intake_path,
         {
@@ -223,6 +327,12 @@ def main():
             "mode": args.mode,
             "ecp_ref": args.ecp_ref,
             "runtime_context": runtime_ctx,
+            "worker_execution_policy": {
+                "source": execution_policy_doc["source"],
+                "max_retries": policy.max_retries,
+                "timeout_ms": policy.timeout_ms,
+                "max_attempts": policy.max_attempts,
+            },
             "checked_at_utc": now.isoformat(),
             "result": "ok",
         },
@@ -296,7 +406,22 @@ def main():
         print(f"loop failed at execute worker policy: {exc}")
         return 1
 
-    rc, out, err = run_cmd(worker_plan["command"])
+    execution_result = execute_worker_command(worker_plan["command"], policy)
+    attempt_sections = []
+    for row in execution_result["attempts"]:
+        attempt_sections.extend(
+            [
+                f"### Attempt {row['attempt_index']}",
+                f"- return_code: {row['return_code']}",
+                f"- timed_out: {row['timed_out']}",
+                f"- duration_ms: {row['duration_ms']}",
+                "```text",
+                row["stdout_tail"],
+                row["stderr_tail"],
+                "```",
+                "",
+            ]
+        )
 
     simulation_path.parent.mkdir(parents=True, exist_ok=True)
     simulation_path.write_text(
@@ -310,19 +435,28 @@ def main():
                 f"- runtime_profile: {runtime_ctx['selected_profile']}",
                 f"- worker_policy_kind: {worker_plan['kind']}",
                 f"- execute command: {' '.join(worker_plan['command'])}",
+                f"- execution_policy_source: {execution_policy_doc['source']}",
+                f"- max_retries: {policy.max_retries}",
+                f"- timeout_ms: {policy.timeout_ms}",
+                f"- max_attempts: {policy.max_attempts}",
+                f"- attempts_allowed: {execution_result['attempts_allowed']}",
+                f"- attempts_executed: {execution_result['attempts_executed']}",
+                f"- execution_reason: {execution_result['reason_code']}",
                 "",
-                "## Output",
-                "```text",
-                out,
-                err,
-                "```",
+                "## Attempt Logs",
+                *attempt_sections,
             ]
         ),
         encoding="utf-8",
     )
 
-    if rc != 0:
-        reason = "runtime_error"
+    if execution_result["status"] != "pass":
+        reason = execution_result["reason_code"]
+        transition_reason = {
+            "attempt_budget_exhausted": "runtime.attempt_budget_exhausted",
+            "runtime_timeout_retries_exhausted": "runtime.execute_timeout",
+            "runtime_error_retries_exhausted": "runtime.execute_error",
+        }.get(reason, "runtime.execute_error")
         write_json(
             verification_path,
             {
@@ -331,6 +465,7 @@ def main():
                 "verdict": "fail",
                 "reason_code": reason,
                 "stage": "execute",
+                "worker_execution": execution_result,
                 "executed_at_utc": utc_now().isoformat(),
             },
         )
@@ -342,14 +477,14 @@ def main():
                 "card_id": args.issue_number,
                 "from_state": "In Progress",
                 "to_state": "Blocked",
-                "transition_reason": "runtime.execute_error",
+                "transition_reason": transition_reason,
                 "actor_type": "agent",
                 "actor_id": "ralph-loop-local",
                 "decided_at_utc": utc_now().isoformat(),
                 "replanning_flag": True,
             },
         )
-        print("loop failed at execute")
+        print(f"loop failed at execute: {reason}")
         return 1
 
     # Step 4: verify
@@ -365,6 +500,13 @@ def main():
             "verdict": verdict,
             "reason_code": reason,
             "runtime_context": runtime_ctx,
+            "worker_execution": execution_result,
+            "worker_execution_policy": {
+                "source": execution_policy_doc["source"],
+                "max_retries": policy.max_retries,
+                "timeout_ms": policy.timeout_ms,
+                "max_attempts": policy.max_attempts,
+            },
             "artifacts": {
                 "intake_check": str(intake_path),
                 "simulation_report": str(simulation_path),

--- a/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
+++ b/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
@@ -190,6 +190,22 @@ with tempfile.TemporaryDirectory() as td:
 
     def fake_run_worker_pack_ok(args):
         captured["args"] = args
+        output_index = args.index("--output") + 1
+        output_path = Path(args[output_index])
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(
+                {
+                    "worker_task_pack": {
+                        "retry_policy": {"max_retries": 2},
+                        "timeout_ms": 32000,
+                    },
+                    "validation_errors": [],
+                },
+                ensure_ascii=True,
+            ),
+            encoding="utf-8",
+        )
         return 0, "worker-pack-ok", ""
 
     mod.run = fake_run_worker_pack_ok
@@ -202,6 +218,8 @@ with tempfile.TemporaryDirectory() as td:
     assert worker_pack_ok["status"] == "pass", worker_pack_ok
     assert worker_pack_ok["reason_code"] == "worker_task_pack_ok", worker_pack_ok
     assert "--task-key" in captured["args"], captured
+    assert worker_pack_ok["worker_task_pack"]["retry_policy"]["max_retries"] == 2, worker_pack_ok
+    assert worker_pack_ok["worker_task_pack"]["timeout_ms"] == 32000, worker_pack_ok
 
     def fake_run_worker_pack_fail(args):
         return 1, "", "worker-pack-fail"
@@ -215,6 +233,9 @@ with tempfile.TemporaryDirectory() as td:
     )
     assert worker_pack_fail["status"] == "fail", worker_pack_fail
     assert worker_pack_fail["reason_code"] == "worker_task_pack_invalid", worker_pack_fail
+    generated_report = Path(captured["args"][captured["args"].index("--output") + 1])
+    if generated_report.exists():
+        generated_report.unlink()
 
 ready_impl_cross_repo = {
     "workflow_state": "ready-implementation",

--- a/planningops/scripts/test_ralph_loop_local_worker_policy.sh
+++ b/planningops/scripts/test_ralph_loop_local_worker_policy.sh
@@ -103,5 +103,39 @@ with tempfile.TemporaryDirectory() as td:
     assert task_ctx["worker_policy"]["command"] == "echo from-task", task_ctx
     assert default_ctx["worker_policy"]["command"] == "echo from-default", default_ctx
 
+    task_ctx["provider_policy"] = {"max_retries": 2, "timeout_ms": 25000}
+    policy_from_runtime = mod.resolve_worker_execution_policy(
+        runtime_ctx=task_ctx,
+        max_attempts=3,
+        worker_task_pack_report=None,
+    )
+    assert policy_from_runtime["source"] == "runtime_context.provider_policy", policy_from_runtime
+    assert policy_from_runtime["policy"].max_retries == 2, policy_from_runtime
+    assert policy_from_runtime["policy"].timeout_ms == 25000, policy_from_runtime
+    assert policy_from_runtime["policy"].max_attempts == 3, policy_from_runtime
+
+    report_path = Path(td) / "worker-task-pack-report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "worker_task_pack": {
+                    "retry_policy": {"max_retries": 1},
+                    "timeout_ms": 45000,
+                }
+            },
+            ensure_ascii=True,
+        ),
+        encoding="utf-8",
+    )
+    policy_from_pack = mod.resolve_worker_execution_policy(
+        runtime_ctx=task_ctx,
+        max_attempts=2,
+        worker_task_pack_report=str(report_path),
+    )
+    assert policy_from_pack["source"] == "worker_task_pack.report", policy_from_pack
+    assert policy_from_pack["policy"].max_retries == 1, policy_from_pack
+    assert policy_from_pack["policy"].timeout_ms == 45000, policy_from_pack
+    assert policy_from_pack["policy"].max_attempts == 2, policy_from_pack
+
 print("ralph_loop_local worker policy contract smoke ok")
 PY

--- a/planningops/scripts/test_worker_executor_contract.sh
+++ b/planningops/scripts/test_worker_executor_contract.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+import importlib.util
+import tempfile
+from pathlib import Path
+
+module_path = Path("planningops/scripts/worker_executor.py")
+spec = importlib.util.spec_from_file_location("worker_executor", module_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+# 1) success path
+success = mod.execute_worker_command(
+    ["python3", "-c", "print('ok')"],
+    mod.WorkerExecutionPolicy(max_retries=1, timeout_ms=2000, max_attempts=3),
+)
+assert success["status"] == "pass", success
+assert success["reason_code"] == "ok", success
+assert success["attempts_executed"] == 1, success
+assert success["final_return_code"] == 0, success
+
+# 2) retry path (fail once, then pass)
+with tempfile.TemporaryDirectory() as td:
+    flag = Path(td) / "flag.txt"
+    retry = mod.execute_worker_command(
+        [
+            "bash",
+            "-lc",
+            f"if [ -f '{flag}' ]; then echo second-ok; exit 0; else touch '{flag}'; echo first-fail 1>&2; exit 1; fi",
+        ],
+        mod.WorkerExecutionPolicy(max_retries=2, timeout_ms=2000, max_attempts=3),
+    )
+    assert retry["status"] == "pass", retry
+    assert retry["attempts_executed"] == 2, retry
+    assert retry["attempts"][0]["return_code"] == 1, retry
+    assert retry["attempts"][1]["return_code"] == 0, retry
+
+# 3) timeout + retry exhausted path
+timeout_fail = mod.execute_worker_command(
+    ["python3", "-c", "import time; time.sleep(0.2)"],
+    mod.WorkerExecutionPolicy(max_retries=1, timeout_ms=50, max_attempts=3),
+)
+assert timeout_fail["status"] == "fail", timeout_fail
+assert timeout_fail["reason_code"] == "runtime_timeout_retries_exhausted", timeout_fail
+assert timeout_fail["attempts_executed"] == 2, timeout_fail
+assert timeout_fail["timed_out"] is True, timeout_fail
+
+# 4) budget exhausted path (budget tighter than retry cap)
+budget_fail = mod.execute_worker_command(
+    ["python3", "-c", "import sys; sys.exit(2)"],
+    mod.WorkerExecutionPolicy(max_retries=5, timeout_ms=2000, max_attempts=1),
+)
+assert budget_fail["status"] == "fail", budget_fail
+assert budget_fail["reason_code"] == "attempt_budget_exhausted", budget_fail
+assert budget_fail["attempts_executed"] == 1, budget_fail
+assert budget_fail["attempt_budget_limited"] is True, budget_fail
+
+# 5) immediate budget exhausted (no attempt permitted)
+no_attempt = mod.execute_worker_command(
+    ["python3", "-c", "print('unused')"],
+    mod.WorkerExecutionPolicy(max_retries=1, timeout_ms=1000, max_attempts=0),
+)
+assert no_attempt["status"] == "fail", no_attempt
+assert no_attempt["reason_code"] == "attempt_budget_exhausted", no_attempt
+assert no_attempt["attempts_executed"] == 0, no_attempt
+
+print("worker_executor contract tests ok")
+PY

--- a/planningops/scripts/worker_executor.py
+++ b/planningops/scripts/worker_executor.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+import subprocess
+import time
+from dataclasses import dataclass
+
+
+STDIO_TAIL_LIMIT = 4000
+
+
+def _tail(text: str, limit: int = STDIO_TAIL_LIMIT):
+    if not text:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[-limit:]
+
+
+def _coerce_int(value, field_name: str):
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be integer") from exc
+
+
+@dataclass(frozen=True)
+class WorkerExecutionPolicy:
+    max_retries: int
+    timeout_ms: int
+    max_attempts: int
+
+    def validate(self):
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be >= 0")
+        if self.timeout_ms <= 0:
+            raise ValueError("timeout_ms must be positive integer")
+        if self.max_attempts < 0:
+            raise ValueError("max_attempts must be >= 0")
+
+
+def execute_worker_command(command, policy: WorkerExecutionPolicy):
+    if not isinstance(command, list) or not command:
+        raise ValueError("worker command must be non-empty list")
+    policy.validate()
+
+    retry_cap_attempts = policy.max_retries + 1
+    attempts_allowed = min(policy.max_attempts, retry_cap_attempts)
+    attempt_budget_limited = attempts_allowed < retry_cap_attempts
+
+    if attempts_allowed <= 0:
+        return {
+            "status": "fail",
+            "reason_code": "attempt_budget_exhausted",
+            "attempts_executed": 0,
+            "attempts_allowed": attempts_allowed,
+            "retry_cap_attempts": retry_cap_attempts,
+            "attempt_budget_limited": attempt_budget_limited,
+            "max_attempts": policy.max_attempts,
+            "max_retries": policy.max_retries,
+            "timeout_ms": policy.timeout_ms,
+            "timed_out": False,
+            "final_return_code": None,
+            "stdout_tail": "",
+            "stderr_tail": "",
+            "attempts": [],
+        }
+
+    attempts = []
+    for attempt_index in range(1, attempts_allowed + 1):
+        started = time.monotonic()
+        timed_out = False
+        return_code = None
+        stdout = ""
+        stderr = ""
+        try:
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=(policy.timeout_ms / 1000.0),
+            )
+            return_code = int(completed.returncode)
+            stdout = completed.stdout or ""
+            stderr = completed.stderr or ""
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            timeout_stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+            timeout_stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+            stdout = timeout_stdout or ""
+            stderr = timeout_stderr or ""
+
+        duration_ms = int((time.monotonic() - started) * 1000)
+        attempt_doc = {
+            "attempt_index": attempt_index,
+            "timed_out": timed_out,
+            "return_code": return_code,
+            "duration_ms": duration_ms,
+            "stdout_tail": _tail(stdout),
+            "stderr_tail": _tail(stderr),
+        }
+        attempts.append(attempt_doc)
+
+        if not timed_out and return_code == 0:
+            break
+
+    last = attempts[-1]
+    if not last["timed_out"] and last["return_code"] == 0:
+        reason_code = "ok"
+        status = "pass"
+    else:
+        status = "fail"
+        if attempt_budget_limited and len(attempts) >= attempts_allowed:
+            reason_code = "attempt_budget_exhausted"
+        elif all(row["timed_out"] for row in attempts):
+            reason_code = "runtime_timeout_retries_exhausted"
+        else:
+            reason_code = "runtime_error_retries_exhausted"
+
+    return {
+        "status": status,
+        "reason_code": reason_code,
+        "attempts_executed": len(attempts),
+        "attempts_allowed": attempts_allowed,
+        "retry_cap_attempts": retry_cap_attempts,
+        "attempt_budget_limited": attempt_budget_limited,
+        "max_attempts": policy.max_attempts,
+        "max_retries": policy.max_retries,
+        "timeout_ms": policy.timeout_ms,
+        "timed_out": bool(last["timed_out"]),
+        "final_return_code": last["return_code"],
+        "stdout_tail": last["stdout_tail"],
+        "stderr_tail": last["stderr_tail"],
+        "attempts": attempts,
+    }

--- a/todos/022-complete-p1-worker-executor-budget-enforcement.md
+++ b/todos/022-complete-p1-worker-executor-budget-enforcement.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: complete
 priority: p1
 issue_id: "022"
 tags: [planningops, worker, reliability, runtime]
@@ -67,10 +67,10 @@ Implement Option 1. Keep policy resolution unchanged, but move execution control
 - `planningops/contracts/attempt-budget-contract.md` (if wording update needed)
 
 ## Acceptance Criteria
-- [ ] Worker command execution enforces timeout/retry bounds from validated runtime/task-pack policy.
-- [ ] Attempt budget (`max_attempts`) is enforced and violation path is explicit.
-- [ ] Exhausted retries emit deterministic reason classification.
-- [ ] Contract tests cover success/retry/timeout/budget-exhausted paths.
+- [x] Worker command execution enforces timeout/retry bounds from validated runtime/task-pack policy.
+- [x] Attempt budget (`max_attempts`) is enforced and violation path is explicit.
+- [x] Exhausted retries emit deterministic reason classification.
+- [x] Contract tests cover success/retry/timeout/budget-exhausted paths.
 
 ## Work Log
 
@@ -85,3 +85,18 @@ Implement Option 1. Keep policy resolution unchanged, but move execution control
 **Learnings:**
 - Runtime reliability gaps are mostly enforcement gaps, not schema-definition gaps.
 
+### 2026-03-05 - Implementation Complete
+
+**By:** Codex
+
+**Actions:**
+- Added `planningops/scripts/worker_executor.py` and enforced retry/timeout/budget policy execution.
+- Wired `planningops/scripts/ralph_loop_local.py` to load validated worker task-pack policy, apply `max_attempts`, and emit deterministic execution reason codes.
+- Updated `planningops/scripts/issue_loop_runner.py` to pass budget/task-pack enforcement context into loop execution and expose attempt-budget guard evidence in selection/output payloads.
+- Expanded regression coverage:
+  - `planningops/scripts/test_worker_executor_contract.sh` (new)
+  - `planningops/scripts/test_ralph_loop_local_worker_policy.sh`
+  - `planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
+
+**Learnings:**
+- Splitting worker execution into a dedicated module keeps policy semantics stable and testable while minimizing drift in loop orchestration code.


### PR DESCRIPTION
## Summary
- Added a dedicated `worker_executor.py` to enforce retry/timeout/attempt-budget execution semantics.
- Wired `ralph_loop_local.py` to consume validated worker task-pack policy and execute worker commands with deterministic exhausted-retry reason codes.
- Wired `issue_loop_runner.py` to propagate attempt-budget/task-pack enforcement context into loop execution and output traces.
- Marked todo `022` as complete and updated its acceptance/work log.

## Scope
- Initiative docs:
  - `planningops/contracts/attempt-budget-contract.md`
  - `planningops/contracts/failure-taxonomy-and-retry-policy.md`
- Workbench docs:
  - `todos/022-complete-p1-worker-executor-budget-enforcement.md`
- `planningops/` scripts/contracts:
  - `planningops/scripts/worker_executor.py`
  - `planningops/scripts/ralph_loop_local.py`
  - `planningops/scripts/issue_loop_runner.py`
  - `planningops/scripts/test_worker_executor_contract.sh`
  - `planningops/scripts/test_ralph_loop_local_worker_policy.sh`
  - `planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
  - `planningops/scripts/README.md`
- `.github/` workflows:
  - none

## Linked Issues
- Closes #22
- Related #23

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_worker_executor_contract.sh`
  - `bash planningops/scripts/test_ralph_loop_local_worker_policy.sh`
  - `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
  - `bash planningops/scripts/test_validate_worker_task_pack_contract.sh`
  - `bash planningops/scripts/test_loop_checkpoint_resume.sh`
  - `bash planningops/scripts/test_lease_lock_watchdog.sh`
  - `python3 -m py_compile planningops/scripts/worker_executor.py planningops/scripts/ralph_loop_local.py planningops/scripts/issue_loop_runner.py planningops/scripts/validate_worker_task_pack.py`

## Risks
- Risk: Introducing a new execution module can drift from worker-task-pack schema expectations if fields change without test updates.
- Rollback: Revert commit `23fd90c` to restore prior single-shot execution path.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
