### PR TITLE
feat: add memory tier contract and rules

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -206,6 +206,7 @@ jobs:
           python3 planningops/scripts/validate_artifact_storage_policy.py --strict
           bash planningops/scripts/test_control_tower_ontology_contract.sh
           bash planningops/scripts/test_ontology_entity_map_contract.sh
+          bash planningops/scripts/test_memory_tier_contract.sh
           bash planningops/scripts/test_audit_branch_protection_contract.sh
           bash planningops/scripts/test_apply_branch_protection_contract.sh
           python3 planningops/scripts/audit_branch_protection.py \

--- a/planningops/config/README.md
+++ b/planningops/config/README.md
@@ -20,6 +20,7 @@ Provide stable configuration sources for project fields, runtime profiles, and c
 - `artifact-storage-policy.json`: artifact tier map, backend selector, and retention policy
 - `repository-governance-policy.json`: default-branch protection baseline and required checks policy
 - `federated-label-taxonomy.json`: execution-repo label catalog and default backfill mapping
+- `memory-tier-rules.json`: machine-readable L0/L1/L2 definitions, triggers, and promotion/archive rules
 
 ## Change Rules
 - Field id updates must be synchronized with validator scripts and CI tests.

--- a/planningops/config/memory-tier-rules.json
+++ b/planningops/config/memory-tier-rules.json
@@ -1,0 +1,126 @@
+{
+  "policy_version": 1,
+  "memory_tiers": {
+    "L0": {
+      "label": "short",
+      "description": "active working memory for unresolved planning context",
+      "default_roots": [
+        "docs/workbench/**",
+        "planningops/artifacts/**",
+        "todos/**"
+      ],
+      "ttl_days": {
+        "min": 7,
+        "max": 14,
+        "default": 14
+      },
+      "required_frontmatter": [
+        "memory_tier",
+        "expires_on"
+      ],
+      "required_when_compacted": [
+        "compacted_into"
+      ],
+      "allowed_next_tiers": [
+        "L1",
+        "L2"
+      ]
+    },
+    "L1": {
+      "label": "mid",
+      "description": "operational canonical memory for reusable policy and design knowledge",
+      "default_roots": [
+        "docs/initiatives/**",
+        "planningops/contracts/**",
+        "planningops/config/**",
+        "planningops/adr/**"
+      ],
+      "review_cycle_days": 90,
+      "required_frontmatter": [
+        "memory_tier"
+      ],
+      "optional_frontmatter": [
+        "expires_on",
+        "compacted_into"
+      ],
+      "allowed_next_tiers": [
+        "L2"
+      ]
+    },
+    "L2": {
+      "label": "long",
+      "description": "institutional archive with deterministic rehydrate pointers",
+      "default_roots": [
+        "docs/archive/**",
+        "planningops/archive-manifest/**"
+      ],
+      "retention_days": 3650,
+      "required_frontmatter": [
+        "memory_tier",
+        "archive_ref"
+      ],
+      "allowed_next_tiers": []
+    }
+  },
+  "frontmatter_keys": {
+    "memory_tier": {
+      "allowed_values": ["L0", "L1", "L2"]
+    },
+    "expires_on": {
+      "required_for_tiers": ["L0"]
+    },
+    "compacted_into": {
+      "required_when": "promoted_or_archived_from_L0"
+    },
+    "archive_ref": {
+      "required_for_tiers": ["L2"]
+    }
+  },
+  "compaction_triggers": [
+    {
+      "code": "stale_l0_uncompacted",
+      "tier": "L0",
+      "max_age_days": 14,
+      "requires": ["compacted_into"]
+    },
+    {
+      "code": "topic_compaction_required",
+      "tier": "L0",
+      "topic_threshold": 3,
+      "requires": ["summary"]
+    },
+    {
+      "code": "closed_issue_memory_summary_missing",
+      "applies_to": "done_plan_items",
+      "requires": ["summary", "evidence_refs", "retained_memory_target"]
+    }
+  ],
+  "promotion_rules": {
+    "L0_to_L1_requires": [
+      "authoritative_source",
+      "validation_evidence",
+      "distilled_summary",
+      "target_canonical_path"
+    ],
+    "L0_to_L2_requires": [
+      "distilled_summary_or_replacement",
+      "archive_ref",
+      "compacted_into"
+    ],
+    "L1_to_L2_requires": [
+      "superseded_by_newer_canonical_record",
+      "archive_ref"
+    ]
+  },
+  "rehydrate_rules": {
+    "required_inputs": [
+      "archive_ref_or_pointer",
+      "output_path"
+    ],
+    "path_root": "repo-root-relative"
+  },
+  "storage_interop": {
+    "artifact_storage_contract": "planningops/contracts/artifact-retention-tier-contract.md",
+    "memory_tier_overrides_storage_tier": false
+  }
+}

--- a/planningops/config/ontology-entity-map.json
+++ b/planningops/config/ontology-entity-map.json
@@ -110,12 +110,12 @@
       "required_fields": ["memory_tier", "source_refs", "summary", "status"],
       "source_of_truth": {
         "repo": "rather-not-work-on/platform-planningops",
-        "path": "planningops/contracts/control-tower-ontology-contract.md"
+        "path": "planningops/contracts/memory-tier-contract.md"
       },
       "sample_refs": [
         {
           "repo": "rather-not-work-on/platform-planningops",
-          "path": "docs/workbench/unified-personal-agent-platform/"
+          "path": "planningops/config/memory-tier-rules.json"
         }
       ]
     }

--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -31,6 +31,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `artifact-sink-contract.md`: backend selector abstraction + pointer/rehydrate behavior
 - `repository-governance-contract.md`: default-branch protection baseline and required-check governance
 - `control-tower-ontology-contract.md`: canonical entity/relation/path model for planningops as control tower
+- `memory-tier-contract.md`: 3-tier memory lifecycle, frontmatter keys, and compaction trigger contract
 - `federated-label-taxonomy-contract.md`: federated required labels and in-scope issue label quality rules
 - `cross-repo-contract-version-pin-policy.md`: external contract version pinning
 - `compatibility-report.md`: compatibility tracking summary

--- a/planningops/contracts/control-tower-ontology-contract.md
+++ b/planningops/contracts/control-tower-ontology-contract.md
@@ -34,7 +34,7 @@ This contract fixes:
 | `Contract` | Normative interface, policy, or behavior boundary. | `contract_id` or canonical contract path | `path`, `owner_repo`, `purpose`, `verification_cmd` | `planningops/contracts/**` or owning repo contract directory |
 | `RepositoryRole` | Declared ownership role for a repository or component. | repository coordinate (`owner/repo`) + component | `repo`, `plane`, `component`, `responsibilities` | `docs/initiatives/**`, `planningops/config/**` |
 | `RuntimeArtifact` | Evidence emitted by execution or validation runs. | `run_id` + `logical_path` within owning repo | `run_id`, `repo`, `logical_path`, `reason_code`, `contract_refs` | owning execution repo or external artifact sink |
-| `MemoryRecord` | Distilled or archived knowledge unit derived from work history. | `memory_id` or canonical path | `memory_tier`, `source_refs`, `summary`, `status` | future memory tier system in planningops |
+| `MemoryRecord` | Distilled or archived knowledge unit derived from work history. | `memory_id` or canonical path | `memory_tier`, `source_refs`, `summary`, `status` | `planningops/contracts/memory-tier-contract.md` + `planningops/config/memory-tier-rules.json` |
 
 ## Canonical Relations
 | Relation | Source -> Target | Meaning | Cardinality rule |
@@ -109,3 +109,4 @@ This contract fixes:
 - `planningops/contracts/control-plane-boundary-contract.md`
 - `planningops/contracts/issue-quality-contract.md`
 - `planningops/contracts/artifact-retention-tier-contract.md`
+- `planningops/contracts/memory-tier-contract.md`

--- a/planningops/contracts/memory-tier-contract.md
+++ b/planningops/contracts/memory-tier-contract.md
@@ -1,0 +1,117 @@
+# Memory Tier Contract
+
+## Purpose
+Define the 3-tier memory lifecycle that keeps `platform-planningops` compact, searchable, and reusable without turning the repository into an unbounded log sink.
+
+This contract makes memory behavior explicit for:
+- where new planning knowledge lands first
+- when it must be distilled, promoted, or archived
+- which metadata fields make compaction and rehydrate deterministic
+
+## Scope
+- Repository: `rather-not-work-on/platform-planningops`
+- Applies to:
+  - planning documents under `docs/workbench/**`, `docs/initiatives/**`, `docs/archive/**`
+  - planning-derived evidence records referenced from `planningops/artifacts/**`
+  - future memory tooling (`memory_compactor.py`, `memory_archive.py`, `memory_rehydrate.py`)
+
+## Memory Model
+Memory tier describes knowledge lifecycle.
+Artifact storage tier describes storage backend and Git retention.
+
+These are related, but not the same:
+- memory tier answers `how fresh/reusable is this knowledge?`
+- artifact storage tier answers `where and how is the artifact stored?`
+
+When both apply, memory tier must not override the artifact backend policy from `planningops/contracts/artifact-retention-tier-contract.md`.
+
+## Tier Definitions
+| Tier | Name | Purpose | Default locations | Retention/SLA | Exit rule |
+|---|---|---|---|---|---|
+| `L0` | short / active working memory | mutable execution context and unresolved working notes | `docs/workbench/**`, open initiative issues, non-promoted planning evidence | TTL `7-14` days | must be promoted to `L1` or archived to `L2` before expiry |
+| `L1` | mid / operational canonical memory | stable reusable operating knowledge | `docs/initiatives/**`, `planningops/contracts/**`, `planningops/config/**`, `planningops/adr/**` | quarterly review cadence | superseded or low-signal records move to `L2` with archive pointer |
+| `L2` | long / institutional archive | historical record kept for future retrieval, not active editing | `docs/archive/**`, `planningops/archive-manifest/**` | long-term retention | rehydrate only through pointer/index or explicit restore flow |
+
+## Frontmatter and Metadata Contract
+### Required keys
+- `memory_tier`
+- `expires_on`
+- `compacted_into`
+- `archive_ref`
+
+### Key rules
+1. `memory_tier`
+   - required for memory-managed planning documents
+   - allowed values: `L0`, `L1`, `L2`
+2. `expires_on`
+   - required for `L0`
+   - optional for `L1`
+   - forbidden for immutable `L2` archive summaries unless used as review date
+3. `compacted_into`
+   - required when an `L0` item has been promoted or archived
+   - points to the repo-root-relative target summary/index path
+4. `archive_ref`
+   - required for `L2`
+   - may be empty for `L0`/`L1`
+
+## Compaction Loop Contract
+1. `capture`
+   - new or volatile knowledge enters `L0`
+2. `validate`
+   - supporting tests/contracts/gates must pass before promotion
+3. `distill`
+   - create a concise summary or canonical contract entry
+4. `promote`
+   - move reusable knowledge to `L1`
+5. `archive`
+   - move historical detail to `L2` with pointer/index
+6. `rehydrate`
+   - reconstruct detail from `archive_ref` or pointer manifest on demand
+
+## Promotion and Archive Rules
+### `L0 -> L1`
+Allowed only when all are true:
+- authoritative source has been chosen
+- validation evidence exists
+- distilled summary exists
+- target canonical path is known
+
+### `L0 -> L2`
+Allowed only when all are true:
+- content has historical value but low active reuse
+- distilled summary exists or an authoritative replacement exists
+- `archive_ref` is assigned
+- `compacted_into` points to the retained summary or replacement path
+
+### `L1 -> L2`
+Allowed when:
+- record is superseded by a newer canonical version
+- historical trace is still useful
+- index/pointer allows deterministic rehydrate
+
+## Trigger Rules
+1. `stale_l0_uncompacted`
+   - fire when an `L0` record exceeds `14` days and has no `compacted_into`
+2. `topic_compaction_required`
+   - fire when `3+` `L0` records share the same topic without a summary
+3. `closed_issue_memory_summary_missing`
+   - fire when a plan item closes without summary/evidence refs that identify the retained memory target
+
+## Path Policy
+- Canonical machine-readable paths must be repo-root-relative.
+- Archive references must resolve through repo-root-relative path or pointer manifest logical path.
+- Human prose may use relative links, but automation must resolve `repo + path`.
+
+## Verification
+- Rules config: `planningops/config/memory-tier-rules.json`
+- Validator: `planningops/scripts/validate_memory_tier_rules.py`
+- Contract test: `bash planningops/scripts/test_memory_tier_contract.sh`
+- Future runtime tooling:
+  - `planningops/scripts/memory_compactor.py`
+  - `planningops/scripts/memory_archive.py`
+  - `planningops/scripts/memory_rehydrate.py`
+
+## Related Contracts
+- `planningops/contracts/control-tower-ontology-contract.md`
+- `planningops/contracts/artifact-retention-tier-contract.md`
+- `planningops/contracts/artifact-sink-contract.md`

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -27,6 +27,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `backlog_stock_replenishment_guard.py`
   - `validate_contracts.py`
   - `validate_ontology_entity_map.py`
+  - `validate_memory_tier_rules.py`
   - `validate_worker_task_pack.py`
   - `validate_project_field_schema.py`
   - `validate_repo_boundaries.py`
@@ -40,6 +41,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `apply_branch_protection.py`
   - `test_control_tower_ontology_contract.sh`
   - `test_ontology_entity_map_contract.sh`
+  - `test_memory_tier_contract.sh`
   - `validate_external_only_commit_guard.py`
   - `migrate_external_only_artifacts.py`
   - `rehydrate_artifact_pointer.py`
@@ -83,6 +85,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_apply_branch_protection_contract.sh`
   - `test_control_tower_ontology_contract.sh`
   - `test_ontology_entity_map_contract.sh`
+  - `test_memory_tier_contract.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_artifact_sink_e2e.sh`
   - `test_*.sh`

--- a/planningops/scripts/test_memory_tier_contract.sh
+++ b/planningops/scripts/test_memory_tier_contract.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+python3 planningops/scripts/validate_memory_tier_rules.py \
+  --rules planningops/config/memory-tier-rules.json \
+  --output "$tmp_dir/memory-tier-rules-valid.json" \
+  --strict
+
+python3 - "$tmp_dir/memory-tier-rules-valid.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "pass", report
+assert report["error_count"] == 0, report
+PY
+
+cat > "$tmp_dir/invalid-rules.json" <<'JSON'
+{
+  "policy_version": 0,
+  "memory_tiers": {
+    "L0": {
+      "default_roots": [],
+      "ttl_days": {"min": 14, "max": 7, "default": 30},
+      "required_frontmatter": [],
+      "allowed_next_tiers": []
+    },
+    "L1": {
+      "default_roots": [],
+      "review_cycle_days": 0,
+      "required_frontmatter": [],
+      "allowed_next_tiers": []
+    }
+  },
+  "frontmatter_keys": {
+    "memory_tier": {"allowed_values": ["L0", "L1"]}
+  },
+  "compaction_triggers": [],
+  "promotion_rules": {},
+  "rehydrate_rules": {
+    "required_inputs": [],
+    "path_root": "absolute"
+  },
+  "storage_interop": {
+    "artifact_storage_contract": "invalid",
+    "memory_tier_overrides_storage_tier": true
+  }
+}
+JSON
+
+set +e
+python3 planningops/scripts/validate_memory_tier_rules.py \
+  --rules "$tmp_dir/invalid-rules.json" \
+  --output "$tmp_dir/memory-tier-rules-invalid.json" \
+  --strict
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for invalid memory tier rules"
+  exit 1
+fi
+
+python3 - <<'PY'
+from pathlib import Path
+
+text = Path("planningops/contracts/memory-tier-contract.md").read_text(encoding="utf-8")
+required = [
+    "`L0`",
+    "`L1`",
+    "`L2`",
+    "`memory_tier`",
+    "`expires_on`",
+    "`compacted_into`",
+    "`archive_ref`",
+    "stale_l0_uncompacted",
+    "topic_compaction_required",
+    "closed_issue_memory_summary_missing",
+]
+missing = [item for item in required if item not in text]
+if missing:
+    raise SystemExit("memory tier contract missing required content: " + ", ".join(missing))
+print("memory tier contract test ok")
+PY

--- a/planningops/scripts/validate_memory_tier_rules.py
+++ b/planningops/scripts/validate_memory_tier_rules.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+
+DEFAULT_RULES = Path("planningops/config/memory-tier-rules.json")
+DEFAULT_OUTPUT = Path("planningops/artifacts/validation/memory-tier-rules-report.json")
+REQUIRED_TIERS = ["L0", "L1", "L2"]
+REQUIRED_TRIGGERS = {
+    "stale_l0_uncompacted",
+    "topic_compaction_required",
+    "closed_issue_memory_summary_missing",
+}
+REQUIRED_FRONTMATTER_KEYS = {"memory_tier", "expires_on", "compacted_into", "archive_ref"}
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def is_non_empty_str_list(values):
+    return isinstance(values, list) and all(isinstance(v, str) and v for v in values) and len(values) > 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate memory tier contract rules")
+    parser.add_argument("--rules", default=str(DEFAULT_RULES))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    rules_path = Path(args.rules)
+    doc = load_json(rules_path)
+    errors = []
+
+    if int(doc.get("policy_version", 0)) < 1:
+        errors.append("policy_version must be >= 1")
+
+    tiers = doc.get("memory_tiers")
+    if not isinstance(tiers, dict):
+        errors.append("memory_tiers must be object")
+        tiers = {}
+
+    for tier_name in REQUIRED_TIERS:
+        tier = tiers.get(tier_name)
+        if not isinstance(tier, dict):
+            errors.append(f"memory_tiers.{tier_name} must be object")
+            continue
+        roots = tier.get("default_roots")
+        if not is_non_empty_str_list(roots):
+            errors.append(f"memory_tiers.{tier_name}.default_roots must be non-empty string list")
+        required_frontmatter = tier.get("required_frontmatter")
+        if not is_non_empty_str_list(required_frontmatter):
+            errors.append(f"memory_tiers.{tier_name}.required_frontmatter must be non-empty string list")
+        next_tiers = tier.get("allowed_next_tiers")
+        if not isinstance(next_tiers, list):
+            errors.append(f"memory_tiers.{tier_name}.allowed_next_tiers must be list")
+
+    l0 = tiers.get("L0", {})
+    ttl = l0.get("ttl_days", {})
+    if not isinstance(ttl, dict):
+        errors.append("memory_tiers.L0.ttl_days must be object")
+    else:
+        min_days = ttl.get("min")
+        max_days = ttl.get("max")
+        default_days = ttl.get("default")
+        if not all(isinstance(v, int) and v > 0 for v in [min_days, max_days, default_days]):
+            errors.append("memory_tiers.L0.ttl_days min/max/default must be positive integers")
+        elif not (min_days <= default_days <= max_days):
+            errors.append("memory_tiers.L0.ttl_days must satisfy min <= default <= max")
+
+    l1 = tiers.get("L1", {})
+    if not isinstance(l1.get("review_cycle_days"), int) or l1.get("review_cycle_days", 0) <= 0:
+        errors.append("memory_tiers.L1.review_cycle_days must be positive integer")
+
+    l2 = tiers.get("L2", {})
+    if not isinstance(l2.get("retention_days"), int) or l2.get("retention_days", 0) <= 0:
+        errors.append("memory_tiers.L2.retention_days must be positive integer")
+
+    frontmatter = doc.get("frontmatter_keys")
+    if not isinstance(frontmatter, dict):
+        errors.append("frontmatter_keys must be object")
+        frontmatter = {}
+    missing_frontmatter = sorted(REQUIRED_FRONTMATTER_KEYS - set(frontmatter))
+    if missing_frontmatter:
+        errors.append("missing frontmatter key rules: " + ", ".join(missing_frontmatter))
+
+    memory_tier_cfg = frontmatter.get("memory_tier", {})
+    allowed_values = memory_tier_cfg.get("allowed_values")
+    if allowed_values != REQUIRED_TIERS:
+        errors.append("frontmatter_keys.memory_tier.allowed_values must equal [L0, L1, L2]")
+
+    triggers = doc.get("compaction_triggers")
+    if not isinstance(triggers, list):
+        errors.append("compaction_triggers must be array")
+        triggers = []
+    trigger_codes = {row.get("code") for row in triggers if isinstance(row, dict)}
+    missing_triggers = sorted(REQUIRED_TRIGGERS - trigger_codes)
+    if missing_triggers:
+        errors.append("missing compaction trigger(s): " + ", ".join(missing_triggers))
+
+    promotion_rules = doc.get("promotion_rules")
+    if not isinstance(promotion_rules, dict):
+        errors.append("promotion_rules must be object")
+    else:
+        for key in ["L0_to_L1_requires", "L0_to_L2_requires", "L1_to_L2_requires"]:
+            if not is_non_empty_str_list(promotion_rules.get(key)):
+                errors.append(f"promotion_rules.{key} must be non-empty string list")
+
+    rehydrate_rules = doc.get("rehydrate_rules")
+    if not isinstance(rehydrate_rules, dict):
+        errors.append("rehydrate_rules must be object")
+    else:
+        if not is_non_empty_str_list(rehydrate_rules.get("required_inputs")):
+            errors.append("rehydrate_rules.required_inputs must be non-empty string list")
+        if rehydrate_rules.get("path_root") != "repo-root-relative":
+            errors.append("rehydrate_rules.path_root must equal repo-root-relative")
+
+    storage_interop = doc.get("storage_interop")
+    if not isinstance(storage_interop, dict):
+        errors.append("storage_interop must be object")
+    else:
+        if storage_interop.get("artifact_storage_contract") != "planningops/contracts/artifact-retention-tier-contract.md":
+            errors.append("storage_interop.artifact_storage_contract must point to artifact-retention-tier-contract.md")
+        if storage_interop.get("memory_tier_overrides_storage_tier") is not False:
+            errors.append("storage_interop.memory_tier_overrides_storage_tier must be false")
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "rules_path": str(rules_path),
+        "error_count": len(errors),
+        "errors": errors,
+        "verdict": "pass" if not errors else "fail",
+    }
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(f"report written: {output_path}")
+    print(f"error_count={len(errors)} verdict={report['verdict']}")
+
+    if args.strict and errors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a canonical memory tier contract for L0/L1/L2 lifecycle, frontmatter keys, and compaction triggers
- add machine-readable memory tier rules plus a validator for future compactor/archive tooling
- wire the new memory tier contract into ontology references and federated CI

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts:
  - `planningops/contracts/memory-tier-contract.md`
  - `planningops/config/memory-tier-rules.json`
  - `planningops/scripts/validate_memory_tier_rules.py`
  - `planningops/scripts/test_memory_tier_contract.sh`
  - `planningops/contracts/control-tower-ontology-contract.md`
  - `planningops/config/ontology-entity-map.json`
- `.github/` workflows:
  - `.github/workflows/federated-ci-matrix.yml`

## Linked Issues
- Closes #103
- Related #95

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `bash planningops/scripts/test_memory_tier_contract.sh`
- [x] `bash planningops/scripts/test_control_tower_ontology_contract.sh`
- [x] `bash planningops/scripts/test_ontology_entity_map_contract.sh`
- [x] `python3 planningops/scripts/validate_memory_tier_rules.py --rules planningops/config/memory-tier-rules.json --output /tmp/memory-tier-rules-report.json --strict`
- [x] `python3 -m py_compile planningops/scripts/validate_memory_tier_rules.py`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/federated-ci-matrix.yml"); puts "yaml ok"'`
- [x] `git diff --check`

## Risks
- Risk: future memory tooling may need extra metadata fields beyond the current contract once compactor/archive executables are implemented.
- Rollback: revert commit `aab33d8` to remove the memory tier contract, validator, and CI hook.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change adds control-plane contract and validator coverage only.
