### PR TITLE
feat(planningops): upgrade verification hard gate with execution evidence schema

### DIFF
--- a/planningops/contracts/requirements-contract.md
+++ b/planningops/contracts/requirements-contract.md
@@ -27,6 +27,8 @@
 24. Touched planningops modules must have up-to-date module `README.md` files and pass module README contract checks.
 25. Before loop execution, runner must validate a deterministic worker task pack (`worker_policy_kind`, rendered `command`, retry/timeout policy, idempotency key).
 26. Worker task pack validation failure must block execution start with explicit preflight failure result.
+27. Verification hard gate must require schema-valid `execution-attempts` evidence (`execution-attempts.json`) and reject `pass` when evidence is missing/invalid.
+28. Verification output (`verdict`, `reason_code`) must be consistency-checked against loop report evidence and written identically into project payload.
 
 ## Non-Functional Requirements
 1. Idempotency: repeated execution for same issue+commit must not duplicate updates.

--- a/planningops/schemas/README.md
+++ b/planningops/schemas/README.md
@@ -12,6 +12,7 @@ Keep local schema copies used for contract validation fixtures and compatibility
 - `plan-execution-contract.schema.json`
 - `meta-plan-graph.schema.json`
 - `worker-task-pack.schema.json`
+- `execution-attempts.schema.json`
 
 ## Change Rules
 - Schema shape changes must be synchronized with `platform-contracts` source schemas.

--- a/planningops/schemas/execution-attempts.schema.json
+++ b/planningops/schemas/execution-attempts.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "execution-attempts-v1",
+  "title": "Execution Attempts Evidence v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "status",
+    "reason_code",
+    "attempts_executed",
+    "attempts_allowed",
+    "retry_cap_attempts",
+    "attempt_budget_limited",
+    "max_attempts",
+    "max_retries",
+    "timeout_ms",
+    "timed_out",
+    "attempts"
+  ],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "reason_code": {
+      "type": "string",
+      "minLength": 1
+    },
+    "attempts_executed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "attempts_allowed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "retry_cap_attempts": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "attempt_budget_limited": {
+      "type": "boolean"
+    },
+    "max_attempts": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "max_retries": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "timeout_ms": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "timed_out": {
+      "type": "boolean"
+    },
+    "final_return_code": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "stdout_tail": {
+      "type": "string"
+    },
+    "stderr_tail": {
+      "type": "string"
+    },
+    "attempts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/attempt"
+      }
+    }
+  },
+  "$defs": {
+    "attempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attempt_index",
+        "timed_out",
+        "return_code",
+        "duration_ms",
+        "stdout_tail",
+        "stderr_tail"
+      ],
+      "properties": {
+        "attempt_index": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timed_out": {
+          "type": "boolean"
+        },
+        "return_code": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stdout_tail": {
+          "type": "string"
+        },
+        "stderr_tail": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -15,7 +15,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `validate_contracts.py`
   - `validate_worker_task_pack.py`
   - `validate_project_field_schema.py`
-  - `verify_loop_run.py`
+  - `verify_loop_run.py` (`--execution-attempts-schema`)
   - `verify_plan_projection.py`
   - `cross_repo_conformance_check.py`
   - `multi_repo_projection_report.py`
@@ -36,6 +36,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_meta_plan_orchestrator_contract.sh`
   - `test_meta_plan_graph_schema_contract.sh`
   - `test_verify_plan_projection_contract.sh`
+  - `test_verify_loop_run_hard_gate_contract.sh`
   - `test_ralph_loop_local_worker_policy.sh`
   - `test_worker_executor_contract.sh`
   - `test_*.sh`

--- a/planningops/scripts/ralph_loop_local.py
+++ b/planningops/scripts/ralph_loop_local.py
@@ -209,6 +209,7 @@ def main():
     base = Path(f"planningops/artifacts/loops/{date_str}/{loop_id}")
     intake_path = base / "intake-check.json"
     simulation_path = base / "simulation-report.md"
+    execution_attempts_path = base / "execution-attempts.json"
     verification_path = base / "verification-report.json"
     patch_summary_path = base / "patch-summary.md"
     transition_log_path = Path(f"planningops/artifacts/transition-log/{date_str}.ndjson")
@@ -407,6 +408,7 @@ def main():
         return 1
 
     execution_result = execute_worker_command(worker_plan["command"], policy)
+    write_json(execution_attempts_path, execution_result)
     attempt_sections = []
     for row in execution_result["attempts"]:
         attempt_sections.extend(
@@ -466,6 +468,13 @@ def main():
                 "reason_code": reason,
                 "stage": "execute",
                 "worker_execution": execution_result,
+                "artifacts": {
+                    "intake_check": str(intake_path),
+                    "simulation_report": str(simulation_path),
+                    "execution_attempts": str(execution_attempts_path),
+                    "verification_report": str(verification_path),
+                    "transition_log": str(transition_log_path),
+                },
                 "executed_at_utc": utc_now().isoformat(),
             },
         )
@@ -510,6 +519,7 @@ def main():
             "artifacts": {
                 "intake_check": str(intake_path),
                 "simulation_report": str(simulation_path),
+                "execution_attempts": str(execution_attempts_path),
                 "verification_report": str(verification_path),
                 "transition_log": str(transition_log_path),
                 "sync_summary": str(summary_path),

--- a/planningops/scripts/test_verify_loop_run_hard_gate_contract.sh
+++ b/planningops/scripts/test_verify_loop_run_hard_gate_contract.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+module_path = Path("planningops/scripts/verify_loop_run.py")
+spec = importlib.util.spec_from_file_location("verify_loop_run", module_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def write(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def write_json(path: Path, doc):
+    write(path, json.dumps(doc, ensure_ascii=True, indent=2))
+
+
+def base_execution_evidence():
+    return {
+        "status": "pass",
+        "reason_code": "ok",
+        "attempts_executed": 1,
+        "attempts_allowed": 2,
+        "retry_cap_attempts": 2,
+        "attempt_budget_limited": False,
+        "max_attempts": 3,
+        "max_retries": 1,
+        "timeout_ms": 30000,
+        "timed_out": False,
+        "final_return_code": 0,
+        "stdout_tail": "ok",
+        "stderr_tail": "",
+        "attempts": [
+            {
+                "attempt_index": 1,
+                "timed_out": False,
+                "return_code": 0,
+                "duration_ms": 12,
+                "stdout_tail": "ok",
+                "stderr_tail": "",
+            }
+        ],
+    }
+
+
+def run_verify(loop_dir: Path, transition_log: Path, output_path: Path, payload_path: Path):
+    argv_before = list(sys.argv)
+    sys.argv = [
+        "verify_loop_run.py",
+        "--loop-dir",
+        str(loop_dir),
+        "--transition-log",
+        str(transition_log),
+        "--output",
+        str(output_path),
+        "--project-payload",
+        str(payload_path),
+    ]
+    rc = mod.main()
+    sys.argv = argv_before
+    return rc, json.loads(output_path.read_text(encoding="utf-8")), json.loads(payload_path.read_text(encoding="utf-8"))
+
+
+with tempfile.TemporaryDirectory() as td:
+    td_path = Path(td)
+    loop_dir = td_path / "loop" / "loop-20260305T000000Z-issue-23"
+    transition_log = td_path / "transition-log.ndjson"
+    output_path = td_path / "verify.json"
+    payload_path = td_path / "payload.json"
+    sync_summary = td_path / "sync-summary.json"
+
+    write_json(loop_dir / "intake-check.json", {"result": "ok"})
+    write(loop_dir / "simulation-report.md", "# simulation")
+    write(loop_dir / "patch-summary.md", "# patch")
+    write_json(sync_summary, {"status": "ok"})
+
+    evidence = base_execution_evidence()
+    write_json(loop_dir / "execution-attempts.json", evidence)
+    write_json(
+        loop_dir / "verification-report.json",
+        {
+            "issue_number": 23,
+            "loop_id": "loop-20260305T000000Z-issue-23",
+            "verdict": "pass",
+            "reason_code": "ok",
+            "worker_execution": evidence,
+            "artifacts": {
+                "sync_summary": str(sync_summary),
+            },
+        },
+    )
+    write(
+        transition_log,
+        json.dumps(
+            {
+                "transition_id": "loop-20260305T000000Z-issue-23-complete",
+                "run_id": "loop-20260305T000000Z-issue-23",
+                "card_id": 23,
+                "from_state": "In Progress",
+                "to_state": "Done",
+                "transition_reason": "verification.ok",
+                "actor_type": "agent",
+                "actor_id": "ralph-loop-local",
+                "decided_at_utc": "2026-03-05T00:00:00+00:00",
+                "replanning_flag": False,
+            },
+            ensure_ascii=True,
+        )
+        + "\n",
+    )
+
+    rc_ok, report_ok, payload_ok = run_verify(loop_dir, transition_log, output_path, payload_path)
+    assert rc_ok == 0, report_ok
+    assert report_ok["verdict"] == "pass", report_ok
+    assert payload_ok["last_verdict"] == "pass", payload_ok
+    assert payload_ok["reason_code"] == "ok", payload_ok
+
+    # Missing execution-attempt artifact must fail hard gate.
+    (loop_dir / "execution-attempts.json").unlink()
+    rc_missing, report_missing, payload_missing = run_verify(loop_dir, transition_log, output_path, payload_path)
+    assert rc_missing == 1, report_missing
+    assert report_missing["verdict"] == "fail", report_missing
+    assert report_missing["reason_code"] == "execution_attempt_evidence_invalid", report_missing
+    assert payload_missing["last_verdict"] == "fail", payload_missing
+
+    # Malformed execution-attempt artifact must fail hard gate.
+    write(loop_dir / "execution-attempts.json", "{invalid-json")
+    rc_bad_json, report_bad_json, _ = run_verify(loop_dir, transition_log, output_path, payload_path)
+    assert rc_bad_json == 1, report_bad_json
+    assert report_bad_json["reason_code"] == "execution_attempt_evidence_invalid", report_bad_json
+
+    # Verdict consistency mismatch must fail even when evidence schema is valid.
+    fail_evidence = dict(base_execution_evidence())
+    fail_evidence.update(
+        {
+            "status": "fail",
+            "reason_code": "runtime_error_retries_exhausted",
+            "final_return_code": 2,
+            "stdout_tail": "",
+            "stderr_tail": "boom",
+            "attempts": [
+                {
+                    "attempt_index": 1,
+                    "timed_out": False,
+                    "return_code": 2,
+                    "duration_ms": 9,
+                    "stdout_tail": "",
+                    "stderr_tail": "boom",
+                }
+            ],
+        }
+    )
+    write_json(loop_dir / "execution-attempts.json", fail_evidence)
+    write_json(
+        loop_dir / "verification-report.json",
+        {
+            "issue_number": 23,
+            "loop_id": "loop-20260305T000000Z-issue-23",
+            "verdict": "pass",
+            "reason_code": "ok",
+            "worker_execution": fail_evidence,
+            "artifacts": {
+                "sync_summary": str(sync_summary),
+            },
+        },
+    )
+    rc_consistency, report_consistency, _ = run_verify(loop_dir, transition_log, output_path, payload_path)
+    assert rc_consistency == 1, report_consistency
+    assert report_consistency["reason_code"] == "verdict_consistency_error", report_consistency
+
+print("verify_loop_run hard gate contract tests ok")
+PY

--- a/planningops/scripts/verify_loop_run.py
+++ b/planningops/scripts/verify_loop_run.py
@@ -24,8 +24,11 @@ REQUIRED_LOOP_ARTIFACTS = [
     "intake-check.json",
     "simulation-report.md",
     "verification-report.json",
+    "execution-attempts.json",
     "patch-summary.md",
 ]
+
+ALLOWED_VERDICTS = {"pass", "fail", "inconclusive"}
 
 
 def load_json(path: Path):
@@ -42,45 +45,285 @@ def load_ndjson(path: Path):
     return rows
 
 
+def append_error(errors, message: str):
+    if message not in errors:
+        errors.append(message)
+
+
+def _resolve_ref(root_schema, ref):
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        raise ValueError(f"unsupported schema ref: {ref}")
+    cursor = root_schema
+    for token in ref[2:].split("/"):
+        cursor = cursor[token]
+    return cursor
+
+
+def _matches_type(value, type_name):
+    if type_name == "object":
+        return isinstance(value, dict)
+    if type_name == "array":
+        return isinstance(value, list)
+    if type_name == "string":
+        return isinstance(value, str)
+    if type_name == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_name == "boolean":
+        return isinstance(value, bool)
+    if type_name == "null":
+        return value is None
+    return True
+
+
+def _type_includes(expected_type, type_name: str):
+    if isinstance(expected_type, list):
+        return type_name in expected_type
+    return expected_type == type_name
+
+
+def _is_valid_type(value, expected_type):
+    if isinstance(expected_type, list):
+        return any(_matches_type(value, t) for t in expected_type)
+    return _matches_type(value, expected_type)
+
+
+def _validate_schema_value(value, schema, root_schema, path: str, errors):
+    if not isinstance(schema, dict):
+        return
+
+    if "$ref" in schema:
+        schema = _resolve_ref(root_schema, schema["$ref"])
+
+    expected_type = schema.get("type")
+    if expected_type and not _is_valid_type(value, expected_type):
+        append_error(errors, f"execution_attempts_schema: {path} expected type {expected_type}")
+        return
+
+    if "enum" in schema and value not in schema["enum"]:
+        append_error(errors, f"execution_attempts_schema: {path} invalid enum value: {value}")
+
+    if _type_includes(expected_type, "string") and isinstance(value, str):
+        min_len = schema.get("minLength")
+        if isinstance(min_len, int) and len(value) < min_len:
+            append_error(errors, f"execution_attempts_schema: {path} minLength violation")
+        pattern = schema.get("pattern")
+        if pattern and not isinstance(pattern, str):
+            append_error(errors, f"execution_attempts_schema: {path} invalid pattern")
+
+    if _type_includes(expected_type, "integer") and isinstance(value, int) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        if isinstance(minimum, int) and value < minimum:
+            append_error(errors, f"execution_attempts_schema: {path} below minimum {minimum}")
+
+    if _type_includes(expected_type, "array") and isinstance(value, list):
+        min_items = schema.get("minItems")
+        if isinstance(min_items, int) and len(value) < min_items:
+            append_error(errors, f"execution_attempts_schema: {path} minItems violation")
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for idx, row in enumerate(value):
+                _validate_schema_value(row, item_schema, root_schema, f"{path}[{idx}]", errors)
+
+    if _type_includes(expected_type, "object") and isinstance(value, dict):
+        required = schema.get("required", [])
+        props = schema.get("properties", {})
+        for key in required:
+            if key not in value:
+                append_error(errors, f"execution_attempts_schema: {path}.{key} is required")
+        if schema.get("additionalProperties") is False:
+            for key in value.keys():
+                if key not in props:
+                    append_error(errors, f"execution_attempts_schema: {path} unexpected key: {key}")
+        for key, prop_schema in props.items():
+            if key in value:
+                _validate_schema_value(value[key], prop_schema, root_schema, f"{path}.{key}", errors)
+
+
+def validate_schema(doc, schema_doc):
+    errors = []
+    if not isinstance(doc, dict):
+        return ["execution_attempts_schema: document must be object"]
+    if not isinstance(schema_doc, dict):
+        return ["execution_attempts_schema: schema document must be object"]
+    _validate_schema_value(doc, schema_doc, schema_doc, "$", errors)
+    return errors
+
+
+def validate_execution_attempt_semantics(evidence):
+    errors = []
+    if not isinstance(evidence, dict):
+        return ["execution_attempts_semantics: evidence must be object"]
+
+    attempts = evidence.get("attempts")
+    if not isinstance(attempts, list):
+        return ["execution_attempts_semantics: attempts must be list"]
+
+    attempts_executed = evidence.get("attempts_executed")
+    if not isinstance(attempts_executed, int):
+        append_error(errors, "execution_attempts_semantics: attempts_executed must be integer")
+    else:
+        if attempts_executed != len(attempts):
+            append_error(
+                errors,
+                "execution_attempts_semantics: attempts_executed must match attempts length",
+            )
+
+    attempts_allowed = evidence.get("attempts_allowed")
+    if isinstance(attempts_allowed, int) and isinstance(attempts_executed, int):
+        if attempts_executed > attempts_allowed:
+            append_error(errors, "execution_attempts_semantics: attempts_executed exceeds attempts_allowed")
+
+    retry_cap_attempts = evidence.get("retry_cap_attempts")
+    if isinstance(retry_cap_attempts, int) and isinstance(attempts_allowed, int):
+        if attempts_allowed > retry_cap_attempts:
+            append_error(errors, "execution_attempts_semantics: attempts_allowed exceeds retry_cap_attempts")
+
+    if attempts:
+        last = attempts[-1]
+        if not isinstance(last, dict):
+            append_error(errors, "execution_attempts_semantics: final attempt must be object")
+        else:
+            status = evidence.get("status")
+            if status == "pass":
+                if last.get("timed_out") is True:
+                    append_error(errors, "execution_attempts_semantics: pass status cannot end in timeout")
+                if last.get("return_code") != 0:
+                    append_error(errors, "execution_attempts_semantics: pass status requires return_code=0")
+
+            timed_out = evidence.get("timed_out")
+            if isinstance(timed_out, bool) and timed_out != bool(last.get("timed_out")):
+                append_error(errors, "execution_attempts_semantics: timed_out must match final attempt")
+
+            final_return_code = evidence.get("final_return_code")
+            if final_return_code != last.get("return_code"):
+                append_error(
+                    errors,
+                    "execution_attempts_semantics: final_return_code must match final attempt return_code",
+                )
+
+    return errors
+
+
+def classify_reason(errors):
+    if any(err.startswith("execution_attempts_schema:") or err.startswith("execution_attempts_semantics:") for err in errors):
+        return "execution_attempt_evidence_invalid"
+    if any(err.startswith("verdict_consistency:") for err in errors):
+        return "verdict_consistency_error"
+    return "schema_or_artifact_error"
+
+
 def main():
     parser = argparse.ArgumentParser(description="Verify loop artifacts and transition-log schema")
     parser.add_argument("--loop-dir", required=True)
     parser.add_argument("--transition-log", required=True)
     parser.add_argument("--output", default="planningops/artifacts/verification/latest-verification.json")
     parser.add_argument("--project-payload", default="planningops/artifacts/verification/latest-project-payload.json")
+    parser.add_argument(
+        "--execution-attempts-schema",
+        default="planningops/schemas/execution-attempts.schema.json",
+        help="Schema used to validate execution-attempt evidence",
+    )
     args = parser.parse_args()
 
     loop_dir = Path(args.loop_dir)
     transition_log = Path(args.transition_log)
     out_path = Path(args.output)
     payload_path = Path(args.project_payload)
+    schema_path = Path(args.execution_attempts_schema)
 
     errors = []
 
     for name in REQUIRED_LOOP_ARTIFACTS:
         if not (loop_dir / name).exists():
-            errors.append(f"missing artifact: {name}")
+            append_error(errors, f"missing artifact: {name}")
 
     if not transition_log.exists():
-        errors.append("missing transition log")
+        append_error(errors, "missing transition log")
         rows = []
     else:
-        rows = load_ndjson(transition_log)
+        try:
+            rows = load_ndjson(transition_log)
+        except Exception as exc:  # noqa: BLE001
+            append_error(errors, f"transition log invalid: {exc}")
+            rows = []
         for idx, row in enumerate(rows):
+            if not isinstance(row, dict):
+                append_error(errors, f"transition row[{idx}] must be object")
+                continue
             for key in REQUIRED_TRANSITION_KEYS:
                 if key not in row:
-                    errors.append(f"transition row[{idx}] missing key: {key}")
+                    append_error(errors, f"transition row[{idx}] missing key: {key}")
 
     verification_doc = {}
-    if (loop_dir / "verification-report.json").exists():
-        verification_doc = load_json(loop_dir / "verification-report.json")
+    verification_path = loop_dir / "verification-report.json"
+    if verification_path.exists():
+        try:
+            verification_doc = load_json(verification_path)
+            if not isinstance(verification_doc, dict):
+                append_error(errors, "verification report must be object")
+                verification_doc = {}
+        except Exception as exc:  # noqa: BLE001
+            append_error(errors, f"verification report invalid: {exc}")
+            verification_doc = {}
 
-    verdict = verification_doc.get("verdict", "inconclusive")
-    reason = verification_doc.get("reason_code", "unknown")
+    execution_attempts_doc = {}
+    execution_attempts_path = loop_dir / "execution-attempts.json"
+    if execution_attempts_path.exists():
+        try:
+            execution_attempts_doc = load_json(execution_attempts_path)
+        except Exception as exc:  # noqa: BLE001
+            append_error(errors, f"execution attempts artifact invalid: {exc}")
+            execution_attempts_doc = {}
 
+    if not schema_path.exists():
+        append_error(errors, f"missing execution-attempts schema: {schema_path}")
+        schema_doc = {}
+    else:
+        try:
+            schema_doc = load_json(schema_path)
+        except Exception as exc:  # noqa: BLE001
+            append_error(errors, f"execution-attempts schema invalid: {exc}")
+            schema_doc = {}
+
+    if execution_attempts_doc and schema_doc:
+        for err in validate_schema(execution_attempts_doc, schema_doc):
+            append_error(errors, err)
+        for err in validate_execution_attempt_semantics(execution_attempts_doc):
+            append_error(errors, err)
+    else:
+        append_error(errors, "execution_attempts_semantics: missing execution-attempt evidence")
+
+    loop_report_verdict = str(verification_doc.get("verdict", "inconclusive"))
+    loop_report_reason = str(verification_doc.get("reason_code", "unknown"))
+    if loop_report_verdict not in ALLOWED_VERDICTS:
+        append_error(errors, f"verdict_consistency: invalid loop verdict: {loop_report_verdict}")
+
+    loop_worker_execution = verification_doc.get("worker_execution")
+    if not isinstance(loop_worker_execution, dict):
+        append_error(errors, "verdict_consistency: verification report missing worker_execution")
+    elif execution_attempts_doc and loop_worker_execution != execution_attempts_doc:
+        append_error(errors, "verdict_consistency: worker_execution mismatch with execution-attempt artifact")
+
+    if loop_report_verdict == "pass":
+        if loop_report_reason != "ok":
+            append_error(errors, "verdict_consistency: pass verdict requires reason_code=ok")
+        if execution_attempts_doc and execution_attempts_doc.get("status") != "pass":
+            append_error(errors, "verdict_consistency: pass verdict requires execution status=pass")
+        sync_summary_path = (
+            verification_doc.get("artifacts", {}).get("sync_summary")
+            if isinstance(verification_doc.get("artifacts"), dict)
+            else None
+        )
+        if not sync_summary_path:
+            append_error(errors, "verdict_consistency: pass verdict requires sync_summary artifact path")
+        elif not Path(str(sync_summary_path)).exists():
+            append_error(errors, "verdict_consistency: pass verdict requires existing sync_summary artifact")
+
+    verdict = loop_report_verdict if loop_report_verdict in ALLOWED_VERDICTS else "fail"
+    reason = loop_report_reason
     if errors:
         verdict = "fail"
-        reason = "schema_or_artifact_error"
+        reason = classify_reason(errors)
 
     current_run_id = verification_doc.get("loop_id")
     current_card_id = verification_doc.get("issue_number")
@@ -94,7 +337,7 @@ def main():
     reason_counts = Counter(row.get("transition_reason", "") for row in scoped_rows)
     repeated_reason_trigger = any(cnt >= 3 for cnt in reason_counts.values())
     replanning_flag_trigger = any(bool(row.get("replanning_flag")) for row in scoped_rows)
-    inconclusive_trigger = verification_doc.get("verdict") == "inconclusive"
+    inconclusive_trigger = verdict == "inconclusive"
 
     replanning_triggered = repeated_reason_trigger or replanning_flag_trigger or inconclusive_trigger
 
@@ -102,8 +345,13 @@ def main():
         "executed_at_utc": datetime.now(timezone.utc).isoformat(),
         "loop_dir": str(loop_dir),
         "transition_log": str(transition_log),
+        "execution_attempts_schema": str(schema_path),
         "verdict": verdict,
         "reason_code": reason,
+        "loop_report": {
+            "verdict": loop_report_verdict,
+            "reason_code": loop_report_reason,
+        },
         "errors": errors,
         "trigger_detection": {
             "scoped_row_count": len(scoped_rows),

--- a/todos/023-complete-p1-verification-hard-gate-upgrade.md
+++ b/todos/023-complete-p1-verification-hard-gate-upgrade.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: complete
 priority: p1
 issue_id: "023"
 tags: [planningops, verifier, contracts, reliability]
@@ -64,10 +64,10 @@ Implement Option 1 and bind verifier to a schema-backed execution evidence contr
 - `planningops/contracts/requirements-contract.md`
 
 ## Acceptance Criteria
-- [ ] Verification fails when execution-attempt evidence is missing or schema-invalid.
-- [ ] Final verdict consistency is enforced across loop report and project payload.
-- [ ] Pass verdict requires execution-attempt evidence and required artifact set.
-- [ ] Regression tests cover missing/malformed attempt artifacts.
+- [x] Verification fails when execution-attempt evidence is missing or schema-invalid.
+- [x] Final verdict consistency is enforced across loop report and project payload.
+- [x] Pass verdict requires execution-attempt evidence and required artifact set.
+- [x] Regression tests cover missing/malformed attempt artifacts.
 
 ## Work Log
 
@@ -82,3 +82,24 @@ Implement Option 1 and bind verifier to a schema-backed execution evidence contr
 **Learnings:**
 - Verifier strictness must follow executor artifact model; otherwise pass/fail semantics diverge.
 
+### 2026-03-05 - Implementation Complete
+
+**By:** Codex
+
+**Actions:**
+- Added `planningops/schemas/execution-attempts.schema.json` and wired it into `verify_loop_run.py` via `--execution-attempts-schema`.
+- Upgraded `planningops/scripts/verify_loop_run.py` hard gate:
+  - requires `execution-attempts.json` in loop artifact set,
+  - validates execution-attempt evidence schema and semantics,
+  - enforces pass-path consistency (`reason_code=ok`, `execution status=pass`, existing `sync_summary`),
+  - enforces consistency between verification report and execution-attempt artifact.
+- Updated `planningops/scripts/ralph_loop_local.py` to persist `execution-attempts.json` and reference it in verification artifacts.
+- Synced requirement contract and module indexes:
+  - `planningops/contracts/requirements-contract.md`
+  - `planningops/schemas/README.md`
+  - `planningops/scripts/README.md`
+- Added regression pack for hard-gate behavior:
+  - `planningops/scripts/test_verify_loop_run_hard_gate_contract.sh`
+
+**Learnings:**
+- Pass signaling needs explicit evidence parity checks, not only artifact existence checks, to prevent false-positive completion.


### PR DESCRIPTION
## Summary
- Added `execution-attempts.schema.json` as a schema-backed runtime evidence contract.
- Upgraded `verify_loop_run.py` to hard-gate verification on execution-attempt evidence presence, schema validity, and pass-path consistency.
- Updated `ralph_loop_local.py` to persist `execution-attempts.json` and expose it in verification artifacts.
- Marked todo `023` as complete.

## Scope
- Initiative docs:
  - `planningops/contracts/requirements-contract.md`
- Workbench docs:
  - `todos/023-complete-p1-verification-hard-gate-upgrade.md`
- `planningops/` scripts/contracts:
  - `planningops/schemas/execution-attempts.schema.json`
  - `planningops/schemas/README.md`
  - `planningops/scripts/verify_loop_run.py`
  - `planningops/scripts/ralph_loop_local.py`
  - `planningops/scripts/test_verify_loop_run_hard_gate_contract.sh`
  - `planningops/scripts/README.md`
- `.github/` workflows:
  - none

## Linked Issues
- Closes #23
- Related #24

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_verify_loop_run_hard_gate_contract.sh`
  - `bash planningops/scripts/test_worker_executor_contract.sh`
  - `bash planningops/scripts/test_ralph_loop_local_worker_policy.sh`
  - `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
  - `python3 -m py_compile planningops/scripts/verify_loop_run.py planningops/scripts/ralph_loop_local.py planningops/scripts/issue_loop_runner.py planningops/scripts/worker_executor.py`

## Risks
- Risk: Tightened verifier may fail legacy/incomplete loop artifacts that previously passed.
- Rollback: Revert commit `6ab255a` to restore prior verification behavior.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
