### PR TITLE
ci(planningops): wire reliability regression pack into required gate

### DIFF
--- a/.github/workflows/planningops-contracts-dryrun.yml
+++ b/.github/workflows/planningops-contracts-dryrun.yml
@@ -22,6 +22,50 @@ jobs:
       - name: Dry-run parser diff pipeline
         run: python3 planningops/scripts/parser_diff_dry_run.py --run-id ci-dry-run --mode dry-run
 
+      - name: Reliability regression pack
+        run: |
+          bash planningops/scripts/test_worker_executor_contract.sh
+          bash planningops/scripts/test_verify_loop_run_hard_gate_contract.sh
+          bash planningops/scripts/test_lease_lock_watchdog.sh
+          bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
+          bash planningops/scripts/test_loop_checkpoint_resume.sh
+          python3 planningops/scripts/validate_worker_task_pack.py \
+            --runtime-profile-file planningops/config/runtime-profiles.json \
+            --task-key issue-18 \
+            --issue-number 18 \
+            --mode dry-run \
+            --loop-profile "L3 Implementation-TDD" \
+            --target-repo rather-not-work-on/platform-planningops \
+            --output planningops/artifacts/validation/worker-task-pack-ci-report.json \
+            --strict
+          python3 - <<'PY'
+          import json
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          summary = {
+              "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+              "check_pack": "planningops-reliability-regression-v1",
+              "checks": [
+                  "test_worker_executor_contract",
+                  "test_verify_loop_run_hard_gate_contract",
+                  "test_lease_lock_watchdog",
+                  "test_issue_loop_runner_multi_repo_intake",
+                  "test_loop_checkpoint_resume",
+                  "validate_worker_task_pack_ci_report",
+              ],
+              "artifacts": {
+                  "parser_diff_summary": "planningops/artifacts/sync-summary/ci-dry-run.json",
+                  "idempotency_ledger": "planningops/artifacts/idempotency/ledger.json",
+                  "worker_task_pack_ci_report": "planningops/artifacts/validation/worker-task-pack-ci-report.json",
+              },
+          }
+          output = Path("planningops/artifacts/ci/reliability-regression-summary.json")
+          output.parent.mkdir(parents=True, exist_ok=True)
+          output.write_text(json.dumps(summary, ensure_ascii=True, indent=2), encoding="utf-8")
+          print(f"summary written: {output}")
+          PY
+
       - name: Upload dry-run artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -29,3 +73,5 @@ jobs:
           path: |
             planningops/artifacts/sync-summary/ci-dry-run.json
             planningops/artifacts/idempotency/ledger.json
+            planningops/artifacts/validation/worker-task-pack-ci-report.json
+            planningops/artifacts/ci/reliability-regression-summary.json

--- a/todos/025-complete-p2-reliability-ci-regression-pack.md
+++ b/todos/025-complete-p2-reliability-ci-regression-pack.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: complete
 priority: p2
 issue_id: "025"
 tags: [planningops, ci, regression, reliability, contracts]
@@ -61,10 +61,10 @@ Implement Option 1 after completion of issues `023` and `024`.
 - `.github/workflows/*` reliability check workflow
 
 ## Acceptance Criteria
-- [ ] CI runs reliability pack on changes to loop runtime scripts/contracts/schemas.
-- [ ] Test matrix includes timeout, retry convergence, budget exhausted, and heartbeat lock safety.
-- [ ] Failing reliability checks block merge.
-- [ ] CI output links to deterministic artifact/report paths.
+- [x] CI runs reliability pack on changes to loop runtime scripts/contracts/schemas.
+- [x] Test matrix includes timeout, retry convergence, budget exhausted, and heartbeat lock safety.
+- [x] Failing reliability checks block merge.
+- [x] CI output links to deterministic artifact/report paths.
 
 ## Work Log
 
@@ -79,3 +79,22 @@ Implement Option 1 after completion of issues `023` and `024`.
 **Learnings:**
 - Reliability guarantees decay quickly without permanent CI enforcement.
 
+### 2026-03-05 - Implementation Complete
+
+**By:** Codex
+
+**Actions:**
+- Upgraded `.github/workflows/planningops-contracts-dryrun.yml` with a dedicated reliability regression pack step.
+- Wired the following regression set into CI:
+  - `planningops/scripts/test_worker_executor_contract.sh`
+  - `planningops/scripts/test_verify_loop_run_hard_gate_contract.sh`
+  - `planningops/scripts/test_lease_lock_watchdog.sh`
+  - `planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
+  - `planningops/scripts/test_loop_checkpoint_resume.sh`
+- Added deterministic CI report generation:
+  - `planningops/artifacts/validation/worker-task-pack-ci-report.json`
+  - `planningops/artifacts/ci/reliability-regression-summary.json`
+- Kept execution inside existing required workflow/job (`PlanningOps Contracts Dry-Run` / `validate-and-dry-run`) so reliability failures block merge.
+
+**Learnings:**
+- Reusing an already-required gate is the lowest-risk way to enforce new reliability invariants without branch-protection drift.


### PR DESCRIPTION
## Summary
- Added a dedicated reliability regression pack step to the required `PlanningOps Contracts Dry-Run` workflow.
- Wired retry/timeout/budget/heartbeat regression scripts into CI.
- Added deterministic CI report outputs for reliability checks.
- Marked todo `025` as complete.

## Scope
- Initiative docs:
  - none
- Workbench docs:
  - `todos/025-complete-p2-reliability-ci-regression-pack.md`
- `planningops/` scripts/contracts:
  - none (CI wiring only)
- `.github/` workflows:
  - `.github/workflows/planningops-contracts-dryrun.yml`

## Linked Issues
- Closes #25
- Related #26

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_worker_executor_contract.sh`
  - `bash planningops/scripts/test_verify_loop_run_hard_gate_contract.sh`
  - `bash planningops/scripts/test_lease_lock_watchdog.sh`
  - `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
  - `bash planningops/scripts/test_loop_checkpoint_resume.sh`
  - `python3 planningops/scripts/validate_contracts.py`
  - `python3 planningops/scripts/parser_diff_dry_run.py --run-id ci-dry-run --mode dry-run`
  - `python3 planningops/scripts/validate_worker_task_pack.py --runtime-profile-file planningops/config/runtime-profiles.json --task-key issue-18 --issue-number 18 --mode dry-run --loop-profile "L3 Implementation-TDD" --target-repo rather-not-work-on/platform-planningops --output planningops/artifacts/validation/worker-task-pack-ci-report.json --strict`

## Risks
- Risk: CI runtime will increase due added regression pack.
- Rollback: Revert commit `fbdb181` to restore prior minimal dry-run gate.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
