### PR TITLE
docs(contracts): define autonomous run policy and stop criteria

### DIFF
--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -13,6 +13,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `implementation-readiness-gate-contract.md`: design-first gate and redefine loop
 - `execution-adapter-interface-contract.md`: adapter hook interface
 - `attempt-budget-contract.md`: per-task loop budget
+- `autonomous-run-policy-contract.md`: convergence/risk-based autonomous run control and stop criteria
 - `worker-task-pack-contract.md`: worker execution bundle and render safety contract
 - `checkpoint-resume-contract.md`: checkpoint and resume behavior
 - `lease-lock-watchdog-contract.md`: concurrency and stale-lock recovery

--- a/planningops/contracts/autonomous-run-policy-contract.md
+++ b/planningops/contracts/autonomous-run-policy-contract.md
@@ -1,0 +1,43 @@
+# Autonomous Run Policy Contract
+
+## Goal
+Define autonomous loop control as convergence/risk/quality bounded execution, not clock-time bounded execution.
+
+## Control Axis
+- Primary control axis: convergence quality and risk gates.
+- Secondary metadata: elapsed runtime (`max_duration_minutes`) and token usage.
+- Prohibited interpretation: fixed-duration target such as "run N hours regardless of quality state".
+
+## Continue Conditions
+Autonomous run may continue only while all are true:
+1. latest verification verdict is not `fail`,
+2. escalation gate is not auto-paused,
+3. lease lock ownership remains valid,
+4. required reliability evidence is present and valid.
+
+## Stop Conditions
+Autonomous run must stop immediately when any occurs:
+1. quality gate failure (`verdict=fail`),
+2. escalation trigger (`same_reason_x3` or `inconclusive_x2`),
+3. safety conflict (`lock_owner_drift` / `heartbeat_refresh_failed` / lock conflict),
+4. missing or invalid required evidence for pass-path verification.
+
+## Replan Linkage
+- Stop by escalation or safety conflict sets `replanning_triggered=true`.
+- Runner must emit:
+  - transition-log event with replanning flag,
+  - replan decision artifact for auto-pause path.
+
+## Testability Mapping
+- Escalation trigger behavior:
+  - implementation: `planningops/scripts/issue_loop_runner.py` (`evaluate_escalation`)
+  - regression: `planningops/scripts/test_escalation_gate.sh`
+- Runtime safety stop behavior:
+  - implementation: `planningops/scripts/issue_loop_runner.py` (`run_with_runtime_heartbeat`)
+  - regression: `planningops/scripts/test_lease_lock_watchdog.sh`
+- Verification evidence stop behavior:
+  - implementation: `planningops/scripts/verify_loop_run.py`
+  - regression: `planningops/scripts/test_verify_loop_run_hard_gate_contract.sh`
+
+## Notes
+- Attempt/token/duration budgets remain useful as operational limits, but they do not override safety and convergence stop rules.

--- a/planningops/contracts/requirements-contract.md
+++ b/planningops/contracts/requirements-contract.md
@@ -29,6 +29,8 @@
 26. Worker task pack validation failure must block execution start with explicit preflight failure result.
 27. Verification hard gate must require schema-valid `execution-attempts` evidence (`execution-attempts.json`) and reject `pass` when evidence is missing/invalid.
 28. Verification output (`verdict`, `reason_code`) must be consistency-checked against loop report evidence and written identically into project payload.
+29. Autonomous run control must be convergence/risk bounded; wall-clock duration is metadata and cannot override safety or quality stop conditions.
+30. Autonomous stop conditions must explicitly include quality failure, escalation trigger, and runtime safety conflict with deterministic evidence output.
 
 ## Non-Functional Requirements
 1. Idempotency: repeated execution for same issue+commit must not duplicate updates.
@@ -38,6 +40,7 @@
 5. Portability: local-first runtime must be migratable to Oracle Cloud by profile switch without contract shape change.
 6. Kanban operation model: execution cadence is non-periodic pull-based; readiness and evidence gates, not sprint windows, determine progression.
 7. Schema mismatch policy: dry-run may emit report-only verdicts for migration visibility; apply mode must fail fast on required field mismatch.
+8. Autonomous operation policy: prioritize quality and convergence over throughput or fixed runtime windows.
 
 ## Naming Contract
 - External contract term is fixed to `Executor`.
@@ -69,5 +72,6 @@
 - Checkpoint resume contract: see `planningops/contracts/checkpoint-resume-contract.md`.
 - Lease lock contract: see `planningops/contracts/lease-lock-watchdog-contract.md`.
 - Escalation contract: see `planningops/contracts/escalation-gate-contract.md`.
+- Autonomous run policy contract: see `planningops/contracts/autonomous-run-policy-contract.md`.
 - Implementation readiness contract: see `planningops/contracts/implementation-readiness-gate-contract.md`.
 - Worker task pack contract: see `planningops/contracts/worker-task-pack-contract.md`.

--- a/todos/026-complete-p1-autonomous-run-policy-and-stop-criteria.md
+++ b/todos/026-complete-p1-autonomous-run-policy-and-stop-criteria.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: complete
 priority: p1
 issue_id: "026"
 tags: [planningops, autonomy, governance, reliability]
@@ -60,9 +60,9 @@ Implement Option 1 and make convergence/risk the only hard control axis for auto
 - `planningops/contracts/requirements-contract.md` (if control semantics need explicit lock)
 
 ## Acceptance Criteria
-- [ ] Autonomous mode definition is explicitly difficulty/convergence bounded, not time bounded.
-- [ ] Stop conditions include quality gate fail + escalation triggers + safety conflicts.
-- [ ] Replan trigger linkage is explicit and testable.
+- [x] Autonomous mode definition is explicitly difficulty/convergence bounded, not time bounded.
+- [x] Stop conditions include quality gate fail + escalation triggers + safety conflicts.
+- [x] Replan trigger linkage is explicit and testable.
 
 ## Work Log
 
@@ -76,3 +76,18 @@ Implement Option 1 and make convergence/risk the only hard control axis for auto
 **Learnings:**
 - Time budget is operational metadata, not primary control logic.
 
+### 2026-03-05 - Implementation Complete
+
+**By:** Codex
+
+**Actions:**
+- Added `planningops/contracts/autonomous-run-policy-contract.md` to formalize convergence/risk-based autonomous run control and deterministic stop criteria.
+- Linked stop/replan logic to existing testable implementation anchors:
+  - `planningops/scripts/issue_loop_runner.py` (`evaluate_escalation`, `run_with_runtime_heartbeat`)
+  - `planningops/scripts/verify_loop_run.py`
+  - tests: `test_escalation_gate.sh`, `test_lease_lock_watchdog.sh`, `test_verify_loop_run_hard_gate_contract.sh`
+- Updated `planningops/contracts/requirements-contract.md` with explicit autonomous control/stop requirements and mapping reference.
+- Updated `planningops/contracts/README.md` contract index.
+
+**Learnings:**
+- Making autonomy control explicit in contracts prevents drift back to time-window interpretations and keeps stop behavior reviewable.


### PR DESCRIPTION
## Summary
- Added `autonomous-run-policy-contract.md` to fix autonomous control semantics as convergence/risk-based (not time-window based).
- Added explicit stop criteria and testability mapping for escalation, runtime safety, and verification evidence gates.
- Synced `requirements-contract.md` and contracts index.
- Marked todo `026` as complete.

## Scope
- Initiative docs:
  - none
- Workbench docs:
  - `todos/026-complete-p1-autonomous-run-policy-and-stop-criteria.md`
- `planningops/` scripts/contracts:
  - `planningops/contracts/autonomous-run-policy-contract.md`
  - `planningops/contracts/requirements-contract.md`
  - `planningops/contracts/README.md`
- `.github/` workflows:
  - none

## Linked Issues
- Closes #26
- Related #27

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_escalation_gate.sh`
  - `bash planningops/scripts/test_lease_lock_watchdog.sh`
  - `bash planningops/scripts/test_verify_loop_run_hard_gate_contract.sh`

## Risks
- Risk: Policy text becomes stricter and may require follow-up alignment in operator runbooks.
- Rollback: Revert commit `924710a`.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
