### PR TITLE
[PO-CT][E22] Exclude closed issues from backlog stock accounting

### DIFF
--- a/planningops/contracts/backlog-stock-replenishment-contract.md
+++ b/planningops/contracts/backlog-stock-replenishment-contract.md
@@ -9,6 +9,8 @@ Three queue classes are mandatory:
 2. `next_up`: near-ready (`Todo` + `ready-*` + dependency blocker exists)
 3. `quality_hardening`: contract/test/governance hardening queue
 
+Closed issues are never counted as stock, even if stale project fields still show `Todo` or `ready-*`.
+
 Stock floor source:
 - `planningops/config/backlog-stock-policy.json`
 

--- a/planningops/fixtures/backlog-stock-items-sample.json
+++ b/planningops/fixtures/backlog-stock-items-sample.json
@@ -2,6 +2,7 @@
   {
     "issue_number": 101,
     "issue_repo": "rather-not-work-on/platform-planningops",
+    "issue_state": "OPEN",
     "status": "Todo",
     "workflow_state": "ready-contract",
     "execution_order": 10,
@@ -12,6 +13,7 @@
   {
     "issue_number": 102,
     "issue_repo": "rather-not-work-on/monday",
+    "issue_state": "OPEN",
     "status": "Todo",
     "workflow_state": "ready-implementation",
     "execution_order": 20,
@@ -22,6 +24,7 @@
   {
     "issue_number": 103,
     "issue_repo": "rather-not-work-on/platform-planningops",
+    "issue_state": "OPEN",
     "status": "Todo",
     "workflow_state": "ready-contract",
     "execution_order": 30,
@@ -32,6 +35,7 @@
   {
     "issue_number": 104,
     "issue_repo": "rather-not-work-on/platform-planningops",
+    "issue_state": "OPEN",
     "status": "Todo",
     "workflow_state": "backlog",
     "execution_order": 40,
@@ -42,9 +46,21 @@
   {
     "issue_number": 105,
     "issue_repo": "rather-not-work-on/platform-planningops",
+    "issue_state": "OPEN",
     "status": "Blocked",
     "workflow_state": "blocked",
     "execution_order": 50,
+    "component": "planningops",
+    "initiative": "unified-personal-agent-platform",
+    "open_dependency_count": 0
+  },
+  {
+    "issue_number": 106,
+    "issue_repo": "rather-not-work-on/platform-planningops",
+    "issue_state": "CLOSED",
+    "status": "Todo",
+    "workflow_state": "ready-contract",
+    "execution_order": 5,
     "component": "planningops",
     "initiative": "unified-personal-agent-platform",
     "open_dependency_count": 0

--- a/planningops/scripts/backlog_stock_replenishment_guard.py
+++ b/planningops/scripts/backlog_stock_replenishment_guard.py
@@ -213,6 +213,7 @@ def normalize_item(raw):
             "component": str(raw.get("component", "")),
             "initiative": str(raw.get("initiative", "")),
             "issue_body": str(raw.get("issue_body", "")),
+            "issue_state": str(raw.get("issue_state", "")),
             "open_dependency_count": raw.get("open_dependency_count"),
         }
 
@@ -233,6 +234,7 @@ def normalize_item(raw):
         "component": str(raw.get("component", "")),
         "initiative": str(raw.get("initiative", "")),
         "issue_body": str(raw.get("issue_body", "")),
+        "issue_state": str(content.get("state", "")),
         "open_dependency_count": raw.get("open_dependency_count"),
     }
 
@@ -251,9 +253,80 @@ def hydrate_issue_body(issue_repo: str, issue_number: int):
     return out, "ok"
 
 
-def hydrate_dependency_counts(rows, offline=False):
+def fetch_issue_metadata_for_repo(repo: str, limit: int = 500):
+    rc, out, err = run(
+        ["gh", "issue", "list", "--repo", repo, "--state", "all", "--limit", str(limit), "--json", "number,state,body"]
+    )
+    if rc != 0:
+        return {}, f"issue_list_failed:{err}"
+    try:
+        rows = json.loads(out)
+    except json.JSONDecodeError:
+        return {}, "issue_list_invalid_json"
+
+    items = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        number = row.get("number")
+        state = str(row.get("state", "")).upper()
+        body = str(row.get("body", ""))
+        if isinstance(number, int):
+            items[number] = {
+                "state": state if state in {"OPEN", "CLOSED"} else "",
+                "body": body,
+            }
+    return items, "ok"
+
+
+def hydrate_issue_states(rows, issue_catalog=None, offline=False):
+    diagnostics = []
+    state_cache = {}
+    issue_catalog = issue_catalog or {}
+    repo_status = {}
+
+    if not offline:
+        repos = sorted({row["issue_repo"] for row in rows if row.get("issue_repo")})
+        for repo in repos:
+            if repo in issue_catalog:
+                continue
+            issue_catalog[repo], repo_status[repo] = fetch_issue_metadata_for_repo(repo)
+
+    for row in rows:
+        issue_state = str(row.get("issue_state", "")).upper()
+        if issue_state in {"OPEN", "CLOSED"}:
+            continue
+
+        key = (row["issue_repo"], row["issue_number"])
+        if key not in state_cache:
+            if offline:
+                state_cache[key] = ("OPEN", "offline_default_open")
+            else:
+                repo = row["issue_repo"]
+                repo_items = issue_catalog.get(repo, {})
+                if row["issue_number"] in repo_items and repo_items[row["issue_number"]].get("state"):
+                    state_cache[key] = (repo_items[row["issue_number"]]["state"], repo_status.get(repo, "ok"))
+                else:
+                    closed, reason = issue_is_closed(row["issue_number"], row["issue_repo"])
+                    state_cache[key] = ("CLOSED" if closed else "OPEN", reason)
+        state_value, reason = state_cache[key]
+        row["issue_state"] = state_value
+        diagnostics.append(
+            {
+                "issue_number": row["issue_number"],
+                "issue_repo": row["issue_repo"],
+                "event": "hydrate_issue_state",
+                "status": reason,
+                "issue_state": state_value,
+            }
+        )
+    return diagnostics
+
+
+def hydrate_dependency_counts(rows, issue_catalog=None, offline=False):
     closed_cache = {}
     diagnostics = []
+    issue_catalog = issue_catalog or {}
 
     for row in rows:
         if isinstance(row.get("open_dependency_count"), int):
@@ -268,8 +341,13 @@ def hydrate_dependency_counts(rows, offline=False):
                 row["depends_on"] = []
                 row["dependency_status"] = "offline_missing_issue_body"
                 continue
-            hydrated_body, status = hydrate_issue_body(row["issue_repo"], row["issue_number"])
-            issue_body = hydrated_body
+            repo_items = issue_catalog.get(row["issue_repo"], {})
+            if row["issue_number"] in repo_items and repo_items[row["issue_number"]].get("body"):
+                issue_body = repo_items[row["issue_number"]]["body"]
+                status = "bulk_issue_metadata"
+            else:
+                hydrated_body, status = hydrate_issue_body(row["issue_repo"], row["issue_number"])
+                issue_body = hydrated_body
             diagnostics.append(
                 {
                     "issue_number": row["issue_number"],
@@ -295,7 +373,11 @@ def hydrate_dependency_counts(rows, offline=False):
                 if offline:
                     closed_cache[key] = (False, "offline_dependency_unknown")
                 else:
-                    closed_cache[key] = issue_is_closed(dep, row["issue_repo"])
+                    repo_items = issue_catalog.get(row["issue_repo"], {})
+                    if dep in repo_items and repo_items[dep].get("state") in {"OPEN", "CLOSED"}:
+                        closed_cache[key] = (repo_items[dep]["state"] == "CLOSED", "bulk_issue_metadata")
+                    else:
+                        closed_cache[key] = issue_is_closed(dep, row["issue_repo"])
             closed, reason = closed_cache[key]
             if not closed:
                 open_count += 1
@@ -313,6 +395,9 @@ def hydrate_dependency_counts(rows, offline=False):
 
 
 def row_matches_rule(row, rule):
+    if str(row.get("issue_state", "")).upper() == "CLOSED":
+        return False
+
     statuses = set(rule.get("statuses") or [])
     if statuses and row.get("status") not in statuses:
         return False
@@ -496,7 +581,9 @@ def main():
             continue
         rows.append(normalized)
 
-    dependency_diagnostics = hydrate_dependency_counts(rows, offline=args.offline)
+    issue_catalog = {}
+    issue_state_diagnostics = hydrate_issue_states(rows, issue_catalog=issue_catalog, offline=args.offline)
+    dependency_diagnostics = hydrate_dependency_counts(rows, issue_catalog=issue_catalog, offline=args.offline)
     stock = evaluate_stock(rows, policy)
     high_value_ready = select_high_value_ready(stock["class_rows"])
 
@@ -537,6 +624,7 @@ def main():
             "breaches": breaches,
         },
         "candidate_validation": candidate_validation,
+        "issue_state_diagnostics": issue_state_diagnostics,
         "dependency_diagnostics": dependency_diagnostics,
     }
     save_json(Path(args.output), report)

--- a/planningops/scripts/test_backlog_stock_replenishment_contract.sh
+++ b/planningops/scripts/test_backlog_stock_replenishment_contract.sh
@@ -17,9 +17,13 @@ policy = mod.load_json(Path("planningops/config/backlog-stock-policy.json"), {})
 items = mod.load_json(Path("planningops/fixtures/backlog-stock-items-sample.json"), [])
 rows = [mod.normalize_item(x) for x in items]
 rows = [x for x in rows if x]
+issue_state_diagnostics = mod.hydrate_issue_states(rows, offline=True)
+assert issue_state_diagnostics == [], issue_state_diagnostics
 mod.hydrate_dependency_counts(rows, offline=True)
 stock = mod.evaluate_stock(rows, policy)
 assert stock["breach_count"] == 0, stock
+ready_numbers = [row["issue_number"] for row in stock["class_rows"]["ready_now"]]
+assert 106 not in ready_numbers, ready_numbers
 
 high_value = mod.select_high_value_ready(stock["class_rows"])
 assert high_value is not None, high_value


### PR DESCRIPTION
## Summary
- exclude closed issues from backlog stock class matching even when stale project fields still show `Todo` or `ready-*`
- hydrate issue state and issue body in bulk per repo so live stock reports remain usable
- add regression coverage for mixed open/closed stock rows and update the stock contract language

## Scope
- Initiative docs:
  - none
- Workbench docs:
  - none
- `planningops/` scripts/contracts:
  - `planningops/scripts/backlog_stock_replenishment_guard.py`
  - `planningops/scripts/test_backlog_stock_replenishment_contract.sh`
  - `planningops/fixtures/backlog-stock-items-sample.json`
  - `planningops/contracts/backlog-stock-replenishment-contract.md`
- `.github/` workflows:
  - none

## Linked Issues
- Closes #138
- Related #86
- Related #87
- Related #88
- Related #89

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_backlog_stock_replenishment_contract.sh`
  - `python3 -m py_compile planningops/scripts/backlog_stock_replenishment_guard.py`
  - `python3 planningops/scripts/backlog_stock_replenishment_guard.py --output /tmp/backlog-stock-report-e22.json`
  - `git diff --check`

## Risks
- Risk: bulk issue metadata hydration assumes `gh issue list --state all --json number,state,body` remains available and returns enough rows for each repo.
- Rollback: revert this PR to return to project-field-only stock accounting.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
