### PR TITLE
feat(planningops): define execution event storage residency

### DIFF
--- a/planningops/config/README.md
+++ b/planningops/config/README.md
@@ -17,7 +17,7 @@ Provide stable configuration sources for project fields, runtime profiles, and c
 - `supervisor-experiment-validation-pack.json`: command pack for automatic worktree comparative execution
 - `refactor-hygiene-policy.json`: single-repo refactor hygiene policy
 - `refactor-hygiene-multi-repo.json`: multi-repo hygiene matrix config
-- `artifact-storage-policy.json`: artifact tier map, backend selector, and retention policy
+- `artifact-storage-policy.json`: artifact tier map, backend selector, retention policy, and local-first execution event residency map
 - `repository-governance-policy.json`: default-branch protection baseline and required checks policy
 - `federated-label-taxonomy.json`: execution-repo label catalog and default backfill mapping
 - `memory-tier-rules.json`: machine-readable L0/L1/L2 definitions, triggers, and promotion/archive rules

--- a/planningops/config/artifact-storage-policy.json
+++ b/planningops/config/artifact-storage-policy.json
@@ -43,6 +43,85 @@
       "mock_base_path": "planningops/runtime-artifacts/oci-mock"
     }
   },
+  "portability_profile": {
+    "mode": "local_first",
+    "default_backend": "local",
+    "approved_migration_backends": ["s3", "oci"],
+    "target_platforms": ["local", "oracle_cloud"],
+    "canonical_pointer_strategy": "git_pointer_only"
+  },
+  "execution_event_families": {
+    "loop_attempts": {
+      "logical_root": "planningops/artifacts/loops/",
+      "residency": "external_only",
+      "pointer_visibility": "git_pointer_only",
+      "default_backend": "local",
+      "migration_backends": ["s3", "oci"],
+      "retention_days": 30,
+      "owner_scripts": [
+        "planningops/scripts/core/loop/runner.py",
+        "planningops/scripts/ralph_loop_local.py"
+      ]
+    },
+    "transition_logs": {
+      "logical_root": "planningops/artifacts/transition-log/",
+      "residency": "external_only",
+      "pointer_visibility": "git_pointer_only",
+      "default_backend": "local",
+      "migration_backends": ["s3", "oci"],
+      "retention_days": 30,
+      "owner_scripts": [
+        "planningops/scripts/core/loop/runner.py",
+        "planningops/scripts/ralph_loop_local.py"
+      ]
+    },
+    "adapter_hook_records": {
+      "logical_root": "planningops/artifacts/adapter-hooks/",
+      "residency": "external_only",
+      "pointer_visibility": "git_pointer_only",
+      "default_backend": "local",
+      "migration_backends": ["s3", "oci"],
+      "retention_days": 30,
+      "owner_scripts": [
+        "planningops/scripts/core/loop/runner.py"
+      ]
+    },
+    "sync_summaries": {
+      "logical_root": "planningops/artifacts/sync-summary/",
+      "residency": "external_only",
+      "pointer_visibility": "git_pointer_only",
+      "default_backend": "local",
+      "migration_backends": ["s3", "oci"],
+      "retention_days": 30,
+      "owner_scripts": [
+        "planningops/scripts/parser_diff_dry_run.py",
+        "planningops/scripts/ralph_loop_local.py"
+      ]
+    },
+    "supervisor_runs": {
+      "logical_root": "planningops/artifacts/supervisor/",
+      "residency": "external_only",
+      "pointer_visibility": "git_pointer_only",
+      "default_backend": "local",
+      "migration_backends": ["s3", "oci"],
+      "retention_days": 30,
+      "owner_scripts": [
+        "planningops/scripts/autonomous_supervisor_loop.py"
+      ]
+    },
+    "experiment_runs": {
+      "logical_root": "planningops/artifacts/experiments/",
+      "residency": "external_only",
+      "pointer_visibility": "git_pointer_only",
+      "default_backend": "local",
+      "migration_backends": ["s3", "oci"],
+      "retention_days": 30,
+      "owner_scripts": [
+        "planningops/scripts/autonomous_supervisor_loop.py",
+        "planningops/scripts/supervisor_experiment_auto_executor.py"
+      ]
+    }
+  },
   "retention": {
     "git_canonical_days": 3650,
     "git_optional_days": 180,

--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -29,6 +29,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `issue-label-taxonomy-contract.md`: required label taxonomy (`task`/priority/area/type) and gates
 - `artifact-retention-tier-contract.md`: Git vs external artifact storage tier policy
 - `artifact-sink-contract.md`: backend selector abstraction + pointer/rehydrate behavior
+- `execution-event-storage-residency-contract.md`: local-first external-only residency map for runtime event families
 - `repository-governance-contract.md`: default-branch protection baseline and required-check governance
 - `control-tower-ontology-contract.md`: canonical entity/relation/path model for planningops as control tower
 - `memory-tier-contract.md`: 3-tier memory lifecycle, frontmatter keys, and compaction trigger contract

--- a/planningops/contracts/artifact-retention-tier-contract.md
+++ b/planningops/contracts/artifact-retention-tier-contract.md
@@ -50,3 +50,6 @@ Backend selection is controlled by:
 - Diff guard command: `python3 planningops/scripts/validate_external_only_commit_guard.py --base-ref <base> --head-ref <head> --strict`
 - Tracked baseline audit: `python3 planningops/scripts/validate_external_only_commit_guard.py --mode tracked --strict`
 - Migration/rehydrate: `planningops/scripts/migrate_external_only_artifacts.py`, `planningops/scripts/rehydrate_artifact_pointer.py`
+
+## Related Contracts
+- `planningops/contracts/execution-event-storage-residency-contract.md`

--- a/planningops/contracts/artifact-sink-contract.md
+++ b/planningops/contracts/artifact-sink-contract.md
@@ -32,3 +32,6 @@ Provide a deterministic write/read/rehydrate abstraction for artifact storage ba
 - Commit guard test: `bash planningops/scripts/test_validate_external_only_commit_guard.sh`
 - Migration test: `bash planningops/scripts/test_migrate_external_only_artifacts_contract.sh`
 - Policy validation: `python3 planningops/scripts/validate_artifact_storage_policy.py --strict`
+
+## Related Contracts
+- `planningops/contracts/execution-event-storage-residency-contract.md`

--- a/planningops/contracts/execution-event-storage-residency-contract.md
+++ b/planningops/contracts/execution-event-storage-residency-contract.md
@@ -1,0 +1,60 @@
+# Execution Event Storage Residency Contract
+
+## Purpose
+Define which runtime/event artifact families must remain external-only, which backend is used by default, and how local-first operation may migrate to S3/OCI without changing canonical evidence semantics.
+
+## Scope
+- Repository: `rather-not-work-on/platform-planningops`
+- Governs execution/event families emitted by:
+  - `planningops/scripts/core/loop/runner.py`
+  - `planningops/scripts/ralph_loop_local.py`
+  - `planningops/scripts/autonomous_supervisor_loop.py`
+  - `planningops/scripts/supervisor_experiment_auto_executor.py`
+  - `planningops/scripts/parser_diff_dry_run.py`
+
+## Residency Rules
+1. Event families under `planningops/artifacts/loops/**`, `transition-log/**`, `adapter-hooks/**`, `sync-summary/**`, `supervisor/**`, and `experiments/**` are `external_only`.
+2. Canonical Git visibility for these families is pointer-only:
+   - payload bytes live in the selected backend
+   - Git retains pointer manifests and canonical validation evidence only
+3. Default backend is `local`.
+4. Approved migration backends are `s3` and `oci`.
+5. Migration must preserve:
+   - `logical_path`
+   - `backend`
+   - `uri`
+   - `sha256`
+   - `written_at_utc`
+
+## Portability Profile
+- Strategy: `local_first`
+- Default target platform: local filesystem
+- Migration targets: `s3`, `oci`
+- Oracle Cloud portability is satisfied through `oci` backend compatibility; contract shape must remain unchanged when backend switches.
+
+## Required Family Map
+Configured in `planningops/config/artifact-storage-policy.json` under `execution_event_families`.
+
+Minimum fields per family:
+- `logical_root`
+- `residency`
+- `pointer_visibility`
+- `default_backend`
+- `migration_backends`
+- `retention_days`
+- `owner_scripts`
+
+## Drift Guard
+- Each `owner_scripts` entry must exist and reference its declared `logical_root`.
+- Each `logical_root` must be covered by the `external_only` tier map.
+- `retention_days` for event families must not exceed `retention.external_only_days`.
+
+## Verification
+- Policy validator: `python3 planningops/scripts/validate_artifact_storage_policy.py --strict`
+- Contract test: `bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh`
+- Commit guard: `python3 planningops/scripts/validate_external_only_commit_guard.py --strict`
+
+## Related Contracts
+- `planningops/contracts/artifact-retention-tier-contract.md`
+- `planningops/contracts/artifact-sink-contract.md`
+- `planningops/contracts/requirements-contract.md`

--- a/planningops/scripts/test_validate_artifact_storage_policy_contract.sh
+++ b/planningops/scripts/test_validate_artifact_storage_policy_contract.sh
@@ -24,6 +24,24 @@ cat > "$tmp_dir/invalid-policy.json" <<'JSON'
       "kind": "local"
     }
   },
+  "portability_profile": {
+    "mode": "remote_first",
+    "default_backend": "s3",
+    "approved_migration_backends": [],
+    "target_platforms": [],
+    "canonical_pointer_strategy": "inline_git"
+  },
+  "execution_event_families": {
+    "broken_family": {
+      "logical_root": "planningops/artifacts/validation",
+      "residency": "git_canonical",
+      "pointer_visibility": "inline_git",
+      "default_backend": "s3",
+      "migration_backends": ["local"],
+      "retention_days": 999,
+      "owner_scripts": ["planningops/scripts/does-not-exist.py"]
+    }
+  },
   "retention": {
     "git_canonical_days": 0,
     "git_optional_days": -1,

--- a/planningops/scripts/validate_artifact_storage_policy.py
+++ b/planningops/scripts/validate_artifact_storage_policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+from fnmatch import fnmatch
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -11,6 +12,15 @@ DEFAULT_POLICY = Path("planningops/config/artifact-storage-policy.json")
 DEFAULT_OUTPUT = Path("planningops/artifacts/validation/artifact-storage-policy-report.json")
 REQUIRED_TIERS = ["git_canonical", "git_optional", "external_only"]
 REQUIRED_BACKENDS = ["local", "s3", "oci"]
+REQUIRED_EVENT_FAMILY_KEYS = [
+    "logical_root",
+    "residency",
+    "pointer_visibility",
+    "default_backend",
+    "migration_backends",
+    "retention_days",
+    "owner_scripts",
+]
 
 
 def now_utc():
@@ -19,6 +29,12 @@ def now_utc():
 
 def load_json(path: Path):
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def logical_root_covered_by_external_only(logical_root: str, tiers: dict):
+    external_patterns = tiers.get("external_only") or []
+    probe = logical_root.rstrip("/") + "/__probe__"
+    return any(isinstance(pattern, str) and pattern and fnmatch(probe, pattern) for pattern in external_patterns)
 
 
 def main():
@@ -87,6 +103,90 @@ def main():
             value = retention.get(key)
             if not isinstance(value, int) or value <= 0:
                 errors.append(f"retention.{key} must be positive integer")
+
+    portability = doc.get("portability_profile")
+    if not isinstance(portability, dict):
+        errors.append("portability_profile must be object")
+        portability = {}
+    else:
+        if portability.get("mode") != "local_first":
+            errors.append("portability_profile.mode must be local_first")
+        portability_default = portability.get("default_backend")
+        if portability_default != default_backend:
+            errors.append("portability_profile.default_backend must match default_external_backend")
+        approved = portability.get("approved_migration_backends")
+        if not isinstance(approved, list) or not approved:
+            errors.append("portability_profile.approved_migration_backends must be non-empty list")
+            approved = []
+        elif not all(isinstance(v, str) and v for v in approved):
+            errors.append("portability_profile.approved_migration_backends entries must be non-empty strings")
+        if any(v == portability_default for v in approved):
+            errors.append("portability_profile.approved_migration_backends must exclude default backend")
+        if any(v not in backends for v in approved):
+            errors.append("portability_profile.approved_migration_backends must reference existing backends")
+        targets = portability.get("target_platforms")
+        if not isinstance(targets, list) or not targets:
+            errors.append("portability_profile.target_platforms must be non-empty list")
+        if portability.get("canonical_pointer_strategy") != "git_pointer_only":
+            errors.append("portability_profile.canonical_pointer_strategy must be git_pointer_only")
+
+    execution_event_families = doc.get("execution_event_families")
+    if not isinstance(execution_event_families, dict) or not execution_event_families:
+        errors.append("execution_event_families must be non-empty object")
+    else:
+        max_external_days = retention.get("external_only_days") if isinstance(retention, dict) else None
+        portability_default = portability.get("default_backend") if isinstance(portability, dict) else None
+        approved_migrations = set(portability.get("approved_migration_backends") or []) if isinstance(portability, dict) else set()
+        for family_name, cfg in execution_event_families.items():
+            if not isinstance(cfg, dict):
+                errors.append(f"execution_event_families.{family_name} must be object")
+                continue
+            for key in REQUIRED_EVENT_FAMILY_KEYS:
+                if key not in cfg:
+                    errors.append(f"execution_event_families.{family_name}.{key} is required")
+            logical_root = cfg.get("logical_root")
+            if not isinstance(logical_root, str) or not logical_root.startswith("planningops/artifacts/") or not logical_root.endswith("/"):
+                errors.append(f"execution_event_families.{family_name}.logical_root must be planningops/artifacts/*/ path")
+            elif isinstance(tiers, dict) and not logical_root_covered_by_external_only(logical_root, tiers):
+                errors.append(f"execution_event_families.{family_name}.logical_root must be covered by tiers.external_only")
+
+            if cfg.get("residency") != "external_only":
+                errors.append(f"execution_event_families.{family_name}.residency must be external_only")
+            if cfg.get("pointer_visibility") != "git_pointer_only":
+                errors.append(f"execution_event_families.{family_name}.pointer_visibility must be git_pointer_only")
+            if cfg.get("default_backend") != portability_default:
+                errors.append(f"execution_event_families.{family_name}.default_backend must match portability profile default")
+
+            migrations = cfg.get("migration_backends")
+            if not isinstance(migrations, list) or not migrations:
+                errors.append(f"execution_event_families.{family_name}.migration_backends must be non-empty list")
+                migrations = []
+            elif not all(isinstance(v, str) and v for v in migrations):
+                errors.append(f"execution_event_families.{family_name}.migration_backends entries must be non-empty strings")
+            if any(v not in approved_migrations for v in migrations):
+                errors.append(f"execution_event_families.{family_name}.migration_backends must stay within portability profile")
+
+            retention_days = cfg.get("retention_days")
+            if not isinstance(retention_days, int) or retention_days <= 0:
+                errors.append(f"execution_event_families.{family_name}.retention_days must be positive integer")
+            elif isinstance(max_external_days, int) and retention_days > max_external_days:
+                errors.append(f"execution_event_families.{family_name}.retention_days exceeds retention.external_only_days")
+
+            owner_scripts = cfg.get("owner_scripts")
+            if not isinstance(owner_scripts, list) or not owner_scripts:
+                errors.append(f"execution_event_families.{family_name}.owner_scripts must be non-empty list")
+                owner_scripts = []
+            for script_path in owner_scripts:
+                if not isinstance(script_path, str) or not script_path:
+                    errors.append(f"execution_event_families.{family_name}.owner_scripts entries must be non-empty strings")
+                    continue
+                path = Path(script_path)
+                if not path.exists():
+                    errors.append(f"execution_event_families.{family_name}.owner_script missing: {script_path}")
+                    continue
+                source = path.read_text(encoding="utf-8")
+                if isinstance(logical_root, str) and logical_root.rstrip("/") not in source:
+                    errors.append(f"execution_event_families.{family_name}.owner_script missing logical_root reference: {script_path}")
 
     commit_guard = doc.get("commit_guard", {})
     if not isinstance(commit_guard, dict):


### PR DESCRIPTION
## Summary
- extend artifact storage policy with local-first execution event family residency and approved migration backends
- add execution event storage residency contract and strengthen artifact policy validation with owner-script drift checks
- connect contract docs/readmes so event storage rules stay discoverable from existing artifact contracts

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: artifact storage policy, validator/test, execution event residency contract, related contract/config READMEs
- `.github/` workflows: none

## Linked Issues
- Closes #143
- Related #144

## Validation
- [x] `python3 -m py_compile planningops/scripts/validate_artifact_storage_policy.py`
- [x] `bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh`
- [x] `python3 planningops/scripts/validate_artifact_storage_policy.py --policy planningops/config/artifact-storage-policy.json --output /tmp/e25-artifact-policy-report.json --strict`
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`

## Risks
- Risk: policy validation is stricter and could fail if event owner scripts change paths without updating config
- Rollback: revert commit `668c593`

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.

## Post-Deploy Monitoring & Validation
- Log/search terms: `execution_event_families`, `portability_profile`, `logical_root must be covered`, `owner_script missing logical_root reference`
- Watch: rerun `python3 planningops/scripts/validate_artifact_storage_policy.py --strict` after any event-path change
- Healthy signals:
  - validator passes on current policy
  - event families all stay `external_only` with `local` default backend
  - `s3`/`oci` remain the only approved migration backends
- Failure signals / rollback trigger:
  - validator fails after runtime path edits without policy updates
  - event family owner scripts stop referencing declared logical roots
  - rollback by reverting commit `668c593`
- Validation window: immediate post-merge
- Owner: Codex
