### PR TITLE
feat: add ontology entity map validator

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -205,6 +205,7 @@ jobs:
           bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh
           python3 planningops/scripts/validate_artifact_storage_policy.py --strict
           bash planningops/scripts/test_control_tower_ontology_contract.sh
+          bash planningops/scripts/test_ontology_entity_map_contract.sh
           bash planningops/scripts/test_audit_branch_protection_contract.sh
           bash planningops/scripts/test_apply_branch_protection_contract.sh
           python3 planningops/scripts/audit_branch_protection.py \

--- a/planningops/config/README.md
+++ b/planningops/config/README.md
@@ -8,6 +8,7 @@ Provide stable configuration sources for project fields, runtime profiles, and c
 - `project-view-conventions.md`: view/filter/sort contract for project operations
 - `runtime-profiles.json`: local/oracle runtime and provider policies
 - `contract-ref-map.json`: C1~C8 schema pointer map
+- `ontology-entity-map.json`: machine-readable ontology entity/relation/repo-role map
 - `repository-boundary-map.json`: control-plane vs execution-repo ownership and script layout rules
 - `script-role-map.json`: recurring core/federation scripts vs one-off script placement rules
 - `issue-quality-rules.json`: backlog issue body quality contract rules

--- a/planningops/config/ontology-entity-map.json
+++ b/planningops/config/ontology-entity-map.json
@@ -1,0 +1,171 @@
+{
+  "initiative": "unified-personal-agent-platform",
+  "version": 1,
+  "path_policy": {
+    "machine_ref_format": "repo+path",
+    "path_root": "repo-root-relative",
+    "human_docs_may_use_initiative_relative_links": true
+  },
+  "entities": [
+    {
+      "entity_type": "Initiative",
+      "id_key": "initiative",
+      "id_pattern": "^[a-z0-9][a-z0-9-]+$",
+      "required_fields": ["initiative", "title", "status"],
+      "source_of_truth": {
+        "repo": "rather-not-work-on/platform-planningops",
+        "path": "docs/initiatives/unified-personal-agent-platform/README.md"
+      },
+      "sample_refs": [
+        {
+          "repo": "rather-not-work-on/platform-planningops",
+          "path": "docs/initiatives/unified-personal-agent-platform/README.md"
+        }
+      ]
+    },
+    {
+      "entity_type": "PlanItem",
+      "id_key": "plan_item_id",
+      "id_pattern": "^[A-Z][0-9]{2}$",
+      "required_fields": [
+        "plan_item_id",
+        "target_repo",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "execution_order",
+        "depends_on"
+      ],
+      "source_of_truth": {
+        "repo": "rather-not-work-on/platform-planningops",
+        "path": ".github/ISSUE_TEMPLATE/planningops-task.yml"
+      },
+      "sample_refs": [
+        {
+          "repo": "rather-not-work-on/platform-planningops",
+          "path": "docs/workbench/unified-personal-agent-platform/plans/2026-03-05-plan-meta-backlog-atomic-decomposition-and-federated-delivery-plan.md"
+        }
+      ]
+    },
+    {
+      "entity_type": "Contract",
+      "id_key": "path",
+      "id_pattern": "^[A-Za-z0-9._/-]+$",
+      "required_fields": ["path", "owner_repo", "purpose", "verification_cmd"],
+      "source_of_truth": {
+        "repo": "rather-not-work-on/platform-planningops",
+        "path": "planningops/contracts/control-tower-ontology-contract.md"
+      },
+      "sample_refs": [
+        {
+          "repo": "rather-not-work-on/platform-planningops",
+          "path": "planningops/contracts/control-tower-ontology-contract.md"
+        },
+        {
+          "repo": "rather-not-work-on/platform-contracts",
+          "path": "schemas/c1-run-lifecycle.schema.json"
+        }
+      ]
+    },
+    {
+      "entity_type": "RepositoryRole",
+      "id_key": "repo",
+      "id_pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$",
+      "required_fields": ["repo", "plane", "component", "responsibilities"],
+      "source_of_truth": {
+        "repo": "rather-not-work-on/platform-planningops",
+        "path": "docs/initiatives/unified-personal-agent-platform/20-repos/README.md"
+      },
+      "sample_refs": [
+        {
+          "repo": "rather-not-work-on/platform-planningops",
+          "path": "planningops/contracts/control-plane-boundary-contract.md"
+        }
+      ]
+    },
+    {
+      "entity_type": "RuntimeArtifact",
+      "id_key": "logical_path",
+      "id_pattern": "^[A-Za-z0-9._/-]+$",
+      "required_fields": ["run_id", "repo", "logical_path", "reason_code", "contract_refs"],
+      "source_of_truth": {
+        "repo": "rather-not-work-on/platform-planningops",
+        "path": "planningops/contracts/artifact-retention-tier-contract.md"
+      },
+      "sample_refs": [
+        {
+          "repo": "rather-not-work-on/platform-provider-gateway",
+          "path": "runtime-artifacts/smoke/<run_id>-primary_success.json"
+        },
+        {
+          "repo": "rather-not-work-on/monday",
+          "path": "runtime-artifacts/integration/<run_id>/planningops-handoff-report.json"
+        }
+      ]
+    },
+    {
+      "entity_type": "MemoryRecord",
+      "id_key": "memory_id",
+      "id_pattern": "^[A-Za-z0-9._:-]+$",
+      "required_fields": ["memory_tier", "source_refs", "summary", "status"],
+      "source_of_truth": {
+        "repo": "rather-not-work-on/platform-planningops",
+        "path": "planningops/contracts/control-tower-ontology-contract.md"
+      },
+      "sample_refs": [
+        {
+          "repo": "rather-not-work-on/platform-planningops",
+          "path": "docs/workbench/unified-personal-agent-platform/"
+        }
+      ]
+    }
+  ],
+  "relations": [
+    {"name": "contains", "from": "Initiative", "to": "PlanItem", "cardinality": "1..n"},
+    {"name": "references", "from": "PlanItem", "to": "Contract", "cardinality": "1..n"},
+    {"name": "targets", "from": "PlanItem", "to": "RepositoryRole", "cardinality": "1"},
+    {"name": "owns", "from": "RepositoryRole", "to": "Contract", "cardinality": "1..n"},
+    {"name": "emits", "from": "RepositoryRole", "to": "RuntimeArtifact", "cardinality": "0..n"},
+    {"name": "evidences", "from": "RuntimeArtifact", "to": "PlanItem", "cardinality": "1..n"},
+    {"name": "validates", "from": "RuntimeArtifact", "to": "Contract", "cardinality": "1..n"},
+    {"name": "compacts", "from": "MemoryRecord", "to": "PlanItem|RuntimeArtifact", "cardinality": "1..n"}
+  ],
+  "repository_roles": [
+    {
+      "repo": "rather-not-work-on/platform-planningops",
+      "plane": "control-plane",
+      "component": "planningops",
+      "responsibilities": ["ontology", "policy", "gates", "project orchestration"]
+    },
+    {
+      "repo": "rather-not-work-on/platform-planningops",
+      "plane": "control-plane",
+      "component": "orchestrator",
+      "responsibilities": ["issue loop coordination", "federated validation", "handoff preparation"]
+    },
+    {
+      "repo": "rather-not-work-on/platform-contracts",
+      "plane": "execution-plane",
+      "component": "contracts",
+      "responsibilities": ["schema ownership", "bundle publication", "consumer pin evidence"]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "plane": "execution-plane",
+      "component": "provider-gateway",
+      "responsibilities": ["provider invocation", "routing policy", "smoke evidence"]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "plane": "execution-plane",
+      "component": "observability-gateway",
+      "responsibilities": ["ingest pipeline", "replay/backfill", "observability evidence"]
+    },
+    {
+      "repo": "rather-not-work-on/monday",
+      "plane": "execution-plane",
+      "component": "runtime",
+      "responsibilities": ["scheduler", "executor-worker handoff", "runtime evidence"]
+    }
+  ]
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -26,6 +26,7 @@ Host executable runners, validators, and contract tests for planningops loops.
 - Validation and reporting:
   - `backlog_stock_replenishment_guard.py`
   - `validate_contracts.py`
+  - `validate_ontology_entity_map.py`
   - `validate_worker_task_pack.py`
   - `validate_project_field_schema.py`
   - `validate_repo_boundaries.py`
@@ -38,6 +39,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `audit_branch_protection.py`
   - `apply_branch_protection.py`
   - `test_control_tower_ontology_contract.sh`
+  - `test_ontology_entity_map_contract.sh`
   - `validate_external_only_commit_guard.py`
   - `migrate_external_only_artifacts.py`
   - `rehydrate_artifact_pointer.py`
@@ -80,6 +82,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_audit_branch_protection_contract.sh`
   - `test_apply_branch_protection_contract.sh`
   - `test_control_tower_ontology_contract.sh`
+  - `test_ontology_entity_map_contract.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_artifact_sink_e2e.sh`
   - `test_*.sh`

--- a/planningops/scripts/test_ontology_entity_map_contract.sh
+++ b/planningops/scripts/test_ontology_entity_map_contract.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+python3 planningops/scripts/validate_ontology_entity_map.py \
+  --map planningops/config/ontology-entity-map.json \
+  --contract planningops/contracts/control-tower-ontology-contract.md \
+  --output "$tmp_dir/ontology-entity-map.valid.json" \
+  --strict
+
+python3 - "$tmp_dir/ontology-entity-map.valid.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "pass", report
+assert report["entity_count"] >= 6, report
+assert report["relation_count"] >= 8, report
+assert report["repository_role_count"] >= 6, report
+PY
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+doc = json.loads(Path("planningops/config/ontology-entity-map.json").read_text(encoding="utf-8"))
+doc["relations"] = [r for r in doc["relations"] if r["name"] != "targets"]
+Path("/tmp/ontology-entity-map.invalid.json").write_text(json.dumps(doc, ensure_ascii=True, indent=2), encoding="utf-8")
+PY
+
+set +e
+python3 planningops/scripts/validate_ontology_entity_map.py \
+  --map /tmp/ontology-entity-map.invalid.json \
+  --contract planningops/contracts/control-tower-ontology-contract.md \
+  --output "$tmp_dir/ontology-entity-map.invalid.report.json" \
+  --strict
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for invalid ontology entity map"
+  exit 1
+fi
+
+echo "ontology entity map contract test ok"

--- a/planningops/scripts/validate_ontology_entity_map.py
+++ b/planningops/scripts/validate_ontology_entity_map.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_MAP = Path("planningops/config/ontology-entity-map.json")
+DEFAULT_CONTRACT = Path("planningops/contracts/control-tower-ontology-contract.md")
+DEFAULT_OUTPUT = Path("planningops/artifacts/validation/ontology-entity-map-report.json")
+
+REQUIRED_ENTITY_TYPES = {
+    "Initiative",
+    "PlanItem",
+    "Contract",
+    "RepositoryRole",
+    "RuntimeArtifact",
+    "MemoryRecord",
+}
+
+REQUIRED_RELATIONS = {
+    ("contains", "Initiative", "PlanItem"),
+    ("references", "PlanItem", "Contract"),
+    ("targets", "PlanItem", "RepositoryRole"),
+    ("owns", "RepositoryRole", "Contract"),
+    ("emits", "RepositoryRole", "RuntimeArtifact"),
+    ("evidences", "RuntimeArtifact", "PlanItem"),
+    ("validates", "RuntimeArtifact", "Contract"),
+    ("compacts", "MemoryRecord", "PlanItem|RuntimeArtifact"),
+}
+
+REQUIRED_REPOS = {
+    "rather-not-work-on/platform-planningops",
+    "rather-not-work-on/platform-contracts",
+    "rather-not-work-on/platform-provider-gateway",
+    "rather-not-work-on/platform-observability-gateway",
+    "rather-not-work-on/monday",
+}
+
+COMPONENTS = {
+    "planningops",
+    "contracts",
+    "provider-gateway",
+    "observability-gateway",
+    "runtime",
+    "orchestrator",
+}
+
+PLAN_ITEM_REQUIRED_FIELDS = {
+    "plan_item_id",
+    "target_repo",
+    "component",
+    "workflow_state",
+    "loop_profile",
+    "execution_order",
+    "depends_on",
+}
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_repo_path_ref(ref: dict):
+    repo = ref.get("repo")
+    path = ref.get("path")
+    if not isinstance(repo, str) or "/" not in repo:
+        return "repo must use owner/repo format"
+    if not isinstance(path, str) or not path or path.startswith("/"):
+        return "path must be repo-root-relative"
+    return None
+
+
+def validate_entity(entity: dict):
+    errors = []
+    entity_type = entity.get("entity_type")
+    if entity_type not in REQUIRED_ENTITY_TYPES:
+        errors.append(f"invalid entity_type: {entity_type}")
+
+    id_pattern = entity.get("id_pattern")
+    if not isinstance(id_pattern, str) or not id_pattern:
+        errors.append(f"{entity_type}: missing id_pattern")
+    else:
+        try:
+            re.compile(id_pattern)
+        except re.error as exc:  # noqa: PERF203
+            errors.append(f"{entity_type}: invalid id_pattern ({exc})")
+
+    required_fields = entity.get("required_fields")
+    if not isinstance(required_fields, list) or not required_fields:
+        errors.append(f"{entity_type}: required_fields must be a non-empty array")
+    elif entity_type == "PlanItem" and not PLAN_ITEM_REQUIRED_FIELDS.issubset(set(required_fields)):
+        errors.append(f"{entity_type}: missing required plan item fields")
+
+    source = entity.get("source_of_truth")
+    if not isinstance(source, dict):
+        errors.append(f"{entity_type}: source_of_truth must be an object")
+    else:
+        issue = validate_repo_path_ref(source)
+        if issue:
+            errors.append(f"{entity_type}: source_of_truth {issue}")
+
+    samples = entity.get("sample_refs")
+    if not isinstance(samples, list) or not samples:
+        errors.append(f"{entity_type}: sample_refs must be a non-empty array")
+    else:
+        for ref in samples:
+            issue = validate_repo_path_ref(ref)
+            if issue:
+                errors.append(f"{entity_type}: sample_ref {issue}")
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate ontology entity map against control-tower ontology contract")
+    parser.add_argument("--map", dest="map_path", default=str(DEFAULT_MAP))
+    parser.add_argument("--contract", default=str(DEFAULT_CONTRACT))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    map_path = Path(args.map_path)
+    contract_path = Path(args.contract)
+    output_path = Path(args.output)
+
+    doc = load_json(map_path)
+    contract_text = contract_path.read_text(encoding="utf-8")
+
+    errors = []
+
+    if doc.get("initiative") != "unified-personal-agent-platform":
+        errors.append("initiative must equal unified-personal-agent-platform")
+
+    path_policy = doc.get("path_policy")
+    if not isinstance(path_policy, dict):
+        errors.append("path_policy must be an object")
+    else:
+        if path_policy.get("machine_ref_format") != "repo+path":
+            errors.append("path_policy.machine_ref_format must equal repo+path")
+        if path_policy.get("path_root") != "repo-root-relative":
+            errors.append("path_policy.path_root must equal repo-root-relative")
+
+    entities = doc.get("entities")
+    if not isinstance(entities, list):
+        errors.append("entities must be an array")
+        entities = []
+    entity_map = {entity.get("entity_type"): entity for entity in entities if isinstance(entity, dict)}
+    missing_entities = sorted(REQUIRED_ENTITY_TYPES - set(entity_map))
+    if missing_entities:
+        errors.append("missing required entity types: " + ", ".join(missing_entities))
+
+    for entity in entities:
+        if isinstance(entity, dict):
+            errors.extend(validate_entity(entity))
+
+    relations = doc.get("relations")
+    if not isinstance(relations, list):
+        errors.append("relations must be an array")
+        relations = []
+    relation_set = {
+        (row.get("name"), row.get("from"), row.get("to"))
+        for row in relations
+        if isinstance(row, dict)
+    }
+    missing_relations = sorted(REQUIRED_RELATIONS - relation_set)
+    if missing_relations:
+        errors.append(
+            "missing required relations: "
+            + ", ".join(f"{name}:{source}->{target}" for name, source, target in missing_relations)
+        )
+
+    role_rows = doc.get("repository_roles")
+    if not isinstance(role_rows, list):
+        errors.append("repository_roles must be an array")
+        role_rows = []
+    repos_present = set()
+    for row in role_rows:
+        if not isinstance(row, dict):
+            errors.append("repository_roles entries must be objects")
+            continue
+        repo = row.get("repo")
+        component = row.get("component")
+        plane = row.get("plane")
+        if not isinstance(repo, str) or "/" not in repo:
+            errors.append("repository role repo must use owner/repo format")
+        else:
+            repos_present.add(repo)
+        if component not in COMPONENTS:
+            errors.append(f"invalid repository role component: {component}")
+        if plane not in {"control-plane", "execution-plane"}:
+            errors.append(f"invalid repository role plane: {plane}")
+        responsibilities = row.get("responsibilities")
+        if not isinstance(responsibilities, list) or not responsibilities:
+            errors.append(f"repository role {repo}:{component} must declare responsibilities")
+
+    missing_repos = sorted(REQUIRED_REPOS - repos_present)
+    if missing_repos:
+        errors.append("missing repository role coverage: " + ", ".join(missing_repos))
+
+    for token in ["`Initiative`", "`PlanItem`", "`Contract`", "`RuntimeArtifact`", "`MemoryRecord`", "repo-root-relative"]:
+        if token not in contract_text:
+            errors.append(f"ontology contract missing expected token: {token}")
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "map_path": str(map_path),
+        "contract_path": str(contract_path),
+        "entity_count": len(entity_map),
+        "relation_count": len(relations),
+        "repository_role_count": len(role_rows),
+        "error_count": len(errors),
+        "errors": errors,
+        "verdict": "pass" if not errors else "fail",
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(f"report written: {output_path}")
+    print(
+        f"entity_count={report['entity_count']} relation_count={report['relation_count']} "
+        f"repository_role_count={report['repository_role_count']} error_count={report['error_count']} verdict={report['verdict']}"
+    )
+
+    if args.strict and errors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the machine-readable ontology entity map for planningops
- validate required entities, relations, repo roles, and repo-root-relative path rules
- wire the new ontology map regression into loop guardrails

## Scope
- `planningops/config/ontology-entity-map.json`
- `planningops/scripts/validate_ontology_entity_map.py`
- `planningops/scripts/test_ontology_entity_map_contract.sh`
- `planningops/config/README.md`
- `planningops/scripts/README.md`
- `.github/workflows/federated-ci-matrix.yml`

## Linked Issues
- #96

## Validation
- `bash planningops/scripts/test_control_tower_ontology_contract.sh`
- `bash planningops/scripts/test_ontology_entity_map_contract.sh`
- `python3 planningops/scripts/validate_ontology_entity_map.py --map planningops/config/ontology-entity-map.json --contract planningops/contracts/control-tower-ontology-contract.md --output /tmp/ontology-entity-map-report.json --strict`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/federated-ci-matrix.yml")'`

## Risks
- downstream memory/federation work now depends on this map as the canonical machine-readable ontology layer

## Review Checklist
- [x] required entity types are present
- [x] required relations are present
- [x] repo references use `owner/repo` + repo-root-relative path rules

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required: configuration/validator and CI guard only.
