### PR TITLE
[B50][E12] Rewire federated conformance and artifact rollout

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -94,6 +94,62 @@ jobs:
             --idempotency artifacts/integration/ci-runtime-${{ github.run_id }}-idempotency.json \
             --transition-log artifacts/integration/ci-runtime-${{ github.run_id }}-scheduler.ndjson
 
+  federated-conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout planningops
+        uses: actions/checkout@v4
+
+      - name: Checkout platform-contracts
+        uses: actions/checkout@v4
+        with:
+          repository: rather-not-work-on/platform-contracts
+          path: platform-contracts
+
+      - name: Checkout provider gateway
+        uses: actions/checkout@v4
+        with:
+          repository: rather-not-work-on/platform-provider-gateway
+          path: platform-provider-gateway
+
+      - name: Checkout observability gateway
+        uses: actions/checkout@v4
+        with:
+          repository: rather-not-work-on/platform-observability-gateway
+          path: platform-observability-gateway
+
+      - name: Checkout monday runtime
+        uses: actions/checkout@v4
+        with:
+          repository: rather-not-work-on/monday
+          path: monday
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install federated evidence dependencies
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r platform-contracts/requirements-dev.txt
+          python3 -m pip install -r platform-provider-gateway/requirements-dev.txt
+          python3 -m pip install -r platform-observability-gateway/requirements-dev.txt
+          python3 -m pip install -r monday/requirements-dev.txt
+
+      - name: Run federated conformance
+        run: |
+          set -euo pipefail
+          python3 planningops/scripts/rollout_external_artifact_policy.py \
+            --workspace-root . \
+            --strict \
+            --output planningops/artifacts/validation/federated-artifact-policy-rollout-report.json
+          python3 planningops/scripts/federation/cross_repo_conformance_check.py \
+            --workspace-root . \
+            --run-id ci-federated-${{ github.run_id }} \
+            --output planningops/artifacts/conformance/ci-federated-${{ github.run_id }}.json
+
   loop-guardrails:
     runs-on: ubuntu-latest
     permissions:
@@ -182,6 +238,7 @@ jobs:
       - provider-profile
       - o11y-replay
       - runtime-handoff
+      - federated-conformance
       - loop-guardrails
     if: always()
     steps:
@@ -202,6 +259,7 @@ jobs:
             "runtime-handoff": "${{ needs.runtime-handoff.result }}",
             "o11y-replay": "${{ needs.o11y-replay.result }}",
             "provider-profile": "${{ needs.provider-profile.result }}",
+            "federated-conformance": "${{ needs.federated-conformance.result }}",
             "loop-guardrails": "${{ needs.loop-guardrails.result }}",
           }
 
@@ -210,6 +268,7 @@ jobs:
             "runtime-handoff": "runtime",
             "o11y-replay": "infra",
             "provider-profile": "infra",
+            "federated-conformance": "federation",
             "loop-guardrails": "policy",
           }
 
@@ -227,7 +286,7 @@ jobs:
             "failure_classification": {
               "count": len(failures),
               "domains": sorted({f["domain"] for f in failures}),
-              "deterministic_rule": "contract-conformance->contract, provider-profile/o11y-replay->infra, runtime-handoff->runtime, loop-guardrails->policy",
+              "deterministic_rule": "contract-conformance->contract, provider-profile/o11y-replay->infra, runtime-handoff->runtime, federated-conformance->federation, loop-guardrails->policy",
             },
             "verdict": "pass" if not failures else "fail",
           }

--- a/planningops/contracts/federated-artifact-storage-contract.md
+++ b/planningops/contracts/federated-artifact-storage-contract.md
@@ -1,0 +1,46 @@
+# Federated Artifact Storage Contract
+
+## Purpose
+Keep runtime-generated evidence out of tracked repository paths across execution repos while preserving deterministic operator access.
+
+## Scope
+- `rather-not-work-on/platform-provider-gateway`
+- `rather-not-work-on/platform-observability-gateway`
+- `rather-not-work-on/monday`
+- validator: `planningops/scripts/rollout_external_artifact_policy.py`
+
+## Rules
+1. Execution repos must default runtime outputs to repo-local `runtime-artifacts/**`.
+2. `runtime-artifacts/` must be gitignored in every execution repo.
+3. CI and regression tests must prefer explicit temporary output paths (`/tmp` or `mktemp`) over tracked repo paths.
+4. Legacy repo-local paths under `artifacts/**` are forbidden for execution-repo runtime outputs.
+5. References to `planningops/artifacts/**` are allowed only when pointing to control-plane evidence consumed by `monday`.
+
+## Required Default Roots
+- `platform-provider-gateway`
+  - `runtime-artifacts/smoke`
+  - `runtime-artifacts/validation`
+  - `runtime-artifacts/launcher`
+- `platform-observability-gateway`
+  - `runtime-artifacts/ingest`
+  - `runtime-artifacts/validation`
+  - `runtime-artifacts/launcher`
+- `monday`
+  - `runtime-artifacts/interface`
+  - `runtime-artifacts/scheduler`
+  - `runtime-artifacts/transition-log`
+  - `runtime-artifacts/integration`
+  - `runtime-artifacts/validation`
+
+## Verification
+```bash
+python3 planningops/scripts/rollout_external_artifact_policy.py \
+  --workspace-root .. \
+  --strict \
+  --output planningops/artifacts/validation/federated-artifact-policy-rollout-report.json
+```
+
+## Failure Handling
+1. Move default output paths from `artifacts/**` to `runtime-artifacts/**`.
+2. Update README/runbook examples to match new defaults.
+3. Re-run repo-local smoke tests and federated conformance.

--- a/planningops/scripts/federation/cross_repo_conformance_check.py
+++ b/planningops/scripts/federation/cross_repo_conformance_check.py
@@ -2,19 +2,17 @@
 
 import argparse
 import json
-import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 import sys
 
 
-EXPECTED_SOURCE_REPO = "rather-not-work-on/platform-contracts"
-PIN_CONSUMERS = [
-    ("rather-not-work-on/platform-provider-gateway", "platform-provider-gateway/config/contract-pin.json"),
-    ("rather-not-work-on/platform-observability-gateway", "platform-observability-gateway/config/contract-pin.json"),
-    ("rather-not-work-on/monday", "monday/contracts/contract-pin.json"),
-]
+PIN_PATHS = {
+    "provider": "platform-provider-gateway/config/contract-pin.json",
+    "observability": "platform-observability-gateway/config/contract-pin.json",
+    "monday": "monday/contracts/contract-pin.json",
+}
 
 
 def resolve_repo_root() -> Path:
@@ -29,51 +27,80 @@ def now_utc():
     return datetime.now(timezone.utc).isoformat()
 
 
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def run_cmd(cmd, cwd: Path):
     completed = subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True)
     return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
 
 
-def parse_report_path(stdout: str):
-    m = re.search(r"report written:\s*(.+)", stdout)
-    if not m:
+def resolve_workspace_root(planningops_repo: Path, raw_workspace_root: str) -> Path:
+    candidates = [
+        (planningops_repo / raw_workspace_root).resolve(),
+        planningops_repo,
+        planningops_repo.parent,
+    ]
+    for candidate in candidates:
+        if (candidate / "platform-contracts").exists() and (candidate / "monday").exists():
+            return candidate
+    return (planningops_repo / raw_workspace_root).resolve()
+
+
+def summarize_report(report_doc: dict | None, keys: list[str]):
+    if not isinstance(report_doc, dict):
         return None
-    return m.group(1).strip()
+    return {key: report_doc.get(key) for key in keys}
 
 
-def validate_pin(workspace_root: Path, consumer_repo: str, rel_path: str):
-    pin_path = workspace_root / rel_path
-    if not pin_path.exists():
-        return {
-            "consumer_repo": consumer_repo,
-            "pin_path": str(pin_path),
-            "verdict": "fail",
-            "reason": "pin_file_missing",
-        }
+def detect_bundle_versions(workspace_root: Path):
+    versions = {}
+    for consumer, rel_path in PIN_PATHS.items():
+        path = workspace_root / rel_path
+        if not path.exists():
+            versions[consumer] = None
+            continue
+        try:
+            versions[consumer] = load_json(path).get("contract_bundle_version")
+        except Exception:  # noqa: BLE001
+            versions[consumer] = None
 
-    doc = json.loads(pin_path.read_text(encoding="utf-8"))
-    errors = []
-    if doc.get("source_repo") != EXPECTED_SOURCE_REPO:
-        errors.append("source_repo_mismatch")
-    if not doc.get("contract_bundle_version"):
-        errors.append("contract_bundle_version_missing")
-    if not isinstance(doc.get("pinned_contracts"), list) or not doc.get("pinned_contracts"):
-        errors.append("pinned_contracts_missing")
-    if doc.get("consumer_repo") != consumer_repo:
-        errors.append("consumer_repo_mismatch")
-
+    distinct_versions = sorted({v for v in versions.values() if v})
     return {
-        "consumer_repo": consumer_repo,
-        "pin_path": str(pin_path),
-        "contract_bundle_version": doc.get("contract_bundle_version"),
-        "pinned_contracts": doc.get("pinned_contracts", []),
-        "verdict": "pass" if not errors else "fail",
-        "errors": errors,
+        "versions_by_repo": versions,
+        "distinct_versions": distinct_versions,
+        "resolved_bundle_version": distinct_versions[0] if len(distinct_versions) == 1 else None,
+        "verdict": "pass" if len(distinct_versions) == 1 else "fail",
     }
 
 
+def add_check(checks, check_id: str, cwd: Path, cmd: list[str], expected_exit: int = 0, report_path: Path | None = None, summary_keys: list[str] | None = None):
+    rc, out, err = run_cmd(cmd, cwd)
+    report_doc = None
+    if report_path and report_path.exists():
+        report_doc = load_json(report_path)
+    check = {
+        "check_id": check_id,
+        "cwd": str(cwd),
+        "command": cmd,
+        "expected_exit": expected_exit,
+        "exit_code": rc,
+        "verdict": "pass" if rc == expected_exit else "fail",
+        "stdout_tail": out[-1000:],
+        "stderr_tail": err[-1000:],
+    }
+    if report_path:
+        check["report_path"] = str(report_path)
+        check["report_exists"] = report_path.exists()
+    if summary_keys:
+        check["report_summary"] = summarize_report(report_doc, summary_keys)
+    checks.append(check)
+    return check, report_doc
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Cross-repo C1~C8 consumer conformance checks")
+    parser = argparse.ArgumentParser(description="Cross-repo execution evidence conformance checks")
     parser.add_argument(
         "--workspace-root",
         default="..",
@@ -88,10 +115,34 @@ def main():
         default=None,
         help="Output report path (default: planningops/artifacts/conformance/<run-id>.json)",
     )
+    parser.add_argument(
+        "--run-root",
+        default=None,
+        help="Directory for support artifacts generated during conformance execution",
+    )
     args = parser.parse_args()
 
     planningops_repo = resolve_repo_root()
-    workspace_root = (planningops_repo / args.workspace_root).resolve()
+    workspace_root = resolve_workspace_root(planningops_repo, args.workspace_root)
+    output_path = (
+        Path(args.output)
+        if args.output
+        else planningops_repo / "planningops" / "artifacts" / "conformance" / f"{args.run_id}.json"
+    )
+    if not output_path.is_absolute():
+        output_path = planningops_repo / output_path
+    run_root = (
+        Path(args.run_root)
+        if args.run_root
+        else (
+            planningops_repo / "planningops" / "artifacts" / "conformance" / args.run_id
+            if str(output_path).startswith(str(planningops_repo / "planningops" / "artifacts" / "conformance"))
+            else output_path.parent / args.run_id
+        )
+    )
+    if not run_root.is_absolute():
+        run_root = planningops_repo / run_root
+    run_root.mkdir(parents=True, exist_ok=True)
 
     contract_repo = workspace_root / "platform-contracts"
     provider_repo = workspace_root / "platform-provider-gateway"
@@ -100,113 +151,469 @@ def main():
 
     checks = []
 
-    def add_check(check_id, cwd: Path, cmd, expected_exit=0):
-        rc, out, err = run_cmd(cmd, cwd)
-        checks.append(
-            {
-                "check_id": check_id,
-                "cwd": str(cwd),
-                "command": cmd,
-                "expected_exit": expected_exit,
-                "exit_code": rc,
-                "verdict": "pass" if rc == expected_exit else "fail",
-                "stdout_tail": out[-1000:],
-                "stderr_tail": err[-1000:],
-            }
-        )
-        return rc, out, err
+    bundle_version_consistency = detect_bundle_versions(workspace_root)
+    bundle_version = bundle_version_consistency["resolved_bundle_version"] or "unknown"
+
+    contracts_dir = run_root / "contracts"
+    provider_dir = run_root / "provider"
+    o11y_dir = run_root / "observability"
+    monday_dir = run_root / "monday"
+    contracts_dir.mkdir(parents=True, exist_ok=True)
+    provider_dir.mkdir(parents=True, exist_ok=True)
+    o11y_dir.mkdir(parents=True, exist_ok=True)
+    monday_dir.mkdir(parents=True, exist_ok=True)
+
+    semver_report = contracts_dir / "semver-classification.json"
+    contract_bundle_report = contracts_dir / "contract-bundle.json"
+    contract_pin_report = contracts_dir / "consumer-contract-pins.json"
 
     add_check(
+        checks,
         "contracts.validate",
         contract_repo,
         ["python3", "scripts/validate_contracts.py", "--root", "."],
         expected_exit=0,
     )
-
-    _, semver_out, _ = add_check(
+    _, semver_doc = add_check(
+        checks,
         "contracts.semver_classification",
         contract_repo,
-        ["python3", "scripts/classify_schema_change.py", "--enforce-expected"],
+        [
+            "python3",
+            "scripts/classify_schema_change.py",
+            "--enforce-expected",
+            "--report",
+            str(semver_report),
+            "--output-dir",
+            str(semver_report.parent),
+        ],
         expected_exit=0,
+        report_path=semver_report,
+        summary_keys=["result_count", "highest_computed_bump"],
     )
+    _, bundle_doc = add_check(
+        checks,
+        "contracts.publish_bundle",
+        contract_repo,
+        [
+            "python3",
+            "scripts/publish_contract_bundle.py",
+            "--bundle-version",
+            bundle_version,
+            "--workspace-root",
+            str(workspace_root),
+            "--bundle-output",
+            str(contract_bundle_report),
+            "--pin-output",
+            str(contract_pin_report),
+            "--strict",
+        ],
+        expected_exit=0 if bundle_version_consistency["verdict"] == "pass" else 1,
+        report_path=contract_bundle_report,
+        summary_keys=["bundle_version", "schema_count", "source_repo"],
+    )
+    contract_pin_doc = load_json(contract_pin_report) if contract_pin_report.exists() else None
 
-    add_check(
+    provider_smoke_dir = provider_dir / "smoke"
+    provider_smoke_dir.mkdir(parents=True, exist_ok=True)
+    provider_primary_report = provider_smoke_dir / f"{args.run_id}-primary_success.json"
+    provider_primary_validation = provider_dir / "primary_success.validation.json"
+    provider_violation_report = provider_smoke_dir / f"{args.run_id}-contract_violation.json"
+    provider_violation_validation = provider_dir / "contract_violation.validation.json"
+    provider_pin_validation = provider_dir / "contract-pin-report.json"
+
+    _, provider_primary_doc = add_check(
+        checks,
         "provider.primary_success",
         provider_repo,
-        ["python3", "scripts/litellm_gateway_smoke.py", "--scenario", "primary_success", "--run-id", args.run_id],
+        [
+            "python3",
+            "scripts/litellm_gateway_smoke.py",
+            "--scenario",
+            "primary_success",
+            "--run-id",
+            args.run_id,
+            "--output-dir",
+            str(provider_smoke_dir),
+        ],
         expected_exit=0,
+        report_path=provider_primary_report,
+        summary_keys=["verdict", "reason_code", "routing_profile"],
     )
-
     add_check(
+        checks,
+        "provider.primary_success_validation",
+        provider_repo,
+        [
+            "python3",
+            "scripts/validate_provider_smoke_evidence.py",
+            "--report",
+            str(provider_primary_report),
+            "--output",
+            str(provider_primary_validation),
+        ],
+        expected_exit=0,
+        report_path=provider_primary_validation,
+        summary_keys=["verdict", "error_count"],
+    )
+    _, provider_violation_doc = add_check(
+        checks,
         "provider.contract_violation_fail_fast",
         provider_repo,
-        ["python3", "scripts/litellm_gateway_smoke.py", "--scenario", "contract_violation", "--run-id", args.run_id],
+        [
+            "python3",
+            "scripts/litellm_gateway_smoke.py",
+            "--scenario",
+            "contract_violation",
+            "--run-id",
+            args.run_id,
+            "--output-dir",
+            str(provider_smoke_dir),
+        ],
         expected_exit=1,
+        report_path=provider_violation_report,
+        summary_keys=["verdict", "reason_code", "routing_profile"],
+    )
+    add_check(
+        checks,
+        "provider.contract_violation_validation",
+        provider_repo,
+        [
+            "python3",
+            "scripts/validate_provider_smoke_evidence.py",
+            "--report",
+            str(provider_violation_report),
+            "--output",
+            str(provider_violation_validation),
+        ],
+        expected_exit=0,
+        report_path=provider_violation_validation,
+        summary_keys=["verdict", "error_count"],
+    )
+    add_check(
+        checks,
+        "provider.contract_pin",
+        provider_repo,
+        [
+            "python3",
+            "scripts/validate_contract_pin.py",
+            "--output",
+            str(provider_pin_validation),
+        ],
+        expected_exit=0,
+        report_path=provider_pin_validation,
+        summary_keys=["verdict", "error_count", "warning_count"],
     )
 
+    o11y_ingest_dir = o11y_dir / "ingest"
+    o11y_ingest_dir.mkdir(parents=True, exist_ok=True)
+    o11y_normal_report = o11y_ingest_dir / f"{args.run_id}-normal.json"
+    o11y_normal_validation = o11y_dir / "normal.validation.json"
+    o11y_replay_report = o11y_ingest_dir / f"{args.run_id}-delay_and_replay.json"
+    o11y_replay_validation = o11y_dir / "delay_and_replay.validation.json"
+    o11y_pin_validation = o11y_dir / "contract-pin-report.json"
+
     add_check(
+        checks,
+        "o11y.normal",
+        o11y_repo,
+        [
+            "python3",
+            "scripts/langfuse_ingest_smoke.py",
+            "--scenario",
+            "normal",
+            "--run-id",
+            args.run_id,
+            "--output-dir",
+            str(o11y_ingest_dir),
+        ],
+        expected_exit=0,
+        report_path=o11y_normal_report,
+        summary_keys=["verdict", "reason_code", "ingest_profile"],
+    )
+    add_check(
+        checks,
+        "o11y.normal_validation",
+        o11y_repo,
+        [
+            "python3",
+            "scripts/validate_ingest_smoke_evidence.py",
+            "--report",
+            str(o11y_normal_report),
+            "--output",
+            str(o11y_normal_validation),
+        ],
+        expected_exit=0,
+        report_path=o11y_normal_validation,
+        summary_keys=["verdict", "error_count"],
+    )
+    _, o11y_replay_doc = add_check(
+        checks,
         "o11y.delay_and_replay",
         o11y_repo,
-        ["python3", "scripts/langfuse_ingest_smoke.py", "--scenario", "delay_and_replay", "--run-id", args.run_id],
+        [
+            "python3",
+            "scripts/langfuse_ingest_smoke.py",
+            "--scenario",
+            "delay_and_replay",
+            "--run-id",
+            args.run_id,
+            "--output-dir",
+            str(o11y_ingest_dir),
+        ],
         expected_exit=0,
+        report_path=o11y_replay_report,
+        summary_keys=["verdict", "reason_code", "ingest_profile"],
     )
+    add_check(
+        checks,
+        "o11y.delay_and_replay_validation",
+        o11y_repo,
+        [
+            "python3",
+            "scripts/validate_ingest_smoke_evidence.py",
+            "--report",
+            str(o11y_replay_report),
+            "--output",
+            str(o11y_replay_validation),
+        ],
+        expected_exit=0,
+        report_path=o11y_replay_validation,
+        summary_keys=["verdict", "error_count"],
+    )
+    add_check(
+        checks,
+        "o11y.contract_pin",
+        o11y_repo,
+        [
+            "python3",
+            "scripts/validate_contract_pin.py",
+            "--output",
+            str(o11y_pin_validation),
+        ],
+        expected_exit=0,
+        report_path=o11y_pin_validation,
+        summary_keys=["verdict", "error_count", "warning_count"],
+    )
+
+    monday_handoff_report = monday_dir / "handoff-smoke-report.json"
+    monday_handoff_validation = monday_dir / "handoff.validation.json"
+    monday_scheduler_report = monday_dir / "scheduler-run-report.json"
+    monday_scheduler_validation = monday_dir / "scheduler.validation.json"
+    monday_integration_report = monday_dir / "planningops-handoff-report.json"
+    monday_integration_validation = monday_dir / "integration.validation.json"
+    monday_queue_out = monday_dir / "queue.from-planningops.json"
+    monday_idempotency = monday_dir / "idempotency.json"
+    monday_transition_log = monday_dir / "scheduler.ndjson"
+    monday_pin_validation = monday_dir / "contract-pin-report.json"
 
     add_check(
-        "runtime.handoff_mapping",
+        checks,
+        "monday.handoff_mapping",
         monday_repo,
-        ["python3", "scripts/validate_handoff_mapping.py"],
+        [
+            "python3",
+            "scripts/validate_handoff_mapping.py",
+            "--run-id",
+            args.run_id,
+            "--output",
+            str(monday_handoff_report),
+        ],
         expected_exit=0,
+        report_path=monday_handoff_report,
+        summary_keys=["verdict", "reason_code", "mismatch_count"],
+    )
+    add_check(
+        checks,
+        "monday.handoff_validation",
+        monday_repo,
+        [
+            "python3",
+            "scripts/validate_runtime_evidence.py",
+            "--kind",
+            "handoff",
+            "--report",
+            str(monday_handoff_report),
+            "--output",
+            str(monday_handoff_validation),
+        ],
+        expected_exit=0,
+        report_path=monday_handoff_validation,
+        summary_keys=["verdict", "error_count"],
+    )
+    _, monday_integration_doc = add_check(
+        checks,
+        "monday.integration",
+        monday_repo,
+        [
+            "python3",
+            "scripts/integrate_planningops_handoff.py",
+            "--planningops-last-run",
+            str(planningops_repo / "planningops" / "artifacts" / "loop-runner" / "last-run.json"),
+            "--run-id",
+            args.run_id,
+            "--handoff-report",
+            str(monday_handoff_report),
+            "--queue-out",
+            str(monday_queue_out),
+            "--scheduler-report",
+            str(monday_scheduler_report),
+            "--integration-report",
+            str(monday_integration_report),
+            "--idempotency",
+            str(monday_idempotency),
+            "--transition-log",
+            str(monday_transition_log),
+        ],
+        expected_exit=0,
+        report_path=monday_integration_report,
+        summary_keys=["verdict", "reason_code", "queue_path"],
+    )
+    add_check(
+        checks,
+        "monday.scheduler_validation",
+        monday_repo,
+        [
+            "python3",
+            "scripts/validate_runtime_evidence.py",
+            "--kind",
+            "scheduler",
+            "--report",
+            str(monday_scheduler_report),
+            "--output",
+            str(monday_scheduler_validation),
+        ],
+        expected_exit=0,
+        report_path=monday_scheduler_validation,
+        summary_keys=["verdict", "error_count"],
+    )
+    add_check(
+        checks,
+        "monday.integration_validation",
+        monday_repo,
+        [
+            "python3",
+            "scripts/validate_runtime_evidence.py",
+            "--kind",
+            "integration",
+            "--report",
+            str(monday_integration_report),
+            "--output",
+            str(monday_integration_validation),
+        ],
+        expected_exit=0,
+        report_path=monday_integration_validation,
+        summary_keys=["verdict", "error_count"],
+    )
+    add_check(
+        checks,
+        "monday.contract_pin",
+        monday_repo,
+        [
+            "python3",
+            "scripts/validate_contract_pin.py",
+            "--output",
+            str(monday_pin_validation),
+        ],
+        expected_exit=0,
+        report_path=monday_pin_validation,
+        summary_keys=["verdict", "error_count", "warning_count"],
     )
 
-    pin_results = [validate_pin(workspace_root, consumer_repo, rel_path) for consumer_repo, rel_path in PIN_CONSUMERS]
-
     semver_major_present = False
-    semver_report_path = parse_report_path(semver_out)
-    if semver_report_path:
-        p = contract_repo / semver_report_path
-        if p.exists():
-            semver_doc = json.loads(p.read_text(encoding="utf-8"))
-            semver_major_present = any(r.get("computed_bump") == "major" for r in semver_doc.get("results", []))
-
-    provider_violation_path = provider_repo / f"artifacts/smoke/{args.run_id}-contract_violation.json"
-    provider_violation_ok = False
-    if provider_violation_path.exists():
-        provider_doc = json.loads(provider_violation_path.read_text(encoding="utf-8"))
-        provider_violation_ok = (
-            provider_doc.get("verdict") == "fail" and provider_doc.get("reason_code") == "contract_violation"
-        )
+    if isinstance(semver_doc, dict):
+        semver_major_present = any(row.get("computed_bump") == "major" for row in semver_doc.get("results", []))
 
     incompatibility_example = {
         "semver_major_example_present": semver_major_present,
-        "provider_fail_fast_example_present": provider_violation_ok,
-        "provider_fail_fast_report": str(provider_violation_path),
-        "verdict": "pass" if semver_major_present and provider_violation_ok else "fail",
+        "provider_fail_fast_example_present": (
+            isinstance(provider_violation_doc, dict)
+            and provider_violation_doc.get("verdict") == "fail"
+            and provider_violation_doc.get("reason_code") == "contract_violation"
+        ),
+        "provider_fail_fast_report": str(provider_violation_report),
+        "verdict": "pass"
+        if semver_major_present
+        and isinstance(provider_violation_doc, dict)
+        and provider_violation_doc.get("verdict") == "fail"
+        and provider_violation_doc.get("reason_code") == "contract_violation"
+        else "fail",
+    }
+
+    evidence_assertions = {
+        "bundle_version_consistency": bundle_version_consistency,
+        "contract_bundle_published": {
+            "report_path": str(contract_bundle_report),
+            "verdict": "pass"
+            if isinstance(bundle_doc, dict) and bundle_doc.get("schema_count", 0) > 0
+            else "fail",
+        },
+        "consumer_pin_evidence": {
+            "report_path": str(contract_pin_report),
+            "verdict": "pass"
+            if isinstance(contract_pin_doc, dict)
+            and all(row.get("verdict") == "pass" for row in contract_pin_doc.get("consumer_results", []))
+            else "fail",
+        },
+        "provider_evidence": {
+            "primary_reason_code": provider_primary_doc.get("reason_code") if isinstance(provider_primary_doc, dict) else None,
+            "violation_reason_code": provider_violation_doc.get("reason_code") if isinstance(provider_violation_doc, dict) else None,
+            "verdict": "pass"
+            if isinstance(provider_primary_doc, dict)
+            and provider_primary_doc.get("verdict") == "pass"
+            and provider_primary_doc.get("reason_code") == "ok"
+            and isinstance(provider_violation_doc, dict)
+            and provider_violation_doc.get("verdict") == "fail"
+            and provider_violation_doc.get("reason_code") == "contract_violation"
+            else "fail",
+        },
+        "observability_evidence": {
+            "replay_reason_code": o11y_replay_doc.get("reason_code") if isinstance(o11y_replay_doc, dict) else None,
+            "verdict": "pass"
+            if isinstance(o11y_replay_doc, dict)
+            and o11y_replay_doc.get("verdict") == "pass"
+            and o11y_replay_doc.get("reason_code") == "replay_recovered"
+            else "fail",
+        },
+        "runtime_evidence": {
+            "integration_reason_code": monday_integration_doc.get("reason_code") if isinstance(monday_integration_doc, dict) else None,
+            "verdict": "pass"
+            if isinstance(monday_integration_doc, dict)
+            and monday_integration_doc.get("verdict") == "pass"
+            and monday_integration_doc.get("reason_code") == "ok"
+            else "fail",
+        },
     }
 
     any_check_fail = any(c["verdict"] != "pass" for c in checks)
-    any_pin_fail = any(p["verdict"] != "pass" for p in pin_results)
-    verdict = "pass" if (not any_check_fail and not any_pin_fail and incompatibility_example["verdict"] == "pass") else "fail"
+    any_assertion_fail = any(row.get("verdict") != "pass" for row in evidence_assertions.values())
+    verdict = "pass" if (not any_check_fail and not any_assertion_fail and incompatibility_example["verdict"] == "pass") else "fail"
 
     report = {
         "generated_at_utc": now_utc(),
         "run_id": args.run_id,
         "workspace_root": str(workspace_root),
+        "run_root": str(run_root),
         "checks": checks,
-        "pin_results": pin_results,
+        "evidence_assertions": evidence_assertions,
         "incompatibility_example": incompatibility_example,
         "verdict": verdict,
     }
 
-    output_path = (
-        Path(args.output)
-        if args.output
-        else planningops_repo / "planningops" / "artifacts" / "conformance" / f"{args.run_id}.json"
-    )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding="utf-8")
 
     print(f"report written: {output_path}")
-    print(f"check_count={len(checks)} pin_count={len(pin_results)} verdict={verdict}")
+    print(
+        " ".join(
+            [
+                f"check_count={len(checks)}",
+                f"assertion_count={len(evidence_assertions)}",
+                f"incompatibility_example={incompatibility_example['verdict']}",
+                f"verdict={verdict}",
+            ]
+        )
+    )
     return 0 if verdict == "pass" else 1
 
 

--- a/planningops/scripts/rollout_external_artifact_policy.py
+++ b/planningops/scripts/rollout_external_artifact_policy.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+
+REPO_RULES = {
+    "platform-provider-gateway": {
+        "required_strings": [
+            (".gitignore", "runtime-artifacts/"),
+            ("scripts/litellm_gateway_smoke.py", 'default="runtime-artifacts/smoke"'),
+            ("scripts/validate_provider_smoke_evidence.py", "runtime-artifacts/validation/provider-smoke-evidence-report.json"),
+            ("scripts/validate_contract_pin.py", "runtime-artifacts/validation/contract-pin-report.json"),
+            ("scripts/litellm_profile_drill.py", "runtime-artifacts/launcher/"),
+        ],
+        "forbidden_strings": [
+            "artifacts/smoke",
+            "artifacts/launcher",
+            "artifacts/validation",
+        ],
+        "forbidden_paths_prefixes": ["artifacts/"],
+    },
+    "platform-observability-gateway": {
+        "required_strings": [
+            (".gitignore", "runtime-artifacts/"),
+            ("scripts/langfuse_ingest_smoke.py", 'default="runtime-artifacts/ingest"'),
+            ("scripts/validate_ingest_smoke_evidence.py", "runtime-artifacts/validation/ingest-smoke-evidence-report.json"),
+            ("scripts/validate_contract_pin.py", "runtime-artifacts/validation/contract-pin-report.json"),
+            ("scripts/langfuse_stack_launcher.sh", "runtime-artifacts/launcher"),
+        ],
+        "forbidden_strings": [
+            "artifacts/ingest",
+            "artifacts/launcher",
+            "artifacts/validation",
+        ],
+        "forbidden_paths_prefixes": ["artifacts/"],
+    },
+    "monday": {
+        "required_strings": [
+            (".gitignore", "runtime-artifacts/"),
+            ("scripts/validate_handoff_mapping.py", "runtime-artifacts/interface/handoff-smoke-report.json"),
+            ("scripts/scheduler_queue.py", "runtime-artifacts/scheduler/run-report.json"),
+            ("scripts/scheduler_queue.py", "runtime-artifacts/transition-log/scheduler.ndjson"),
+            ("scripts/integrate_planningops_handoff.py", "runtime-artifacts/integration/"),
+            ("scripts/validate_runtime_evidence.py", "runtime-artifacts/validation/runtime-evidence-report.json"),
+            ("scripts/validate_contract_pin.py", "runtime-artifacts/validation/contract-pin-report.json"),
+        ],
+        "forbidden_strings": [
+            "artifacts/interface",
+            "artifacts/scheduler",
+            "artifacts/integration",
+            "artifacts/transition-log",
+            "artifacts/validation",
+        ],
+        "forbidden_paths_prefixes": ["artifacts/"],
+        "allowed_prefixes": ["planningops/artifacts/"],
+    },
+}
+
+SCAN_SUFFIXES = (".md", ".py", ".sh", ".yml", ".yaml", ".json")
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in [current] + list(current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return Path(__file__).resolve().parents[3]
+
+
+def resolve_workspace_root(planningops_repo: Path, raw_workspace_root: str) -> Path:
+    candidates = [
+        (planningops_repo / raw_workspace_root).resolve(),
+        planningops_repo,
+        planningops_repo.parent,
+    ]
+    for candidate in candidates:
+        if (candidate / "platform-provider-gateway").exists() and (candidate / "monday").exists():
+            return candidate
+    return (planningops_repo / raw_workspace_root).resolve()
+
+
+def iter_repo_files(repo_root: Path):
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(part == ".git" for part in path.parts):
+            continue
+        if path.name.startswith("._") or path.name == ".DS_Store":
+            continue
+        if path.suffix not in SCAN_SUFFIXES:
+            continue
+        yield path
+
+
+def line_has_allowed_prefix(line: str, allowed_prefixes: list[str]):
+    return any(prefix in line for prefix in allowed_prefixes)
+
+
+def validate_repo(repo_root: Path, rule: dict):
+    required_errors = []
+    forbidden_refs = []
+    forbidden_paths = []
+
+    for rel_path, snippet in rule["required_strings"]:
+        path = repo_root / rel_path
+        if not path.exists():
+            required_errors.append({"path": rel_path, "reason": "file_missing", "snippet": snippet})
+            continue
+        text = path.read_text(encoding="utf-8")
+        if snippet not in text:
+            required_errors.append({"path": rel_path, "reason": "snippet_missing", "snippet": snippet})
+
+    allowed_prefixes = rule.get("allowed_prefixes", [])
+    for path in iter_repo_files(repo_root):
+        rel_path = str(path.relative_to(repo_root))
+        if any(rel_path.startswith(prefix) for prefix in rule.get("forbidden_paths_prefixes", [])):
+            forbidden_paths.append(rel_path)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for forbidden in rule["forbidden_strings"]:
+                if forbidden not in line:
+                    continue
+                if f"runtime-{forbidden}" in line:
+                    continue
+                if line_has_allowed_prefix(line, allowed_prefixes):
+                    continue
+                forbidden_refs.append(
+                    {
+                        "path": rel_path,
+                        "line": lineno,
+                        "forbidden": forbidden,
+                        "text": line.strip(),
+                    }
+                )
+
+    verdict = "pass" if not required_errors and not forbidden_refs and not forbidden_paths else "fail"
+    return {
+        "repo": repo_root.name,
+        "required_errors": required_errors,
+        "forbidden_refs": forbidden_refs,
+        "forbidden_paths": forbidden_paths,
+        "verdict": verdict,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate federated rollout of execution-repo external-only artifact defaults")
+    parser.add_argument("--workspace-root", default="..")
+    parser.add_argument(
+        "--output",
+        default="planningops/artifacts/validation/federated-artifact-policy-rollout-report.json",
+    )
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    planningops_repo = resolve_repo_root()
+    workspace_root = resolve_workspace_root(planningops_repo, args.workspace_root)
+
+    repos = []
+    for repo_name, rule in REPO_RULES.items():
+        repo_root = workspace_root / repo_name
+        if not repo_root.exists():
+            repos.append({"repo": repo_name, "verdict": "fail", "required_errors": [{"path": ".", "reason": "repo_missing"}], "forbidden_refs": [], "forbidden_paths": []})
+            continue
+        repos.append(validate_repo(repo_root, rule))
+
+    verdict = "pass" if all(repo["verdict"] == "pass" for repo in repos) else "fail"
+    report = {
+        "generated_at_utc": now_utc(),
+        "workspace_root": str(workspace_root),
+        "contract_ref": "planningops/contracts/federated-artifact-storage-contract.md",
+        "repo_results": repos,
+        "verdict": verdict,
+    }
+
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = planningops_repo / output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding="utf-8")
+
+    print(f"report written: {output_path}")
+    print(f"repo_count={len(repos)} verdict={verdict}")
+    return 0 if verdict == "pass" or not args.strict else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- rewire federated conformance so planningops consumes repo-owned evidence validators instead of raw repo-specific smoke parsing
- add federated artifact storage rollout contract and validator for execution repos
- wire artifact rollout validation into federated CI and keep local tmp conformance runs from leaving support artifacts in tracked planningops paths

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: `planningops/scripts/federation/cross_repo_conformance_check.py`, `planningops/scripts/rollout_external_artifact_policy.py`, `planningops/contracts/federated-artifact-storage-contract.md`
- `.github/` workflows: `.github/workflows/federated-ci-matrix.yml`

## Linked Issues
- Closes #108
- Closes #120
- Related https://github.com/rather-not-work-on/platform-provider-gateway/issues/2
- Related https://github.com/rather-not-work-on/platform-observability-gateway/issues/2
- Related https://github.com/rather-not-work-on/monday/issues/3

## Validation
- [ ] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python planningops/scripts/rollout_external_artifact_policy.py --workspace-root .. --strict --output /tmp/federated-artifact-policy-rollout-report.json`
  - `python planningops/scripts/federation/cross_repo_conformance_check.py --workspace-root .. --run-id local-federated-check-3 --output /tmp/planningops-fed-report-3.json`

## Risks
- Risk: federated CI now depends on execution-repo validator contracts staying stable; drift will fail planningops orchestration earlier.
- Rollback: revert this PR to restore the previous planningops-side conformance implementation and artifact rollout gate.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.