### PR TITLE
feat(planningops): project wave7 runtime policy backlog

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-behavior-wave7.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-behavior-wave7.execution-contract.json
@@ -1,0 +1,77 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-behavior-wave7",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-behavior-wave7-implementation-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "Y10",
+        "execution_order": 10,
+        "title": "monday handoff planning baseline",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [],
+        "primary_output": "packages/agent-kernel/src/handoff_plan.ts",
+        "required_checks": [
+          "monday-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "Y20",
+        "execution_order": 20,
+        "title": "provider routing policy baseline",
+        "target_repo": "rather-not-work-on/platform-provider-gateway",
+        "component": "provider_gateway",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [],
+        "primary_output": "services/provider-runtime/src/routing_policy.ts",
+        "required_checks": [
+          "provider-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "Y30",
+        "execution_order": 30,
+        "title": "observability replay policy baseline",
+        "target_repo": "rather-not-work-on/platform-observability-gateway",
+        "component": "observability_gateway",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [],
+        "primary_output": "buffer/replay-worker/src/replay_policy.ts",
+        "required_checks": [
+          "observability-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "Y40",
+        "execution_order": 40,
+        "title": "runtime behavior wave7 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "backlog",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/runtime-behavior-wave7-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-behavior-wave7-implementation-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-behavior-wave7-implementation-issue-pack.md
@@ -1,0 +1,61 @@
+---
+title: plan: Runtime Behavior Wave 7 Implementation Issue Pack
+type: plan
+date: 2026-03-09
+updated: 2026-03-09
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the next executable issue pack that turns the wave6 behavior baselines into repo-owned policy helpers without requiring live infrastructure rollout.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - behavior
+  - policy
+  - backlog
+---
+
+# Runtime Behavior Wave 7 Implementation Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- `X10` to `X40` are merged and their outputs exist
+- `planningops/artifacts/validation/runtime-behavior-wave6-review.json` recorded `verdict=pass`
+- the next uncertainty is no longer baseline behavior ownership but repo-local policy selection
+
+## Goal
+
+Promote implicit runtime choices into deterministic repo-owned policy helpers.
+
+The rule for this wave is strict:
+- keep external infra mocked or local-only
+- move policy logic into the owning repo instead of planningops
+- keep contract expansion reactive unless a new shared payload is proven necessary
+
+## Wave 7 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `Y10` | 10 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `packages/agent-kernel/src/handoff_plan.ts` |
+| `Y20` | 20 | `rather-not-work-on/platform-provider-gateway` | `provider_gateway` | `ready_implementation` | `services/provider-runtime/src/routing_policy.ts` |
+| `Y30` | 30 | `rather-not-work-on/platform-observability-gateway` | `observability_gateway` | `ready_implementation` | `buffer/replay-worker/src/replay_policy.ts` |
+| `Y40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `backlog` | `planningops/artifacts/validation/runtime-behavior-wave7-review.json` |
+
+## Decomposition Rules
+
+- `Y10` adds a monday-owned handoff planning helper so agent-kernel can derive deterministic handoff records from task plans instead of leaving the mapping implicit.
+- `Y20` adds a provider-owned routing policy helper so provider runtime can resolve the effective provider through explicit policy instead of direct registry lookups only.
+- `Y30` adds an observability-owned replay policy helper so replay worker can decide whether to sink or skip batches through repo-local policy rather than fixed unconditional replay.
+- `Y40` validates that the three execution repos deepened policy ownership without reopening a shared-contract gap or violating repo boundaries.
+
+## Dependencies
+
+- `Y40` depends on `Y10`, `Y20`, `Y30`
+
+## Explicit Non-Goals
+
+- no live LiteLLM or Langfuse runtime deployment yet
+- no queue scheduler or long-running worker orchestration yet
+- no new shared schema unless `Y40` records explicit cross-repo gap evidence

--- a/planningops/artifacts/validation/runtime-behavior-wave7-issue-quality-report.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave7-issue-quality-report.json
@@ -1,0 +1,10 @@
+{
+  "generated_at_utc": "2026-03-09T03:22:53.727376+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_scanned": 4,
+  "issues_in_scope": 4,
+  "violation_count": 0,
+  "violations": [],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/runtime-behavior-wave7-label-backfill-report.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave7-label-backfill-report.json
@@ -1,0 +1,67 @@
+{
+  "generated_at_utc": "2026-03-09T03:22:49.118560+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "mode": "apply",
+  "issues_in_scope": 4,
+  "issues_with_missing_labels": 4,
+  "issues_applied": 4,
+  "rows": [
+    {
+      "number": 198,
+      "title": "plan: [40] runtime behavior wave7 review",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/198",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/governance"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 197,
+      "title": "plan: [30] observability replay policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/197",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/observability",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 196,
+      "title": "plan: [20] provider routing policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/196",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/provider",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 195,
+      "title": "plan: [10] monday handoff planning baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/195",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/runtime",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    }
+  ]
+}

--- a/planningops/artifacts/validation/runtime-behavior-wave7-projection-report.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave7-projection-report.json
@@ -1,0 +1,106 @@
+{
+  "mode": "apply",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-behavior-wave7.execution-contract.json",
+  "validation_errors": [],
+  "results": [
+    {
+      "plan_item_id": "Y10",
+      "execution_order": 10,
+      "issue_number": 195,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/195",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    },
+    {
+      "plan_item_id": "Y20",
+      "execution_order": 20,
+      "issue_number": 196,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/196",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    },
+    {
+      "plan_item_id": "Y30",
+      "execution_order": 30,
+      "issue_number": 197,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/197",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    },
+    {
+      "plan_item_id": "Y40",
+      "execution_order": 40,
+      "issue_number": 198,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/198",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    }
+  ],
+  "plan_id": "uap-runtime-behavior-wave7",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-behavior-wave7-implementation-issue-pack.md",
+  "items_total": 4,
+  "open_issues_scanned": 0,
+  "closed_issues_scanned": 0,
+  "verdict": "pass"
+}


### PR DESCRIPTION
## Summary
- add the wave7 runtime policy issue pack and execution contract
- project wave7 backlog items into planningops issues with label backfill and issue-quality evidence
- prepare the next monday/provider/observability execution wave

## Scope
- planningops wave7 plan and execution contract only
- planningops backlog projection and issue metadata sync only
- no execution-repo code changes in this PR

## Linked Issues
- refs #195
- refs #196
- refs #197
- refs #198

## Validation
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-behavior-wave7.execution-contract.json --apply --output planningops/artifacts/validation/runtime-behavior-wave7-projection-report.json
- python3 planningops/scripts/backfill_issue_labels.py --repo rather-not-work-on/platform-planningops --apply --output planningops/artifacts/validation/runtime-behavior-wave7-label-backfill-report.json
- python3 planningops/scripts/validate_issue_quality.py --strict --output planningops/artifacts/validation/runtime-behavior-wave7-issue-quality-report.json

## Risks
- wave7 issues would become stale if execution repos drift before the pack merges
- backlog projection can create low-value churn if later waves rename outputs again

## Review Checklist
- [x] wave7 plan doc and execution contract are aligned
- [x] projected issues were created with labels and project fields
- [x] issue-quality passed after backfill
