### PR TITLE
feat: add deterministic memory rehydrate flow

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -209,6 +209,7 @@ jobs:
           bash planningops/scripts/test_memory_tier_contract.sh
           bash planningops/scripts/test_memory_compactor_contract.sh
           bash planningops/scripts/test_memory_archive_contract.sh
+          bash planningops/scripts/test_memory_rehydrate_contract.sh
           bash planningops/scripts/test_audit_branch_protection_contract.sh
           bash planningops/scripts/test_apply_branch_protection_contract.sh
           python3 planningops/scripts/audit_branch_protection.py \

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -21,5 +21,6 @@ summary: Long-term archive root for memory records compacted out of active workb
 ## Validation
 ```bash
 python3 planningops/scripts/memory_archive.py --source <repo-relative-source> --compacted-into <repo-relative-target>
+python3 planningops/scripts/memory_rehydrate.py --manifest <archive-ref-or-manifest-path>
 python3 planningops/scripts/validate_memory_archive_manifest.py --manifest <manifest-path> --schema planningops/schemas/memory-archive-manifest.schema.json --strict
 ```

--- a/planningops/archive-manifest/README.md
+++ b/planningops/archive-manifest/README.md
@@ -7,4 +7,5 @@ Store deterministic pointer manifests for archived memory records so future rehy
 - one manifest per archived source document
 - manifest path is the canonical `archive_ref`
 - manifest must validate against `planningops/schemas/memory-archive-manifest.schema.json`
+- manifest must retain source frontmatter/order required for deterministic rehydrate
 - manifest fields stay repo-root-relative so local and CI paths resolve the same way

--- a/planningops/contracts/memory-tier-contract.md
+++ b/planningops/contracts/memory-tier-contract.md
@@ -107,6 +107,7 @@ Allowed when:
 - Validator: `planningops/scripts/validate_memory_tier_rules.py`
 - Check mode: `python3 planningops/scripts/memory_compactor.py --mode check`
 - Archive command: `python3 planningops/scripts/memory_archive.py --source <repo-relative-source> --compacted-into <repo-relative-target>`
+- Rehydrate command: `python3 planningops/scripts/memory_rehydrate.py --manifest <archive-ref-or-manifest-path>`
 - Manifest schema: `planningops/schemas/memory-archive-manifest.schema.json`
 - Contract test: `bash planningops/scripts/test_memory_tier_contract.sh`
 - Future runtime tooling:

--- a/planningops/schemas/memory-archive-manifest.schema.json
+++ b/planningops/schemas/memory-archive-manifest.schema.json
@@ -14,6 +14,8 @@
     "compacted_into",
     "memory_tier",
     "initiative",
+    "source_frontmatter",
+    "source_frontmatter_order",
     "source_checksum_sha256",
     "archive_checksum_sha256"
   ],
@@ -51,6 +53,19 @@
     },
     "initiative": {
       "type": "string"
+    },
+    "source_frontmatter": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "source_frontmatter_order": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
     "source_checksum_sha256": {
       "type": "string",

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -24,6 +24,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `github_sync_adapter.py`
   - `repo_execution_adapters.py`
   - `memory_archive.py`
+  - `memory_rehydrate.py`
 - Validation and reporting:
   - `backlog_stock_replenishment_guard.py`
   - `memory_compactor.py`
@@ -47,6 +48,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_memory_tier_contract.sh`
   - `test_memory_compactor_contract.sh`
   - `test_memory_archive_contract.sh`
+  - `test_memory_rehydrate_contract.sh`
   - `validate_external_only_commit_guard.py`
   - `migrate_external_only_artifacts.py`
   - `rehydrate_artifact_pointer.py`
@@ -93,6 +95,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_memory_tier_contract.sh`
   - `test_memory_compactor_contract.sh`
   - `test_memory_archive_contract.sh`
+  - `test_memory_rehydrate_contract.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_artifact_sink_e2e.sh`
   - `test_*.sh`

--- a/planningops/scripts/memory_archive.py
+++ b/planningops/scripts/memory_archive.py
@@ -20,25 +20,27 @@ def now_utc():
 
 def parse_frontmatter(text: str):
     if not text.startswith("---\n"):
-        return {}, text
+        return {}, [], text
     lines = text.splitlines()
     meta = {}
+    order = []
     idx = 1
     for idx in range(1, len(lines)):
         line = lines[idx]
         if line.strip() == "---":
             body = "\n".join(lines[idx + 1 :]).lstrip("\n")
-            return meta, body
+            return meta, order, body
         if ":" not in line:
             continue
         key, value = line.split(":", 1)
         meta[key.strip()] = value.strip()
-    return {}, text
+        order.append(key.strip())
+    return {}, [], text
 
 
-def render_frontmatter(meta: dict, body: str):
+def render_frontmatter(meta: dict, body: str, preferred_order: list[str] | None = None):
     ordered_keys = []
-    preferred = [
+    preferred = preferred_order or [
         "title",
         "type",
         "date",
@@ -149,7 +151,8 @@ def main():
         raise SystemExit(f"compacted target not found: {compacted_into}")
 
     source_text = source_path.read_text(encoding="utf-8")
-    meta, body = parse_frontmatter(source_text)
+    source_meta, source_order, body = parse_frontmatter(source_text)
+    meta = dict(source_meta)
     archive_ref = manifest_rel
     meta.pop("expires_on", None)
     meta["memory_tier"] = "L2"
@@ -158,7 +161,11 @@ def main():
     if not meta.get("status"):
         meta["status"] = "archived"
 
-    archived_text = render_frontmatter(meta, body)
+    archived_order = [key for key in source_order if key != "expires_on"]
+    for key in ["memory_tier", "compacted_into", "archive_ref"]:
+        if key not in archived_order:
+            archived_order.append(key)
+    archived_text = render_frontmatter(meta, body, preferred_order=archived_order)
     archived_at = args.archived_at or now_utc()
     archive_path = root / archive_rel
     manifest_path = root / manifest_rel
@@ -172,7 +179,9 @@ def main():
         "archive_ref": archive_ref,
         "compacted_into": compacted_into,
         "memory_tier": "L2",
-        "initiative": meta.get("initiative", ""),
+        "initiative": source_meta.get("initiative", ""),
+        "source_frontmatter": source_meta,
+        "source_frontmatter_order": source_order,
         "source_checksum_sha256": sha256_text(source_text),
         "archive_checksum_sha256": sha256_text(archived_text),
     }

--- a/planningops/scripts/memory_rehydrate.py
+++ b/planningops/scripts/memory_rehydrate.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_OUTPUT = "planningops/artifacts/validation/memory-rehydrate-report.json"
+DEFAULT_REHYDRATE_ROOT = "planningops/artifacts/rehydrate"
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_frontmatter(text: str):
+    if not text.startswith("---\n"):
+        return {}, text
+    lines = text.splitlines()
+    meta = {}
+    for idx in range(1, len(lines)):
+        line = lines[idx]
+        if line.strip() == "---":
+            body = "\n".join(lines[idx + 1 :]).lstrip("\n")
+            return meta, body
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        meta[key.strip()] = value.strip()
+    return {}, text
+
+
+def render_frontmatter(meta: dict, order: list[str], body: str):
+    ordered_keys = []
+    for key in order:
+        if key in meta and key not in ordered_keys:
+            ordered_keys.append(key)
+    for key in meta:
+        if key not in ordered_keys:
+            ordered_keys.append(key)
+    lines = ["---"]
+    for key in ordered_keys:
+        lines.append(f"{key}: {meta[key]}")
+    lines.append("---")
+    return "\n".join(lines) + "\n\n" + body.rstrip() + "\n"
+
+
+def sha256_text(text: str):
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def default_output_path(source_path: str):
+    return str(Path(DEFAULT_REHYDRATE_ROOT) / Path(source_path))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Rehydrate archived memory records back into source-like documents")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--output-path", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT)
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_absolute():
+        manifest_path = root / manifest_path
+    report_path = Path(args.output)
+    if not report_path.is_absolute():
+        report_path = (Path.cwd() / report_path).resolve()
+
+    if not manifest_path.exists():
+        report = {
+            "generated_at_utc": now_utc(),
+            "mode": "dry-run" if args.dry_run else "apply",
+            "manifest_path": str(manifest_path),
+            "error_count": 1,
+            "errors": [f"manifest path not found: {manifest_path}"],
+            "verdict": "fail",
+        }
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+        print(f"report written: {report_path}")
+        print("error_count=1 verdict=fail")
+        return 1 if args.strict else 0
+
+    manifest = load_json(manifest_path)
+    required_keys = [
+        "archive_path",
+        "source_path",
+        "source_checksum_sha256",
+        "source_frontmatter",
+        "source_frontmatter_order",
+    ]
+    missing = [key for key in required_keys if key not in manifest]
+    if missing:
+        report = {
+            "generated_at_utc": now_utc(),
+            "mode": "dry-run" if args.dry_run else "apply",
+            "manifest_path": str(manifest_path),
+            "error_count": 1,
+            "errors": [f"manifest missing required key(s): {', '.join(missing)}"],
+            "verdict": "fail",
+        }
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+        print(f"report written: {report_path}")
+        print("error_count=1 verdict=fail")
+        return 1 if args.strict else 0
+
+    archive_path = root / manifest["archive_path"]
+    if not archive_path.exists():
+        raise SystemExit(f"archive path not found: {manifest['archive_path']}")
+
+    output_path = Path(args.output_path) if args.output_path else root / default_output_path(manifest["source_path"])
+    if not output_path.is_absolute():
+        output_path = root / output_path
+
+    archive_text = archive_path.read_text(encoding="utf-8")
+    _, body = parse_frontmatter(archive_text)
+    source_meta = dict(manifest.get("source_frontmatter") or {})
+    source_order = list(manifest.get("source_frontmatter_order") or list(source_meta.keys()))
+    restored_text = render_frontmatter(source_meta, source_order, body)
+    restored_checksum = sha256_text(restored_text)
+    checksum_match = restored_checksum == manifest.get("source_checksum_sha256")
+
+    if not args.dry_run:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(restored_text, encoding="utf-8")
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "mode": "dry-run" if args.dry_run else "apply",
+        "manifest_path": str(manifest_path),
+        "archive_path": manifest["archive_path"],
+        "source_path": manifest["source_path"],
+        "output_path": str(output_path),
+        "restored_checksum_sha256": restored_checksum,
+        "source_checksum_sha256": manifest.get("source_checksum_sha256"),
+        "checksum_match": checksum_match,
+        "verdict": "pass" if checksum_match else "fail",
+    }
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(f"report written: {report_path}")
+    print(f"checksum_match={str(checksum_match).lower()} verdict={report['verdict']}")
+    if args.strict and not checksum_match:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/planningops/scripts/test_memory_archive_contract.sh
+++ b/planningops/scripts/test_memory_archive_contract.sh
@@ -93,6 +93,8 @@ assert manifest["manifest_version"] == 1, manifest
 assert manifest["archive_ref"] == manifest["manifest_path"], manifest
 assert manifest["memory_tier"] == "L2", manifest
 assert manifest["compacted_into"] == "docs/initiatives/unified-personal-agent-platform/contracts/sample-contract.md", manifest
+assert manifest["source_frontmatter"]["title"] == "plan: Sample", manifest
+assert "title" in manifest["source_frontmatter_order"], manifest
 PY
 
 python3 - "$archive_path" <<'PY'

--- a/planningops/scripts/test_memory_rehydrate_contract.sh
+++ b/planningops/scripts/test_memory_rehydrate_contract.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/repo"
+mkdir -p \
+  "$fixture_root/docs/workbench/unified-personal-agent-platform/plans" \
+  "$fixture_root/docs/initiatives/unified-personal-agent-platform/contracts"
+
+source_rel="docs/workbench/unified-personal-agent-platform/plans/2026-03-07-roundtrip-plan.md"
+compacted_rel="docs/initiatives/unified-personal-agent-platform/contracts/roundtrip-contract.md"
+
+cat > "$fixture_root/$source_rel" <<'EOF'
+---
+title: plan: Roundtrip
+type: plan
+date: 2026-03-07
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: reference
+summary: Roundtrip fixture for archive and rehydrate.
+topic: roundtrip
+memory_tier: L0
+compacted_into: docs/initiatives/unified-personal-agent-platform/contracts/roundtrip-contract.md
+---
+
+# Roundtrip Plan
+EOF
+
+cat > "$fixture_root/$compacted_rel" <<'EOF'
+---
+title: Roundtrip Contract
+type: contract
+date: 2026-03-08
+initiative: unified-personal-agent-platform
+lifecycle: canonical
+status: active
+summary: Canonical target for roundtrip fixture.
+memory_tier: L1
+---
+EOF
+
+python3 planningops/scripts/memory_archive.py \
+  --root "$fixture_root" \
+  --source "$source_rel" \
+  --compacted-into "$compacted_rel" \
+  --archived-at 2026-03-08T00:00:00Z \
+  --output "$tmp_dir/archive-report.json" \
+  --strict
+
+manifest_rel="planningops/archive-manifest/docs/workbench/unified-personal-agent-platform/plans/2026-03-07-roundtrip-plan.json"
+rehydrated_rel="planningops/artifacts/rehydrate/docs/workbench/unified-personal-agent-platform/plans/2026-03-07-roundtrip-plan.md"
+
+python3 planningops/scripts/memory_rehydrate.py \
+  --root "$fixture_root" \
+  --manifest "$manifest_rel" \
+  --output-path "$rehydrated_rel" \
+  --output "$tmp_dir/rehydrate-report.json" \
+  --strict
+
+test -f "$fixture_root/$rehydrated_rel"
+
+python3 - "$fixture_root/$source_rel" "$fixture_root/$rehydrated_rel" "$tmp_dir/rehydrate-report.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source_text = Path(sys.argv[1]).read_text(encoding="utf-8")
+rehydrated_text = Path(sys.argv[2]).read_text(encoding="utf-8")
+report = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+assert source_text == rehydrated_text, report
+assert report["checksum_match"] is True, report
+assert report["verdict"] == "pass", report
+PY
+
+set +e
+python3 planningops/scripts/memory_rehydrate.py \
+  --root "$fixture_root" \
+  --manifest missing-manifest.json \
+  --output "$tmp_dir/rehydrate-missing-report.json" \
+  --strict
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for missing manifest"
+  exit 1
+fi
+
+echo "memory rehydrate contract test ok"

--- a/planningops/scripts/validate_memory_archive_manifest.py
+++ b/planningops/scripts/validate_memory_archive_manifest.py
@@ -32,10 +32,22 @@ def validate(instance, schema, path="$"):
         properties = schema.get("properties", {})
         for key, value in instance.items():
             if key not in properties:
-                if schema.get("additionalProperties") is False:
+                additional = schema.get("additionalProperties", True)
+                if additional is False:
                     errors.append(f"{path}.{key}: additional property not allowed")
+                elif isinstance(additional, dict):
+                    errors.extend(validate(value, additional, f"{path}.{key}"))
                 continue
             errors.extend(validate(value, properties[key], f"{path}.{key}"))
+        return errors
+
+    if expected_type == "array":
+        if not isinstance(instance, list):
+            return [f"{path}: expected array"]
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for idx, value in enumerate(instance):
+                errors.extend(validate(value, item_schema, f"{path}[{idx}]"))
         return errors
 
     if expected_type == "string":


### PR DESCRIPTION
## Summary
- extend archive manifests with source frontmatter/order so archived records can be reconstructed deterministically
- add `memory_rehydrate.py` to resolve a manifest into a source-like restored document with checksum verification
- add roundtrip contract coverage and wire rehydrate validation into federated CI

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts:
  - `planningops/scripts/memory_rehydrate.py`
  - `planningops/scripts/test_memory_rehydrate_contract.sh`
  - `planningops/scripts/memory_archive.py`
  - `planningops/scripts/test_memory_archive_contract.sh`
  - `planningops/scripts/validate_memory_archive_manifest.py`
  - `planningops/contracts/memory-tier-contract.md`
  - `planningops/schemas/memory-archive-manifest.schema.json`
- `.github/` workflows:
  - `.github/workflows/federated-ci-matrix.yml`
- archive/docs roots:
  - `docs/archive/README.md`
  - `planningops/archive-manifest/README.md`

## Linked Issues
- Closes #106
- Related #105

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `bash planningops/scripts/test_memory_archive_contract.sh`
- [x] `bash planningops/scripts/test_memory_rehydrate_contract.sh`
- [x] `python3 -m py_compile planningops/scripts/memory_archive.py planningops/scripts/validate_memory_archive_manifest.py planningops/scripts/memory_rehydrate.py`
- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/federated-ci-matrix.yml"); puts "yaml ok"'`

## Risks
- Risk: deterministic rehydrate depends on manifest-stored source frontmatter/order, so future manifest shape changes must preserve those fields.
- Rollback: revert commit `04a2eb0` to remove rehydrate support and manifest extensions.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.

## Post-Deploy Monitoring & Validation
- Expected healthy signal: `bash planningops/scripts/test_memory_rehydrate_contract.sh` remains green and reports `checksum_match=true`.
- Failure signal: rehydrated output checksum diverges from stored source checksum or manifest validation fails after future archive changes.
- Rollback trigger: revert if manifest evolution breaks deterministic rehydrate for existing archived records.
