### PR TITLE
feat: review wave6 runtime behavior

### DIFF
--- a/planningops/artifacts/validation/runtime-behavior-wave6-review.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave6-review.json
@@ -1,0 +1,87 @@
+{
+  "generated_at_utc": "2026-03-09T03:17:10.168006+00:00",
+  "wave_id": "uap-runtime-behavior-wave6",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/fixtures/runtime-behavior-wave6-review-spec.json",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 190,
+      "state": "CLOSED",
+      "title": "plan: [10] monday run lifecycle baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/190",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 191,
+      "state": "CLOSED",
+      "title": "plan: [20] provider runtime registry baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/191",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 192,
+      "state": "CLOSED",
+      "title": "plan: [30] observability dispatch mode baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/192",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "gap_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/initiatives/unified-personal-agent-platform/20-repos/platform-contracts/30-execution-plan/runtime-interface-contract-gap-matrix.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass"
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/orchestrator/src/run_lifecycle.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/orchestrator/src/mission_orchestrator.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/services/provider-runtime/src/provider_registry.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/services/provider-runtime/src/provider_runtime.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/services/telemetry-gateway/src/dispatch_mode.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/services/telemetry-gateway/src/telemetry_gateway.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    }
+  ],
+  "check_count": 10,
+  "failure_count": 0,
+  "verdict": "pass"
+}

--- a/planningops/fixtures/runtime-behavior-wave6-review-spec.json
+++ b/planningops/fixtures/runtime-behavior-wave6-review-spec.json
@@ -1,0 +1,74 @@
+{
+  "wave_id": "uap-runtime-behavior-wave6",
+  "issues_repo": "rather-not-work-on/platform-planningops",
+  "required_closed_issues": [190, 191, 192],
+  "gap_checks": [
+    {
+      "path": "docs/initiatives/unified-personal-agent-platform/20-repos/platform-contracts/30-execution-plan/runtime-interface-contract-gap-matrix.md",
+      "must_contain": [
+        "| `rather-not-work-on/monday` | internal runtime ports between orchestrator, executor, kernel, and adapters | `C1`, `C2`, `C3`, `C8` | no gap | keep port interfaces repo-local in `contract-bindings` |",
+        "| `rather-not-work-on/platform-provider-gateway` | runtime-to-driver request/result and routing interfaces | `C4` | no gap | keep driver/runtime interfaces repo-local; normalize to `C4` at the public boundary |",
+        "| `rather-not-work-on/platform-observability-gateway` | ingest/buffer/replay/sink interfaces | `C5` | no gap | keep buffer/sink interfaces repo-local; normalize to `C5` at the public ingest boundary |"
+      ]
+    }
+  ],
+  "file_checks": [
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/orchestrator/src/run_lifecycle.ts",
+      "must_contain": [
+        "export function deriveRunLifecycle",
+        "export function buildRunRef",
+        "terminalOutcome"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/orchestrator/src/mission_orchestrator.ts",
+      "must_contain": [
+        "import { buildRunRef } from \"./run_lifecycle.js\";",
+        "return buildRunRef(runId, outcome);"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "services/provider-runtime/src/provider_registry.ts",
+      "must_contain": [
+        "export class StaticProviderDriverRegistry",
+        "find(providerKey: string): ProviderDriver | undefined"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "services/provider-runtime/src/provider_runtime.ts",
+      "must_contain": [
+        "provider_not_registered",
+        "this.dependencies.registry?.find(request.providerKey)"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "services/telemetry-gateway/src/dispatch_mode.ts",
+      "must_contain": [
+        "export type TelemetryDispatchMode",
+        "export function resolveDispatchMode",
+        "return \"noop\";"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "services/telemetry-gateway/src/telemetry_gateway.ts",
+      "must_contain": [
+        "const dispatchMode = resolveDispatchMode",
+        "dispatchMode === \"buffer_only\"",
+        "accepted: dispatchMode !== \"noop\""
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the wave6 review spec for runtime behavior baselines
- generate the wave6 review artifact after X10, X20, and X30 completed
- confirm that the new behavior baselines did not reopen a shared contract gap

## Scope
- planningops review spec and validation artifact
- no execution-repo code changes in this PR

## Linked Issues
- Closes #193

## Validation
- python3 planningops/scripts/federation/review_interface_adoption.py --spec planningops/fixtures/runtime-behavior-wave6-review-spec.json --workspace-root .. --output planningops/artifacts/validation/runtime-behavior-wave6-review.json
- python3 -m py_compile planningops/scripts/federation/review_interface_adoption.py
- git diff --check

## Risks
- review remains marker-based, so future refactors must update the spec to avoid false negatives
- artifact captures the current wave6 closeout state rather than an always-on invariant

## Review Checklist
- [x] dependent execution issues are closed before review generation
- [x] no-gap contract stance still matches the canonical gap matrix
- [x] behavior baseline markers are present in all three execution repos