### PR TITLE
feat(planningops): project wave8 runtime normalization backlog

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-behavior-wave8.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-behavior-wave8.execution-contract.json
@@ -1,0 +1,77 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-behavior-wave8",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-behavior-wave8-implementation-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "Z10",
+        "execution_order": 10,
+        "title": "monday executor event policy baseline",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [],
+        "primary_output": "packages/executor-ralph-loop/src/event_policy.ts",
+        "required_checks": [
+          "monday-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "Z20",
+        "execution_order": 20,
+        "title": "provider outcome policy baseline",
+        "target_repo": "rather-not-work-on/platform-provider-gateway",
+        "component": "provider_gateway",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [],
+        "primary_output": "services/provider-runtime/src/outcome_policy.ts",
+        "required_checks": [
+          "provider-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "Z30",
+        "execution_order": 30,
+        "title": "observability delivery policy baseline",
+        "target_repo": "rather-not-work-on/platform-observability-gateway",
+        "component": "observability_gateway",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [],
+        "primary_output": "sinks/langfuse-sink/src/delivery_policy.ts",
+        "required_checks": [
+          "observability-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "Z40",
+        "execution_order": 40,
+        "title": "runtime behavior wave8 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "backlog",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/runtime-behavior-wave8-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-behavior-wave8-implementation-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-behavior-wave8-implementation-issue-pack.md
@@ -1,0 +1,61 @@
+---
+title: plan: Runtime Behavior Wave 8 Implementation Issue Pack
+type: plan
+date: 2026-03-09
+updated: 2026-03-09
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the next executable issue pack that turns wave7 policy helpers into deterministic runtime normalization helpers for events, provider outcomes, and sink delivery.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - behavior
+  - normalization
+  - backlog
+---
+
+# Runtime Behavior Wave 8 Implementation Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- `Y10` to `Y40` are merged and their outputs exist
+- `planningops/artifacts/validation/runtime-behavior-wave7-review.json` recorded `verdict=pass`
+- the next uncertainty is no longer baseline policy ownership but normalization of repo-local runtime outputs
+
+## Goal
+
+Replace remaining pass-through stubs with deterministic normalization helpers owned by each execution repo.
+
+The rule for this wave is strict:
+- keep infrastructure local-only and mocked where necessary
+- move normalization logic into the repo that owns the runtime boundary
+- keep shared contracts reactive unless a new cross-repo payload is proven necessary
+
+## Wave 8 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `Z10` | 10 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `packages/executor-ralph-loop/src/event_policy.ts` |
+| `Z20` | 20 | `rather-not-work-on/platform-provider-gateway` | `provider_gateway` | `ready_implementation` | `services/provider-runtime/src/outcome_policy.ts` |
+| `Z30` | 30 | `rather-not-work-on/platform-observability-gateway` | `observability_gateway` | `ready_implementation` | `sinks/langfuse-sink/src/delivery_policy.ts` |
+| `Z40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `backlog` | `planningops/artifacts/validation/runtime-behavior-wave8-review.json` |
+
+## Decomposition Rules
+
+- `Z10` adds a monday-owned executor event policy helper so telemetry emission is derived from outcome and handoff context through explicit runtime helpers.
+- `Z20` adds a provider-owned outcome policy helper so provider runtime normalizes driver reason codes instead of passing opaque values through unchanged.
+- `Z30` adds an observability-owned delivery policy helper so sink delivery normalizes blank or malformed event payloads through repo-local rules.
+- `Z40` validates that the three execution repos deepened normalization behavior without reopening a shared-contract gap or violating repo boundaries.
+
+## Dependencies
+
+- `Z40` depends on `Z10`, `Z20`, `Z30`
+
+## Explicit Non-Goals
+
+- no live LiteLLM or Langfuse deployment yet
+- no queue scheduler or long-running worker orchestration yet
+- no new shared schema unless `Z40` records explicit cross-repo gap evidence

--- a/planningops/artifacts/validation/runtime-behavior-wave8-issue-quality-report.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave8-issue-quality-report.json
@@ -1,0 +1,10 @@
+{
+  "generated_at_utc": "2026-03-09T03:33:32.667968+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_scanned": 4,
+  "issues_in_scope": 4,
+  "violation_count": 0,
+  "violations": [],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/runtime-behavior-wave8-label-backfill-report.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave8-label-backfill-report.json
@@ -1,0 +1,67 @@
+{
+  "generated_at_utc": "2026-03-09T03:33:30.005641+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "mode": "apply",
+  "issues_in_scope": 4,
+  "issues_with_missing_labels": 4,
+  "issues_applied": 4,
+  "rows": [
+    {
+      "number": 204,
+      "title": "plan: [40] runtime behavior wave8 review",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/204",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/governance"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 203,
+      "title": "plan: [30] observability delivery policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/203",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/observability",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 202,
+      "title": "plan: [20] provider outcome policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/202",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/provider",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 201,
+      "title": "plan: [10] monday executor event policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/201",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/runtime",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    }
+  ]
+}

--- a/planningops/artifacts/validation/runtime-behavior-wave8-projection-report.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave8-projection-report.json
@@ -1,0 +1,106 @@
+{
+  "mode": "apply",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-behavior-wave8.execution-contract.json",
+  "validation_errors": [],
+  "results": [
+    {
+      "plan_item_id": "Z10",
+      "execution_order": 10,
+      "issue_number": 201,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/201",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    },
+    {
+      "plan_item_id": "Z20",
+      "execution_order": 20,
+      "issue_number": 202,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/202",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    },
+    {
+      "plan_item_id": "Z30",
+      "execution_order": 30,
+      "issue_number": 203,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/203",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    },
+    {
+      "plan_item_id": "Z40",
+      "execution_order": 40,
+      "issue_number": 204,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/204",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    }
+  ],
+  "plan_id": "uap-runtime-behavior-wave8",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-behavior-wave8-implementation-issue-pack.md",
+  "items_total": 4,
+  "open_issues_scanned": 0,
+  "closed_issues_scanned": 0,
+  "verdict": "pass"
+}


### PR DESCRIPTION
## Summary
- add the wave8 runtime normalization issue pack and execution contract
- project wave8 backlog items into planningops issues with label backfill and issue-quality evidence
- prepare the next monday/provider/observability execution wave

## Scope
- planningops wave8 plan and execution contract only
- planningops backlog projection and issue metadata sync only
- no execution-repo code changes in this PR

## Linked Issues
- refs #201
- refs #202
- refs #203
- refs #204

## Validation
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-behavior-wave8.execution-contract.json --apply --output planningops/artifacts/validation/runtime-behavior-wave8-projection-report.json
- python3 planningops/scripts/backfill_issue_labels.py --repo rather-not-work-on/platform-planningops --apply --output planningops/artifacts/validation/runtime-behavior-wave8-label-backfill-report.json
- python3 planningops/scripts/validate_issue_quality.py --strict --output planningops/artifacts/validation/runtime-behavior-wave8-issue-quality-report.json

## Risks
- wave8 normalization helpers may need renaming if downstream payloads change in later runtime integration work
- backlog projection can create churn if the next wave changes repo boundaries again

## Review Checklist
- [x] wave8 plan doc and execution contract are aligned
- [x] projected issues were created with labels and project fields
- [x] issue-quality passed after backfill
