### PR TITLE
feat(planningops): add runtime heartbeat and lock drift safety

### DIFF
--- a/planningops/contracts/lease-lock-watchdog-contract.md
+++ b/planningops/contracts/lease-lock-watchdog-contract.md
@@ -17,7 +17,9 @@ Prevent duplicate issue execution and detect stale/zombie lock state.
 - Only one active lock per issue is allowed.
 - If active lock is not expired, new run must fail with lock conflict.
 - Expired lock may be reclaimed as stale recovery.
-- Owner must refresh heartbeat at stage boundaries.
+- Owner must refresh heartbeat at stage boundaries and during runtime execution window.
+- Runtime heartbeat must stop when worker exits or controlled interruption occurs.
+- Runtime lock ownership drift (`owner_id` mismatch or heartbeat refresh failure) must be detected and classified as runtime failure.
 - Owner must release lock on completion or controlled interruption.
 
 ## Watchdog Report
@@ -27,3 +29,4 @@ Prevent duplicate issue execution and detect stale/zombie lock state.
   - `events` timeline
   - `release_ok`
   - stale lock recovery signal when applicable
+  - runtime heartbeat events (`runtime_heartbeat_started|runtime_heartbeat_tick|runtime_heartbeat_drift_detected|runtime_heartbeat_stopped`) when worker execution window is entered

--- a/planningops/scripts/issue_loop_runner.py
+++ b/planningops/scripts/issue_loop_runner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import threading
 from datetime import datetime, timezone, timedelta
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -142,6 +143,122 @@ def release_issue_lock(issue_num: int, owner_id: str):
         return False
     path.unlink()
     return True
+
+
+def read_issue_lock(issue_num: int):
+    path = lock_path(issue_num)
+    if not path.exists():
+        return {
+            "exists": False,
+            "path": str(path),
+            "doc": {},
+        }
+    doc = load_json(path, {})
+    return {
+        "exists": True,
+        "path": str(path),
+        "doc": doc if isinstance(doc, dict) else {},
+    }
+
+
+def run_with_runtime_heartbeat(command, issue_num: int, owner_id: str, ttl_seconds: int):
+    if ttl_seconds <= 0:
+        raise ValueError("ttl_seconds must be positive")
+
+    heartbeat_interval_seconds = max(1, ttl_seconds // 3)
+    heartbeat_interval_seconds = min(heartbeat_interval_seconds, 30)
+    started_at = datetime.now(timezone.utc).isoformat()
+
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    stop_event = threading.Event()
+    state = {
+        "drift_detected": False,
+        "drift_reason": "",
+    }
+    heartbeat_events = [
+        {
+            "event": "runtime_heartbeat_started",
+            "decided_at_utc": started_at,
+            "issue_number": issue_num,
+            "lock_owner_id": owner_id,
+            "pid": process.pid,
+            "heartbeat_interval_seconds": heartbeat_interval_seconds,
+        }
+    ]
+    event_lock = threading.Lock()
+
+    def monitor_loop():
+        while not stop_event.wait(heartbeat_interval_seconds):
+            heartbeat_refreshed = heartbeat_issue_lock(issue_num, owner_id, ttl_seconds)
+            lock_snapshot = read_issue_lock(issue_num)
+            lock_owner = lock_snapshot["doc"].get("owner_id") if lock_snapshot["exists"] else None
+            lock_owner_matches = bool(lock_snapshot["exists"]) and lock_owner == owner_id
+            drift_reason = ""
+            if not lock_owner_matches:
+                drift_reason = "lock_owner_drift"
+            elif not heartbeat_refreshed:
+                drift_reason = "heartbeat_refresh_failed"
+
+            event = {
+                "event": "runtime_heartbeat_tick",
+                "decided_at_utc": datetime.now(timezone.utc).isoformat(),
+                "issue_number": issue_num,
+                "heartbeat_refreshed": heartbeat_refreshed,
+                "lock_exists": lock_snapshot["exists"],
+                "lock_owner": lock_owner,
+                "lock_owner_matches": lock_owner_matches,
+                "drift_detected": bool(drift_reason),
+                "drift_reason": drift_reason or None,
+            }
+            with event_lock:
+                heartbeat_events.append(event)
+
+            if drift_reason:
+                state["drift_detected"] = True
+                state["drift_reason"] = drift_reason
+                with event_lock:
+                    heartbeat_events.append(
+                        {
+                            "event": "runtime_heartbeat_drift_detected",
+                            "decided_at_utc": datetime.now(timezone.utc).isoformat(),
+                            "issue_number": issue_num,
+                            "drift_reason": drift_reason,
+                        }
+                    )
+                try:
+                    process.terminate()
+                except Exception:  # noqa: BLE001
+                    pass
+                return
+
+    monitor_thread = threading.Thread(target=monitor_loop, daemon=True)
+    monitor_thread.start()
+    out, err = process.communicate()
+    stop_event.set()
+    monitor_thread.join(timeout=1.0)
+    ended_at = datetime.now(timezone.utc).isoformat()
+
+    with event_lock:
+        heartbeat_events.append(
+            {
+                "event": "runtime_heartbeat_stopped",
+                "decided_at_utc": ended_at,
+                "issue_number": issue_num,
+                "return_code": process.returncode,
+                "drift_detected": state["drift_detected"],
+                "drift_reason": state["drift_reason"] or None,
+            }
+        )
+
+    return {
+        "return_code": int(process.returncode),
+        "stdout": out.strip(),
+        "stderr": err.strip(),
+        "drift_detected": state["drift_detected"],
+        "drift_reason": state["drift_reason"] or None,
+        "heartbeat_events": heartbeat_events,
+        "heartbeat_interval_seconds": heartbeat_interval_seconds,
+    }
 
 
 def evaluate_escalation(issue_num: int, verdict: str, reason_code: str):
@@ -1051,9 +1168,9 @@ def main():
             resume_stage = None
 
     if not reused_loop_artifacts:
-        # run loop
-        rc_loop, out_loop, err_loop = run(
-            [
+        # run loop with runtime-window heartbeat pump and lock drift detection
+        loop_run = run_with_runtime_heartbeat(
+            command=[
                 "python3",
                 "planningops/scripts/ralph_loop_local.py",
                 "--issue-number",
@@ -1068,8 +1185,50 @@ def main():
                 str(max_attempts),
                 "--worker-task-pack-report",
                 str(worker_task_pack_preflight.get("report_path")),
-            ]
+            ],
+            issue_num=issue_num,
+            owner_id=lock_owner_id,
+            ttl_seconds=args.lease_ttl_seconds,
         )
+        rc_loop = loop_run["return_code"]
+        out_loop = loop_run["stdout"]
+        err_loop = loop_run["stderr"]
+        watchdog_events.extend(loop_run["heartbeat_events"])
+
+        if loop_run["drift_detected"]:
+            release_ok = release_issue_lock(issue_num, lock_owner_id)
+            watchdog_events.append(
+                {
+                    "event": "lock_released_after_runtime_drift",
+                    "decided_at_utc": datetime.now(timezone.utc).isoformat(),
+                    "release_ok": release_ok,
+                }
+            )
+            save_json(
+                watchdog_path,
+                {
+                    "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+                    "issue_number": issue_num,
+                    "verdict": "fail",
+                    "stage": "loop_executed",
+                    "reason_code": loop_run["drift_reason"],
+                    "release_ok": release_ok,
+                    "events": watchdog_events,
+                },
+            )
+            clear_checkpoint(issue_num)
+            print(
+                json.dumps(
+                    {
+                        "result": "runtime_lock_drift_detected",
+                        "issue_number": issue_num,
+                        "reason_code": loop_run["drift_reason"],
+                        "watchdog_report": str(watchdog_path),
+                    },
+                    ensure_ascii=True,
+                )
+            )
+            return 8
 
         # find latest loop dir for this issue
         loop_root = Path("planningops/artifacts/loops")

--- a/planningops/scripts/test_lease_lock_watchdog.sh
+++ b/planningops/scripts/test_lease_lock_watchdog.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 python3 - <<'PY'
 import importlib.util
 import json
+import threading
+import time
 import tempfile
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -40,6 +42,56 @@ with tempfile.TemporaryDirectory() as td:
     assert mod.heartbeat_issue_lock(issue_number, "owner-b", ttl_seconds=300) is True
     assert mod.release_issue_lock(issue_number, "owner-b") is True
     assert not mod.lock_path(issue_number).exists(), mod.lock_path(issue_number)
+
+    # Runtime-window heartbeat should tick while worker command is running.
+    runtime_issue = 778
+    acquired_runtime, _, _ = mod.acquire_issue_lock(runtime_issue, "owner-runtime", ttl_seconds=3)
+    assert acquired_runtime is True
+    runtime_run = mod.run_with_runtime_heartbeat(
+        command=["python3", "-c", "import time; time.sleep(2); print('done')"],
+        issue_num=runtime_issue,
+        owner_id="owner-runtime",
+        ttl_seconds=3,
+    )
+    assert runtime_run["drift_detected"] is False, runtime_run
+    assert runtime_run["return_code"] == 0, runtime_run
+    runtime_events = runtime_run["heartbeat_events"]
+    assert any(e.get("event") == "runtime_heartbeat_started" for e in runtime_events), runtime_events
+    assert any(e.get("event") == "runtime_heartbeat_stopped" for e in runtime_events), runtime_events
+    assert any(
+        e.get("event") == "runtime_heartbeat_tick" and e.get("heartbeat_refreshed") is True
+        for e in runtime_events
+    ), runtime_events
+    assert mod.release_issue_lock(runtime_issue, "owner-runtime") is True
+
+    # Lock owner drift during runtime should be detected and classified.
+    drift_issue = 779
+    acquired_drift, _, _ = mod.acquire_issue_lock(drift_issue, "owner-drift", ttl_seconds=3)
+    assert acquired_drift is True
+
+    def mutate_owner():
+        time.sleep(1.2)
+        drift_path = mod.lock_path(drift_issue)
+        drift_doc = json.loads(drift_path.read_text(encoding="utf-8"))
+        drift_doc["owner_id"] = "owner-hijack"
+        drift_path.write_text(json.dumps(drift_doc, ensure_ascii=True, indent=2), encoding="utf-8")
+
+    t = threading.Thread(target=mutate_owner, daemon=True)
+    t.start()
+    drift_run = mod.run_with_runtime_heartbeat(
+        command=["python3", "-c", "import time; time.sleep(6); print('late')"],
+        issue_num=drift_issue,
+        owner_id="owner-drift",
+        ttl_seconds=3,
+    )
+    t.join(timeout=1.0)
+    assert drift_run["drift_detected"] is True, drift_run
+    assert drift_run["drift_reason"] == "lock_owner_drift", drift_run
+    drift_events = drift_run["heartbeat_events"]
+    assert any(e.get("event") == "runtime_heartbeat_drift_detected" for e in drift_events), drift_events
+    drift_path = mod.lock_path(drift_issue)
+    if drift_path.exists():
+        drift_path.unlink()
 
 print("lease lock watchdog contract smoke ok")
 PY

--- a/todos/024-complete-p2-inflight-heartbeat-lock-safety.md
+++ b/todos/024-complete-p2-inflight-heartbeat-lock-safety.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: complete
 priority: p2
 issue_id: "024"
 tags: [planningops, lock, watchdog, reliability, concurrency]
@@ -65,10 +65,10 @@ Implement Option 1 and emit explicit watchdog events for runtime-window heartbea
 - `planningops/scripts/test_lease_lock_watchdog.sh` (or equivalent regression script)
 
 ## Acceptance Criteria
-- [ ] Heartbeat refresh runs during worker execution window.
-- [ ] Lock ownership drift during execution is detected and classified.
-- [ ] Watchdog artifact includes runtime-window heartbeat events.
-- [ ] Regression test covers long-running execution with lock safety assertions.
+- [x] Heartbeat refresh runs during worker execution window.
+- [x] Lock ownership drift during execution is detected and classified.
+- [x] Watchdog artifact includes runtime-window heartbeat events.
+- [x] Regression test covers long-running execution with lock safety assertions.
 
 ## Work Log
 
@@ -83,3 +83,20 @@ Implement Option 1 and emit explicit watchdog events for runtime-window heartbea
 **Learnings:**
 - Stage-only heartbeat is insufficient once worker runtime becomes policy-driven and potentially long-lived.
 
+### 2026-03-05 - Implementation Complete
+
+**By:** Codex
+
+**Actions:**
+- Added runtime-window heartbeat pump and lock drift detection in `planningops/scripts/issue_loop_runner.py`:
+  - new helper `run_with_runtime_heartbeat(...)`,
+  - runtime event taxonomy (`runtime_heartbeat_started|runtime_heartbeat_tick|runtime_heartbeat_drift_detected|runtime_heartbeat_stopped`),
+  - explicit drift classification (`lock_owner_drift` / `heartbeat_refresh_failed`) and fail-fast path.
+- Integrated heartbeat-runner into loop execution path and wired runtime heartbeat events into watchdog report timeline.
+- Updated lock contract wording in `planningops/contracts/lease-lock-watchdog-contract.md` to require runtime heartbeat and drift classification.
+- Expanded regression coverage in `planningops/scripts/test_lease_lock_watchdog.sh`:
+  - long-running runtime heartbeat success path,
+  - lock owner drift injection path with classification assertion.
+
+**Learnings:**
+- Runtime heartbeat must verify ownership as a first-class condition; refresh result alone is not enough to classify lock safety reliably.


### PR DESCRIPTION
## Summary
- Added a runtime-window heartbeat pump for loop execution and lock ownership drift detection.
- Upgraded loop execution path to classify lock drift (`lock_owner_drift` / `heartbeat_refresh_failed`) and fail fast with watchdog evidence.
- Extended lease lock contract to require runtime heartbeat and event taxonomy.
- Marked todo `024` as complete.

## Scope
- Initiative docs:
  - `planningops/contracts/lease-lock-watchdog-contract.md`
- Workbench docs:
  - `todos/024-complete-p2-inflight-heartbeat-lock-safety.md`
- `planningops/` scripts/contracts:
  - `planningops/scripts/issue_loop_runner.py`
  - `planningops/scripts/test_lease_lock_watchdog.sh`
- `.github/` workflows:
  - none

## Linked Issues
- Closes #24
- Related #25

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_lease_lock_watchdog.sh`
  - `bash planningops/scripts/test_loop_checkpoint_resume.sh`
  - `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
  - `python3 -m py_compile planningops/scripts/issue_loop_runner.py`

## Risks
- Risk: Runtime heartbeat introduces concurrency/thread timing behavior around subprocess lifecycle.
- Rollback: Revert commit `a596c2a` to restore stage-boundary-only heartbeat behavior.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
