### PR TITLE
D17: Define artifact retention tiers and external storage policy

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -142,6 +142,8 @@ jobs:
           bash planningops/scripts/test_validate_script_roles_contract.sh
           bash planningops/scripts/test_validate_issue_quality_contract.sh
           python3 planningops/scripts/validate_issue_quality.py --strict
+          bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh
+          python3 planningops/scripts/validate_artifact_storage_policy.py --strict
           bash planningops/scripts/test_normalize_ready_implementation_blueprint_refs.sh
           bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
           bash planningops/scripts/test_ralph_loop_local_worker_policy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **._*
 __pycache__/
 *.pyc
+planningops/runtime-artifacts/

--- a/planningops/adr/README.md
+++ b/planningops/adr/README.md
@@ -8,6 +8,7 @@ Record architecture decisions and locked tradeoffs for planningops runtime topol
 - `adr-0002-local-first-runtime-profile-and-naming.md`
 - `adr-0003-cross-repo-topology-bootstrap.md`
 - `adr-0004-control-plane-thin-core-boundary.md`
+- `adr-0005-artifact-retention-and-external-storage-policy.md`
 
 ## Change Rules
 - New ADRs are append-only; avoid rewriting historical decisions.

--- a/planningops/adr/adr-0005-artifact-retention-and-external-storage-policy.md
+++ b/planningops/adr/adr-0005-artifact-retention-and-external-storage-policy.md
@@ -1,0 +1,43 @@
+# ADR-0005: Artifact Retention Tiers and External Storage Policy
+
+## Status
+Accepted
+
+## Context
+Planningops and execution repos accumulate high-frequency runtime artifacts. Committing all generated files to Git lowers review signal-to-noise and increases maintenance drag.
+
+We need:
+1. Deterministic evidence paths for governance.
+2. Tiered retention policy for Git vs external storage.
+3. Migration path that works local-first and can move to S3/OCI.
+
+## Decision
+1. Introduce three artifact tiers:
+   - `git-canonical`
+   - `git-optional`
+   - `external-only`
+2. External-only artifacts are stored by sink backend (`local|s3|oci`) and represented in Git by pointer manifests.
+3. Policy source is fixed at `planningops/config/artifact-storage-policy.json`.
+4. Contract and validation are enforced by:
+   - `planningops/contracts/artifact-retention-tier-contract.md`
+   - `planningops/scripts/validate_artifact_storage_policy.py`
+5. Rollout follows checklist and rollback steps in:
+   - `planningops/quality/artifact-storage-rollout-checklist.md`
+
+## Consequences
+### Positive
+- Less Git noise for high-frequency execution logs.
+- Clear SoT boundary: policy/summary in Git, bulk runtime logs in external sink.
+- Backend migration path local -> S3/OCI without changing logical artifact contract.
+
+### Negative
+- Additional operational complexity (sink config, pointer lifecycle, rehydrate tooling).
+- Need CI guardrails to prevent accidental commit of external-only paths.
+
+## Alternatives Considered
+1. Keep all artifacts in Git.
+   - Rejected: long-term review/merge overhead too high.
+2. Move all artifacts external-only.
+   - Rejected: loses canonical governance evidence in Git.
+3. Manual per-run decision.
+   - Rejected: non-deterministic and hard to automate.

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -21,3 +21,20 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
 - Artifacts are evidence outputs; do not treat them as source configuration.
 - New artifact roots require README update and deterministic naming policy.
 - Generated paths should be stable and include run ids where replay matters.
+
+## Retention Tiers
+- `git-canonical`
+  - Keep in Git as normative evidence.
+  - Examples: `validation/`, `program/`, `meta-plan/`.
+- `git-optional`
+  - Keep only for milestones/audits.
+  - Examples: selected `conformance/`, `pilot/`, `refactor-hygiene/latest.json`.
+- `external-only`
+  - Store outside Git via artifact sink backend.
+  - Examples: `loops/`, `sync-summary/`, `transition-log/`, `adapter-hooks/`, `supervisor/`, `experiments/`.
+
+Policy references:
+- contract: `planningops/contracts/artifact-retention-tier-contract.md`
+- config: `planningops/config/artifact-storage-policy.json`
+- ADR: `planningops/adr/adr-0005-artifact-retention-and-external-storage-policy.md`
+- rollout checklist: `planningops/quality/artifact-storage-rollout-checklist.md`

--- a/planningops/config/README.md
+++ b/planningops/config/README.md
@@ -16,6 +16,7 @@ Provide stable configuration sources for project fields, runtime profiles, and c
 - `supervisor-experiment-validation-pack.json`: command pack for automatic worktree comparative execution
 - `refactor-hygiene-policy.json`: single-repo refactor hygiene policy
 - `refactor-hygiene-multi-repo.json`: multi-repo hygiene matrix config
+- `artifact-storage-policy.json`: artifact tier map, backend selector, and retention policy
 
 ## Change Rules
 - Field id updates must be synchronized with validator scripts and CI tests.

--- a/planningops/config/artifact-storage-policy.json
+++ b/planningops/config/artifact-storage-policy.json
@@ -1,0 +1,54 @@
+{
+  "policy_version": 1,
+  "default_external_backend": "local",
+  "pointer_manifest_root": "planningops/artifacts/pointers",
+  "tiers": {
+    "git_canonical": [
+      "planningops/artifacts/validation/**",
+      "planningops/artifacts/program/**",
+      "planningops/artifacts/meta-plan/**",
+      "planningops/artifacts/verification/latest-*.json",
+      "planningops/artifacts/ci/federated-ci-summary.json"
+    ],
+    "git_optional": [
+      "planningops/artifacts/conformance/**",
+      "planningops/artifacts/pilot/**",
+      "planningops/artifacts/refactor-hygiene/latest.json"
+    ],
+    "external_only": [
+      "planningops/artifacts/loops/**",
+      "planningops/artifacts/sync-summary/**",
+      "planningops/artifacts/transition-log/**",
+      "planningops/artifacts/adapter-hooks/**",
+      "planningops/artifacts/supervisor/**",
+      "planningops/artifacts/experiments/**"
+    ]
+  },
+  "backends": {
+    "local": {
+      "kind": "local",
+      "base_path": "planningops/runtime-artifacts/local"
+    },
+    "s3": {
+      "kind": "s3_mock",
+      "bucket": "planningops-artifacts-dev",
+      "prefix": "planningops",
+      "mock_base_path": "planningops/runtime-artifacts/s3-mock"
+    },
+    "oci": {
+      "kind": "oci_mock",
+      "namespace": "planningops-local",
+      "bucket": "planningops-artifacts-dev",
+      "prefix": "planningops",
+      "mock_base_path": "planningops/runtime-artifacts/oci-mock"
+    }
+  },
+  "retention": {
+    "git_canonical_days": 3650,
+    "git_optional_days": 180,
+    "external_only_days": 30
+  },
+  "commit_guard": {
+    "forbidden_external_only_in_git": true
+  }
+}

--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -27,6 +27,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `script-role-separation-contract.md`: recurring core scripts vs one-off script separation rules
 - `issue-quality-contract.md`: backlog issue body quality baseline and verification rules
 - `issue-label-taxonomy-contract.md`: required label taxonomy (`task`/priority/area/type) and gates
+- `artifact-retention-tier-contract.md`: Git vs external artifact storage tier policy
 - `cross-repo-contract-version-pin-policy.md`: external contract version pinning
 - `compatibility-report.md`: compatibility tracking summary
 

--- a/planningops/contracts/artifact-retention-tier-contract.md
+++ b/planningops/contracts/artifact-retention-tier-contract.md
@@ -1,0 +1,48 @@
+# Artifact Retention Tier Contract
+
+## Purpose
+Reduce Git noise while preserving deterministic evidence and rehydrate paths.
+
+## Scope
+- Repository: `rather-not-work-on/platform-planningops`
+- Applies to files under `planningops/artifacts/**` produced by runtime scripts.
+
+## Tier Definitions
+1. `git-canonical`
+   - Commit to Git as source-of-truth evidence.
+   - Examples: `validation/`, `program/`, `meta-plan/`, `verification/latest-*`, `ci/federated-ci-summary.json`.
+2. `git-optional`
+   - Commit only for selected milestones/audits; default is no commit.
+   - Examples: `conformance/`, `pilot/`, `refactor-hygiene/latest.json`.
+3. `external-only`
+   - Do not commit to Git; store in external backend and keep pointer manifest in Git.
+   - Examples: `loops/`, `sync-summary/`, `transition-log/`, `adapter-hooks/`, `supervisor/`, `experiments/`.
+
+## Storage Backends
+- `local`: local filesystem sink (default)
+- `s3`: S3-compatible object sink (mockable)
+- `oci`: OCI Object Storage sink (mockable)
+
+Backend selection is controlled by:
+- config: `planningops/config/artifact-storage-policy.json`
+- runtime override: `PLANNINGOPS_ARTIFACT_SINK_BACKEND`
+
+## Pointer Manifest Contract
+- Pointer root: `planningops/artifacts/pointers/`
+- Each externalized artifact must emit a pointer JSON with:
+  - `logical_path`
+  - `backend`
+  - `uri`
+  - `sha256`
+  - `bytes`
+  - `written_at_utc`
+
+## Retention Contract
+- `external-only` artifacts follow backend retention windows and compaction rules.
+- Pointer manifests remain in Git until corresponding runbook retention expiry.
+- Rehydrate must resolve pointer -> backend object deterministically.
+
+## Verification
+- Policy config: `planningops/config/artifact-storage-policy.json`
+- Validator: `planningops/scripts/validate_artifact_storage_policy.py`
+- Test: `bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh`

--- a/planningops/quality/README.md
+++ b/planningops/quality/README.md
@@ -6,9 +6,9 @@ Define checklist-style quality criteria for topology and loop verification.
 ## Contents
 - `loop-verification-checklist.md`
 - `topology-bootstrap-checklist.md`
+- `artifact-storage-rollout-checklist.md`
 
 ## Change Rules
 - Checklist criteria should be testable and map to concrete artifacts.
 - New gates must define pass/fail evidence, not vague recommendations.
 - Checklist updates must stay aligned with `requirements-contract.md`.
-

--- a/planningops/quality/artifact-storage-rollout-checklist.md
+++ b/planningops/quality/artifact-storage-rollout-checklist.md
@@ -1,0 +1,32 @@
+# Artifact Storage Rollout Checklist
+
+## Goal
+Roll out tiered artifact storage with safe fallback and deterministic rehydrate behavior.
+
+## Pre-Flight
+- [ ] `planningops/config/artifact-storage-policy.json` passes validator.
+- [ ] `planningops/contracts/artifact-retention-tier-contract.md` is approved.
+- [ ] External backend credentials (if non-local) are configured in runtime environment.
+- [ ] Pointer manifest path (`planningops/artifacts/pointers/`) is writable.
+
+## Rollout Steps
+1. Set backend selector (`PLANNINGOPS_ARTIFACT_SINK_BACKEND`) to target backend.
+2. Run sink dry-run/migration command on sample artifacts.
+3. Validate pointer manifests are generated and resolvable.
+4. Run loop/supervisor/review flows and verify no regressions.
+5. Enable commit guard for `external_only` paths in CI.
+
+## Verification
+- [ ] External-only writes produce pointer manifests in Git path.
+- [ ] Canonical outputs remain under `planningops/artifacts/validation/**` (or other canonical roots).
+- [ ] Rehydrate can restore at least one external object using pointer metadata.
+
+## Rollback Plan
+1. Set `PLANNINGOPS_ARTIFACT_SINK_BACKEND=local`.
+2. Disable external-only commit guard temporarily if emergency hotfix requires it.
+3. Re-run validation suite and confirm loop runtime output stability.
+4. Keep pointer manifests; do not delete existing external payloads until post-incident review.
+
+## Post-Rollout
+- [ ] Record backend and retention settings in runbook/issue closure.
+- [ ] Attach dry-run report and at least one rehydrate evidence log.

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -32,6 +32,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `validate_script_roles.py`
   - `validate_issue_quality.py`
   - `backfill_issue_labels.py`
+  - `validate_artifact_storage_policy.py`
   - `verify_loop_run.py` (`--execution-attempts-schema`)
   - `verify_plan_projection.py`
   - `cross_repo_conformance_check.py`
@@ -66,6 +67,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_repo_boundaries_contract.sh`
   - `test_validate_script_roles_contract.sh`
   - `test_validate_issue_quality_contract.sh`
+  - `test_validate_artifact_storage_policy_contract.sh`
   - `test_*.sh`
 
 ## Change Rules

--- a/planningops/scripts/test_validate_artifact_storage_policy_contract.sh
+++ b/planningops/scripts/test_validate_artifact_storage_policy_contract.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 planningops/scripts/validate_artifact_storage_policy.py \
+  --policy planningops/config/artifact-storage-policy.json \
+  --output planningops/artifacts/validation/artifact-storage-policy-valid.test.json \
+  --strict
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat > "$tmp_dir/invalid-policy.json" <<'JSON'
+{
+  "policy_version": 0,
+  "default_external_backend": "",
+  "pointer_manifest_root": "planningops/artifacts/invalid-root",
+  "tiers": {
+    "git_canonical": [],
+    "git_optional": [],
+    "external_only": []
+  },
+  "backends": {
+    "local": {
+      "kind": "local"
+    }
+  },
+  "retention": {
+    "git_canonical_days": 0,
+    "git_optional_days": -1,
+    "external_only_days": 0
+  },
+  "commit_guard": {
+    "forbidden_external_only_in_git": "yes"
+  }
+}
+JSON
+
+set +e
+python3 planningops/scripts/validate_artifact_storage_policy.py \
+  --policy "$tmp_dir/invalid-policy.json" \
+  --output "$tmp_dir/artifact-storage-policy-invalid.test.json" \
+  --strict
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for invalid artifact-storage policy fixture"
+  exit 1
+fi
+
+echo "artifact storage policy contract test ok"

--- a/planningops/scripts/validate_artifact_storage_policy.py
+++ b/planningops/scripts/validate_artifact_storage_policy.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+
+DEFAULT_POLICY = Path("planningops/config/artifact-storage-policy.json")
+DEFAULT_OUTPUT = Path("planningops/artifacts/validation/artifact-storage-policy-report.json")
+REQUIRED_TIERS = ["git_canonical", "git_optional", "external_only"]
+REQUIRED_BACKENDS = ["local", "s3", "oci"]
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate artifact storage policy contract")
+    parser.add_argument("--policy", default=str(DEFAULT_POLICY))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    policy_path = Path(args.policy)
+    doc = load_json(policy_path)
+    errors = []
+
+    if int(doc.get("policy_version", 0)) < 1:
+        errors.append("policy_version must be >= 1")
+
+    default_backend = doc.get("default_external_backend")
+    if not isinstance(default_backend, str) or not default_backend:
+        errors.append("default_external_backend must be non-empty string")
+
+    pointer_root = doc.get("pointer_manifest_root")
+    if not isinstance(pointer_root, str) or not pointer_root.startswith("planningops/artifacts/pointers"):
+        errors.append("pointer_manifest_root must start with planningops/artifacts/pointers")
+
+    tiers = doc.get("tiers")
+    if not isinstance(tiers, dict):
+        errors.append("tiers must be object")
+        tiers = {}
+    else:
+        for tier_name in REQUIRED_TIERS:
+            values = tiers.get(tier_name)
+            if not isinstance(values, list) or len(values) == 0:
+                errors.append(f"tiers.{tier_name} must be non-empty list")
+            elif not all(isinstance(v, str) and v for v in values):
+                errors.append(f"tiers.{tier_name} entries must be non-empty strings")
+
+    backends = doc.get("backends")
+    if not isinstance(backends, dict):
+        errors.append("backends must be object")
+        backends = {}
+    else:
+        for backend_name in REQUIRED_BACKENDS:
+            cfg = backends.get(backend_name)
+            if not isinstance(cfg, dict):
+                errors.append(f"backends.{backend_name} must be object")
+                continue
+            kind = cfg.get("kind")
+            if not isinstance(kind, str) or not kind:
+                errors.append(f"backends.{backend_name}.kind must be non-empty string")
+            if backend_name == "local":
+                if not isinstance(cfg.get("base_path"), str) or not cfg.get("base_path"):
+                    errors.append("backends.local.base_path must be non-empty string")
+            else:
+                for key in ["bucket", "prefix", "mock_base_path"]:
+                    if not isinstance(cfg.get(key), str) or not cfg.get(key):
+                        errors.append(f"backends.{backend_name}.{key} must be non-empty string")
+
+    if isinstance(default_backend, str) and default_backend not in backends:
+        errors.append("default_external_backend must reference existing backends key")
+
+    retention = doc.get("retention", {})
+    if not isinstance(retention, dict):
+        errors.append("retention must be object")
+    else:
+        for key in ["git_canonical_days", "git_optional_days", "external_only_days"]:
+            value = retention.get(key)
+            if not isinstance(value, int) or value <= 0:
+                errors.append(f"retention.{key} must be positive integer")
+
+    commit_guard = doc.get("commit_guard", {})
+    if not isinstance(commit_guard, dict):
+        errors.append("commit_guard must be object")
+    elif not isinstance(commit_guard.get("forbidden_external_only_in_git"), bool):
+        errors.append("commit_guard.forbidden_external_only_in_git must be boolean")
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "policy_path": str(policy_path),
+        "error_count": len(errors),
+        "errors": errors,
+        "verdict": "pass" if not errors else "fail",
+    }
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding="utf-8")
+
+    print(f"report written: {out}")
+    print(f"error_count={len(errors)} verdict={report['verdict']}")
+    if args.strict and errors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Define and validate tiered artifact retention/storage policy so planningops can keep canonical evidence in Git while moving high-frequency runtime artifacts to external backends.

## Scope
- Add ADR + contract for artifact retention tiers (`git-canonical`, `git-optional`, `external-only`)
- Add policy config (`planningops/config/artifact-storage-policy.json`) with backend matrix (`local|s3|oci`) and retention windows
- Add rollout/rollback checklist (`planningops/quality/artifact-storage-rollout-checklist.md`)
- Add policy validator + contract test
- Wire policy checks into federated CI loop-guardrails

## Linked Issues
- Closes #112

## Validation
- `bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh`
- `python3 planningops/scripts/validate_artifact_storage_policy.py --strict --output /tmp/artifact-storage-policy-report.live.json`

## Risks
- Tier globs may require iterative refinement as new artifact roots are introduced.
- Backend matrix currently validates schema/policy and mock paths; runtime sink integration is handled in D18.

## Review Checklist
- [x] ADR + contract + config are aligned on tier/backends/retention terms.
- [x] Rollout checklist includes rollback steps.
- [x] CI now enforces policy validator and regression contract test.
- [x] Policy keeps local-first defaults while preserving S3/OCI migration path.
