### PR TITLE
feat: enforce strict memory CI gates

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -210,6 +210,12 @@ jobs:
           bash planningops/scripts/test_memory_compactor_contract.sh
           bash planningops/scripts/test_memory_archive_contract.sh
           bash planningops/scripts/test_memory_rehydrate_contract.sh
+          python3 planningops/scripts/memory_compactor.py \
+            --mode check \
+            --root . \
+            --rules planningops/config/memory-tier-rules.json \
+            --output planningops/artifacts/validation/memory-gate-report.json \
+            --strict
           bash planningops/scripts/test_audit_branch_protection_contract.sh
           bash planningops/scripts/test_apply_branch_protection_contract.sh
           python3 planningops/scripts/audit_branch_protection.py \

--- a/planningops/contracts/memory-tier-contract.md
+++ b/planningops/contracts/memory-tier-contract.md
@@ -106,6 +106,7 @@ Allowed when:
 - Rules config: `planningops/config/memory-tier-rules.json`
 - Validator: `planningops/scripts/validate_memory_tier_rules.py`
 - Check mode: `python3 planningops/scripts/memory_compactor.py --mode check`
+- CI gate: `python3 planningops/scripts/memory_compactor.py --mode check --root . --rules planningops/config/memory-tier-rules.json --output planningops/artifacts/validation/memory-gate-report.json --strict`
 - Archive command: `python3 planningops/scripts/memory_archive.py --source <repo-relative-source> --compacted-into <repo-relative-target>`
 - Rehydrate command: `python3 planningops/scripts/memory_rehydrate.py --manifest <archive-ref-or-manifest-path>`
 - Manifest schema: `planningops/schemas/memory-archive-manifest.schema.json`

--- a/planningops/scripts/memory_compactor.py
+++ b/planningops/scripts/memory_compactor.py
@@ -152,6 +152,7 @@ def build_record(path: Path, root: Path, rules: dict, as_of: date):
     anchor_date, anchor_source = pick_anchor_date(meta, path)
     expires_on = parse_iso_date(meta.get("expires_on"))
     compacted_into = str(meta.get("compacted_into") or "").strip()
+    archive_ref = str(meta.get("archive_ref") or "").strip()
     topic = derive_topic(meta, path)
     age_days = max((as_of - anchor_date).days, 0)
     return {
@@ -166,6 +167,7 @@ def build_record(path: Path, root: Path, rules: dict, as_of: date):
         "age_days": age_days,
         "expires_on": expires_on.isoformat() if expires_on else None,
         "compacted_into": compacted_into,
+        "archive_ref": archive_ref,
         "frontmatter_present": bool(meta),
     }
 
@@ -226,6 +228,81 @@ def detect_duplicate_topics(records: list[dict], rules: dict):
     return findings
 
 
+def detect_archive_linkage(records: list[dict], root: Path):
+    findings = []
+    index = {row["path"]: row for row in records}
+    for row in records:
+        if Path(row["path"]).name == "README.md":
+            continue
+        is_archive_record = row["path"].startswith("docs/archive/")
+        if not is_archive_record and row["memory_tier"] != "L2":
+            continue
+        archive_ref = row.get("archive_ref") or ""
+        if not archive_ref:
+            findings.append(
+                {
+                    "code": "missing_archive_linkage",
+                    "path": row["path"],
+                    "reason": "archive_ref_missing",
+                }
+            )
+            continue
+        manifest_path = root / archive_ref
+        if not manifest_path.exists():
+            findings.append(
+                {
+                    "code": "missing_archive_linkage",
+                    "path": row["path"],
+                    "archive_ref": archive_ref,
+                    "reason": "manifest_missing",
+                }
+            )
+            continue
+        try:
+            manifest = load_json(manifest_path)
+        except Exception as exc:  # noqa: BLE001
+            findings.append(
+                {
+                    "code": "missing_archive_linkage",
+                    "path": row["path"],
+                    "archive_ref": archive_ref,
+                    "reason": f"manifest_unreadable:{exc}",
+                }
+            )
+            continue
+        if manifest.get("archive_path") != row["path"]:
+            findings.append(
+                {
+                    "code": "missing_archive_linkage",
+                    "path": row["path"],
+                    "archive_ref": archive_ref,
+                    "reason": "archive_path_mismatch",
+                }
+            )
+            continue
+        if manifest.get("archive_ref") != archive_ref:
+            findings.append(
+                {
+                    "code": "missing_archive_linkage",
+                    "path": row["path"],
+                    "archive_ref": archive_ref,
+                    "reason": "archive_ref_mismatch",
+                }
+            )
+            continue
+        source_path = manifest.get("source_path")
+        if source_path and source_path in index and index[source_path].get("compacted_into") not in {"", row["compacted_into"]}:
+            findings.append(
+                {
+                    "code": "missing_archive_linkage",
+                    "path": row["path"],
+                    "archive_ref": archive_ref,
+                    "reason": "compacted_target_mismatch",
+                }
+            )
+    return findings
+
+
 def main():
     parser = argparse.ArgumentParser(description="Memory compactor dry validator for L0/L1/L2 planning knowledge")
     parser.add_argument("--mode", choices=["check"], default="check")
@@ -253,7 +330,8 @@ def main():
 
     stale_l0 = detect_stale_l0(records, rules, as_of)
     duplicate_topics = detect_duplicate_topics(records, rules)
-    trigger_count = len(stale_l0) + len(duplicate_topics)
+    archive_linkage = detect_archive_linkage(records, root)
+    trigger_count = len(stale_l0) + len(duplicate_topics) + len(archive_linkage)
 
     report = {
         "generated_at_utc": now_utc(),
@@ -267,6 +345,7 @@ def main():
         "error_count": len(errors),
         "stale_l0_uncompacted": stale_l0,
         "topic_compaction_required": duplicate_topics,
+        "missing_archive_linkage": archive_linkage,
         "errors": errors,
         "verdict": "pass" if trigger_count == 0 and not errors else "fail",
     }

--- a/planningops/scripts/test_memory_compactor_contract.sh
+++ b/planningops/scripts/test_memory_compactor_contract.sh
@@ -109,6 +109,7 @@ assert report["verdict"] == "fail", report
 assert report["trigger_count"] == 4, report
 assert len(report["stale_l0_uncompacted"]) == 3, report
 assert len(report["topic_compaction_required"]) == 1, report
+assert len(report["missing_archive_linkage"]) == 0, report
 topic = report["topic_compaction_required"][0]
 assert topic["topic"] == "alpha", topic
 assert topic["record_count"] == 3, topic
@@ -164,6 +165,49 @@ report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 assert report["verdict"] == "pass", report
 assert report["trigger_count"] == 0, report
 assert report["error_count"] == 0, report
+PY
+
+archive_root="$tmp_dir/archive-repo"
+mkdir -p "$archive_root/docs/archive/workbench/unified-personal-agent-platform/plans"
+
+cat > "$archive_root/docs/archive/workbench/unified-personal-agent-platform/plans/2026-03-07-archived-plan.md" <<'EOF'
+---
+title: Archived Plan
+type: plan
+date: 2026-03-07
+initiative: unified-personal-agent-platform
+lifecycle: canonical
+status: archived
+summary: Archived plan missing archive ref.
+memory_tier: L2
+compacted_into: docs/initiatives/unified-personal-agent-platform/contracts/archived-contract.md
+---
+EOF
+
+set +e
+python3 planningops/scripts/memory_compactor.py \
+  --mode check \
+  --root "$archive_root" \
+  --rules planningops/config/memory-tier-rules.json \
+  --as-of 2026-03-08 \
+  --output "$tmp_dir/report-archive-link-missing.json" \
+  --strict
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for missing archive linkage"
+  exit 1
+fi
+
+python3 - "$tmp_dir/report-archive-link-missing.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert len(report["missing_archive_linkage"]) == 1, report
+assert report["missing_archive_linkage"][0]["reason"] == "archive_ref_missing", report
 PY
 
 python3 - <<'PY'


### PR DESCRIPTION
## Summary
- promote `memory_compactor.py --mode check --strict` into the federated CI guardrail chain
- extend the memory gate to fail on missing archive linkage, not only stale L0 and duplicate workbench topics
- keep the gate deterministic by writing a fixed validation report artifact path in CI

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts:
  - `planningops/scripts/memory_compactor.py`
  - `planningops/scripts/test_memory_compactor_contract.sh`
  - `planningops/contracts/memory-tier-contract.md`
- `.github/` workflows:
  - `.github/workflows/federated-ci-matrix.yml`

## Linked Issues
- Closes #107
- Related #106

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `bash planningops/scripts/test_memory_compactor_contract.sh`
- [x] `python3 planningops/scripts/memory_compactor.py --mode check --root . --rules planningops/config/memory-tier-rules.json --output /tmp/a44-memory-gate-report.json --strict`
- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/federated-ci-matrix.yml"); puts "yaml ok"'`

## Risks
- Risk: future archive/readme/layout changes under `docs/archive` or `planningops/archive-manifest` could create new false positives if they are mistaken for L2 records.
- Rollback: revert commit `df41834` to remove strict memory CI enforcement and archive linkage detection.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.

## Post-Deploy Monitoring & Validation
- Expected healthy signal: CI writes `planningops/artifacts/validation/memory-gate-report.json` with `trigger_count=0` and `verdict=pass` on `main`.
- Failure signal: stale L0 records, duplicate workbench topics without summary, or archived docs missing `archive_ref`/manifest linkage.
- Rollback trigger: revert if live main begins failing because non-record docs are being misclassified as archived memory.
