### PR TITLE
feat: add memory archive manifest flow

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -208,6 +208,7 @@ jobs:
           bash planningops/scripts/test_ontology_entity_map_contract.sh
           bash planningops/scripts/test_memory_tier_contract.sh
           bash planningops/scripts/test_memory_compactor_contract.sh
+          bash planningops/scripts/test_memory_archive_contract.sh
           bash planningops/scripts/test_audit_branch_protection_contract.sh
           bash planningops/scripts/test_apply_branch_protection_contract.sh
           python3 planningops/scripts/audit_branch_protection.py \

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,25 @@
+---
+title: Archive Root
+type: hub
+date: 2026-03-08
+initiative: unified-personal-agent-platform
+lifecycle: canonical
+status: active
+summary: Long-term archive root for memory records compacted out of active workbench usage.
+---
+
+# Archive Root
+
+`docs/archive` stores archived markdown copies that have been compacted out of active working memory.
+
+## Contract
+- archive documents are immutable `L2` records
+- archive copies must include `memory_tier: L2`
+- archive copies must include `archive_ref` pointing at `planningops/archive-manifest/**`
+- archive copies must include `compacted_into` pointing at the retained canonical summary or replacement
+
+## Validation
+```bash
+python3 planningops/scripts/memory_archive.py --source <repo-relative-source> --compacted-into <repo-relative-target>
+python3 planningops/scripts/validate_memory_archive_manifest.py --manifest <manifest-path> --schema planningops/schemas/memory-archive-manifest.schema.json --strict
+```

--- a/planningops/archive-manifest/README.md
+++ b/planningops/archive-manifest/README.md
@@ -1,0 +1,10 @@
+# planningops/archive-manifest
+
+## Purpose
+Store deterministic pointer manifests for archived memory records so future rehydrate commands can restore or inspect long-term context without searching raw history.
+
+## Contract
+- one manifest per archived source document
+- manifest path is the canonical `archive_ref`
+- manifest must validate against `planningops/schemas/memory-archive-manifest.schema.json`
+- manifest fields stay repo-root-relative so local and CI paths resolve the same way

--- a/planningops/contracts/memory-tier-contract.md
+++ b/planningops/contracts/memory-tier-contract.md
@@ -106,6 +106,8 @@ Allowed when:
 - Rules config: `planningops/config/memory-tier-rules.json`
 - Validator: `planningops/scripts/validate_memory_tier_rules.py`
 - Check mode: `python3 planningops/scripts/memory_compactor.py --mode check`
+- Archive command: `python3 planningops/scripts/memory_archive.py --source <repo-relative-source> --compacted-into <repo-relative-target>`
+- Manifest schema: `planningops/schemas/memory-archive-manifest.schema.json`
 - Contract test: `bash planningops/scripts/test_memory_tier_contract.sh`
 - Future runtime tooling:
   - `planningops/scripts/memory_compactor.py`

--- a/planningops/schemas/README.md
+++ b/planningops/schemas/README.md
@@ -13,6 +13,7 @@ Keep local schema copies used for contract validation fixtures and compatibility
 - `meta-plan-graph.schema.json`
 - `worker-task-pack.schema.json`
 - `execution-attempts.schema.json`
+- `memory-archive-manifest.schema.json`
 
 ## Change Rules
 - Schema shape changes must be synchronized with `platform-contracts` source schemas.

--- a/planningops/schemas/memory-archive-manifest.schema.json
+++ b/planningops/schemas/memory-archive-manifest.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "planningops/schemas/memory-archive-manifest.schema.json",
+  "title": "Memory Archive Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "manifest_version",
+    "archived_at_utc",
+    "source_path",
+    "archive_path",
+    "manifest_path",
+    "archive_ref",
+    "compacted_into",
+    "memory_tier",
+    "initiative",
+    "source_checksum_sha256",
+    "archive_checksum_sha256"
+  ],
+  "properties": {
+    "manifest_version": {
+      "type": "integer"
+    },
+    "archived_at_utc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "archive_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "manifest_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "archive_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "compacted_into": {
+      "type": "string",
+      "minLength": 1
+    },
+    "memory_tier": {
+      "type": "string",
+      "const": "L2"
+    },
+    "initiative": {
+      "type": "string"
+    },
+    "source_checksum_sha256": {
+      "type": "string",
+      "minLength": 64
+    },
+    "archive_checksum_sha256": {
+      "type": "string",
+      "minLength": 64
+    }
+  }
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -23,9 +23,11 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `meta_plan_orchestrator.py`
   - `github_sync_adapter.py`
   - `repo_execution_adapters.py`
+  - `memory_archive.py`
 - Validation and reporting:
   - `backlog_stock_replenishment_guard.py`
   - `memory_compactor.py`
+  - `validate_memory_archive_manifest.py`
   - `validate_contracts.py`
   - `validate_ontology_entity_map.py`
   - `validate_memory_tier_rules.py`
@@ -44,6 +46,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_ontology_entity_map_contract.sh`
   - `test_memory_tier_contract.sh`
   - `test_memory_compactor_contract.sh`
+  - `test_memory_archive_contract.sh`
   - `validate_external_only_commit_guard.py`
   - `migrate_external_only_artifacts.py`
   - `rehydrate_artifact_pointer.py`
@@ -89,6 +92,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_ontology_entity_map_contract.sh`
   - `test_memory_tier_contract.sh`
   - `test_memory_compactor_contract.sh`
+  - `test_memory_archive_contract.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_artifact_sink_e2e.sh`
   - `test_*.sh`

--- a/planningops/scripts/memory_archive.py
+++ b/planningops/scripts/memory_archive.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_ARCHIVE_ROOT = "docs/archive"
+DEFAULT_MANIFEST_ROOT = "planningops/archive-manifest"
+DEFAULT_OUTPUT = "planningops/artifacts/validation/memory-archive-report.json"
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_frontmatter(text: str):
+    if not text.startswith("---\n"):
+        return {}, text
+    lines = text.splitlines()
+    meta = {}
+    idx = 1
+    for idx in range(1, len(lines)):
+        line = lines[idx]
+        if line.strip() == "---":
+            body = "\n".join(lines[idx + 1 :]).lstrip("\n")
+            return meta, body
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        meta[key.strip()] = value.strip()
+    return {}, text
+
+
+def render_frontmatter(meta: dict, body: str):
+    ordered_keys = []
+    preferred = [
+        "title",
+        "type",
+        "date",
+        "updated",
+        "initiative",
+        "lifecycle",
+        "status",
+        "summary",
+        "topic",
+        "memory_tier",
+        "compacted_into",
+        "archive_ref",
+    ]
+    for key in preferred:
+        if key in meta:
+            ordered_keys.append(key)
+    for key in meta:
+        if key not in ordered_keys:
+            ordered_keys.append(key)
+    frontmatter = ["---"]
+    for key in ordered_keys:
+        frontmatter.append(f"{key}: {meta[key]}")
+    frontmatter.append("---")
+    return "\n".join(frontmatter) + "\n\n" + body.rstrip() + "\n"
+
+
+def is_repo_relative(path_text: str):
+    text = str(path_text or "").strip()
+    return bool(text) and not text.startswith("/") and ".." not in Path(text).parts
+
+
+def default_archive_path(source_rel: str):
+    rel = Path(source_rel)
+    rel_parts = rel.parts
+    if rel_parts and rel_parts[0] == "docs":
+        rel = Path(*rel_parts[1:])
+    return str(Path(DEFAULT_ARCHIVE_ROOT) / rel)
+
+
+def default_manifest_path(source_rel: str):
+    rel = Path(source_rel)
+    return str(Path(DEFAULT_MANIFEST_ROOT) / rel.with_suffix(".json"))
+
+
+def sha256_text(text: str):
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Archive a memory document and emit a deterministic pointer manifest")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--source", required=True, help="repo-root-relative source markdown path")
+    parser.add_argument("--compacted-into", required=True, help="repo-root-relative retained summary/canonical path")
+    parser.add_argument("--archive-path", default=None, help="repo-root-relative archive markdown path")
+    parser.add_argument("--manifest-path", default=None, help="repo-root-relative manifest json path")
+    parser.add_argument("--archived-at", default=None, help="override archived_at_utc (ISO-8601)")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT)
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    errors = []
+    root = Path(args.root).resolve()
+    source_rel = str(Path(args.source).as_posix())
+    compacted_into = str(Path(args.compacted_into).as_posix())
+
+    if not is_repo_relative(source_rel):
+        errors.append("source must be repo-root-relative")
+    if not is_repo_relative(compacted_into):
+        errors.append("compacted_into must be repo-root-relative")
+
+    source_path = root / source_rel
+    compacted_path = root / compacted_into
+    archive_rel = args.archive_path or default_archive_path(source_rel)
+    manifest_rel = args.manifest_path or default_manifest_path(source_rel)
+
+    if not is_repo_relative(archive_rel):
+        errors.append("archive_path must be repo-root-relative")
+    if not is_repo_relative(manifest_rel):
+        errors.append("manifest_path must be repo-root-relative")
+    if archive_rel == source_rel:
+        errors.append("archive_path must differ from source")
+    if not archive_rel.startswith(f"{DEFAULT_ARCHIVE_ROOT}/"):
+        errors.append(f"archive_path must stay under {DEFAULT_ARCHIVE_ROOT}/")
+    if not manifest_rel.startswith(f"{DEFAULT_MANIFEST_ROOT}/"):
+        errors.append(f"manifest_path must stay under {DEFAULT_MANIFEST_ROOT}/")
+    if errors:
+        report = {
+            "generated_at_utc": now_utc(),
+            "mode": "dry-run" if args.dry_run else "apply",
+            "source_path": source_rel,
+            "archive_path": archive_rel,
+            "manifest_path": manifest_rel,
+            "error_count": len(errors),
+            "errors": errors,
+            "verdict": "fail",
+        }
+        output_path = (Path.cwd() / args.output).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+        print(f"report written: {output_path}")
+        print(f"error_count={len(errors)} verdict=fail")
+        return 1 if args.strict else 0
+
+    if not source_path.exists():
+        raise SystemExit(f"source not found: {source_rel}")
+    if not compacted_path.exists():
+        raise SystemExit(f"compacted target not found: {compacted_into}")
+
+    source_text = source_path.read_text(encoding="utf-8")
+    meta, body = parse_frontmatter(source_text)
+    archive_ref = manifest_rel
+    meta.pop("expires_on", None)
+    meta["memory_tier"] = "L2"
+    meta["compacted_into"] = compacted_into
+    meta["archive_ref"] = archive_ref
+    if not meta.get("status"):
+        meta["status"] = "archived"
+
+    archived_text = render_frontmatter(meta, body)
+    archived_at = args.archived_at or now_utc()
+    archive_path = root / archive_rel
+    manifest_path = root / manifest_rel
+
+    manifest = {
+        "manifest_version": 1,
+        "archived_at_utc": archived_at,
+        "source_path": source_rel,
+        "archive_path": archive_rel,
+        "manifest_path": manifest_rel,
+        "archive_ref": archive_ref,
+        "compacted_into": compacted_into,
+        "memory_tier": "L2",
+        "initiative": meta.get("initiative", ""),
+        "source_checksum_sha256": sha256_text(source_text),
+        "archive_checksum_sha256": sha256_text(archived_text),
+    }
+
+    if not args.dry_run:
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+        archive_path.write_text(archived_text, encoding="utf-8")
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "mode": "dry-run" if args.dry_run else "apply",
+        "source_path": source_rel,
+        "archive_path": archive_rel,
+        "manifest_path": manifest_rel,
+        "error_count": 0,
+        "errors": [],
+        "manifest": manifest,
+        "verdict": "pass",
+    }
+
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = (Path.cwd() / output_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(f"report written: {output_path}")
+    print(f"archive_path={archive_rel} manifest_path={manifest_rel} verdict=pass")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/planningops/scripts/test_memory_archive_contract.sh
+++ b/planningops/scripts/test_memory_archive_contract.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/repo"
+mkdir -p \
+  "$fixture_root/docs/workbench/unified-personal-agent-platform/plans" \
+  "$fixture_root/docs/initiatives/unified-personal-agent-platform/contracts"
+
+cat > "$fixture_root/docs/workbench/unified-personal-agent-platform/plans/2026-03-07-sample-plan.md" <<'EOF'
+---
+title: plan: Sample
+type: plan
+date: 2026-03-07
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: reference
+summary: Sample workbench plan ready for archive.
+topic: sample
+memory_tier: L0
+compacted_into: docs/initiatives/unified-personal-agent-platform/contracts/sample-contract.md
+---
+
+# Sample Plan
+EOF
+
+cat > "$fixture_root/docs/initiatives/unified-personal-agent-platform/contracts/sample-contract.md" <<'EOF'
+---
+title: Sample Contract
+type: contract
+date: 2026-03-08
+initiative: unified-personal-agent-platform
+lifecycle: canonical
+status: active
+summary: Canonical target for sample.
+memory_tier: L1
+---
+EOF
+
+python3 planningops/scripts/memory_archive.py \
+  --root "$fixture_root" \
+  --source docs/workbench/unified-personal-agent-platform/plans/2026-03-07-sample-plan.md \
+  --compacted-into docs/initiatives/unified-personal-agent-platform/contracts/sample-contract.md \
+  --archived-at 2026-03-08T00:00:00Z \
+  --output "$tmp_dir/archive-report.json" \
+  --strict
+
+archive_path="$fixture_root/docs/archive/workbench/unified-personal-agent-platform/plans/2026-03-07-sample-plan.md"
+manifest_path="$fixture_root/planningops/archive-manifest/docs/workbench/unified-personal-agent-platform/plans/2026-03-07-sample-plan.json"
+
+test -f "$archive_path"
+test -f "$manifest_path"
+
+python3 planningops/scripts/validate_memory_archive_manifest.py \
+  --manifest "$manifest_path" \
+  --schema planningops/schemas/memory-archive-manifest.schema.json \
+  --output "$tmp_dir/archive-manifest-validation.json" \
+  --strict
+
+python3 - "$manifest_path" "$tmp_dir/invalid-manifest.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+manifest.pop("archive_ref")
+Path(sys.argv[2]).write_text(json.dumps(manifest, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+python3 planningops/scripts/validate_memory_archive_manifest.py \
+  --manifest "$tmp_dir/invalid-manifest.json" \
+  --schema planningops/schemas/memory-archive-manifest.schema.json \
+  --output "$tmp_dir/archive-manifest-invalid-validation.json" \
+  --strict
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for invalid manifest schema"
+  exit 1
+fi
+
+python3 - "$manifest_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert manifest["manifest_version"] == 1, manifest
+assert manifest["archive_ref"] == manifest["manifest_path"], manifest
+assert manifest["memory_tier"] == "L2", manifest
+assert manifest["compacted_into"] == "docs/initiatives/unified-personal-agent-platform/contracts/sample-contract.md", manifest
+PY
+
+python3 - "$archive_path" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+required = [
+    "memory_tier: L2",
+    "archive_ref: planningops/archive-manifest/docs/workbench/unified-personal-agent-platform/plans/2026-03-07-sample-plan.json",
+    "compacted_into: docs/initiatives/unified-personal-agent-platform/contracts/sample-contract.md",
+]
+missing = [item for item in required if item not in text]
+if missing:
+    raise SystemExit("archived markdown missing fields: " + ", ".join(missing))
+PY
+
+set +e
+python3 planningops/scripts/memory_archive.py \
+  --root "$fixture_root" \
+  --source docs/workbench/unified-personal-agent-platform/plans/2026-03-07-sample-plan.md \
+  --compacted-into missing/target.md \
+  --output "$tmp_dir/archive-report-invalid.json" \
+  --strict
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for missing compacted target"
+  exit 1
+fi
+
+echo "memory archive contract test ok"

--- a/planningops/scripts/validate_memory_archive_manifest.py
+++ b/planningops/scripts/validate_memory_archive_manifest.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_SCHEMA = Path("planningops/schemas/memory-archive-manifest.schema.json")
+DEFAULT_OUTPUT = Path("planningops/artifacts/validation/memory-archive-manifest-report.json")
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate(instance, schema, path="$"):
+    errors = []
+    expected_type = schema.get("type")
+    if expected_type == "object":
+        if not isinstance(instance, dict):
+            return [f"{path}: expected object"]
+        required = schema.get("required", [])
+        for key in required:
+            if key not in instance:
+                errors.append(f"{path}.{key}: missing required property")
+        properties = schema.get("properties", {})
+        for key, value in instance.items():
+            if key not in properties:
+                if schema.get("additionalProperties") is False:
+                    errors.append(f"{path}.{key}: additional property not allowed")
+                continue
+            errors.extend(validate(value, properties[key], f"{path}.{key}"))
+        return errors
+
+    if expected_type == "string":
+        if not isinstance(instance, str):
+            return [f"{path}: expected string"]
+        if schema.get("minLength") and len(instance) < schema["minLength"]:
+            errors.append(f"{path}: string shorter than minLength {schema['minLength']}")
+        if "const" in schema and instance != schema["const"]:
+            errors.append(f"{path}: expected const {schema['const']}")
+        if "enum" in schema and instance not in schema["enum"]:
+            errors.append(f"{path}: expected one of {schema['enum']}")
+        return errors
+
+    if expected_type == "integer":
+        if not isinstance(instance, int) or isinstance(instance, bool):
+            return [f"{path}: expected integer"]
+        return errors
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate memory archive manifest against local schema")
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--schema", default=str(DEFAULT_SCHEMA))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    schema_path = Path(args.schema)
+    manifest = load_json(manifest_path)
+    schema = load_json(schema_path)
+    errors = validate(manifest, schema)
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "manifest_path": str(manifest_path.resolve()),
+        "schema_path": str(schema_path.resolve()),
+        "error_count": len(errors),
+        "errors": errors,
+        "verdict": "pass" if not errors else "fail",
+    }
+
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = (Path.cwd() / output_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(f"report written: {output_path}")
+    print(f"error_count={len(errors)} verdict={report['verdict']}")
+    return 0 if not errors or not args.strict else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `memory_archive.py` to create L2 archive copies plus deterministic pointer manifests
- add `memory-archive-manifest.schema.json` and a local schema-driven validator for manifest shape checks
- add archive root documentation and fixture-based contract coverage, then wire the test into federated CI

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts:
  - `planningops/scripts/memory_archive.py`
  - `planningops/scripts/validate_memory_archive_manifest.py`
  - `planningops/scripts/test_memory_archive_contract.sh`
  - `planningops/contracts/memory-tier-contract.md`
  - `planningops/schemas/memory-archive-manifest.schema.json`
  - `planningops/archive-manifest/README.md`
- `.github/` workflows:
  - `.github/workflows/federated-ci-matrix.yml`
- archive/docs roots:
  - `docs/archive/README.md`

## Linked Issues
- Closes #105
- Related #104

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `bash planningops/scripts/test_memory_archive_contract.sh`
- [x] `python3 -m py_compile planningops/scripts/memory_archive.py planningops/scripts/validate_memory_archive_manifest.py`
- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/federated-ci-matrix.yml"); puts "yaml ok"'`

## Risks
- Risk: default archive copy behavior duplicates source content until later phases decide when original L0 sources can be compacted or removed.
- Rollback: revert commit `4fb1438` to remove archive manifest generation and schema validation.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.

## Post-Deploy Monitoring & Validation
- Expected healthy signal: `bash planningops/scripts/test_memory_archive_contract.sh` remains green and manifest validation stays `error_count=0` for valid fixtures.
- Failure signal: archive manifest validation begins failing or generated archive paths escape `docs/archive/**` / `planningops/archive-manifest/**`.
- Rollback trigger: revert if new archive writes are not deterministic or manifest paths stop being repo-root-relative.
