### PR TITLE
feat: add memory compactor check mode

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -207,6 +207,7 @@ jobs:
           bash planningops/scripts/test_control_tower_ontology_contract.sh
           bash planningops/scripts/test_ontology_entity_map_contract.sh
           bash planningops/scripts/test_memory_tier_contract.sh
+          bash planningops/scripts/test_memory_compactor_contract.sh
           bash planningops/scripts/test_audit_branch_protection_contract.sh
           bash planningops/scripts/test_apply_branch_protection_contract.sh
           python3 planningops/scripts/audit_branch_protection.py \

--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -27,6 +27,7 @@ summary: Initiative-scoped workbench for ephemeral brainstorm/plan/audit artifac
 ```bash
 bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
 bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all
+python3 planningops/scripts/memory_compactor.py --mode check --root . --rules planningops/config/memory-tier-rules.json
 ```
 
 ## Active Plans

--- a/planningops/contracts/memory-tier-contract.md
+++ b/planningops/contracts/memory-tier-contract.md
@@ -105,6 +105,7 @@ Allowed when:
 ## Verification
 - Rules config: `planningops/config/memory-tier-rules.json`
 - Validator: `planningops/scripts/validate_memory_tier_rules.py`
+- Check mode: `python3 planningops/scripts/memory_compactor.py --mode check`
 - Contract test: `bash planningops/scripts/test_memory_tier_contract.sh`
 - Future runtime tooling:
   - `planningops/scripts/memory_compactor.py`

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -25,6 +25,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `repo_execution_adapters.py`
 - Validation and reporting:
   - `backlog_stock_replenishment_guard.py`
+  - `memory_compactor.py`
   - `validate_contracts.py`
   - `validate_ontology_entity_map.py`
   - `validate_memory_tier_rules.py`
@@ -42,6 +43,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_control_tower_ontology_contract.sh`
   - `test_ontology_entity_map_contract.sh`
   - `test_memory_tier_contract.sh`
+  - `test_memory_compactor_contract.sh`
   - `validate_external_only_commit_guard.py`
   - `migrate_external_only_artifacts.py`
   - `rehydrate_artifact_pointer.py`
@@ -86,6 +88,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_control_tower_ontology_contract.sh`
   - `test_ontology_entity_map_contract.sh`
   - `test_memory_tier_contract.sh`
+  - `test_memory_compactor_contract.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_artifact_sink_e2e.sh`
   - `test_*.sh`

--- a/planningops/scripts/memory_compactor.py
+++ b/planningops/scripts/memory_compactor.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+
+import argparse
+import fnmatch
+import json
+import re
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_RULES = Path("planningops/config/memory-tier-rules.json")
+DEFAULT_OUTPUT = Path("planningops/artifacts/validation/memory-compactor-check-report.json")
+MARKDOWN_SUFFIXES = {".md", ".markdown"}
+IGNORED_NAMES = {".DS_Store", "Thumbs.db"}
+TOPIC_STOP_WORDS = {
+    "audit",
+    "audits",
+    "brainstorm",
+    "brainstorms",
+    "hub",
+    "hubs",
+    "note",
+    "notes",
+    "packet",
+    "packets",
+    "plan",
+    "plans",
+    "report",
+    "reports",
+}
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def normalize_rel_path(path: Path, root: Path):
+    return path.relative_to(root).as_posix()
+
+
+def parse_frontmatter(text: str):
+    if not text.startswith("---\n"):
+        return {}
+    result = {}
+    lines = text.splitlines()
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return result
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        result[key.strip()] = value.strip()
+    return {}
+
+
+def parse_iso_date(raw_value: str | None):
+    if not raw_value:
+        return None
+    value = str(raw_value).strip().strip("`")
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def extract_filename_date(path: Path):
+    match = re.match(r"^(\d{4}-\d{2}-\d{2})-", path.name)
+    if not match:
+        return None
+    return parse_iso_date(match.group(1))
+
+
+def normalize_topic(raw_value: str):
+    value = str(raw_value or "").strip().lower()
+    value = re.sub(r"^plan[:\s-]+", "", value)
+    tokens = [token for token in re.split(r"[^a-z0-9]+", value) if token]
+    while tokens and tokens[-1] in TOPIC_STOP_WORDS:
+        tokens.pop()
+    return "-".join(tokens)
+
+
+def derive_topic(meta: dict, path: Path):
+    if meta.get("topic"):
+        return normalize_topic(meta["topic"])
+    if meta.get("title"):
+        topic = normalize_topic(meta["title"])
+        if topic:
+            return topic
+    stem = re.sub(r"^\d{4}-\d{2}-\d{2}-", "", path.stem)
+    return normalize_topic(stem)
+
+
+def infer_tier(rel_path: str, meta: dict, rules: dict):
+    explicit = str(meta.get("memory_tier") or "").strip()
+    if explicit:
+        return explicit
+    for tier_name, tier_cfg in (rules.get("memory_tiers") or {}).items():
+        for pattern in tier_cfg.get("default_roots", []):
+            if fnmatch.fnmatch(rel_path, pattern):
+                return tier_name
+    return None
+
+
+def iter_markdown_files(root: Path):
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(part == ".git" for part in path.parts):
+            continue
+        if path.name.startswith("._") or path.name in IGNORED_NAMES:
+            continue
+        if path.suffix.lower() not in MARKDOWN_SUFFIXES:
+            continue
+        yield path
+
+
+def pick_anchor_date(meta: dict, path: Path):
+    for key in ["updated", "date"]:
+        parsed = parse_iso_date(meta.get(key))
+        if parsed:
+            return parsed, key
+    filename_date = extract_filename_date(path)
+    if filename_date:
+        return filename_date, "filename"
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).date(), "mtime"
+
+
+def stale_trigger_cfg(rules: dict):
+    for row in rules.get("compaction_triggers", []):
+        if row.get("code") == "stale_l0_uncompacted":
+            return row
+    return {}
+
+
+def duplicate_trigger_cfg(rules: dict):
+    for row in rules.get("compaction_triggers", []):
+        if row.get("code") == "topic_compaction_required":
+            return row
+    return {}
+
+
+def build_record(path: Path, root: Path, rules: dict, as_of: date):
+    rel_path = normalize_rel_path(path, root)
+    text = path.read_text(encoding="utf-8")
+    meta = parse_frontmatter(text)
+    tier = infer_tier(rel_path, meta, rules)
+    anchor_date, anchor_source = pick_anchor_date(meta, path)
+    expires_on = parse_iso_date(meta.get("expires_on"))
+    compacted_into = str(meta.get("compacted_into") or "").strip()
+    topic = derive_topic(meta, path)
+    age_days = max((as_of - anchor_date).days, 0)
+    return {
+        "path": rel_path,
+        "memory_tier": tier,
+        "type": meta.get("type", ""),
+        "status": meta.get("status", ""),
+        "topic": topic,
+        "topic_compaction_scope": rel_path.startswith("docs/workbench/") or bool(meta.get("topic")),
+        "anchor_date": anchor_date.isoformat(),
+        "anchor_source": anchor_source,
+        "age_days": age_days,
+        "expires_on": expires_on.isoformat() if expires_on else None,
+        "compacted_into": compacted_into,
+        "frontmatter_present": bool(meta),
+    }
+
+
+def detect_stale_l0(records: list[dict], rules: dict, as_of: date):
+    trigger = stale_trigger_cfg(rules)
+    max_age_days = int(trigger.get("max_age_days", 14))
+    findings = []
+    for row in records:
+        if row["memory_tier"] != "L0":
+            continue
+        if row["compacted_into"]:
+            continue
+        expired = row["expires_on"] and as_of > date.fromisoformat(row["expires_on"])
+        if expired or row["age_days"] > max_age_days:
+            findings.append(
+                {
+                    "code": "stale_l0_uncompacted",
+                    "path": row["path"],
+                    "topic": row["topic"],
+                    "age_days": row["age_days"],
+                    "anchor_date": row["anchor_date"],
+                    "anchor_source": row["anchor_source"],
+                    "expires_on": row["expires_on"],
+                }
+            )
+    return findings
+
+
+def detect_duplicate_topics(records: list[dict], rules: dict):
+    trigger = duplicate_trigger_cfg(rules)
+    threshold = int(trigger.get("topic_threshold", 3))
+    groups = {}
+    for row in records:
+        if row["memory_tier"] != "L0":
+            continue
+        if not row["topic_compaction_scope"]:
+            continue
+        if not row["topic"]:
+            continue
+        groups.setdefault(row["topic"], []).append(row)
+
+    findings = []
+    for topic, rows in sorted(groups.items()):
+        if len(rows) < threshold:
+            continue
+        retained_targets = sorted({row["compacted_into"] for row in rows if row["compacted_into"]})
+        if retained_targets:
+            continue
+        findings.append(
+            {
+                "code": "topic_compaction_required",
+                "topic": topic,
+                "record_count": len(rows),
+                "paths": [row["path"] for row in rows],
+            }
+        )
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Memory compactor dry validator for L0/L1/L2 planning knowledge")
+    parser.add_argument("--mode", choices=["check"], default="check")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--rules", default=str(DEFAULT_RULES))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--as-of", default=None, help="YYYY-MM-DD override for deterministic checks")
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    rules_path = Path(args.rules).resolve()
+    rules = load_json(rules_path)
+    as_of = parse_iso_date(args.as_of) if args.as_of else datetime.now(timezone.utc).date()
+    if as_of is None:
+        raise SystemExit("--as-of must be YYYY-MM-DD")
+
+    records = []
+    errors = []
+    for path in iter_markdown_files(root):
+        try:
+            records.append(build_record(path, root, rules, as_of))
+        except Exception as exc:  # noqa: BLE001
+            errors.append({"path": str(path), "error": str(exc)})
+
+    stale_l0 = detect_stale_l0(records, rules, as_of)
+    duplicate_topics = detect_duplicate_topics(records, rules)
+    trigger_count = len(stale_l0) + len(duplicate_topics)
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "mode": args.mode,
+        "root": str(root),
+        "rules_path": str(rules_path),
+        "as_of": as_of.isoformat(),
+        "record_count": len(records),
+        "l0_record_count": sum(1 for row in records if row["memory_tier"] == "L0"),
+        "trigger_count": trigger_count,
+        "error_count": len(errors),
+        "stale_l0_uncompacted": stale_l0,
+        "topic_compaction_required": duplicate_topics,
+        "errors": errors,
+        "verdict": "pass" if trigger_count == 0 and not errors else "fail",
+    }
+
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = (Path.cwd() / output_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+    print(f"report written: {output_path}")
+    print(
+        "record_count={record_count} l0_record_count={l0_record_count} trigger_count={trigger_count} error_count={error_count} verdict={verdict}".format(
+            **report
+        )
+    )
+
+    if args.strict and report["verdict"] != "pass":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/planningops/scripts/test_memory_compactor_contract.sh
+++ b/planningops/scripts/test_memory_compactor_contract.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/repo"
+mkdir -p \
+  "$fixture_root/docs/workbench/unified-personal-agent-platform/brainstorms" \
+  "$fixture_root/docs/workbench/unified-personal-agent-platform/plans" \
+  "$fixture_root/docs/workbench/unified-personal-agent-platform/audits" \
+  "$fixture_root/docs/initiatives/unified-personal-agent-platform"
+
+cat > "$fixture_root/docs/workbench/unified-personal-agent-platform/brainstorms/2026-02-01-alpha-brainstorm.md" <<'EOF'
+---
+title: Alpha Brainstorm
+type: brainstorm
+date: 2026-02-01
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Alpha brainstorming context.
+topic: alpha
+---
+EOF
+
+cat > "$fixture_root/docs/workbench/unified-personal-agent-platform/plans/2026-02-02-alpha-plan.md" <<'EOF'
+---
+title: plan: Alpha
+type: plan
+date: 2026-02-02
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Alpha planning context.
+topic: alpha
+---
+EOF
+
+cat > "$fixture_root/docs/workbench/unified-personal-agent-platform/audits/2026-02-03-alpha-audit.md" <<'EOF'
+---
+title: Alpha Audit
+type: audit
+date: 2026-02-03
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Alpha audit context.
+topic: alpha
+---
+EOF
+
+cat > "$fixture_root/docs/workbench/unified-personal-agent-platform/plans/2026-02-01-delta-plan.md" <<'EOF'
+---
+title: plan: Delta
+type: plan
+date: 2026-02-01
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: reference
+summary: Delta plan compacted into canonical memory.
+topic: delta
+compacted_into: docs/initiatives/unified-personal-agent-platform/10-platform/contracts/memory-summary.md
+---
+EOF
+
+cat > "$fixture_root/docs/workbench/unified-personal-agent-platform/plans/2026-03-07-fresh-plan.md" <<'EOF'
+---
+title: plan: Fresh
+type: plan
+date: 2026-03-07
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Fresh plan should not trip stale detection.
+topic: fresh
+---
+EOF
+
+cat > "$fixture_root/docs/initiatives/unified-personal-agent-platform/memory-summary.md" <<'EOF'
+---
+title: Memory Summary
+type: contract
+date: 2026-03-08
+initiative: unified-personal-agent-platform
+lifecycle: canonical
+status: active
+summary: Canonical summary placeholder.
+memory_tier: L1
+---
+EOF
+
+touch "$fixture_root/docs/workbench/unified-personal-agent-platform/brainstorms/._ignored.md"
+
+python3 planningops/scripts/memory_compactor.py \
+  --mode check \
+  --root "$fixture_root" \
+  --rules planningops/config/memory-tier-rules.json \
+  --as-of 2026-03-08 \
+  --output "$tmp_dir/report-dirty.json"
+
+python3 - "$tmp_dir/report-dirty.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "fail", report
+assert report["trigger_count"] == 4, report
+assert len(report["stale_l0_uncompacted"]) == 3, report
+assert len(report["topic_compaction_required"]) == 1, report
+topic = report["topic_compaction_required"][0]
+assert topic["topic"] == "alpha", topic
+assert topic["record_count"] == 3, topic
+assert report["error_count"] == 0, report
+PY
+
+set +e
+python3 planningops/scripts/memory_compactor.py \
+  --mode check \
+  --root "$fixture_root" \
+  --rules planningops/config/memory-tier-rules.json \
+  --as-of 2026-03-08 \
+  --output "$tmp_dir/report-dirty-strict.json" \
+  --strict
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for stale or duplicate L0 memory"
+  exit 1
+fi
+
+clean_root="$tmp_dir/clean-repo"
+mkdir -p "$clean_root/docs/workbench/unified-personal-agent-platform/plans"
+
+cat > "$clean_root/docs/workbench/unified-personal-agent-platform/plans/2026-03-07-clean-plan.md" <<'EOF'
+---
+title: plan: Clean
+type: plan
+date: 2026-03-07
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Fresh workbench item.
+topic: clean
+---
+EOF
+
+python3 planningops/scripts/memory_compactor.py \
+  --mode check \
+  --root "$clean_root" \
+  --rules planningops/config/memory-tier-rules.json \
+  --as-of 2026-03-08 \
+  --output "$tmp_dir/report-clean.json" \
+  --strict
+
+python3 - "$tmp_dir/report-clean.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "pass", report
+assert report["trigger_count"] == 0, report
+assert report["error_count"] == 0, report
+PY
+
+python3 - <<'PY'
+from pathlib import Path
+
+text = Path("planningops/contracts/memory-tier-contract.md").read_text(encoding="utf-8")
+required = [
+    "stale_l0_uncompacted",
+    "topic_compaction_required",
+    "planningops/scripts/memory_compactor.py",
+]
+missing = [item for item in required if item not in text]
+if missing:
+    raise SystemExit("memory tier contract missing compactor references: " + ", ".join(missing))
+print("memory compactor contract test ok")
+PY


### PR DESCRIPTION
## Summary
- add `memory_compactor.py --mode check` to scan L0 memory records from path defaults and frontmatter metadata
- flag stale uncompacted L0 records and duplicate workbench topics, with strict exit support for future CI use
- add a fixture-based contract test and expose the check command in memory/workbench docs

## Scope
- Initiative docs:
- Workbench docs:
  - `docs/workbench/unified-personal-agent-platform/README.md`
- `planningops/` scripts/contracts:
  - `planningops/scripts/memory_compactor.py`
  - `planningops/scripts/test_memory_compactor_contract.sh`
  - `planningops/scripts/README.md`
  - `planningops/contracts/memory-tier-contract.md`
- `.github/` workflows:
  - `.github/workflows/federated-ci-matrix.yml`

## Linked Issues
- Closes #104
- Related #103

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `bash planningops/scripts/test_memory_tier_contract.sh`
- [x] `bash planningops/scripts/test_memory_compactor_contract.sh`
- [x] `python3 -m py_compile planningops/scripts/memory_compactor.py planningops/scripts/validate_memory_tier_rules.py`
- [x] `python3 planningops/scripts/memory_compactor.py --mode check --root . --rules planningops/config/memory-tier-rules.json --output /tmp/a41-memory-compactor-live-report.json`
- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/federated-ci-matrix.yml"); puts "yaml ok"'`

## Risks
- Risk: the current topic heuristic is intentionally conservative and may miss duplicate topics that are not in workbench paths and do not declare `topic` frontmatter.
- Rollback: revert commit `2e05c79` to remove the check-mode compactor and its CI contract test.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.

## Post-Deploy Monitoring & Validation
- Live dry report: `/tmp/a41-memory-compactor-live-report.json`
- Expected healthy signal: `trigger_count=0`, `error_count=0`, `verdict=pass` on current `main` when run non-strict.
- Failure signal: new stale L0 or duplicate workbench topic groups appear once strict mode is enabled in later CI phases.
- Rollback trigger: revert if current `main` starts producing false-positive duplicate topic groups for non-workbench artifacts.
