### PR TITLE
[028] Add backlog stock/replenishment loop gate

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -140,6 +140,7 @@ jobs:
           bash planningops/scripts/test_loop_checkpoint_resume.sh
           bash planningops/scripts/test_lease_lock_watchdog.sh
           bash planningops/scripts/test_escalation_gate.sh
+          bash planningops/scripts/test_backlog_stock_replenishment_contract.sh
 
   federated-summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/planningops-contracts-dryrun.yml
+++ b/.github/workflows/planningops-contracts-dryrun.yml
@@ -29,6 +29,7 @@ jobs:
           bash planningops/scripts/test_lease_lock_watchdog.sh
           bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
           bash planningops/scripts/test_loop_checkpoint_resume.sh
+          bash planningops/scripts/test_backlog_stock_replenishment_contract.sh
           python3 planningops/scripts/validate_worker_task_pack.py \
             --runtime-profile-file planningops/config/runtime-profiles.json \
             --task-key issue-18 \
@@ -52,6 +53,7 @@ jobs:
                   "test_lease_lock_watchdog",
                   "test_issue_loop_runner_multi_repo_intake",
                   "test_loop_checkpoint_resume",
+                  "test_backlog_stock_replenishment_contract",
                   "validate_worker_task_pack_ci_report",
               ],
               "artifacts": {

--- a/planningops/README.md
+++ b/planningops/README.md
@@ -72,6 +72,7 @@ python3 planningops/scripts/build_meta_plan_graph.py --contract-file planningops
 python3 planningops/scripts/meta_plan_orchestrator.py --meta-graph-contract planningops/fixtures/meta-plan-graph-sample.json --mode dry-run --strict
 python3 planningops/scripts/validate_worker_task_pack.py --task-key issue-18 --issue-number 18 --mode dry-run --loop-profile "L3 Implementation-TDD" --strict
 python3 planningops/scripts/verify_plan_projection.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --snapshot-file planningops/fixtures/plan-projection-snapshot-sample.json --strict
+python3 planningops/scripts/backlog_stock_replenishment_guard.py --items-file planningops/fixtures/backlog-stock-items-sample.json --candidate-file planningops/fixtures/backlog-replenishment-candidates-sample.json
 bash planningops/scripts/test_compile_plan_to_backlog_contract.sh
 bash planningops/scripts/test_build_meta_plan_graph_contract.sh
 bash planningops/scripts/test_verify_plan_projection_contract.sh
@@ -79,6 +80,7 @@ bash planningops/scripts/test_meta_plan_graph_schema_contract.sh
 bash planningops/scripts/test_meta_plan_orchestrator_contract.sh
 bash planningops/scripts/test_ralph_loop_local_worker_policy.sh
 bash planningops/scripts/test_validate_worker_task_pack_contract.sh
+bash planningops/scripts/test_backlog_stock_replenishment_contract.sh
 python3 planningops/scripts/normalize_ready_implementation_blueprint_refs.py
 python3 planningops/scripts/run_track2_contract_pack_validation.py --strict
 python3 planningops/scripts/cross_repo_conformance_check.py

--- a/planningops/config/README.md
+++ b/planningops/config/README.md
@@ -9,6 +9,7 @@ Provide stable configuration sources for project fields, runtime profiles, and c
 - `runtime-profiles.json`: local/oracle runtime and provider policies
 - `contract-ref-map.json`: C1~C8 schema pointer map
 - `ready-implementation-blueprint-defaults.json`: blueprint ref normalization defaults by `target_repo`
+- `backlog-stock-policy.json`: queue class stock floors and replenishment candidate requirements
 - `refactor-hygiene-policy.json`: single-repo refactor hygiene policy
 - `refactor-hygiene-multi-repo.json`: multi-repo hygiene matrix config
 

--- a/planningops/config/backlog-stock-policy.json
+++ b/planningops/config/backlog-stock-policy.json
@@ -1,0 +1,41 @@
+{
+  "policy_id": "backlog-stock-replenishment-v1",
+  "queue_classes": [
+    {
+      "name": "ready_now",
+      "description": "Immediate pull candidates with no open dependency blockers.",
+      "min_stock": 1,
+      "rule": {
+        "statuses": ["Todo"],
+        "workflow_states": ["ready-contract", "ready-implementation"],
+        "dependency_mode": "all_closed"
+      }
+    },
+    {
+      "name": "next_up",
+      "description": "Todo items that become executable after dependency completion.",
+      "min_stock": 2,
+      "rule": {
+        "statuses": ["Todo"],
+        "workflow_states": ["ready-contract", "ready-implementation"],
+        "dependency_mode": "has_open"
+      }
+    },
+    {
+      "name": "quality_hardening",
+      "description": "Contract/test/governance hardening queue that keeps quality floor stable.",
+      "min_stock": 2,
+      "rule": {
+        "statuses": ["Todo"],
+        "workflow_states": ["backlog", "ready-contract"],
+        "components": ["planningops"],
+        "dependency_mode": "any"
+      }
+    }
+  ],
+  "candidate_requirements": {
+    "require_evidence_refs": true,
+    "require_depends_on_field": true,
+    "require_acceptance_criteria": true
+  }
+}

--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -15,6 +15,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `attempt-budget-contract.md`: per-task loop budget
 - `autonomous-run-policy-contract.md`: convergence/risk-based autonomous run control and stop criteria
 - `worktree-comparative-experiment-protocol.md`: A/B branch-worktree experiment trigger, artifact, and scoring protocol
+- `backlog-stock-replenishment-contract.md`: queue stock floor + evidence-backed replenishment gate
 - `worker-task-pack-contract.md`: worker execution bundle and render safety contract
 - `checkpoint-resume-contract.md`: checkpoint and resume behavior
 - `lease-lock-watchdog-contract.md`: concurrency and stale-lock recovery

--- a/planningops/contracts/backlog-stock-replenishment-contract.md
+++ b/planningops/contracts/backlog-stock-replenishment-contract.md
@@ -1,0 +1,56 @@
+# Backlog Stock and Replenishment Contract
+
+## Goal
+Keep autonomous Kanban execution stable by enforcing queue stock floors and evidence-backed replenishment quality.
+
+## Queue Classes
+Three queue classes are mandatory:
+1. `ready_now`: executable now (`Todo` + `ready-*` + no open dependency blocker)
+2. `next_up`: near-ready (`Todo` + `ready-*` + dependency blocker exists)
+3. `quality_hardening`: contract/test/governance hardening queue
+
+Stock floor source:
+- `planningops/config/backlog-stock-policy.json`
+
+## High-Value Pull Rule
+- Intake must apply `high_value_ready_first`.
+- Selection target is always the smallest `(execution_order, issue_number)` inside `ready_now`.
+- `backlog`/non-ready cards cannot preempt a `ready_now` candidate even when they have smaller `execution_order`.
+
+## Replenishment Gate
+New follow-up backlog candidates must be evidence-backed and normalized before queue insertion.
+
+Required candidate fields:
+1. `title`
+2. `evidence_refs` (one or more artifact refs)
+3. `depends_on` (field required; empty list allowed only when explicitly independent)
+4. `acceptance_criteria` (non-empty checklist)
+
+Candidate normalization output must include:
+- deterministic `candidate_id`
+- baseline issue body template with:
+  - `depends_on`
+  - checklist-style acceptance criteria
+  - evidence references section
+
+## Gate Behavior
+- Stock gate fails when any queue class is below `min_stock`.
+- Replenishment gate fails when any candidate misses required fields.
+- Report-only mode is allowed for observation runs, but strict mode is required for CI/contract validation.
+
+## Artifacts
+- Policy config:
+  - `planningops/config/backlog-stock-policy.json`
+- Validation report:
+  - `planningops/artifacts/validation/backlog-stock-report.json`
+- Runner replenishment candidate artifact:
+  - `planningops/artifacts/backlog/issue-<n>-replenishment-candidates.json`
+
+## Testability Mapping
+- stock/replenishment validation implementation:
+  - `planningops/scripts/backlog_stock_replenishment_guard.py`
+- high-value-ready selection enforcement:
+  - `planningops/scripts/issue_loop_runner.py`
+- regression:
+  - `planningops/scripts/test_backlog_stock_replenishment_contract.sh`
+  - `planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`

--- a/planningops/contracts/problem-contract.md
+++ b/planningops/contracts/problem-contract.md
@@ -26,6 +26,7 @@ Resolve `platform-planningops` issues autonomously in repeatable loops with expl
 - `project_field_payload.json` (must include `last_verdict`, `last_reason`, `loop_profile`)
 - `adapter-pre.json` (repo pre-hook result payload)
 - `adapter-post.json` (repo post-hook result payload)
+- `backlog-replenishment-candidates.json` (evidence-backed follow-up candidates; empty allowed)
 
 ## Success Condition
 A loop is successful only when:

--- a/planningops/contracts/requirements-contract.md
+++ b/planningops/contracts/requirements-contract.md
@@ -32,6 +32,10 @@
 29. Autonomous run control must be convergence/risk bounded; wall-clock duration is metadata and cannot override safety or quality stop conditions.
 30. Autonomous stop conditions must explicitly include quality failure, escalation trigger, and runtime safety conflict with deterministic evidence output.
 31. High-uncertainty or architecture-tradeoff changes must use branch/worktree comparative experiment protocol with artifact-backed selection record.
+32. Backlog operation must define queue classes (`ready_now`, `next_up`, `quality_hardening`) with explicit minimum stock targets.
+33. Intake selection must enforce `high_value_ready_first` so non-ready cards cannot preempt a ready-now candidate.
+34. Replenishment candidates must be evidence-backed and rejected when artifact references are missing.
+35. Replenishment candidate normalization must preserve dependency baseline (`depends_on`) and checklist acceptance criteria.
 
 ## Non-Functional Requirements
 1. Idempotency: repeated execution for same issue+commit must not duplicate updates.
@@ -75,5 +79,6 @@
 - Escalation contract: see `planningops/contracts/escalation-gate-contract.md`.
 - Autonomous run policy contract: see `planningops/contracts/autonomous-run-policy-contract.md`.
 - Worktree comparative experiment protocol: see `planningops/contracts/worktree-comparative-experiment-protocol.md`.
+- Backlog stock/replenishment contract: see `planningops/contracts/backlog-stock-replenishment-contract.md`.
 - Implementation readiness contract: see `planningops/contracts/implementation-readiness-gate-contract.md`.
 - Worker task pack contract: see `planningops/contracts/worker-task-pack-contract.md`.

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -11,6 +11,8 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `meta-plan-graph-sample.json`: minimal valid MPG v1 graph sample
 - `worker-task-pack-sample.json`: minimal valid worker task pack sample
 - `track1-kpi-baseline-ci.json`: strict gate KPI baseline input
+- `backlog-stock-items-sample.json`: normalized project-item sample for stock gate checks
+- `backlog-replenishment-candidates-sample.json`: evidence-backed replenishment candidate sample
 
 ## Change Rules
 - Fixtures must be static and deterministic.

--- a/planningops/fixtures/backlog-replenishment-candidates-sample.json
+++ b/planningops/fixtures/backlog-replenishment-candidates-sample.json
@@ -1,0 +1,18 @@
+{
+  "candidates": [
+    {
+      "candidate_id": "candidate-001",
+      "title": "Harden dependency unblock path for ready-implementation lane",
+      "target_repo": "rather-not-work-on/monday",
+      "depends_on": [101],
+      "acceptance_criteria": [
+        "Dependency mapping is documented and reproducible.",
+        "Validation gate confirms no dependency regression."
+      ],
+      "evidence_refs": [
+        "planningops/artifacts/verification/issue-101-verification.json",
+        "planningops/artifacts/loop-runner/last-run.json"
+      ]
+    }
+  ]
+}

--- a/planningops/fixtures/backlog-stock-items-sample.json
+++ b/planningops/fixtures/backlog-stock-items-sample.json
@@ -1,0 +1,52 @@
+[
+  {
+    "issue_number": 101,
+    "issue_repo": "rather-not-work-on/platform-planningops",
+    "status": "Todo",
+    "workflow_state": "ready-contract",
+    "execution_order": 10,
+    "component": "planningops",
+    "initiative": "unified-personal-agent-platform",
+    "open_dependency_count": 0
+  },
+  {
+    "issue_number": 102,
+    "issue_repo": "rather-not-work-on/monday",
+    "status": "Todo",
+    "workflow_state": "ready-implementation",
+    "execution_order": 20,
+    "component": "runtime",
+    "initiative": "unified-personal-agent-platform",
+    "open_dependency_count": 1
+  },
+  {
+    "issue_number": 103,
+    "issue_repo": "rather-not-work-on/platform-planningops",
+    "status": "Todo",
+    "workflow_state": "ready-contract",
+    "execution_order": 30,
+    "component": "planningops",
+    "initiative": "unified-personal-agent-platform",
+    "open_dependency_count": 2
+  },
+  {
+    "issue_number": 104,
+    "issue_repo": "rather-not-work-on/platform-planningops",
+    "status": "Todo",
+    "workflow_state": "backlog",
+    "execution_order": 40,
+    "component": "planningops",
+    "initiative": "unified-personal-agent-platform",
+    "open_dependency_count": 0
+  },
+  {
+    "issue_number": 105,
+    "issue_repo": "rather-not-work-on/platform-planningops",
+    "status": "Blocked",
+    "workflow_state": "blocked",
+    "execution_order": 50,
+    "component": "planningops",
+    "initiative": "unified-personal-agent-platform",
+    "open_dependency_count": 0
+  }
+]

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -12,6 +12,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `github_sync_adapter.py`
   - `repo_execution_adapters.py`
 - Validation and reporting:
+  - `backlog_stock_replenishment_guard.py`
   - `validate_contracts.py`
   - `validate_worker_task_pack.py`
   - `validate_project_field_schema.py`
@@ -37,6 +38,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_meta_plan_graph_schema_contract.sh`
   - `test_verify_plan_projection_contract.sh`
   - `test_verify_loop_run_hard_gate_contract.sh`
+  - `test_backlog_stock_replenishment_contract.sh`
   - `test_ralph_loop_local_worker_policy.sh`
   - `test_worker_executor_contract.sh`
   - `test_*.sh`

--- a/planningops/scripts/backlog_stock_replenishment_guard.py
+++ b/planningops/scripts/backlog_stock_replenishment_guard.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_STOCK_POLICY_FILE = Path("planningops/config/backlog-stock-policy.json")
+DEFAULT_OUTPUT_FILE = Path("planningops/artifacts/validation/backlog-stock-report.json")
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def run(args):
+    cp = subprocess.run(args, capture_output=True, text=True)
+    return cp.returncode, cp.stdout.strip(), cp.stderr.strip()
+
+
+def load_json(path: Path, default):
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_json(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
+def parse_depends_on(issue_body: str):
+    deps = set()
+    for line in issue_body.splitlines():
+        if "depends_on:" in line:
+            deps.update(int(n) for n in re.findall(r"#(\d+)", line))
+    return sorted(deps)
+
+
+def parse_issue_ref_to_int(value):
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            return int(stripped)
+        match = re.match(r"#(\d+)$", stripped)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def normalize_replenishment_depends(depends_raw):
+    if depends_raw is None:
+        return None, "depends_on is required"
+    if not isinstance(depends_raw, list):
+        return None, "depends_on must be a list"
+
+    normalized = []
+    invalid = []
+    for dep in depends_raw:
+        parsed = parse_issue_ref_to_int(dep)
+        if parsed is None:
+            invalid.append(dep)
+            continue
+        normalized.append(parsed)
+    if invalid:
+        return None, f"depends_on contains invalid values: {invalid}"
+    return sorted(set(normalized)), None
+
+
+def normalize_acceptance_criteria(value):
+    if not isinstance(value, list):
+        return None, "acceptance_criteria must be a list"
+    normalized = [str(x).strip() for x in value if str(x).strip()]
+    if not normalized:
+        return None, "acceptance_criteria must include at least one checklist item"
+    return normalized, None
+
+
+def normalize_evidence_refs(candidate):
+    refs = candidate.get("evidence_refs")
+    if refs is None and candidate.get("evidence_ref") is not None:
+        refs = [candidate.get("evidence_ref")]
+    if refs is None:
+        return []
+    if isinstance(refs, list):
+        return [str(x).strip() for x in refs if str(x).strip()]
+    if isinstance(refs, str) and refs.strip():
+        return [refs.strip()]
+    return []
+
+
+def render_issue_body_baseline(candidate):
+    depends = candidate.get("depends_on", [])
+    depends_text = ", ".join(f"#{d}" for d in depends) if depends else "-"
+    criteria_lines = "\n".join(f"- [ ] {row}" for row in candidate.get("acceptance_criteria", []))
+    evidence_lines = "\n".join(f"- `{row}`" for row in candidate.get("evidence_refs", []))
+    if not evidence_lines:
+        evidence_lines = "- (none)"
+
+    return "\n".join(
+        [
+            "## Context",
+            "- evidence-backed follow-up candidate",
+            "",
+            "## Evidence",
+            evidence_lines,
+            "",
+            "## Execution Order",
+            "- execution_order: <TBD>",
+            f"- depends_on: {depends_text}",
+            "",
+            "## Scope",
+            "- Clarify/patch root cause with deterministic artifacts",
+            "",
+            "## Acceptance Criteria",
+            criteria_lines,
+        ]
+    )
+
+
+def validate_replenishment_candidates(candidates, requirements):
+    require_evidence = bool(requirements.get("require_evidence_refs", True))
+    require_depends = bool(requirements.get("require_depends_on_field", True))
+    require_acceptance = bool(requirements.get("require_acceptance_criteria", True))
+
+    normalized = []
+    violations = []
+    for idx, raw in enumerate(candidates):
+        entry = raw if isinstance(raw, dict) else {}
+        candidate_id = str(entry.get("candidate_id") or f"candidate-{idx + 1}")
+        title = str(entry.get("title", "")).strip()
+        evidence_refs = normalize_evidence_refs(entry)
+
+        depends_on = []
+        depends_error = None
+        if require_depends or "depends_on" in entry:
+            depends_on, depends_error = normalize_replenishment_depends(entry.get("depends_on"))
+
+        acceptance_criteria = []
+        acceptance_error = None
+        if require_acceptance or "acceptance_criteria" in entry:
+            acceptance_criteria, acceptance_error = normalize_acceptance_criteria(entry.get("acceptance_criteria"))
+
+        errors = []
+        if not title:
+            errors.append("title is required")
+        if require_evidence and not evidence_refs:
+            errors.append("evidence_refs is required and must be non-empty")
+        if depends_error:
+            errors.append(depends_error)
+        if acceptance_error:
+            errors.append(acceptance_error)
+
+        candidate = {
+            "candidate_id": candidate_id,
+            "title": title,
+            "target_repo": str(entry.get("target_repo", "")).strip() or None,
+            "depends_on": depends_on if isinstance(depends_on, list) else [],
+            "acceptance_criteria": acceptance_criteria if isinstance(acceptance_criteria, list) else [],
+            "evidence_refs": evidence_refs,
+            "body_baseline": "",
+        }
+        if not errors:
+            candidate["body_baseline"] = render_issue_body_baseline(candidate)
+
+        normalized.append(candidate)
+        if errors:
+            violations.append(
+                {
+                    "index": idx,
+                    "candidate_id": candidate_id,
+                    "errors": errors,
+                }
+            )
+
+    return {
+        "candidate_count": len(candidates),
+        "violation_count": len(violations),
+        "violations": violations,
+        "normalized_candidates": normalized,
+    }
+
+
+def normalize_item(raw):
+    if not isinstance(raw, dict):
+        return None
+
+    # normalized row input
+    if raw.get("issue_number") is not None and raw.get("issue_repo"):
+        issue_number = parse_issue_ref_to_int(raw.get("issue_number"))
+        if issue_number is None:
+            return None
+        return {
+            "issue_number": issue_number,
+            "issue_repo": str(raw.get("issue_repo")),
+            "status": str(raw.get("status", "")),
+            "workflow_state": str(raw.get("workflow_state", "")),
+            "execution_order": int(raw.get("execution_order") or 0),
+            "component": str(raw.get("component", "")),
+            "initiative": str(raw.get("initiative", "")),
+            "issue_body": str(raw.get("issue_body", "")),
+            "open_dependency_count": raw.get("open_dependency_count"),
+        }
+
+    # gh project item-list shape
+    content = raw.get("content", {})
+    if content.get("type") != "Issue":
+        return None
+    issue_number = content.get("number")
+    issue_repo = content.get("repository")
+    if issue_number is None or not issue_repo:
+        return None
+    return {
+        "issue_number": int(issue_number),
+        "issue_repo": str(issue_repo),
+        "status": str(raw.get("status", "")),
+        "workflow_state": str(raw.get("workflow_state", "")),
+        "execution_order": int(raw.get("execution_order") or 0),
+        "component": str(raw.get("component", "")),
+        "initiative": str(raw.get("initiative", "")),
+        "issue_body": str(raw.get("issue_body", "")),
+        "open_dependency_count": raw.get("open_dependency_count"),
+    }
+
+
+def issue_is_closed(issue_number: int, repo: str):
+    rc, out, _ = run(["gh", "issue", "view", str(issue_number), "--repo", repo, "--json", "state", "--jq", ".state"])
+    if rc != 0:
+        return False, "issue_view_failed"
+    return out.strip().upper() == "CLOSED", "ok"
+
+
+def hydrate_issue_body(issue_repo: str, issue_number: int):
+    rc, out, err = run(["gh", "issue", "view", str(issue_number), "--repo", issue_repo, "--json", "body", "--jq", ".body"])
+    if rc != 0:
+        return "", f"issue_body_fetch_failed:{err}"
+    return out, "ok"
+
+
+def hydrate_dependency_counts(rows, offline=False):
+    closed_cache = {}
+    diagnostics = []
+
+    for row in rows:
+        if isinstance(row.get("open_dependency_count"), int):
+            row["depends_on"] = []
+            row["dependency_status"] = "provided"
+            continue
+
+        issue_body = row.get("issue_body", "")
+        if not issue_body:
+            if offline:
+                row["open_dependency_count"] = 999
+                row["depends_on"] = []
+                row["dependency_status"] = "offline_missing_issue_body"
+                continue
+            hydrated_body, status = hydrate_issue_body(row["issue_repo"], row["issue_number"])
+            issue_body = hydrated_body
+            diagnostics.append(
+                {
+                    "issue_number": row["issue_number"],
+                    "issue_repo": row["issue_repo"],
+                    "event": "hydrate_issue_body",
+                    "status": status,
+                }
+            )
+        row["issue_body"] = issue_body
+
+        deps = parse_depends_on(issue_body)
+        row["depends_on"] = deps
+        if not deps:
+            row["open_dependency_count"] = 0
+            row["dependency_status"] = "clear"
+            continue
+
+        open_count = 0
+        dep_errors = 0
+        for dep in deps:
+            key = (row["issue_repo"], dep)
+            if key not in closed_cache:
+                if offline:
+                    closed_cache[key] = (False, "offline_dependency_unknown")
+                else:
+                    closed_cache[key] = issue_is_closed(dep, row["issue_repo"])
+            closed, reason = closed_cache[key]
+            if not closed:
+                open_count += 1
+            if reason != "ok":
+                dep_errors += 1
+
+        row["open_dependency_count"] = open_count
+        if dep_errors:
+            row["dependency_status"] = "dependency_state_unknown"
+        elif open_count == 0:
+            row["dependency_status"] = "clear"
+        else:
+            row["dependency_status"] = "blocked"
+    return diagnostics
+
+
+def row_matches_rule(row, rule):
+    statuses = set(rule.get("statuses") or [])
+    if statuses and row.get("status") not in statuses:
+        return False
+
+    workflow_states = set(rule.get("workflow_states") or [])
+    if workflow_states and row.get("workflow_state") not in workflow_states:
+        return False
+
+    components = set(rule.get("components") or [])
+    if components and row.get("component") not in components:
+        return False
+
+    dependency_mode = str(rule.get("dependency_mode", "any"))
+    open_count = int(row.get("open_dependency_count") or 0)
+    if dependency_mode == "all_closed" and open_count != 0:
+        return False
+    if dependency_mode == "has_open" and open_count <= 0:
+        return False
+
+    return True
+
+
+def evaluate_stock(rows, policy):
+    queue_classes = policy.get("queue_classes") or []
+    stock_rows = []
+    breaches = []
+    class_rows = {}
+    for queue_class in queue_classes:
+        name = str(queue_class.get("name", "")).strip()
+        rule = queue_class.get("rule") or {}
+        min_stock = int(queue_class.get("min_stock") or 0)
+
+        matched = [row for row in rows if row_matches_rule(row, rule)]
+        matched_sorted = sorted(matched, key=lambda x: (x.get("execution_order", 0), x.get("issue_number", 0)))
+        class_rows[name] = matched_sorted
+
+        row = {
+            "name": name,
+            "min_stock": min_stock,
+            "actual_stock": len(matched_sorted),
+            "met": len(matched_sorted) >= min_stock,
+            "issue_refs": [
+                {
+                    "issue_number": m.get("issue_number"),
+                    "issue_repo": m.get("issue_repo"),
+                    "execution_order": m.get("execution_order"),
+                    "open_dependency_count": m.get("open_dependency_count"),
+                }
+                for m in matched_sorted
+            ],
+        }
+        stock_rows.append(row)
+        if not row["met"]:
+            breaches.append(
+                {
+                    "queue_class": name,
+                    "min_stock": min_stock,
+                    "actual_stock": len(matched_sorted),
+                    "shortage": min_stock - len(matched_sorted),
+                }
+            )
+
+    return {
+        "stock_rows": stock_rows,
+        "breach_count": len(breaches),
+        "breaches": breaches,
+        "class_rows": class_rows,
+    }
+
+
+def select_high_value_ready(class_rows):
+    ready_rows = class_rows.get("ready_now", [])
+    if not ready_rows:
+        return None
+    selected = sorted(ready_rows, key=lambda x: (x.get("execution_order", 0), x.get("issue_number", 0)))[0]
+    return {
+        "issue_number": selected.get("issue_number"),
+        "issue_repo": selected.get("issue_repo"),
+        "execution_order": selected.get("execution_order"),
+        "workflow_state": selected.get("workflow_state"),
+        "reason": "high_value_ready_first",
+    }
+
+
+def fetch_project_items(owner: str, project_num: int, limit: int):
+    rc, out, err = run(
+        [
+            "gh",
+            "project",
+            "item-list",
+            str(project_num),
+            "--owner",
+            owner,
+            "--limit",
+            str(limit),
+            "--format",
+            "json",
+        ]
+    )
+    if rc != 0:
+        raise RuntimeError(f"failed to fetch project item-list: {err}")
+    doc = json.loads(out)
+    return doc.get("items", [])
+
+
+def validate_policy(policy):
+    errors = []
+    if not isinstance(policy, dict):
+        return ["stock policy must be object"]
+    queue_classes = policy.get("queue_classes")
+    if not isinstance(queue_classes, list) or not queue_classes:
+        errors.append("queue_classes must be non-empty list")
+    else:
+        seen = set()
+        for idx, queue_class in enumerate(queue_classes):
+            if not isinstance(queue_class, dict):
+                errors.append(f"queue_classes[{idx}] must be object")
+                continue
+            name = str(queue_class.get("name", "")).strip()
+            if not name:
+                errors.append(f"queue_classes[{idx}].name is required")
+            elif name in seen:
+                errors.append(f"duplicate queue class name: {name}")
+            seen.add(name)
+            min_stock = queue_class.get("min_stock")
+            if not isinstance(min_stock, int) or min_stock < 0:
+                errors.append(f"queue_classes[{idx}].min_stock must be non-negative integer")
+            if not isinstance(queue_class.get("rule"), dict):
+                errors.append(f"queue_classes[{idx}].rule must be object")
+    req = policy.get("candidate_requirements")
+    if not isinstance(req, dict):
+        errors.append("candidate_requirements must be object")
+    return errors
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Backlog stock and replenishment quality gate")
+    parser.add_argument("--owner", default="rather-not-work-on")
+    parser.add_argument("--project-num", type=int, default=2)
+    parser.add_argument("--initiative", default="unified-personal-agent-platform")
+    parser.add_argument("--items-file", default=None, help="Optional item snapshot JSON file")
+    parser.add_argument("--stock-policy-file", default=str(DEFAULT_STOCK_POLICY_FILE))
+    parser.add_argument("--candidate-file", default=None, help="Optional replenishment candidate JSON file")
+    parser.add_argument("--offline", action="store_true", help="Do not fetch issue body/dependency state via gh API")
+    parser.add_argument("--report-only", action="store_true", help="Always exit 0; report verdict only")
+    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT_FILE))
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    policy_path = Path(args.stock_policy_file)
+    policy = load_json(policy_path, {})
+    policy_errors = validate_policy(policy)
+    if policy_errors:
+        report = {
+            "generated_at_utc": now_utc(),
+            "verdict": "fail",
+            "reason_code": "invalid_stock_policy",
+            "stock_policy_file": str(policy_path),
+            "policy_errors": policy_errors,
+        }
+        save_json(Path(args.output), report)
+        print(f"report written: {args.output}")
+        print("verdict=fail reason=invalid_stock_policy")
+        return 0 if args.report_only else 1
+
+    if args.items_file:
+        raw_items = load_json(Path(args.items_file), [])
+    else:
+        raw_items = fetch_project_items(args.owner, args.project_num, args.limit)
+
+    rows = []
+    for raw in raw_items:
+        normalized = normalize_item(raw)
+        if not normalized:
+            continue
+        if normalized.get("initiative") and normalized.get("initiative") != args.initiative:
+            continue
+        rows.append(normalized)
+
+    dependency_diagnostics = hydrate_dependency_counts(rows, offline=args.offline)
+    stock = evaluate_stock(rows, policy)
+    high_value_ready = select_high_value_ready(stock["class_rows"])
+
+    candidates = []
+    if args.candidate_file:
+        candidate_payload = load_json(Path(args.candidate_file), {})
+        if isinstance(candidate_payload, dict) and isinstance(candidate_payload.get("candidates"), list):
+            candidates = candidate_payload.get("candidates")
+        elif isinstance(candidate_payload, list):
+            candidates = candidate_payload
+    candidate_requirements = policy.get("candidate_requirements") or {}
+    candidate_validation = validate_replenishment_candidates(candidates, candidate_requirements)
+
+    breaches = stock["breaches"]
+    candidate_violations = candidate_validation["violations"]
+    verdict = "pass" if not breaches and not candidate_violations else "fail"
+    reason_code = "ok" if verdict == "pass" else "stock_or_candidate_gate_failed"
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "verdict": verdict,
+        "reason_code": reason_code,
+        "policy_file": str(policy_path),
+        "initiative": args.initiative,
+        "project": {
+            "owner": args.owner,
+            "project_num": args.project_num,
+        },
+        "selection_policy": {
+            "name": "high_value_ready_first",
+            "source_queue_class": "ready_now",
+            "selected": high_value_ready,
+        },
+        "stock": {
+            "evaluated_items": len(rows),
+            "rows": stock["stock_rows"],
+            "breach_count": stock["breach_count"],
+            "breaches": breaches,
+        },
+        "candidate_validation": candidate_validation,
+        "dependency_diagnostics": dependency_diagnostics,
+    }
+    save_json(Path(args.output), report)
+    print(f"report written: {args.output}")
+    print(
+        "verdict={verdict} stock_breaches={stock_breaches} candidate_violations={candidate_violations}".format(
+            verdict=verdict,
+            stock_breaches=len(breaches),
+            candidate_violations=len(candidate_violations),
+        )
+    )
+    return 0 if args.report_only or verdict == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/issue_loop_runner.py
+++ b/planningops/scripts/issue_loop_runner.py
@@ -37,6 +37,7 @@ WORKFLOW_TO_STATUS = {
     "blocked": "blocked",
     "done": "done",
 }
+HIGH_VALUE_READY_STATES = {"ready-contract", "ready-implementation"}
 
 
 def run(args):
@@ -646,7 +647,13 @@ def normalize_candidates(items, allowed_workflow_states):
             }
         )
 
-    candidates.sort(key=lambda x: (x["order"], x["number"]))
+    candidates.sort(
+        key=lambda x: (
+            0 if x.get("workflow_state") in HIGH_VALUE_READY_STATES else 1,
+            x["order"],
+            x["number"],
+        )
+    )
     return candidates
 
 
@@ -673,6 +680,11 @@ def build_selection_trace(candidates, selected, attempts, allowed_workflow_state
         }
 
     return {
+        "selection_policy": {
+            "name": "high_value_ready_first",
+            "ready_workflow_states": sorted(HIGH_VALUE_READY_STATES),
+            "tie_breaker": ["execution_order_asc", "issue_number_asc"],
+        },
         "allowed_workflow_states": sorted(allowed_workflow_states),
         "candidate_count": len(candidates),
         "candidates": [
@@ -697,6 +709,47 @@ def build_selection_trace(candidates, selected, attempts, allowed_workflow_state
         "attempts": attempts,
         "selected": selected_ref,
     }
+
+
+def build_replenishment_candidates(
+    issue_num: int,
+    payload: dict,
+    selected: dict,
+    verification_path: Path,
+    payload_path: Path,
+    watchdog_path: Path,
+    replan_decision_path: Path | None,
+):
+    verdict = str(payload.get("last_verdict", "")).lower()
+    reason_code = str(payload.get("reason_code", "")).strip() or "unknown_reason"
+    trigger = bool(payload.get("replanning_triggered")) or bool(payload.get("auto_paused"))
+    if verdict not in {"fail", "inconclusive"} and not trigger:
+        return []
+
+    evidence_refs = [str(verification_path), str(payload_path), str(watchdog_path)]
+    if replan_decision_path:
+        evidence_refs.append(str(replan_decision_path))
+
+    target_repo = selected.get("target_repo") or selected.get("issue_repo") or ""
+    candidate = {
+        "candidate_id": f"issue-{issue_num}-follow-up",
+        "title": f"Recovery follow-up for issue #{issue_num} ({reason_code})",
+        "target_repo": target_repo,
+        "depends_on": [issue_num],
+        "acceptance_criteria": [
+            f"Root cause for `{reason_code}` is documented with evidence.",
+            "Contract/plan references are updated before resuming implementation.",
+            "A rerun exits escalation state without repeating the previous trigger.",
+        ],
+        "evidence_refs": evidence_refs,
+        "generated_from": {
+            "issue_number": issue_num,
+            "verdict": verdict,
+            "reason_code": reason_code,
+        },
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    return [candidate]
 
 
 def ensure_text_field(owner: str, project_num: int, field_name: str):
@@ -1437,6 +1490,50 @@ def main():
                 "replanning_flag": True,
             },
         )
+
+    replenishment_candidates = build_replenishment_candidates(
+        issue_num=issue_num,
+        payload=payload,
+        selected=selected,
+        verification_path=verification_path,
+        payload_path=payload_path,
+        watchdog_path=watchdog_path,
+        replan_decision_path=replan_decision_path,
+    )
+    replenishment_path = Path(f"planningops/artifacts/backlog/issue-{issue_num}-replenishment-candidates.json")
+    save_json(
+        replenishment_path,
+        {
+            "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+            "issue_number": issue_num,
+            "issue_repo": selected.get("issue_repo"),
+            "target_repo": selected.get("target_repo"),
+            "last_verdict": payload.get("last_verdict"),
+            "reason_code": payload.get("reason_code"),
+            "candidate_count": len(replenishment_candidates),
+            "candidates": replenishment_candidates,
+        },
+    )
+    payload["replenishment_candidates_path"] = str(replenishment_path)
+    payload["replenishment_candidates_count"] = len(replenishment_candidates)
+    if replenishment_candidates:
+        append_ndjson(
+            transition_log,
+            {
+                "transition_id": f"{loop_id}-backlog-replenishment",
+                "run_id": loop_id,
+                "card_id": issue_num,
+                "from_state": selected.get("workflow_state", "ready-contract"),
+                "to_state": selected.get("workflow_state", "ready-contract"),
+                "transition_reason": "backlog.replenishment.generated",
+                "actor_type": "agent",
+                "actor_id": "issue-loop-runner",
+                "decided_at_utc": datetime.now(timezone.utc).isoformat(),
+                "replanning_flag": bool(payload.get("replanning_triggered")),
+                "candidate_count": len(replenishment_candidates),
+                "candidate_ids": [c.get("candidate_id") for c in replenishment_candidates],
+            },
+        )
     save_json(payload_path, payload)
 
     verification_loop_ref = verification.get("loop_dir", "")
@@ -1464,6 +1561,7 @@ def main():
             f"- adapter_pre_artifact: {pre_hook_path}",
             f"- adapter_post_artifact: {post_hook_path}",
             f"- replan_decision: {replan_decision_path}" if replan_decision_path else "- replan_decision: none",
+            f"- replenishment_candidates: {replenishment_path} ({len(replenishment_candidates)})",
         ]
     )
 
@@ -1664,6 +1762,8 @@ def main():
             "adapter_post_hook": post_hook_result,
             "adapter_pre_artifact": str(pre_hook_path),
             "adapter_post_artifact": str(post_hook_path),
+            "replenishment_candidates_path": str(replenishment_path),
+            "replenishment_candidates_count": len(replenishment_candidates),
             "generated_at_utc": datetime.now(timezone.utc).isoformat(),
             "runtime_profile_file": args.runtime_profile_file,
             "no_feedback": args.no_feedback,
@@ -1760,6 +1860,8 @@ def main():
         "adapter_post_hook": post_hook_result,
         "adapter_pre_artifact": str(pre_hook_path),
         "adapter_post_artifact": str(post_hook_path),
+        "replenishment_candidates_path": str(replenishment_path),
+        "replenishment_candidates_count": len(replenishment_candidates),
         "loop_rc": rc_loop,
         "verify_rc": rc_verify,
         "already_processed": already_processed,

--- a/planningops/scripts/test_backlog_stock_replenishment_contract.sh
+++ b/planningops/scripts/test_backlog_stock_replenishment_contract.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+import importlib.util
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+module_path = Path("planningops/scripts/backlog_stock_replenishment_guard.py")
+spec = importlib.util.spec_from_file_location("backlog_stock_replenishment_guard", module_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+policy = mod.load_json(Path("planningops/config/backlog-stock-policy.json"), {})
+items = mod.load_json(Path("planningops/fixtures/backlog-stock-items-sample.json"), [])
+rows = [mod.normalize_item(x) for x in items]
+rows = [x for x in rows if x]
+mod.hydrate_dependency_counts(rows, offline=True)
+stock = mod.evaluate_stock(rows, policy)
+assert stock["breach_count"] == 0, stock
+
+high_value = mod.select_high_value_ready(stock["class_rows"])
+assert high_value is not None, high_value
+assert high_value["issue_number"] == 101, high_value
+assert high_value["reason"] == "high_value_ready_first", high_value
+
+invalid_candidates = [
+    {
+        "candidate_id": "bad-1",
+        "title": "Missing fields example",
+        "depends_on": ["#101"],
+    }
+]
+candidate_validation = mod.validate_replenishment_candidates(invalid_candidates, policy["candidate_requirements"])
+assert candidate_validation["violation_count"] == 1, candidate_validation
+assert "evidence_refs is required and must be non-empty" in candidate_validation["violations"][0]["errors"], candidate_validation
+assert "acceptance_criteria must be a list" in candidate_validation["violations"][0]["errors"], candidate_validation
+
+with tempfile.TemporaryDirectory() as td:
+    td_path = Path(td)
+    pass_report = td_path / "report-pass.json"
+    pass_rc = subprocess.run(
+        [
+            "python3",
+            "planningops/scripts/backlog_stock_replenishment_guard.py",
+            "--stock-policy-file",
+            "planningops/config/backlog-stock-policy.json",
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--candidate-file",
+            "planningops/fixtures/backlog-replenishment-candidates-sample.json",
+            "--offline",
+            "--output",
+            str(pass_report),
+        ],
+        check=False,
+    ).returncode
+    assert pass_rc == 0, pass_rc
+    pass_doc = json.loads(pass_report.read_text(encoding="utf-8"))
+    assert pass_doc["verdict"] == "pass", pass_doc
+
+    bad_candidates_path = td_path / "bad-candidates.json"
+    bad_candidates_path.write_text(
+        json.dumps(
+            {
+                "candidates": [
+                    {
+                        "candidate_id": "bad-2",
+                        "title": "No evidence refs",
+                        "depends_on": [101],
+                        "acceptance_criteria": [],
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    fail_report = td_path / "report-fail.json"
+    fail_rc = subprocess.run(
+        [
+            "python3",
+            "planningops/scripts/backlog_stock_replenishment_guard.py",
+            "--stock-policy-file",
+            "planningops/config/backlog-stock-policy.json",
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--candidate-file",
+            str(bad_candidates_path),
+            "--offline",
+            "--output",
+            str(fail_report),
+        ],
+        check=False,
+    ).returncode
+    assert fail_rc == 1, fail_rc
+    fail_doc = json.loads(fail_report.read_text(encoding="utf-8"))
+    assert fail_doc["verdict"] == "fail", fail_doc
+    assert fail_doc["candidate_validation"]["violation_count"] == 1, fail_doc
+
+print("backlog stock/replenishment contract tests ok")
+PY

--- a/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
+++ b/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
@@ -48,6 +48,11 @@ assert [c["number"] for c in candidates] == [42, 77], candidates
 assert candidates[0]["issue_repo"] == "rather-not-work-on/monday", candidates[0]
 assert candidates[1]["issue_repo"] == "rather-not-work-on/platform-planningops", candidates[1]
 
+# High-value ready-first rule must prioritize ready-* over backlog even when backlog has lower execution_order.
+allowed_with_backlog = {"backlog", "ready-contract", "ready-implementation"}
+candidates_with_backlog = mod.normalize_candidates(items, allowed_with_backlog)
+assert [c["number"] for c in candidates_with_backlog] == [42, 77, 101], candidates_with_backlog
+
 selected = dict(candidates[1])
 selected["deps"] = [41]
 attempts = [
@@ -247,6 +252,32 @@ assert l4_profile == "L4 Integration-Reconcile", l4_profile
 
 l5_profile = mod.determine_loop_profile(selected, {"replanning_triggered": True}, "rather-not-work-on/platform-planningops")
 assert l5_profile == "L5 Recovery-Replan", l5_profile
+
+replenishment_candidates = mod.build_replenishment_candidates(
+    issue_num=77,
+    payload={"last_verdict": "fail", "reason_code": "runtime_error_retries_exhausted", "replanning_triggered": True},
+    selected={"target_repo": "rather-not-work-on/platform-planningops", "issue_repo": "rather-not-work-on/platform-planningops"},
+    verification_path=Path("planningops/artifacts/verification/issue-77-verification.json"),
+    payload_path=Path("planningops/artifacts/verification/issue-77-project-payload.json"),
+    watchdog_path=Path("planningops/artifacts/loop-runner/watchdog/issue-77.json"),
+    replan_decision_path=Path("planningops/artifacts/replan/issue-77.md"),
+)
+assert len(replenishment_candidates) == 1, replenishment_candidates
+candidate = replenishment_candidates[0]
+assert candidate["depends_on"] == [77], candidate
+assert candidate["evidence_refs"], candidate
+assert candidate["acceptance_criteria"], candidate
+
+no_replenishment = mod.build_replenishment_candidates(
+    issue_num=77,
+    payload={"last_verdict": "pass", "reason_code": "ok", "replanning_triggered": False, "auto_paused": False},
+    selected={"target_repo": "rather-not-work-on/platform-planningops", "issue_repo": "rather-not-work-on/platform-planningops"},
+    verification_path=Path("planningops/artifacts/verification/issue-77-verification.json"),
+    payload_path=Path("planningops/artifacts/verification/issue-77-project-payload.json"),
+    watchdog_path=Path("planningops/artifacts/loop-runner/watchdog/issue-77.json"),
+    replan_decision_path=None,
+)
+assert no_replenishment == [], no_replenishment
 
 budget_default, budget_errors_default = mod.parse_attempt_budget("no budget fields")
 assert budget_default["max_attempts"] == 3, budget_default

--- a/todos/028-complete-p1-backlog-stock-and-replenishment-loop.md
+++ b/todos/028-complete-p1-backlog-stock-and-replenishment-loop.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: complete
 priority: p1
 issue_id: "028"
 tags: [planningops, backlog, kanban, queue, autonomy]
@@ -61,10 +61,10 @@ Implement Option 1 and make backlog quality filters part of the autonomous gate.
 - `todos/` governance notes if needed
 
 ## Acceptance Criteria
-- [ ] Queue classes and minimum stock targets are defined.
-- [ ] Replenishment requires evidence-backed candidate generation.
-- [ ] New backlog entries include dependency and acceptance criteria baseline.
-- [ ] “Immediate high-value ready item first” rule is explicitly enforced.
+- [x] Queue classes and minimum stock targets are defined.
+- [x] Replenishment requires evidence-backed candidate generation.
+- [x] New backlog entries include dependency and acceptance criteria baseline.
+- [x] “Immediate high-value ready item first” rule is explicitly enforced.
 
 ## Work Log
 
@@ -78,3 +78,24 @@ Implement Option 1 and make backlog quality filters part of the autonomous gate.
 **Learnings:**
 - Sustainable autonomy requires queue health controls, not only runner controls.
 
+### 2026-03-05 - Implementation Complete
+
+**By:** Codex
+
+**Actions:**
+- Added backlog stock/replenishment contract and policy (`planningops/contracts/backlog-stock-replenishment-contract.md`, `planningops/config/backlog-stock-policy.json`).
+- Added stock/replenishment guard script and regression test (`planningops/scripts/backlog_stock_replenishment_guard.py`, `planningops/scripts/test_backlog_stock_replenishment_contract.sh`).
+- Enforced explicit `high_value_ready_first` ordering in intake selection (`planningops/scripts/issue_loop_runner.py`).
+- Added evidence-backed replenishment candidate artifact generation in runner output (`planningops/artifacts/backlog/issue-<n>-replenishment-candidates.json`).
+- Wired new contract test into CI guardrails.
+
+**Validation:**
+- `python3 -m py_compile planningops/scripts/issue_loop_runner.py planningops/scripts/backlog_stock_replenishment_guard.py`
+- `bash planningops/scripts/test_worker_executor_contract.sh`
+- `bash planningops/scripts/test_verify_loop_run_hard_gate_contract.sh`
+- `bash planningops/scripts/test_lease_lock_watchdog.sh`
+- `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
+- `bash planningops/scripts/test_loop_checkpoint_resume.sh`
+- `bash planningops/scripts/test_validate_worker_task_pack_contract.sh`
+- `bash planningops/scripts/test_backlog_stock_replenishment_contract.sh`
+- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`


### PR DESCRIPTION
## Summary
- add backlog stock/replenishment contract and policy (`ready_now`, `next_up`, `quality_hardening`) with explicit stock floors
- add `backlog_stock_replenishment_guard.py` to enforce stock gate + evidence-backed candidate validation
- enforce `high_value_ready_first` intake ordering in `issue_loop_runner.py` and emit replenishment candidate artifacts
- wire new regression test into CI guardrails and update module docs/fixtures

## Validation
- `python3 -m py_compile planningops/scripts/issue_loop_runner.py planningops/scripts/backlog_stock_replenishment_guard.py`
- `bash planningops/scripts/test_worker_executor_contract.sh`
- `bash planningops/scripts/test_verify_loop_run_hard_gate_contract.sh`
- `bash planningops/scripts/test_lease_lock_watchdog.sh`
- `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
- `bash planningops/scripts/test_loop_checkpoint_resume.sh`
- `bash planningops/scripts/test_validate_worker_task_pack_contract.sh`
- `bash planningops/scripts/test_backlog_stock_replenishment_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Backlog
- complete: `todos/028-complete-p1-backlog-stock-and-replenishment-loop.md`
