### PR TITLE
feat: add control-tower ontology contract

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -204,6 +204,7 @@ jobs:
           python3 planningops/scripts/validate_issue_quality.py --strict
           bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh
           python3 planningops/scripts/validate_artifact_storage_policy.py --strict
+          bash planningops/scripts/test_control_tower_ontology_contract.sh
           bash planningops/scripts/test_audit_branch_protection_contract.sh
           bash planningops/scripts/test_apply_branch_protection_contract.sh
           python3 planningops/scripts/audit_branch_protection.py \

--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -30,6 +30,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `artifact-retention-tier-contract.md`: Git vs external artifact storage tier policy
 - `artifact-sink-contract.md`: backend selector abstraction + pointer/rehydrate behavior
 - `repository-governance-contract.md`: default-branch protection baseline and required-check governance
+- `control-tower-ontology-contract.md`: canonical entity/relation/path model for planningops as control tower
 - `federated-label-taxonomy-contract.md`: federated required labels and in-scope issue label quality rules
 - `cross-repo-contract-version-pin-policy.md`: external contract version pinning
 - `compatibility-report.md`: compatibility tracking summary

--- a/planningops/contracts/control-tower-ontology-contract.md
+++ b/planningops/contracts/control-tower-ontology-contract.md
@@ -1,0 +1,111 @@
+# Control-Tower Ontology Contract
+
+## Purpose
+Define the canonical entity model that lets `platform-planningops` operate as the org-level source of truth without absorbing runtime implementation from execution repositories.
+
+This contract fixes:
+- the core nouns used across plans, issues, contracts, and evidence
+- the allowed relations between those nouns
+- the identifier and path rules that keep machine-readable references stable across repositories
+
+## Scope
+- Repository: `rather-not-work-on/platform-planningops`
+- Applies to:
+  - backlog/project metadata managed from planningops
+  - canonical docs under `docs/initiatives/**`
+  - planning contracts/config under `planningops/contracts/**` and `planningops/config/**`
+  - cross-repo evidence references imported from `monday` and `platform-*` repositories
+
+## Control-Tower Principles
+1. `platform-planningops` owns ontology, policy, sequencing, and gates.
+2. Execution repositories own runtime behavior and runtime evidence generation.
+3. Ontology links must be explicit enough that an agent can resolve:
+   - what an item is
+   - which repo owns it
+   - which contracts govern it
+   - which evidence proves it
+4. PlanningOps may index or validate runtime evidence, but it must not become the implementation home for provider, observability, or runtime internals.
+
+## Entity Types
+| Entity | Description | Canonical identifier | Minimum required fields | Primary SoT |
+|---|---|---|---|---|
+| `Initiative` | Top-level strategic scope spanning multiple repos and plans. | `initiative` slug (for example `unified-personal-agent-platform`) | `initiative`, `title`, `status` | `docs/initiatives/**` |
+| `PlanItem` | Atomic execution unit tracked as issue/backlog card. | `plan_item_id` (`A10`, `B20`, `C90`) | `plan_item_id`, `target_repo`, `component`, `workflow_state`, `loop_profile`, `depends_on` | GitHub issue body + project fields |
+| `Contract` | Normative interface, policy, or behavior boundary. | `contract_id` or canonical contract path | `path`, `owner_repo`, `purpose`, `verification_cmd` | `planningops/contracts/**` or owning repo contract directory |
+| `RepositoryRole` | Declared ownership role for a repository or component. | repository coordinate (`owner/repo`) + component | `repo`, `plane`, `component`, `responsibilities` | `docs/initiatives/**`, `planningops/config/**` |
+| `RuntimeArtifact` | Evidence emitted by execution or validation runs. | `run_id` + `logical_path` within owning repo | `run_id`, `repo`, `logical_path`, `reason_code`, `contract_refs` | owning execution repo or external artifact sink |
+| `MemoryRecord` | Distilled or archived knowledge unit derived from work history. | `memory_id` or canonical path | `memory_tier`, `source_refs`, `summary`, `status` | future memory tier system in planningops |
+
+## Canonical Relations
+| Relation | Source -> Target | Meaning | Cardinality rule |
+|---|---|---|---|
+| `contains` | `Initiative -> PlanItem` | initiative owns the execution unit | initiative contains `1..n` plan items |
+| `references` | `PlanItem -> Contract` | plan item is governed by the contract | every plan item references `>=1` contract |
+| `targets` | `PlanItem -> RepositoryRole` | plan item is delivered in one owning repo/component | every plan item targets exactly `1` repository role |
+| `owns` | `RepositoryRole -> Contract` | repo/component is the authoritative owner of a contract | a contract has exactly `1` owner repo |
+| `emits` | `RepositoryRole -> RuntimeArtifact` | runtime or validator in that repo emits evidence | runtime artifacts have exactly `1` emitting repo |
+| `evidences` | `RuntimeArtifact -> PlanItem` | artifact proves plan-item progress or completion | every done/reviewed plan item should have `>=1` evidence link |
+| `validates` | `RuntimeArtifact -> Contract` | artifact was validated against contract(s) | every artifact references `>=1` governing contract when available |
+| `compacts` | `MemoryRecord -> PlanItem|RuntimeArtifact` | memory record distills work or evidence history | memory records compact `>=1` source ref |
+
+## Repository Role Classification
+### Plane values
+- `control-plane`
+- `execution-plane`
+
+### Canonical repository roles
+| Repo | Plane | Primary component values | Responsibility |
+|---|---|---|---|
+| `rather-not-work-on/platform-planningops` | `control-plane` | `planningops`, `orchestrator` | ontology, policy, gates, backlog/project orchestration |
+| `rather-not-work-on/platform-contracts` | `execution-plane` | `contracts` | shared schema/interface ownership |
+| `rather-not-work-on/platform-provider-gateway` | `execution-plane` | `provider-gateway` | provider invocation runtime and smoke evidence |
+| `rather-not-work-on/platform-observability-gateway` | `execution-plane` | `observability-gateway` | replay/backfill/ingest runtime and evidence |
+| `rather-not-work-on/monday` | `execution-plane` | `runtime` | executor/worker runtime, scheduler, handoff boundary |
+
+## Identifier and Path Rules
+### Identifier rules
+- `initiative` must use the canonical slug shared by docs and project fields.
+- `plan_item_id` must match `^[A-Z][0-9]{2}$`.
+- `target_repo` must use full repository coordinates (`owner/repo`), not shorthand.
+- `component` must use the canonical project field vocabulary:
+  - `planningops`
+  - `contracts`
+  - `provider-gateway`
+  - `observability-gateway`
+  - `runtime`
+  - `orchestrator`
+- `workflow_state` must follow the project workflow field vocabulary (`backlog`, `ready-contract`, `ready-implementation`, `in-progress`, `review-gate`, `blocked`, `done`).
+
+### Path root rules
+- Machine-readable file references must be represented as:
+  - `repo`: owning repository coordinate
+  - `path`: repo-root-relative path
+- `initiative`-relative paths are allowed in prose links, but not as canonical machine-readable ontology references.
+- Runtime artifacts stored externally must still preserve:
+  - `repo`
+  - `logical_path` (repo-root-relative logical destination)
+  - backend pointer (`uri`)
+- PlanningOps canonical knowledge paths are repo-root-relative under one of:
+  - `docs/initiatives/**`
+  - `planningops/contracts/**`
+  - `planningops/config/**`
+  - `planningops/adr/**`
+
+## Ontology Invariants
+1. Every `PlanItem` belongs to exactly one `Initiative`.
+2. Every `PlanItem` has exactly one `target_repo` and one dominant output artifact.
+3. Every `PlanItem` references at least one `Contract` before entering `in-progress`.
+4. A `RuntimeArtifact` without `repo`, `logical_path`, or governing refs is invalid for completion evidence.
+5. A `MemoryRecord` cannot compact sources from multiple initiatives without an explicit cross-initiative note.
+6. `platform-planningops` may validate evidence from execution repos, but runtime ownership remains with the emitting repo.
+
+## Verification
+- Backlog/project metadata quality: `python3 planningops/scripts/validate_issue_quality.py --strict`
+- Ontology contract regression: `bash planningops/scripts/test_control_tower_ontology_contract.sh`
+- Boundary consistency: `bash planningops/scripts/test_validate_repo_boundaries_contract.sh`
+- Follow-up machine map: `planningops/config/ontology-entity-map.json` (A11)
+
+## Related Contracts
+- `planningops/contracts/control-plane-boundary-contract.md`
+- `planningops/contracts/issue-quality-contract.md`
+- `planningops/contracts/artifact-retention-tier-contract.md`

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -37,6 +37,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `validate_artifact_storage_policy.py`
   - `audit_branch_protection.py`
   - `apply_branch_protection.py`
+  - `test_control_tower_ontology_contract.sh`
   - `validate_external_only_commit_guard.py`
   - `migrate_external_only_artifacts.py`
   - `rehydrate_artifact_pointer.py`
@@ -78,6 +79,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_artifact_storage_policy_contract.sh`
   - `test_audit_branch_protection_contract.sh`
   - `test_apply_branch_protection_contract.sh`
+  - `test_control_tower_ontology_contract.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_artifact_sink_e2e.sh`
   - `test_*.sh`

--- a/planningops/scripts/test_control_tower_ontology_contract.sh
+++ b/planningops/scripts/test_control_tower_ontology_contract.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+contract="planningops/contracts/control-tower-ontology-contract.md"
+
+if [[ ! -f "$contract" ]]; then
+  echo "missing ontology contract: $contract"
+  exit 1
+fi
+
+python3 - "$contract" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+required_headings = [
+    "# Control-Tower Ontology Contract",
+    "## Purpose",
+    "## Scope",
+    "## Entity Types",
+    "## Canonical Relations",
+    "## Repository Role Classification",
+    "## Identifier and Path Rules",
+    "## Ontology Invariants",
+    "## Verification",
+]
+required_entities = [
+    "`Initiative`",
+    "`PlanItem`",
+    "`Contract`",
+    "`RepositoryRole`",
+    "`RuntimeArtifact`",
+    "`MemoryRecord`",
+]
+required_relations = [
+    "`contains`",
+    "`references`",
+    "`targets`",
+    "`owns`",
+    "`emits`",
+    "`evidences`",
+    "`validates`",
+    "`compacts`",
+]
+required_terms = [
+    "repo-root-relative",
+    "target_repo",
+    "component",
+    "workflow_state",
+    "rather-not-work-on/platform-planningops",
+    "rather-not-work-on/platform-contracts",
+    "rather-not-work-on/platform-provider-gateway",
+    "rather-not-work-on/platform-observability-gateway",
+    "rather-not-work-on/monday",
+]
+
+missing = []
+for item in required_headings + required_entities + required_relations + required_terms:
+    if item not in text:
+        missing.append(item)
+
+if missing:
+    raise SystemExit("missing required ontology contract content: " + ", ".join(missing))
+
+print("control tower ontology contract test ok")
+PY


### PR DESCRIPTION
## Summary
- add the first control-tower ontology contract for planningops
- define canonical entities, relations, repo roles, and machine-readable path rules
- add a regression test and wire it into loop guardrails

## Scope
- `planningops/contracts/control-tower-ontology-contract.md`
- `planningops/scripts/test_control_tower_ontology_contract.sh`
- `planningops/contracts/README.md`
- `planningops/scripts/README.md`
- `.github/workflows/federated-ci-matrix.yml`

## Linked Issues
- #95

## Validation
- `bash planningops/scripts/test_control_tower_ontology_contract.sh`
- `bash planningops/scripts/test_validate_repo_boundaries_contract.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/federated-ci-matrix.yml")'`

## Risks
- ontology vocabulary is now normative, so later A11/A40 work must follow these identifiers and path rules

## Review Checklist
- [x] entity types cover initiative/plan item/contract/runtime artifact/memory record
- [x] path root rule is repo-root-relative for machine-readable refs
- [x] loop guardrails exercises the new ontology contract regression

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required: documentation/contract and CI guard only.
