### PR TITLE
feat(planningops): review wave8 runtime normalization

### DIFF
--- a/planningops/artifacts/validation/runtime-behavior-wave8-review.json
+++ b/planningops/artifacts/validation/runtime-behavior-wave8-review.json
@@ -1,0 +1,87 @@
+{
+  "generated_at_utc": "2026-03-09T03:37:19.038995+00:00",
+  "wave_id": "uap-runtime-behavior-wave8",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/fixtures/runtime-behavior-wave8-review-spec.json",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 201,
+      "state": "CLOSED",
+      "title": "plan: [10] monday executor event policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/201",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 202,
+      "state": "CLOSED",
+      "title": "plan: [20] provider outcome policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/202",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 203,
+      "state": "CLOSED",
+      "title": "plan: [30] observability delivery policy baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/203",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "gap_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/initiatives/unified-personal-agent-platform/20-repos/platform-contracts/30-execution-plan/runtime-interface-contract-gap-matrix.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass"
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/executor-ralph-loop/src/event_policy.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/executor-ralph-loop/src/ralph_loop_executor.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/services/provider-runtime/src/outcome_policy.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/services/provider-runtime/src/provider_runtime.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/sinks/langfuse-sink/src/delivery_policy.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/sinks/langfuse-sink/src/langfuse_sink.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    }
+  ],
+  "check_count": 10,
+  "failure_count": 0,
+  "verdict": "pass"
+}

--- a/planningops/fixtures/runtime-behavior-wave8-review-spec.json
+++ b/planningops/fixtures/runtime-behavior-wave8-review-spec.json
@@ -1,0 +1,74 @@
+{
+  "wave_id": "uap-runtime-behavior-wave8",
+  "issues_repo": "rather-not-work-on/platform-planningops",
+  "required_closed_issues": [201, 202, 203],
+  "gap_checks": [
+    {
+      "path": "docs/initiatives/unified-personal-agent-platform/20-repos/platform-contracts/30-execution-plan/runtime-interface-contract-gap-matrix.md",
+      "must_contain": [
+        "| `rather-not-work-on/monday` | internal runtime ports between orchestrator, executor, kernel, and adapters | `C1`, `C2`, `C3`, `C8` | no gap | keep port interfaces repo-local in `contract-bindings` |",
+        "| `rather-not-work-on/platform-provider-gateway` | runtime-to-driver request/result and routing interfaces | `C4` | no gap | keep driver/runtime interfaces repo-local; normalize to `C4` at the public boundary |",
+        "| `rather-not-work-on/platform-observability-gateway` | ingest/buffer/replay/sink interfaces | `C5` | no gap | keep buffer/sink interfaces repo-local; normalize to `C5` at the public ingest boundary |"
+      ]
+    }
+  ],
+  "file_checks": [
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/executor-ralph-loop/src/event_policy.ts",
+      "must_contain": [
+        "export function buildExecutorEvent",
+        "return \"executor.completed\";",
+        "return `mission:${mission.missionId}:task:${handoff.taskId}`;"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/executor-ralph-loop/src/ralph_loop_executor.ts",
+      "must_contain": [
+        "import { buildExecutorEvent } from \"./event_policy.js\";",
+        "this.dependencies.telemetry?.emit(buildExecutorEvent(context, providerOutcome, handoff));"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "services/provider-runtime/src/outcome_policy.ts",
+      "must_contain": [
+        "export function normalizeProviderOutcome",
+        "provider_result_unclassified",
+        "const ALLOWED_REASON_CODES = new Set"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "services/provider-runtime/src/provider_runtime.ts",
+      "must_contain": [
+        "return normalizeProviderOutcome({",
+        "return normalizeProviderOutcome(driver.invoke(request));"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "sinks/langfuse-sink/src/delivery_policy.ts",
+      "must_contain": [
+        "export function buildDeliveryOutcome",
+        "\"telemetry.unknown\"",
+        "delivered: envelope.runId.trim().length > 0"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "sinks/langfuse-sink/src/langfuse_sink.ts",
+      "must_contain": [
+        "import { buildDeliveryOutcome } from \"./delivery_policy.js\";",
+        "return buildDeliveryOutcome(envelope);"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the wave8 review spec for cross-repo runtime normalization adoption
- record the passing wave8 review artifact after monday/provider/observability merges
- close the final planningops review gate for the wave8 pack

## Scope
- planningops wave8 review artifact only
- planningops wave8 fixture/spec only
- no execution repo code changes in this PR

## Linked Issues
- closes #204
- refs #201
- refs #202
- refs #203

## Validation
- python3 planningops/scripts/federation/review_interface_adoption.py --spec planningops/fixtures/runtime-behavior-wave8-review-spec.json --workspace-root .. --output planningops/artifacts/validation/runtime-behavior-wave8-review.json
- git diff --check

## Risks
- the review artifact is only as strong as the markers encoded in the fixture spec
- later refactors may require updating the spec markers to avoid stale false negatives

## Review Checklist
- [x] required execution repo issues are closed
- [x] wave8 file markers resolve in monday/provider/observability
- [x] review artifact recorded verdict=pass
