### PR TITLE
fix(planningops): separate inventory cards from executable backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/planningops-task.yml
+++ b/.github/ISSUE_TEMPLATE/planningops-task.yml
@@ -13,11 +13,12 @@ body:
     id: planning_context
     attributes:
       label: Planning Context
-      description: Include plan_item_id/target_repo/component/workflow_state/loop_profile/execution_order/depends_on.
+      description: Include plan_item_id/target_repo/component/workflow_state/loop_profile/execution_order/depends_on. Add execution_kind when the card is inventory-only.
       placeholder: |
         - plan_item_id: `...`
         - target_repo: `owner/repo`
         - component: `...`
+        - execution_kind: `executable` # optional; use `inventory` for non-executable stock/support cards
         - workflow_state: `...`
         - loop_profile: `...`
         - execution_order: `...`

--- a/planningops/config/backlog-stock-policy.json
+++ b/planningops/config/backlog-stock-policy.json
@@ -8,6 +8,7 @@
       "rule": {
         "statuses": ["Todo"],
         "workflow_states": ["ready-contract", "ready-implementation"],
+        "execution_kinds": ["executable"],
         "dependency_mode": "all_closed"
       }
     },
@@ -18,6 +19,7 @@
       "rule": {
         "statuses": ["Todo"],
         "workflow_states": ["ready-contract", "ready-implementation"],
+        "execution_kinds": ["executable"],
         "dependency_mode": "has_open"
       }
     },
@@ -29,6 +31,7 @@
         "statuses": ["Todo"],
         "workflow_states": ["backlog", "ready-contract"],
         "components": ["planningops"],
+        "execution_kinds": ["executable"],
         "dependency_mode": "any"
       }
     }

--- a/planningops/contracts/backlog-stock-replenishment-contract.md
+++ b/planningops/contracts/backlog-stock-replenishment-contract.md
@@ -5,11 +5,19 @@ Keep autonomous Kanban execution stable by enforcing queue stock floors and evid
 
 ## Queue Classes
 Three queue classes are mandatory:
-1. `ready_now`: executable now (`Todo` + `ready-*` + no open dependency blocker)
-2. `next_up`: near-ready (`Todo` + `ready-*` + dependency blocker exists)
-3. `quality_hardening`: contract/test/governance hardening queue
+1. `ready_now`: executable now (`Todo` + `ready-*` + `execution_kind=executable` + no open dependency blocker)
+2. `next_up`: near-ready (`Todo` + `ready-*` + `execution_kind=executable` + dependency blocker exists)
+3. `quality_hardening`: executable contract/test/governance hardening queue
 
 Closed issues are never counted as stock, even if stale project fields still show `Todo` or `ready-*`.
+Inventory cards are never counted as stock, even when they remain open for audit or replenishment bookkeeping.
+
+## Execution Kind Semantics
+- Issue body metadata may declare `execution_kind`.
+- Allowed values:
+  - `executable` (default when omitted)
+  - `inventory`
+- `inventory` means the issue exists to preserve queue memory, replenishment history, or bookkeeping state. It is not eligible for stock floors or live pull selection.
 
 Stock floor source:
 - `planningops/config/backlog-stock-policy.json`
@@ -18,6 +26,7 @@ Stock floor source:
 - Intake must apply `high_value_ready_first`.
 - Selection target is always the smallest `(execution_order, issue_number)` inside `ready_now`.
 - `backlog`/non-ready cards cannot preempt a `ready_now` candidate even when they have smaller `execution_order`.
+- `execution_kind=inventory` cards must be skipped before dependency and blueprint checks.
 
 ## Replenishment Gate
 New follow-up backlog candidates must be evidence-backed and normalized before queue insertion.
@@ -31,6 +40,7 @@ Required candidate fields:
 Candidate normalization output must include:
 - deterministic `candidate_id`
 - baseline issue body template with:
+  - `execution_kind`
   - `depends_on`
   - checklist-style acceptance criteria
   - evidence references section

--- a/planningops/contracts/control-tower-ontology-contract.md
+++ b/planningops/contracts/control-tower-ontology-contract.md
@@ -67,6 +67,9 @@ This contract fixes:
 - `initiative` must use the canonical slug shared by docs and project fields.
 - `plan_item_id` must match `^[A-Z][0-9]{2}$`.
 - `target_repo` must use full repository coordinates (`owner/repo`), not shorthand.
+- `execution_kind` may be used to refine delivery semantics:
+  - `executable` (default when omitted)
+  - `inventory`
 - `component` must use the canonical project field vocabulary:
   - `planningops`
   - `contracts`
@@ -98,6 +101,7 @@ This contract fixes:
 4. A `RuntimeArtifact` without `repo`, `logical_path`, or governing refs is invalid for completion evidence.
 5. A `MemoryRecord` cannot compact sources from multiple initiatives without an explicit cross-initiative note.
 6. `platform-planningops` may validate evidence from execution repos, but runtime ownership remains with the emitting repo.
+7. `execution_kind=inventory` items are valid backlog records, but they are not eligible for executable queue stock or loop pull selection.
 
 ## Verification
 - Backlog/project metadata quality: `python3 planningops/scripts/validate_issue_quality.py --strict`

--- a/planningops/contracts/requirements-contract.md
+++ b/planningops/contracts/requirements-contract.md
@@ -1,7 +1,7 @@
 # Ralph Loop Requirements Contract
 
 ## Functional Requirements
-1. Intake must select only issues where `Status=Todo` and `workflow_state in {ready-contract, ready-implementation}`, then enforce `execution_order` ascending.
+1. Intake must select only issues where `Status=Todo`, `workflow_state in {ready-contract, ready-implementation}`, and `execution_kind=executable` (default when omitted), then enforce `execution_order` ascending.
 2. Intake must block issues with unsatisfied `depends_on`.
 3. Selector must deterministically assign `loop_profile` from issue context and transition history (`L1|L2|L3|L4|L5`), including explicit contract-stage simulation signals (`simulation_required`, `uncertainty_level`).
 4. Each loop must produce deterministic artifacts for the same input and commit.
@@ -32,17 +32,18 @@
 29. Autonomous run control must be convergence/risk bounded; wall-clock duration is metadata and cannot override safety or quality stop conditions.
 30. Autonomous stop conditions must explicitly include quality failure, escalation trigger, and runtime safety conflict with deterministic evidence output.
 31. High-uncertainty or architecture-tradeoff changes must use branch/worktree comparative experiment protocol with artifact-backed selection record.
-32. Backlog operation must define queue classes (`ready_now`, `next_up`, `quality_hardening`) with explicit minimum stock targets.
+32. Backlog operation must define queue classes (`ready_now`, `next_up`, `quality_hardening`) with explicit minimum stock targets for executable work only.
 33. Intake selection must enforce `high_value_ready_first` so non-ready cards cannot preempt a ready-now candidate.
 34. Replenishment candidates must be evidence-backed and rejected when artifact references are missing.
-35. Replenishment candidate normalization must preserve dependency baseline (`depends_on`) and checklist acceptance criteria.
-36. Supervisor loop must orchestrate multi-cycle `plan -> work -> review -> replan` with deterministic per-cycle records.
-37. Supervisor must evaluate experiment triggers from uncertainty/simulation signals and emit explicit experiment trigger artifacts.
-38. Supervisor decisions must treat replan and replenishment outputs as first-class cycle outputs.
-39. Supervisor summary must publish final stop reason and contract references for each run.
-40. Supervisor experiment trigger must be able to invoke an automatic comparative executor that creates deterministic option worktrees.
-41. Automatic comparative executor must emit per-option reports and weighted decision record artifacts.
-42. Automatic comparative executor failure must map to supervisor stop reason `experiment_auto_executor_failed`.
+35. Replenishment candidate normalization must preserve `execution_kind`, dependency baseline (`depends_on`), and checklist acceptance criteria.
+36. Inventory-only backlog cards must remain distinguishable via issue metadata and must never satisfy executable stock floors or live pull selection.
+37. Supervisor loop must orchestrate multi-cycle `plan -> work -> review -> replan` with deterministic per-cycle records.
+38. Supervisor must evaluate experiment triggers from uncertainty/simulation signals and emit explicit experiment trigger artifacts.
+39. Supervisor decisions must treat replan and replenishment outputs as first-class cycle outputs.
+40. Supervisor summary must publish final stop reason and contract references for each run.
+41. Supervisor experiment trigger must be able to invoke an automatic comparative executor that creates deterministic option worktrees.
+42. Automatic comparative executor must emit per-option reports and weighted decision record artifacts.
+43. Automatic comparative executor failure must map to supervisor stop reason `experiment_auto_executor_failed`.
 
 ## Non-Functional Requirements
 1. Idempotency: repeated execution for same issue+commit must not duplicate updates.

--- a/planningops/fixtures/backlog-replenishment-candidates-sample.json
+++ b/planningops/fixtures/backlog-replenishment-candidates-sample.json
@@ -4,6 +4,7 @@
       "candidate_id": "candidate-001",
       "title": "Harden dependency unblock path for ready-implementation lane",
       "target_repo": "rather-not-work-on/monday",
+      "execution_kind": "executable",
       "depends_on": [101],
       "acceptance_criteria": [
         "Dependency mapping is documented and reproducible.",

--- a/planningops/fixtures/backlog-stock-items-sample.json
+++ b/planningops/fixtures/backlog-stock-items-sample.json
@@ -64,5 +64,17 @@
     "component": "planningops",
     "initiative": "unified-personal-agent-platform",
     "open_dependency_count": 0
+  },
+  {
+    "issue_number": 107,
+    "issue_repo": "rather-not-work-on/platform-planningops",
+    "issue_state": "OPEN",
+    "status": "Todo",
+    "workflow_state": "ready-contract",
+    "execution_kind": "inventory",
+    "execution_order": 8,
+    "component": "planningops",
+    "initiative": "unified-personal-agent-platform",
+    "open_dependency_count": 0
   }
 ]

--- a/planningops/scripts/backlog_stock_replenishment_guard.py
+++ b/planningops/scripts/backlog_stock_replenishment_guard.py
@@ -6,6 +6,19 @@ import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+import sys
+
+
+SCRIPTS_ROOT = Path(__file__).resolve().parent
+if str(SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_ROOT))
+
+from core.loop.selection import (
+    EXECUTION_KIND_EXECUTABLE,
+    is_executable_execution_kind,
+    normalize_execution_kind,
+    parse_execution_kind,
+)
 
 
 DEFAULT_STOCK_POLICY_FILE = Path("planningops/config/backlog-stock-policy.json")
@@ -100,6 +113,7 @@ def render_issue_body_baseline(candidate):
     criteria_lines = "\n".join(f"- [ ] {row}" for row in candidate.get("acceptance_criteria", []))
     evidence_lines = "\n".join(f"- `{row}`" for row in candidate.get("evidence_refs", []))
     target_repo = str(candidate.get("target_repo") or "").strip() or "rather-not-work-on/platform-planningops"
+    execution_kind = candidate.get("execution_kind") or EXECUTION_KIND_EXECUTABLE
 
     return "\n".join(
         [
@@ -107,6 +121,7 @@ def render_issue_body_baseline(candidate):
             f"- plan_item_id: `{candidate.get('candidate_id', '')}`",
             f"- target_repo: `{target_repo}`",
             "- component: `planningops`",
+            f"- execution_kind: `{execution_kind}`",
             "- workflow_state: `ready_contract`",
             "- loop_profile: `l1_contract_clarification`",
             "- execution_order: `0`",
@@ -144,6 +159,7 @@ def validate_replenishment_candidates(candidates, requirements):
         candidate_id = str(entry.get("candidate_id") or f"candidate-{idx + 1}")
         title = str(entry.get("title", "")).strip()
         evidence_refs = normalize_evidence_refs(entry)
+        execution_kind, execution_kind_error = normalize_execution_kind(entry.get("execution_kind"), default=EXECUTION_KIND_EXECUTABLE)
 
         depends_on = []
         depends_error = None
@@ -160,6 +176,8 @@ def validate_replenishment_candidates(candidates, requirements):
             errors.append("title is required")
         if require_evidence and not evidence_refs:
             errors.append("evidence_refs is required and must be non-empty")
+        if execution_kind_error:
+            errors.append(execution_kind_error)
         if depends_error:
             errors.append(depends_error)
         if acceptance_error:
@@ -169,6 +187,7 @@ def validate_replenishment_candidates(candidates, requirements):
             "candidate_id": candidate_id,
             "title": title,
             "target_repo": str(entry.get("target_repo", "")).strip() or None,
+            "execution_kind": execution_kind,
             "depends_on": depends_on if isinstance(depends_on, list) else [],
             "acceptance_criteria": acceptance_criteria if isinstance(acceptance_criteria, list) else [],
             "evidence_refs": evidence_refs,
@@ -215,6 +234,7 @@ def normalize_item(raw):
             "issue_body": str(raw.get("issue_body", "")),
             "issue_state": str(raw.get("issue_state", "")),
             "open_dependency_count": raw.get("open_dependency_count"),
+            "execution_kind": normalize_execution_kind(raw.get("execution_kind"), default=EXECUTION_KIND_EXECUTABLE)[0],
         }
 
     # gh project item-list shape
@@ -236,6 +256,7 @@ def normalize_item(raw):
         "issue_body": str(raw.get("issue_body", "")),
         "issue_state": str(content.get("state", "")),
         "open_dependency_count": raw.get("open_dependency_count"),
+        "execution_kind": normalize_execution_kind(raw.get("execution_kind"), default=EXECUTION_KIND_EXECUTABLE)[0],
     }
 
 
@@ -330,6 +351,8 @@ def hydrate_dependency_counts(rows, issue_catalog=None, offline=False):
 
     for row in rows:
         if isinstance(row.get("open_dependency_count"), int):
+            if row.get("issue_body"):
+                row["execution_kind"] = parse_execution_kind(row["issue_body"], default=row.get("execution_kind") or EXECUTION_KIND_EXECUTABLE)
             row["depends_on"] = []
             row["dependency_status"] = "provided"
             continue
@@ -357,6 +380,7 @@ def hydrate_dependency_counts(rows, issue_catalog=None, offline=False):
                 }
             )
         row["issue_body"] = issue_body
+        row["execution_kind"] = parse_execution_kind(issue_body, default=row.get("execution_kind") or EXECUTION_KIND_EXECUTABLE)
 
         deps = parse_depends_on(issue_body)
         row["depends_on"] = deps
@@ -396,6 +420,11 @@ def hydrate_dependency_counts(rows, issue_catalog=None, offline=False):
 
 def row_matches_rule(row, rule):
     if str(row.get("issue_state", "")).upper() == "CLOSED":
+        return False
+
+    execution_kind = row.get("execution_kind") or EXECUTION_KIND_EXECUTABLE
+    allowed_execution_kinds = set(rule.get("execution_kinds") or [EXECUTION_KIND_EXECUTABLE])
+    if allowed_execution_kinds and execution_kind not in allowed_execution_kinds:
         return False
 
     statuses = set(rule.get("statuses") or [])
@@ -444,6 +473,7 @@ def evaluate_stock(rows, policy):
                     "issue_number": m.get("issue_number"),
                     "issue_repo": m.get("issue_repo"),
                     "execution_order": m.get("execution_order"),
+                    "execution_kind": m.get("execution_kind"),
                     "open_dependency_count": m.get("open_dependency_count"),
                 }
                 for m in matched_sorted
@@ -477,6 +507,7 @@ def select_high_value_ready(class_rows):
         "issue_number": selected.get("issue_number"),
         "issue_repo": selected.get("issue_repo"),
         "execution_order": selected.get("execution_order"),
+        "execution_kind": selected.get("execution_kind"),
         "workflow_state": selected.get("workflow_state"),
         "reason": "high_value_ready_first",
     }
@@ -525,8 +556,17 @@ def validate_policy(policy):
             min_stock = queue_class.get("min_stock")
             if not isinstance(min_stock, int) or min_stock < 0:
                 errors.append(f"queue_classes[{idx}].min_stock must be non-negative integer")
-            if not isinstance(queue_class.get("rule"), dict):
+            rule = queue_class.get("rule")
+            if not isinstance(rule, dict):
                 errors.append(f"queue_classes[{idx}].rule must be object")
+                continue
+            execution_kinds = rule.get("execution_kinds") or []
+            if execution_kinds and not isinstance(execution_kinds, list):
+                errors.append(f"queue_classes[{idx}].rule.execution_kinds must be list")
+            for raw_kind in execution_kinds:
+                _, error = normalize_execution_kind(raw_kind, default=EXECUTION_KIND_EXECUTABLE)
+                if error:
+                    errors.append(f"queue_classes[{idx}].rule.execution_kinds invalid: {raw_kind}")
     req = policy.get("candidate_requirements")
     if not isinstance(req, dict):
         errors.append("candidate_requirements must be object")
@@ -619,6 +659,10 @@ def main():
         },
         "stock": {
             "evaluated_items": len(rows),
+            "execution_kind_counts": {
+                "executable": sum(1 for row in rows if is_executable_execution_kind(row.get("execution_kind"))),
+                "inventory": sum(1 for row in rows if not is_executable_execution_kind(row.get("execution_kind"))),
+            },
             "rows": stock["stock_rows"],
             "breach_count": stock["breach_count"],
             "breaches": breaches,

--- a/planningops/scripts/core/loop/runner.py
+++ b/planningops/scripts/core/loop/runner.py
@@ -30,15 +30,18 @@ from core.loop.checkpoint_lock import (
     save_checkpoint as _save_checkpoint,
 )
 from core.loop.selection import (
+    EXECUTION_KIND_EXECUTABLE,
     HIGH_VALUE_READY_STATES,
     build_replenishment_candidates,
     build_selection_trace,
     determine_loop_profile,
     ensure_single_select_field,
     ensure_text_field,
+    is_executable_execution_kind,
     normalize_candidates,
     parse_blueprint_refs,
     parse_depends_on,
+    parse_execution_kind,
     parse_plan_item_id,
     parse_selector_hints,
 )
@@ -540,7 +543,20 @@ def main():
         attempt_budget, budget_errors = parse_attempt_budget(issue_body)
         selector_hints = parse_selector_hints(issue_body)
         blueprint_meta = parse_blueprint_refs(issue_body)
+        execution_kind = parse_execution_kind(issue_body, default=EXECUTION_KIND_EXECUTABLE)
         c["plan_item_id"] = plan_item_id
+        c["execution_kind"] = execution_kind
+        if not is_executable_execution_kind(execution_kind):
+            selection_attempts.append(
+                {
+                    "number": num,
+                    "issue_repo": issue_repo,
+                    "result": "inventory_only",
+                    "plan_item_id": plan_item_id,
+                    "execution_kind": execution_kind,
+                }
+            )
+            continue
         if budget_errors:
             selection_attempts.append(
                 {
@@ -580,6 +596,7 @@ def main():
                     "issue_repo": issue_repo,
                     "result": "selected",
                     "plan_item_id": plan_item_id,
+                    "execution_kind": execution_kind,
                     "depends_on": deps,
                     "dep_checks": closed_checks,
                     "attempt_budget": attempt_budget,
@@ -594,6 +611,7 @@ def main():
                 "issue_repo": issue_repo,
                 "result": "dependency_blocked",
                 "plan_item_id": plan_item_id,
+                "execution_kind": execution_kind,
                 "depends_on": deps,
                 "dep_checks": closed_checks,
                 "selector_hints": selector_hints,

--- a/planningops/scripts/core/loop/selection.py
+++ b/planningops/scripts/core/loop/selection.py
@@ -9,6 +9,17 @@ import re
 
 
 HIGH_VALUE_READY_STATES = {"ready-contract", "ready-implementation"}
+EXECUTION_KIND_EXECUTABLE = "executable"
+EXECUTION_KIND_INVENTORY = "inventory"
+EXECUTION_KIND_ALIASES = {
+    "executable": EXECUTION_KIND_EXECUTABLE,
+    "execute": EXECUTION_KIND_EXECUTABLE,
+    "real": EXECUTION_KIND_EXECUTABLE,
+    "inventory": EXECUTION_KIND_INVENTORY,
+    "inventory_only": EXECUTION_KIND_INVENTORY,
+    "stock_seed": EXECUTION_KIND_INVENTORY,
+    "seed": EXECUTION_KIND_INVENTORY,
+}
 
 
 def parse_depends_on(issue_body: str):
@@ -17,6 +28,32 @@ def parse_depends_on(issue_body: str):
         if "depends_on:" in line:
             deps.update(int(n) for n in re.findall(r"#(\d+)", line))
     return sorted(deps)
+
+
+def normalize_execution_kind(raw: str | None, default: str = EXECUTION_KIND_EXECUTABLE):
+    if raw is None:
+        return default, None
+    value = str(raw).strip().strip("`")
+    if not value:
+        return default, None
+    key = re.sub(r"[\s-]+", "_", value.lower())
+    mapped = EXECUTION_KIND_ALIASES.get(key)
+    if mapped:
+        return mapped, None
+    return None, f"unsupported execution_kind: {value}"
+
+
+def parse_execution_kind(issue_body: str, default: str = EXECUTION_KIND_EXECUTABLE):
+    match = re.search(r"(?mi)^(?:-\s*)?execution_kind:\s*`?([^`\n]+)`?\s*$", issue_body or "")
+    if not match:
+        return default
+    parsed, error = normalize_execution_kind(match.group(1), default=default)
+    return parsed or default
+
+
+def is_executable_execution_kind(execution_kind: str):
+    normalized, _ = normalize_execution_kind(execution_kind, default=EXECUTION_KIND_EXECUTABLE)
+    return normalized == EXECUTION_KIND_EXECUTABLE
 
 
 def parse_plan_item_id(issue_body: str):
@@ -106,6 +143,9 @@ def normalize_candidates(items, allowed_workflow_states, high_value_ready_states
 
         target_repo = it.get("target_repo") or issue_repo
         order = it.get("execution_order") or 0
+        execution_kind, _ = normalize_execution_kind(it.get("execution_kind"), default=EXECUTION_KIND_EXECUTABLE)
+        if not is_executable_execution_kind(execution_kind):
+            continue
         candidates.append(
             {
                 "item": it,
@@ -118,6 +158,7 @@ def normalize_candidates(items, allowed_workflow_states, high_value_ready_states
                 "workflow_state": workflow_state,
                 "issue_repo": issue_repo,
                 "target_repo": target_repo,
+                "execution_kind": execution_kind,
             }
         )
 
@@ -146,6 +187,7 @@ def build_selection_trace(candidates, selected, attempts, allowed_workflow_state
             "loop_profile": selected.get("loop_profile"),
             "initiative": selected.get("initiative"),
             "plan_item_id": selected.get("plan_item_id"),
+            "execution_kind": selected.get("execution_kind", EXECUTION_KIND_EXECUTABLE),
             "depends_on": selected.get("deps", []),
             "attempt_budget": selected.get("attempt_budget", default_attempt_budget or {}),
             "simulation_required": selected.get("simulation_required", False),
@@ -174,6 +216,7 @@ def build_selection_trace(candidates, selected, attempts, allowed_workflow_state
                 "loop_profile": c.get("loop_profile"),
                 "initiative": c.get("initiative"),
                 "plan_item_id": c.get("plan_item_id"),
+                "execution_kind": c.get("execution_kind", EXECUTION_KIND_EXECUTABLE),
                 "simulation_required": c.get("simulation_required", False),
                 "uncertainty_level": c.get("uncertainty_level"),
                 "blueprint_refs": c.get("blueprint_refs", {}),
@@ -210,6 +253,7 @@ def build_replenishment_candidates(
         "candidate_id": f"issue-{issue_num}-follow-up",
         "title": f"Recovery follow-up for issue #{issue_num} ({reason_code})",
         "target_repo": target_repo,
+        "execution_kind": EXECUTION_KIND_EXECUTABLE,
         "depends_on": [issue_num],
         "acceptance_criteria": [
             f"Root cause for `{reason_code}` is documented with evidence.",

--- a/planningops/scripts/test_backlog_stock_replenishment_contract.sh
+++ b/planningops/scripts/test_backlog_stock_replenishment_contract.sh
@@ -24,11 +24,17 @@ stock = mod.evaluate_stock(rows, policy)
 assert stock["breach_count"] == 0, stock
 ready_numbers = [row["issue_number"] for row in stock["class_rows"]["ready_now"]]
 assert 106 not in ready_numbers, ready_numbers
+assert 107 not in ready_numbers, ready_numbers
+quality_numbers = [row["issue_number"] for row in stock["class_rows"]["quality_hardening"]]
+assert 107 not in quality_numbers, quality_numbers
+assert stock["stock_rows"][0]["issue_refs"][0]["execution_kind"] == "executable", stock["stock_rows"][0]["issue_refs"]
+assert mod.parse_execution_kind("- execution_kind: `inventory`") == "inventory"
 
 high_value = mod.select_high_value_ready(stock["class_rows"])
 assert high_value is not None, high_value
 assert high_value["issue_number"] == 101, high_value
 assert high_value["reason"] == "high_value_ready_first", high_value
+assert high_value["execution_kind"] == "executable", high_value
 
 invalid_candidates = [
     {
@@ -41,6 +47,11 @@ candidate_validation = mod.validate_replenishment_candidates(invalid_candidates,
 assert candidate_validation["violation_count"] == 1, candidate_validation
 assert "evidence_refs is required and must be non-empty" in candidate_validation["violations"][0]["errors"], candidate_validation
 assert "acceptance_criteria must be a list" in candidate_validation["violations"][0]["errors"], candidate_validation
+
+good_candidates = mod.load_json(Path("planningops/fixtures/backlog-replenishment-candidates-sample.json"), {})
+good_validation = mod.validate_replenishment_candidates(good_candidates["candidates"], policy["candidate_requirements"])
+assert good_validation["violation_count"] == 0, good_validation
+assert "execution_kind: `executable`" in good_validation["normalized_candidates"][0]["body_baseline"], good_validation
 
 with tempfile.TemporaryDirectory() as td:
     td_path = Path(td)
@@ -64,6 +75,7 @@ with tempfile.TemporaryDirectory() as td:
     assert pass_rc == 0, pass_rc
     pass_doc = json.loads(pass_report.read_text(encoding="utf-8"))
     assert pass_doc["verdict"] == "pass", pass_doc
+    assert pass_doc["stock"]["execution_kind_counts"]["inventory"] == 1, pass_doc
 
     bad_candidates_path = td_path / "bad-candidates.json"
     bad_candidates_path.write_text(

--- a/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
+++ b/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
@@ -23,6 +23,14 @@ items = [
     {
         "status": "Todo",
         "workflow_state": "ready-contract",
+        "execution_order": 1,
+        "execution_kind": "inventory",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "content": {"type": "Issue", "number": 78, "repository": "rather-not-work-on/platform-planningops"},
+    },
+    {
+        "status": "Todo",
+        "workflow_state": "ready-contract",
         "execution_order": 10,
         "target_repo": "rather-not-work-on/monday",
         "content": {"type": "Issue", "number": 42, "repository": "rather-not-work-on/monday"},
@@ -64,6 +72,7 @@ trace = mod.build_selection_trace(candidates, selected, attempts, allowed)
 assert trace["candidate_count"] == 2, trace
 assert trace["selected"]["number"] == 77, trace
 assert trace["selected"]["target_repo"] == "rather-not-work-on/platform-planningops", trace
+assert trace["selected"]["execution_kind"] == "executable", trace
 
 l1_profile = mod.determine_loop_profile(selected, {}, "rather-not-work-on/platform-planningops")
 assert l1_profile == "L1 Contract-Clarification", l1_profile
@@ -85,6 +94,9 @@ assert l2_profile_uncertainty == "L2 Simulation", l2_profile_uncertainty
 selector_hints = mod.parse_selector_hints("simulation_required: true\nuncertainty_level: critical\n")
 assert selector_hints["simulation_required"] is True, selector_hints
 assert selector_hints["uncertainty_level"] == "critical", selector_hints
+assert mod.parse_execution_kind("- execution_kind: `inventory`") == "inventory"
+assert mod.parse_execution_kind("execution_kind: executable") == "executable"
+assert mod.parse_execution_kind("no marker") == "executable"
 
 blueprint_ok = mod.parse_blueprint_refs(
     "\n".join(

--- a/planningops/scripts/test_issue_loop_runner_wrapper_compat.sh
+++ b/planningops/scripts/test_issue_loop_runner_wrapper_compat.sh
@@ -27,6 +27,9 @@ assert wrapper_mod.determine_loop_profile(selected, payload, control_repo) == ca
 assert wrapper_mod.parse_selector_hints("simulation_required: true\nuncertainty_level: high\n") == canonical_mod.parse_selector_hints(
     "simulation_required: true\nuncertainty_level: high\n"
 )
+assert wrapper_mod.parse_execution_kind("- execution_kind: inventory") == canonical_mod.parse_execution_kind(
+    "- execution_kind: inventory"
+)
 assert wrapper_mod.parse_blueprint_refs("interface_contract_refs: a\n") == canonical_mod.parse_blueprint_refs(
     "interface_contract_refs: a\n"
 )


### PR DESCRIPTION
## Summary
- introduce `execution_kind` semantics so inventory-only issues are distinguishable from executable backlog
- exclude inventory cards from backlog stock accounting and live loop selection
- migrate `#86`-`#89` to `execution_kind=inventory` with `workflow_state=backlog`

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: backlog stock policy/contract, ontology/requirements contract, loop selection/runner, stock guard, regression fixtures/tests
- `.github/` workflows: none

## Linked Issues
- Closes #140
- Related #86
- Related #87
- Related #88
- Related #89

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `python3 -m py_compile planningops/scripts/core/loop/selection.py planningops/scripts/core/loop/runner.py planningops/scripts/backlog_stock_replenishment_guard.py planningops/scripts/validate_issue_quality.py`
- [x] `bash planningops/scripts/test_backlog_stock_replenishment_contract.sh`
- [x] `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
- [x] `bash planningops/scripts/test_issue_loop_runner_wrapper_compat.sh`
- [x] `python3 planningops/scripts/validate_issue_quality.py --strict --repo rather-not-work-on/platform-planningops --output /tmp/e23-issue-quality.json`
- [x] Live stock summary after migration shows `#140` as selected executable card and keeps `#86`-`#89` inventory-only

## Risks
- Risk: executable issues that accidentally declare an invalid `execution_kind` could be filtered from stock/selection until metadata is corrected
- Rollback: revert commit `b537172` and restore stock seed issue bodies if inventory separation must be undone

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.

## Post-Deploy Monitoring & Validation
- Log/search terms: `inventory_only`, `execution_kind`, `high_value_ready_first`, `stock_breaches`
- Watch: `python3 planningops/scripts/backlog_stock_replenishment_guard.py --report-only --output /tmp/backlog-stock-post-e23.json`
- Healthy signals:
  - `ready_now` selection points to an executable issue
  - `#86`-`#89` do not appear in executable stock rows
  - live pull selection skips inventory issues
- Failure signals / rollback trigger:
  - inventory issues appear in `ready_now`, `next_up`, or live pull selection
  - executable issues with omitted `execution_kind` are incorrectly excluded
  - rollback by reverting commit `b537172`
- Validation window: immediate post-merge and next live stock check
- Owner: Codex
