### PR TITLE
feat: apply branch protection baseline across federated repos

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -2,10 +2,9 @@ name: Federated CI Matrix
 
 on:
   pull_request:
-    paths:
-      - "planningops/**"
-      - ".github/workflows/federated-ci-matrix.yml"
-      - ".github/workflows/issue-quality-gate.yml"
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -206,6 +205,7 @@ jobs:
           bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh
           python3 planningops/scripts/validate_artifact_storage_policy.py --strict
           bash planningops/scripts/test_audit_branch_protection_contract.sh
+          bash planningops/scripts/test_apply_branch_protection_contract.sh
           python3 planningops/scripts/audit_branch_protection.py \
             --policy planningops/config/repository-governance-policy.json \
             --output planningops/artifacts/validation/branch-protection-audit-report.json \
@@ -296,6 +296,8 @@ jobs:
           )
           print("summary written: planningops/artifacts/ci/federated-ci-summary.json")
           print(f"verdict={doc['verdict']} failures={len(failures)}")
+          if failures:
+              raise SystemExit(1)
           PY
 
       - name: Upload federated summary artifact

--- a/.github/workflows/planningops-contracts-dryrun.yml
+++ b/.github/workflows/planningops-contracts-dryrun.yml
@@ -2,10 +2,9 @@ name: PlanningOps Contracts Dry-Run
 
 on:
   pull_request:
-    paths:
-      - "planningops/**"
-      - "docs/workbench/unified-personal-agent-platform/**"
-      - ".github/workflows/planningops-contracts-dryrun.yml"
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/planningops/config/README.md
+++ b/planningops/config/README.md
@@ -26,3 +26,4 @@ Provide stable configuration sources for project fields, runtime profiles, and c
 - Contract map paths must stay repo-root-relative and portable across local/CI.
 - Script role map changes must keep root wrapper compatibility for moved entrypoints.
 - Issue quality rule changes must align with `planningops/contracts/issue-quality-contract.md`.
+- Governance policy required checks must use real GitHub check context names, not workflow display names.

--- a/planningops/config/repository-governance-policy.json
+++ b/planningops/config/repository-governance-policy.json
@@ -14,34 +14,34 @@
   "repos": [
     {
       "name": "platform-planningops",
-      "required_status_checks_any": [
-        "Federated CI Matrix",
-        "loop-guardrails"
+      "required_status_checks_all": [
+        "template-and-link-check",
+        "validate-and-dry-run",
+        "federated-summary"
       ]
     },
     {
       "name": "platform-contracts",
-      "required_status_checks_any": [
-        "Contracts Check",
-        "Contracts Compatibility Check"
+      "required_status_checks_all": [
+        "contracts"
       ]
     },
     {
       "name": "monday",
-      "required_status_checks_any": [
-        "Monday Local CI"
+      "required_status_checks_all": [
+        "monday-local-ci"
       ]
     },
     {
       "name": "platform-provider-gateway",
-      "required_status_checks_any": [
-        "Provider Gateway Local CI"
+      "required_status_checks_all": [
+        "provider-local-ci"
       ]
     },
     {
       "name": "platform-observability-gateway",
-      "required_status_checks_any": [
-        "Observability Gateway Local CI"
+      "required_status_checks_all": [
+        "observability-local-ci"
       ]
     }
   ]

--- a/planningops/contracts/repository-governance-contract.md
+++ b/planningops/contracts/repository-governance-contract.md
@@ -22,6 +22,7 @@ Per governed repo default branch:
 6. Conversation resolution must be required.
 7. Force pushes and deletions must be disabled.
 8. Required status checks must satisfy repo-specific policy (`all` and/or `any` sets).
+9. Branch-protection-required checks must be emitted on every pull request for that repo. Path-filtered checks cannot be marked as required unless the workflow still produces the context for all PRs.
 
 ## Source of Truth
 - Policy config: `planningops/config/repository-governance-policy.json`
@@ -34,3 +35,4 @@ Per governed repo default branch:
 ## Operational Notes
 - `--strict` mode fails when baseline violations are found.
 - `--allow-fetch-failure` turns fetch errors into `inconclusive` (soft-fail only when strict mode is also enabled).
+- Live apply uses `planningops/scripts/apply_branch_protection.py` and expects concrete `required_status_checks_all` values in policy.

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -36,6 +36,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `validate_federated_issue_quality.py`
   - `validate_artifact_storage_policy.py`
   - `audit_branch_protection.py`
+  - `apply_branch_protection.py`
   - `validate_external_only_commit_guard.py`
   - `migrate_external_only_artifacts.py`
   - `rehydrate_artifact_pointer.py`
@@ -76,6 +77,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_federated_issue_quality_contract.sh`
   - `test_validate_artifact_storage_policy_contract.sh`
   - `test_audit_branch_protection_contract.sh`
+  - `test_apply_branch_protection_contract.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_artifact_sink_e2e.sh`
   - `test_*.sh`

--- a/planningops/scripts/apply_branch_protection.py
+++ b/planningops/scripts/apply_branch_protection.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_POLICY = Path("planningops/config/repository-governance-policy.json")
+DEFAULT_OUTPUT = Path("planningops/artifacts/validation/branch-protection-apply-report.json")
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def run(cmd, input_text=None):
+    cp = subprocess.run(cmd, input=input_text, capture_output=True, text=True)
+    return cp.returncode, cp.stdout.strip(), cp.stderr.strip()
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def merged_policy_row(defaults: dict, repo_row: dict, default_branch: str):
+    merged = dict(defaults)
+    merged.update(repo_row)
+    if "branch_pattern" not in merged:
+        merged["branch_pattern"] = default_branch
+    return merged
+
+
+def load_snapshot(snapshot_path: Path):
+    doc = load_json(snapshot_path)
+    repos = doc.get("repositories")
+    if not isinstance(repos, list):
+        raise ValueError("snapshot file must include 'repositories' array")
+
+    parsed = {}
+    for row in repos:
+        if not isinstance(row, dict):
+            continue
+        name = row.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        parsed[name] = {
+            "name": name,
+            "default_branch": (row.get("default_branch") or "main"),
+        }
+    return parsed
+
+
+def fetch_repo_snapshot(owner: str, repo_name: str):
+    rc, out, err = run(
+        [
+            "gh",
+            "api",
+            f"repos/{owner}/{repo_name}",
+            "-H",
+            "Accept: application/vnd.github+json",
+        ]
+    )
+    if rc != 0:
+        raise RuntimeError(err or out or "repository fetch failed")
+
+    doc = json.loads(out)
+    default_branch = (doc.get("default_branch") or "main").strip() or "main"
+    return {
+        "name": doc.get("name") or repo_name,
+        "default_branch": default_branch,
+    }
+
+
+def normalize_contexts(values):
+    seen = []
+    for value in values:
+        if isinstance(value, str):
+            ctx = value.strip()
+            if ctx and ctx not in seen:
+                seen.append(ctx)
+    return seen
+
+
+def required_contexts(policy_row: dict):
+    required_all = normalize_contexts(policy_row.get("required_status_checks_all") or [])
+    required_any = normalize_contexts(policy_row.get("required_status_checks_any") or [])
+
+    if required_any and not required_all:
+        raise ValueError("branch protection apply requires 'required_status_checks_all'; 'required_status_checks_any' is audit-only")
+
+    if bool(policy_row.get("require_status_checks")) and not required_all:
+        raise ValueError("required status checks enabled but no concrete 'required_status_checks_all' contexts are configured")
+
+    return required_all
+
+
+def build_payload(policy_row: dict):
+    payload = {
+        "enforce_admins": bool(policy_row.get("enforce_admins")),
+        "restrictions": None,
+        "allow_force_pushes": bool(policy_row.get("allow_force_pushes")),
+        "allow_deletions": bool(policy_row.get("allow_deletions")),
+        "required_conversation_resolution": bool(policy_row.get("require_conversation_resolution")),
+    }
+
+    if "require_linear_history" in policy_row:
+        payload["required_linear_history"] = bool(policy_row.get("require_linear_history"))
+
+    if bool(policy_row.get("require_status_checks")):
+        payload["required_status_checks"] = {
+            "strict": bool(policy_row.get("require_strict_status_checks")),
+            "contexts": required_contexts(policy_row),
+        }
+    else:
+        payload["required_status_checks"] = None
+
+    if bool(policy_row.get("require_approving_reviews")):
+        payload["required_pull_request_reviews"] = {
+            "dismiss_stale_reviews": False,
+            "require_code_owner_reviews": False,
+            "required_approving_review_count": int(policy_row.get("min_approving_review_count", 1) or 1),
+            "require_last_push_approval": False,
+        }
+    else:
+        payload["required_pull_request_reviews"] = None
+
+    return payload
+
+
+def apply_payload(owner: str, repo_name: str, branch_name: str, payload: dict):
+    rc, out, err = run(
+        [
+            "gh",
+            "api",
+            f"repos/{owner}/{repo_name}/branches/{branch_name}/protection",
+            "--method",
+            "PUT",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "--input",
+            "-",
+        ],
+        input_text=json.dumps(payload, ensure_ascii=True),
+    )
+    if rc != 0:
+        raise RuntimeError(err or out or "branch protection apply failed")
+
+    doc = json.loads(out)
+    required_checks = ((doc.get("required_status_checks") or {}).get("contexts") or [])
+    required_reviews = (doc.get("required_pull_request_reviews") or {}).get("required_approving_review_count")
+
+    return {
+        "url": doc.get("url"),
+        "required_status_checks": required_checks,
+        "required_approving_review_count": required_reviews,
+        "allow_force_pushes": bool((doc.get("allow_force_pushes") or {}).get("enabled")),
+        "allow_deletions": bool((doc.get("allow_deletions") or {}).get("enabled")),
+        "required_conversation_resolution": bool((doc.get("required_conversation_resolution") or {}).get("enabled")),
+        "enforce_admins": bool((doc.get("enforce_admins") or {}).get("enabled")),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply default-branch protection baseline from governance policy")
+    parser.add_argument("--policy", default=str(DEFAULT_POLICY))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--snapshot-file", default=None, help="Optional repo metadata snapshot JSON path")
+    parser.add_argument("--apply", action="store_true", help="Apply GitHub mutations (default: dry-run)")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--repos", default="", help="Comma-separated repo names to limit apply scope")
+    args = parser.parse_args()
+
+    policy_path = Path(args.policy)
+    output_path = Path(args.output)
+    policy = load_json(policy_path)
+
+    owner = policy.get("owner")
+    default_branch = (policy.get("default_branch") or "main").strip() or "main"
+    defaults = policy.get("defaults") if isinstance(policy.get("defaults"), dict) else {}
+    repos = [r for r in (policy.get("repos") or []) if isinstance(r, dict)]
+    repo_filter = {x.strip() for x in args.repos.split(",") if x.strip()}
+
+    if not isinstance(owner, str) or not owner:
+        print("invalid policy: owner is required", file=sys.stderr)
+        return 2
+
+    snapshots = {}
+    if args.snapshot_file:
+        snapshots = load_snapshot(Path(args.snapshot_file))
+    else:
+        for repo_row in repos:
+            repo_name = repo_row.get("name")
+            if repo_filter and repo_name not in repo_filter:
+                continue
+            if not isinstance(repo_name, str) or not repo_name:
+                continue
+            snapshots[repo_name] = fetch_repo_snapshot(owner, repo_name)
+
+    results = []
+    errors = []
+
+    for repo_row in repos:
+        repo_name = repo_row.get("name")
+        if repo_filter and repo_name not in repo_filter:
+            continue
+        if not isinstance(repo_name, str) or not repo_name:
+            continue
+
+        snapshot = snapshots.get(repo_name)
+        if not snapshot:
+            errors.append({"repo": repo_name, "message": "snapshot not available"})
+            continue
+
+        branch_name = (snapshot.get("default_branch") or default_branch).strip() or default_branch
+        merged = merged_policy_row(defaults, repo_row, branch_name)
+
+        try:
+            payload = build_payload(merged)
+            row = {
+                "repo": repo_name,
+                "branch": branch_name,
+                "mode": "apply" if args.apply else "dry-run",
+                "required_status_checks": ((payload.get("required_status_checks") or {}).get("contexts") or []),
+                "payload": payload,
+            }
+            if args.apply:
+                row["response"] = apply_payload(owner, repo_name, branch_name, payload)
+            results.append(row)
+        except Exception as exc:  # noqa: BLE001
+            errors.append({"repo": repo_name, "message": str(exc)})
+
+    verdict = "pass" if not errors else "fail"
+    report = {
+        "generated_at_utc": now_utc(),
+        "mode": "apply" if args.apply else "dry-run",
+        "policy_path": str(policy_path),
+        "owner": owner,
+        "repo_count": len(repos if not repo_filter else [r for r in repos if r.get("name") in repo_filter]),
+        "repo_evaluated_count": len(results),
+        "error_count": len(errors),
+        "results": results,
+        "errors": errors,
+        "verdict": verdict,
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(f"report written: {output_path}")
+    print(
+        f"repo_evaluated_count={report['repo_evaluated_count']} error_count={report['error_count']} verdict={report['verdict']}"
+    )
+
+    if args.strict and errors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/test_apply_branch_protection_contract.sh
+++ b/planningops/scripts/test_apply_branch_protection_contract.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat > "$tmp_dir/policy.json" <<'JSON'
+{
+  "owner": "rather-not-work-on",
+  "default_branch": "main",
+  "defaults": {
+    "require_approving_reviews": true,
+    "min_approving_review_count": 1,
+    "require_conversation_resolution": true,
+    "require_status_checks": true,
+    "require_strict_status_checks": true,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "enforce_admins": false
+  },
+  "repos": [
+    {
+      "name": "platform-planningops",
+      "required_status_checks_all": [
+        "template-and-link-check",
+        "validate-and-dry-run",
+        "federated-summary"
+      ]
+    },
+    {
+      "name": "platform-provider-gateway",
+      "required_status_checks_all": [
+        "provider-local-ci"
+      ]
+    }
+  ]
+}
+JSON
+
+cat > "$tmp_dir/snapshot.json" <<'JSON'
+{
+  "repositories": [
+    {"name": "platform-planningops", "default_branch": "main"},
+    {"name": "platform-provider-gateway", "default_branch": "main"}
+  ]
+}
+JSON
+
+python3 planningops/scripts/apply_branch_protection.py \
+  --policy "$tmp_dir/policy.json" \
+  --snapshot-file "$tmp_dir/snapshot.json" \
+  --output "$tmp_dir/branch-protection-apply.test.json" \
+  --strict
+
+python3 - "$tmp_dir/branch-protection-apply.test.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "pass", report
+assert report["repo_evaluated_count"] == 2, report
+
+rows = {row["repo"]: row for row in report["results"]}
+planningops = rows["platform-planningops"]
+provider = rows["platform-provider-gateway"]
+
+assert planningops["required_status_checks"] == [
+    "template-and-link-check",
+    "validate-and-dry-run",
+    "federated-summary",
+], planningops
+assert provider["required_status_checks"] == ["provider-local-ci"], provider
+
+payload = planningops["payload"]
+assert payload["required_status_checks"]["strict"] is True, payload
+assert payload["required_pull_request_reviews"]["required_approving_review_count"] == 1, payload
+assert payload["allow_force_pushes"] is False, payload
+assert payload["allow_deletions"] is False, payload
+assert payload["required_conversation_resolution"] is True, payload
+PY
+
+cat > "$tmp_dir/policy-invalid.json" <<'JSON'
+{
+  "owner": "rather-not-work-on",
+  "default_branch": "main",
+  "defaults": {
+    "require_approving_reviews": true,
+    "min_approving_review_count": 1,
+    "require_conversation_resolution": true,
+    "require_status_checks": true,
+    "require_strict_status_checks": true,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "enforce_admins": false
+  },
+  "repos": [
+    {
+      "name": "platform-planningops",
+      "required_status_checks_any": ["template-and-link-check", "federated-summary"]
+    }
+  ]
+}
+JSON
+
+set +e
+python3 planningops/scripts/apply_branch_protection.py \
+  --policy "$tmp_dir/policy-invalid.json" \
+  --snapshot-file "$tmp_dir/snapshot.json" \
+  --output "$tmp_dir/branch-protection-apply-invalid.test.json" \
+  --strict
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure when only required_status_checks_any is configured"
+  exit 1
+fi
+
+echo "branch protection apply contract test ok"

--- a/planningops/scripts/test_audit_branch_protection_contract.sh
+++ b/planningops/scripts/test_audit_branch_protection_contract.sh
@@ -21,11 +21,11 @@ cat > "$tmp_dir/policy.json" <<'JSON'
   "repos": [
     {
       "name": "platform-planningops",
-      "required_status_checks_any": ["Federated CI Matrix", "loop-guardrails"]
+      "required_status_checks_all": ["template-and-link-check", "validate-and-dry-run", "federated-summary"]
     },
     {
       "name": "monday",
-      "required_status_checks_any": ["Monday Local CI"]
+      "required_status_checks_all": ["monday-local-ci"]
     }
   ]
 }
@@ -43,7 +43,11 @@ cat > "$tmp_dir/snapshot-valid.json" <<'JSON'
           "requiresApprovingReviews": true,
           "requiredApprovingReviewCount": 1,
           "requiresStatusChecks": true,
-          "requiredStatusCheckContexts": ["loop-guardrails"],
+          "requiredStatusCheckContexts": [
+            "template-and-link-check",
+            "validate-and-dry-run",
+            "federated-summary"
+          ],
           "requiresStrictStatusChecks": true,
           "requiresConversationResolution": true,
           "allowsForcePushes": false,
@@ -61,7 +65,7 @@ cat > "$tmp_dir/snapshot-valid.json" <<'JSON'
           "requiresApprovingReviews": true,
           "requiredApprovingReviewCount": 1,
           "requiresStatusChecks": true,
-          "requiredStatusCheckContexts": ["Monday Local CI"],
+          "requiredStatusCheckContexts": ["monday-local-ci"],
           "requiresStrictStatusChecks": true,
           "requiresConversationResolution": true,
           "allowsForcePushes": false,
@@ -92,7 +96,10 @@ cat > "$tmp_dir/snapshot-invalid.json" <<'JSON'
           "requiresApprovingReviews": true,
           "requiredApprovingReviewCount": 1,
           "requiresStatusChecks": true,
-          "requiredStatusCheckContexts": ["loop-guardrails"],
+          "requiredStatusCheckContexts": [
+            "template-and-link-check",
+            "validate-and-dry-run"
+          ],
           "requiresStrictStatusChecks": true,
           "requiresConversationResolution": true,
           "allowsForcePushes": false,


### PR DESCRIPTION
## Summary
- normalize governance policy to real check context names
- add a repeatable branch protection apply script with dry-run coverage
- make required planningops checks always emit on pull requests and fail summary when federated jobs fail

## Scope
- `planningops/config/repository-governance-policy.json`
- `planningops/contracts/repository-governance-contract.md`
- `planningops/scripts/apply_branch_protection.py`
- `planningops/scripts/test_apply_branch_protection_contract.sh`
- `.github/workflows/planningops-contracts-dryrun.yml`
- `.github/workflows/federated-ci-matrix.yml`

## Linked Issues
- #123

## Validation
- `bash planningops/scripts/test_audit_branch_protection_contract.sh`
- `bash planningops/scripts/test_apply_branch_protection_contract.sh`
- `python3 planningops/scripts/apply_branch_protection.py --policy planningops/config/repository-governance-policy.json --output /tmp/branch-protection-apply-dryrun.json --strict`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/planningops-contracts-dryrun.yml .github/workflows/federated-ci-matrix.yml`

## Risks
- planningops federated CI now runs on every pull request and push to main
- branch protection apply depends on GitHub REST behavior for branch protection payloads

## Review Checklist
- [x] required check contexts match live GitHub job names
- [x] required planningops checks now emit on every pull request
- [x] dry-run apply report succeeds for all governed repos
