### PR TITLE
feat: review wave5 interface adoption

### DIFF
--- a/planningops/artifacts/validation/runtime-behavior-wave5-interface-review.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave5-interface-review.json
@@ -1,0 +1,115 @@
+{
+  "generated_at_utc": "2026-03-09T03:00:28.985968+00:00",
+  "wave_id": "uap-runtime-behavior-wave5",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/fixtures/runtime-behavior-wave5-interface-review-spec.json",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 181,
+      "state": "CLOSED",
+      "title": "plan: [20] monday orchestrator and executor port adoption",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/181",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 183,
+      "state": "CLOSED",
+      "title": "plan: [40] provider adapter typed adoption",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/183",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 185,
+      "state": "CLOSED",
+      "title": "plan: [60] observability replay and sink typed adoption",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/185",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "gap_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/initiatives/unified-personal-agent-platform/20-repos/platform-contracts/30-execution-plan/runtime-interface-contract-gap-matrix.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass"
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/contract-bindings/src/runtime_ports.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/orchestrator/src/orchestrator_ports.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/executor-ralph-loop/src/ralph_loop_executor.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/services/provider-runtime/src/provider_driver.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/adapters/provider-codex/src/driver.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/adapters/provider-claude/src/driver.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/adapters/provider-local-llm/src/driver.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/services/telemetry-gateway/src/telemetry_ports.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/buffer/replay-worker/src/replay_worker.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/sinks/langfuse-sink/src/langfuse_sink.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    }
+  ],
+  "check_count": 14,
+  "failure_count": 0,
+  "verdict": "pass"
+}

--- a/planningops/fixtures/runtime-behavior-wave5-interface-review-spec.json
+++ b/planningops/fixtures/runtime-behavior-wave5-interface-review-spec.json
@@ -1,0 +1,113 @@
+{
+  "wave_id": "uap-runtime-behavior-wave5",
+  "issues_repo": "rather-not-work-on/platform-planningops",
+  "required_closed_issues": [181, 183, 185],
+  "gap_checks": [
+    {
+      "path": "docs/initiatives/unified-personal-agent-platform/20-repos/platform-contracts/30-execution-plan/runtime-interface-contract-gap-matrix.md",
+      "must_contain": [
+        "| `rather-not-work-on/monday` | internal runtime ports between orchestrator, executor, kernel, and adapters | `C1`, `C2`, `C3`, `C8` | no gap | keep port interfaces repo-local in `contract-bindings` |",
+        "| `rather-not-work-on/platform-provider-gateway` | runtime-to-driver request/result and routing interfaces | `C4` | no gap | keep driver/runtime interfaces repo-local; normalize to `C4` at the public boundary |",
+        "| `rather-not-work-on/platform-observability-gateway` | ingest/buffer/replay/sink interfaces | `C5` | no gap | keep buffer/sink interfaces repo-local; normalize to `C5` at the public ingest boundary |"
+      ]
+    }
+  ],
+  "file_checks": [
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/contract-bindings/src/runtime_ports.ts",
+      "must_contain": [
+        "export interface ProviderInvocationPort",
+        "export interface TelemetryEmitPort",
+        "export interface MessagingAckPort",
+        "export interface ExecutorLoopDependencies"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/orchestrator/src/orchestrator_ports.ts",
+      "must_contain": [
+        "export interface MissionPlannerPort",
+        "export interface MissionExecutorPort",
+        "export interface MissionOrchestratorDependencies"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/executor-ralph-loop/src/ralph_loop_executor.ts",
+      "must_contain": [
+        "this.dependencies.provider.invoke(",
+        "this.dependencies.telemetry?.emit(",
+        "this.dependencies.messaging?.acknowledge("
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "services/provider-runtime/src/provider_driver.ts",
+      "must_contain": [
+        "export interface ProviderDriver",
+        "invoke(request: ProviderInvocationRequest): ProviderInvocationResult;"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "adapters/provider-codex/src/driver.ts",
+      "must_contain": [
+        "implements ProviderDriver",
+        "reasonCode: \"codex_complete\""
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "adapters/provider-claude/src/driver.ts",
+      "must_contain": [
+        "implements ProviderDriver",
+        "reasonCode: \"claude_complete\""
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "adapters/provider-local-llm/src/driver.ts",
+      "must_contain": [
+        "implements ProviderDriver",
+        "reasonCode: \"local_llm_complete\""
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "services/telemetry-gateway/src/telemetry_ports.ts",
+      "must_contain": [
+        "export interface TelemetryIngestPort",
+        "export interface TelemetryBufferAppendPort",
+        "export interface TelemetrySinkDeliveryPort"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "buffer/replay-worker/src/replay_worker.ts",
+      "must_contain": [
+        "TelemetrySinkDeliveryPort",
+        "export interface ReplayWorkerDependencies",
+        "this.dependencies.sink.deliver(event);"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "sinks/langfuse-sink/src/langfuse_sink.ts",
+      "must_contain": [
+        "implements TelemetrySinkDeliveryPort",
+        "runId: envelope.runId"
+      ]
+    }
+  ]
+}

--- a/planningops/scripts/federation/README.md
+++ b/planningops/scripts/federation/README.md
@@ -11,6 +11,7 @@ Keep cross-repository execution entrypoints isolated from the planningops core l
 - `multi_repo_projection_report.py`: repo-level projection drift aggregation
 - `run_local_oracle_rehearsal.py`: local-first vs oracle_cloud rehearsal harness
 - `validate_execution_wave_readiness.py`: readiness validator for plan waves that must verify prerequisite outputs and closed issues before projecting the next issue pack
+- `review_interface_adoption.py`: spec-driven cross-repo review generator for completed interface waves
 - `federated_ci_matrix_local.sh`: local federated CI matrix runner
 
 Compatibility wrappers are kept at `planningops/scripts/*.py|*.sh`; `repo_execution_adapters.py` remains the legacy root name for `adapter_registry.py`.

--- a/planningops/scripts/federation/review_interface_adoption.py
+++ b/planningops/scripts/federation/review_interface_adoption.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in [current] + list(current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return Path(__file__).resolve().parents[4]
+
+
+def resolve_workspace_root(planningops_repo: Path, raw_workspace_root: str) -> Path:
+    base = (planningops_repo / raw_workspace_root).resolve()
+    if base.exists():
+        return base
+    sibling_root = planningops_repo.parent
+    if (sibling_root / "monday").exists() and (sibling_root / "platform-provider-gateway").exists():
+        return sibling_root
+    return base
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run(cmd: list[str]) -> tuple[int, str, str]:
+    cp = subprocess.run(cmd, capture_output=True, text=True)
+    return cp.returncode, cp.stdout.strip(), cp.stderr.strip()
+
+
+def issue_state(repo: str, number: int) -> dict:
+    rc, out, err = run(["gh", "issue", "view", str(number), "--repo", repo, "--json", "number,state,title,url"])
+    if rc != 0:
+        return {
+            "number": number,
+            "state": "UNKNOWN",
+            "title": "",
+            "url": "",
+            "verdict": "fail",
+            "message": err or out or "gh issue view failed",
+        }
+    doc = json.loads(out)
+    verdict = "pass" if doc.get("state") == "CLOSED" else "fail"
+    return {
+        "number": doc.get("number"),
+        "state": doc.get("state"),
+        "title": doc.get("title"),
+        "url": doc.get("url"),
+        "verdict": verdict,
+        "message": "" if verdict == "pass" else "issue not closed",
+    }
+
+
+def substring_check(path: Path, markers: list[str]) -> dict:
+    if not path.exists():
+        return {
+            "path": str(path),
+            "exists": False,
+            "missing_markers": markers,
+            "verdict": "fail",
+        }
+
+    text = path.read_text(encoding="utf-8")
+    missing = [marker for marker in markers if marker not in text]
+    return {
+        "path": str(path),
+        "exists": True,
+        "missing_markers": missing,
+        "verdict": "pass" if not missing else "fail",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Review cross-repo interface adoption against a wave spec")
+    parser.add_argument("--spec", required=True, help="Spec JSON describing required closed issues and file markers")
+    parser.add_argument("--workspace-root", default="..", help="Workspace root containing sibling repositories")
+    parser.add_argument("--output", required=True, help="Output report path")
+    args = parser.parse_args()
+
+    planningops_repo = resolve_repo_root()
+    workspace_root = resolve_workspace_root(planningops_repo, args.workspace_root)
+
+    spec_path = Path(args.spec)
+    if not spec_path.is_absolute():
+        spec_path = planningops_repo / spec_path
+    spec = load_json(spec_path)
+
+    issues_repo = str(spec.get("issues_repo") or "rather-not-work-on/platform-planningops")
+    issue_checks = [issue_state(issues_repo, int(number)) for number in spec.get("required_closed_issues") or []]
+
+    gap_checks = []
+    for row in spec.get("gap_checks") or []:
+        path = planningops_repo / str(row.get("path") or "")
+        gap_checks.append(substring_check(path, list(row.get("must_contain") or [])))
+
+    file_checks = []
+    for row in spec.get("file_checks") or []:
+        repo_dir = workspace_root / str(row.get("repo_dir") or "")
+        path = repo_dir / str(row.get("path") or "")
+        file_report = substring_check(path, list(row.get("must_contain") or []))
+        file_report["repo"] = str(row.get("repo") or "")
+        file_checks.append(file_report)
+
+    failures = [row for row in issue_checks if row["verdict"] != "pass"]
+    failures.extend(row for row in gap_checks if row["verdict"] != "pass")
+    failures.extend(row for row in file_checks if row["verdict"] != "pass")
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "wave_id": str(spec.get("wave_id") or ""),
+        "spec": str(spec_path),
+        "workspace_root": str(workspace_root),
+        "issue_checks": issue_checks,
+        "gap_checks": gap_checks,
+        "file_checks": file_checks,
+        "check_count": len(issue_checks) + len(gap_checks) + len(file_checks),
+        "failure_count": len(failures),
+        "verdict": "pass" if not failures else "fail",
+    }
+
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = planningops_repo / output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    return 0 if report["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a spec-driven federation review script for completed interface waves
- capture wave5 interface adoption expectations in a committed review spec
- generate the wave5 interface review artifact after W11, W21, and W31 completed

## Scope
- planningops federation review tooling
- wave5 interface adoption review evidence
- no execution-repo code changes in this PR

## Linked Issues
- Closes #186

## Validation
- python3 -m py_compile planningops/scripts/federation/review_interface_adoption.py
- python3 planningops/scripts/federation/review_interface_adoption.py --spec planningops/fixtures/runtime-behavior-wave5-interface-review-spec.json --workspace-root .. --output planningops/artifacts/validation/runtime-behavior-wave5-interface-review.json
- python3 planningops/scripts/validate_repo_boundaries.py
- python3 planningops/scripts/validate_script_roles.py
- git diff --check

## Risks
- review script is marker-based, so future refactors will require spec updates to avoid false negatives
- artifact intentionally reflects the current wave5 closeout state and should not be treated as a timeless invariant

## Review Checklist
- [x] issue dependencies are closed before generating the review artifact
- [x] cross-repo no-gap decision is verified against the canonical gap matrix
- [x] planningops federation boundary gates still pass