### PR TITLE
feat(planningops): review wave7 runtime policy

### DIFF
--- a/planningops/artifacts/validation/runtime-behavior-wave7-review.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave7-review.json
@@ -1,0 +1,87 @@
+{
+  "generated_at_utc": "2026-03-09T03:29:42.868842+00:00",
+  "wave_id": "uap-runtime-behavior-wave7",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/fixtures/runtime-behavior-wave7-review-spec.json",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 195,
+      "state": "CLOSED",
+      "title": "plan: [10] monday handoff planning baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/195",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 196,
+      "state": "CLOSED",
+      "title": "plan: [20] provider routing policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/196",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 197,
+      "state": "CLOSED",
+      "title": "plan: [30] observability replay policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/197",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "gap_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/initiatives/unified-personal-agent-platform/20-repos/platform-contracts/30-execution-plan/runtime-interface-contract-gap-matrix.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass"
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/agent-kernel/src/handoff_plan.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/orchestrator/src/mission_orchestrator.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/services/provider-runtime/src/routing_policy.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/services/provider-runtime/src/provider_runtime.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/buffer/replay-worker/src/replay_policy.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/buffer/replay-worker/src/replay_worker.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    }
+  ],
+  "check_count": 10,
+  "failure_count": 0,
+  "verdict": "pass"
+}

--- a/planningops/fixtures/runtime-behavior-wave7-review-spec.json
+++ b/planningops/fixtures/runtime-behavior-wave7-review-spec.json
@@ -1,0 +1,77 @@
+{
+  "wave_id": "uap-runtime-behavior-wave7",
+  "issues_repo": "rather-not-work-on/platform-planningops",
+  "required_closed_issues": [195, 196, 197],
+  "gap_checks": [
+    {
+      "path": "docs/initiatives/unified-personal-agent-platform/20-repos/platform-contracts/30-execution-plan/runtime-interface-contract-gap-matrix.md",
+      "must_contain": [
+        "| `rather-not-work-on/monday` | internal runtime ports between orchestrator, executor, kernel, and adapters | `C1`, `C2`, `C3`, `C8` | no gap | keep port interfaces repo-local in `contract-bindings` |",
+        "| `rather-not-work-on/platform-provider-gateway` | runtime-to-driver request/result and routing interfaces | `C4` | no gap | keep driver/runtime interfaces repo-local; normalize to `C4` at the public boundary |",
+        "| `rather-not-work-on/platform-observability-gateway` | ingest/buffer/replay/sink interfaces | `C5` | no gap | keep buffer/sink interfaces repo-local; normalize to `C5` at the public ingest boundary |"
+      ]
+    }
+  ],
+  "file_checks": [
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/agent-kernel/src/handoff_plan.ts",
+      "must_contain": [
+        "export function buildHandoffPlan",
+        "const taskId = buildTaskId",
+        "handoffId: buildHandoffId"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/orchestrator/src/mission_orchestrator.ts",
+      "must_contain": [
+        "const handoffs = buildHandoffPlan",
+        "const primaryHandoff = handoffs[0];",
+        "this.dependencies.executor.execute(mission, primaryHandoff)"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "services/provider-runtime/src/routing_policy.ts",
+      "must_contain": [
+        "export function resolveProviderKey",
+        "input.defaultProviderKey",
+        "input.registeredProviderKeys.length === 1"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "services/provider-runtime/src/provider_runtime.ts",
+      "must_contain": [
+        "const providerKey = resolveProviderKey",
+        "defaultProviderKey: this.dependencies.defaultProviderKey",
+        "const driver = this.dependencies.registry?.find(providerKey)"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "buffer/replay-worker/src/replay_policy.ts",
+      "must_contain": [
+        "export function resolveReplayPolicy",
+        "dispatchMode: \"skip\"",
+        "dispatchMode: \"replay\""
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "buffer/replay-worker/src/replay_worker.ts",
+      "must_contain": [
+        "const replayPolicy = resolveReplayPolicy",
+        "if (replayPolicy.dispatchMode === \"skip\")",
+        "replayed: false"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the wave7 review spec for cross-repo runtime policy adoption
- record the passing wave7 review artifact after monday/provider/observability merges
- close the final planningops review gate for the wave7 pack

## Scope
- planningops wave7 review artifact only
- planningops wave7 fixture/spec only
- no execution repo code changes in this PR

## Linked Issues
- closes #198
- refs #195
- refs #196
- refs #197

## Validation
- python3 planningops/scripts/federation/review_interface_adoption.py --spec planningops/fixtures/runtime-behavior-wave7-review-spec.json --workspace-root .. --output planningops/artifacts/validation/runtime-behavior-wave7-review.json
- git diff --check

## Risks
- the review artifact is only as strong as the markers encoded in the fixture spec
- later refactors may require updating the spec markers to avoid stale false negatives

## Review Checklist
- [x] required execution repo issues are closed
- [x] wave7 file markers resolve in monday/provider/observability
- [x] review artifact recorded verdict=pass
