### PR TITLE
feat: stack runtime infra backlog waves

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave11.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave11.execution-contract.json
@@ -1,0 +1,77 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-infra-wave11",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave11-implementation-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "AC10",
+        "execution_order": 10,
+        "title": "monday local runtime composition baseline",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "packages/orchestrator/src/default_local_runtime.ts",
+        "required_checks": [
+          "monday-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "AC20",
+        "execution_order": 20,
+        "title": "provider LiteLLM local composer baseline",
+        "target_repo": "rather-not-work-on/platform-provider-gateway",
+        "component": "provider_gateway",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "services/provider-gateway-composer/src/default_litellm_runtime.ts",
+        "required_checks": [
+          "provider-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "AC30",
+        "execution_order": 30,
+        "title": "observability Langfuse local composer baseline",
+        "target_repo": "rather-not-work-on/platform-observability-gateway",
+        "component": "observability_gateway",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "services/telemetry-gateway-composer/src/default_langfuse_gateway.ts",
+        "required_checks": [
+          "observability-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "AC40",
+        "execution_order": 40,
+        "title": "runtime infra wave11 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "backlog",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/runtime-infra-wave11-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave12.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave12.execution-contract.json
@@ -1,0 +1,77 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-infra-wave12",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave12-local-smoke-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "AD10",
+        "execution_order": 10,
+        "title": "monday local mission smoke baseline",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "scripts/run_local_runtime_smoke.py",
+        "required_checks": [
+          "monday-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "AD20",
+        "execution_order": 20,
+        "title": "provider live local smoke baseline",
+        "target_repo": "rather-not-work-on/platform-provider-gateway",
+        "component": "provider_gateway",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "scripts/litellm_live_smoke.py",
+        "required_checks": [
+          "provider-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "AD30",
+        "execution_order": 30,
+        "title": "observability live local smoke baseline",
+        "target_repo": "rather-not-work-on/platform-observability-gateway",
+        "component": "observability_gateway",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "scripts/langfuse_live_smoke.py",
+        "required_checks": [
+          "observability-local-ci",
+          "implementation-readiness-dryrun"
+        ]
+      },
+      {
+        "plan_item_id": "AD40",
+        "execution_order": 40,
+        "title": "runtime infra wave12 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "backlog",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/runtime-infra-wave12-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave11-implementation-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave11-implementation-issue-pack.md
@@ -1,0 +1,63 @@
+---
+title: plan: Runtime Infra Wave 11 Implementation Issue Pack
+type: plan
+date: 2026-03-09
+updated: 2026-03-09
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the next executable issue pack that wires local-first runtime profiles and launcher-aware transport composition into monday, provider, and observability without collapsing repository boundaries.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - infra
+  - local-first
+  - backlog
+---
+
+# Runtime Infra Wave 11 Implementation Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- `AB10` to `AB40` are merged and their outputs exist
+- `planningops/artifacts/validation/runtime-behavior-wave10-review.json` recorded `verdict=pass`
+- default composition now lives in repo-owned composer layers, so the next uncertainty is local profile wiring rather than dependency topology
+
+## Goal
+
+Attach local-first runtime profile and launcher knowledge to the new composer layers so later end-to-end smokes can run without rewriting core packages.
+
+The rule for this wave is strict:
+- monday owns local runtime composition that binds profiled provider and telemetry clients without knowing launcher internals
+- platform-provider-gateway owns LiteLLM local composer wiring on top of the existing launcher/profile drill
+- platform-observability-gateway owns Langfuse local composer wiring on top of the existing launcher/replay drill
+- planningops verifies profile portability and evidence paths, but does not own runtime factory code
+
+## Wave 11 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `AC10` | 10 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `packages/orchestrator/src/default_local_runtime.ts` |
+| `AC20` | 20 | `rather-not-work-on/platform-provider-gateway` | `provider_gateway` | `ready_implementation` | `services/provider-gateway-composer/src/default_litellm_runtime.ts` |
+| `AC30` | 30 | `rather-not-work-on/platform-observability-gateway` | `observability_gateway` | `ready_implementation` | `services/telemetry-gateway-composer/src/default_langfuse_gateway.ts` |
+| `AC40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `backlog` | `planningops/artifacts/validation/runtime-infra-wave11-review.json` |
+
+## Decomposition Rules
+
+- `AC10` adds a monday-owned local runtime composer that resolves the active runtime profile and builds profiled provider/o11y clients through existing default runtime composition.
+- `AC20` adds a provider-owned local LiteLLM composer that translates runtime profile input into a ready local provider runtime without moving launcher logic into core runtime.
+- `AC30` adds an observability-owned local Langfuse composer that translates runtime profile input into a ready local telemetry gateway without moving launcher or replay logic into core gateway.
+- `AC40` validates that local profile wiring stays in composer layers, keeps profile portability intact, and does not rewrite artifact residency or evidence paths.
+
+## Dependencies
+
+- `AC40` depends on `AC10`, `AC20`, `AC30`
+
+## Explicit Non-Goals
+
+- no live Oracle Cloud activation yet
+- no federated end-to-end mission smoke yet
+- no long-running daemon or scheduler loop changes yet
+- no secrets bootstrap automation in planningops

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave12-local-smoke-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave12-local-smoke-issue-pack.md
@@ -1,0 +1,63 @@
+---
+title: plan: Runtime Infra Wave 12 Local Smoke Issue Pack
+type: plan
+date: 2026-03-09
+updated: 2026-03-09
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the next executable issue pack that proves a local-first federated smoke path across monday, provider, observability, and planningops after profile-aware composer wiring lands.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - smoke
+  - federated
+  - backlog
+---
+
+# Runtime Infra Wave 12 Local Smoke Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- runtime infra wave11 is the preceding wave and must land first
+- launcher/profile drill scripts already exist in provider and observability repos
+- the next missing evidence is an integrated local-first smoke that uses repo-owned composer layers end to end
+
+## Goal
+
+Create a repeatable local-first smoke path that exercises planningops-driven execution through monday, provider, and observability with stable evidence outputs.
+
+The rule for this wave is strict:
+- monday owns the local mission smoke entrypoint
+- platform-provider-gateway owns the launcher-backed provider smoke path
+- platform-observability-gateway owns the launcher-backed ingest smoke path
+- planningops owns only the federated smoke review and gate evidence
+
+## Wave 12 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `AD10` | 10 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/run_local_runtime_smoke.py` |
+| `AD20` | 20 | `rather-not-work-on/platform-provider-gateway` | `provider_gateway` | `ready_implementation` | `scripts/litellm_live_smoke.py` |
+| `AD30` | 30 | `rather-not-work-on/platform-observability-gateway` | `observability_gateway` | `ready_implementation` | `scripts/langfuse_live_smoke.py` |
+| `AD40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `backlog` | `planningops/artifacts/validation/runtime-infra-wave12-review.json` |
+
+## Decomposition Rules
+
+- `AD10` adds a monday-owned local smoke entrypoint that drives one local mission cycle through profiled runtime composition and writes deterministic runtime evidence.
+- `AD20` adds a provider-owned live local smoke wrapper that uses the launcher/profile drill boundary and emits stable smoke evidence without changing existing contract schemas.
+- `AD30` adds an observability-owned live local smoke wrapper that uses the launcher/replay boundary and emits stable smoke evidence without changing existing contract schemas.
+- `AD40` validates that the three smoke entrypoints compose cleanly under planningops and that local-first evidence remains portable to later OCI rehearsals.
+
+## Dependencies
+
+- `AD40` depends on `AD10`, `AD20`, `AD30`
+
+## Explicit Non-Goals
+
+- no Oracle Cloud execution yet
+- no autonomous long-running scheduler soak test yet
+- no NanoClaw integration yet
+- no GitHub issue execution loop attached to the smoke path yet

--- a/planningops/artifacts/validation/runtime-infra-backlog-issue-quality-report.json
+++ b/planningops/artifacts/validation/runtime-infra-backlog-issue-quality-report.json
@@ -1,0 +1,10 @@
+{
+  "generated_at_utc": "2026-03-09T08:10:26.436665+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_scanned": 8,
+  "issues_in_scope": 8,
+  "violation_count": 0,
+  "violations": [],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/runtime-infra-backlog-label-backfill-report.json
+++ b/planningops/artifacts/validation/runtime-infra-backlog-label-backfill-report.json
@@ -1,0 +1,123 @@
+{
+  "generated_at_utc": "2026-03-09T08:10:26.214863+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "mode": "apply",
+  "issues_in_scope": 8,
+  "issues_with_missing_labels": 8,
+  "issues_applied": 8,
+  "rows": [
+    {
+      "number": 230,
+      "title": "plan: [40] runtime infra wave11 review",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/230",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/governance"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 229,
+      "title": "plan: [40] runtime infra wave12 review",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/229",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/governance"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 228,
+      "title": "plan: [30] observability Langfuse local composer baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/228",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/observability",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 227,
+      "title": "plan: [30] observability live local smoke baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/227",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/observability",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 226,
+      "title": "plan: [20] provider LiteLLM local composer baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/226",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/provider",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 225,
+      "title": "plan: [20] provider live local smoke baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/225",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/provider",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 224,
+      "title": "plan: [10] monday local runtime composition baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/224",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/runtime",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 223,
+      "title": "plan: [10] monday local mission smoke baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/223",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/runtime",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    }
+  ]
+}

--- a/planningops/artifacts/validation/runtime-infra-wave11-projection-report.json
+++ b/planningops/artifacts/validation/runtime-infra-wave11-projection-report.json
@@ -1,0 +1,106 @@
+{
+  "mode": "dry-run",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave11.execution-contract.json",
+  "validation_errors": [],
+  "results": [
+    {
+      "plan_item_id": "AC10",
+      "execution_order": 10,
+      "issue_number": 224,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/224",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(runtime)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l3_implementation_tdd)",
+        "plan_lane(m3_guardrails)"
+      ]
+    },
+    {
+      "plan_item_id": "AC20",
+      "execution_order": 20,
+      "issue_number": 226,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/226",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(provider_gateway)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l3_implementation_tdd)",
+        "plan_lane(m3_guardrails)"
+      ]
+    },
+    {
+      "plan_item_id": "AC30",
+      "execution_order": 30,
+      "issue_number": 228,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/228",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(observability_gateway)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l3_implementation_tdd)",
+        "plan_lane(m3_guardrails)"
+      ]
+    },
+    {
+      "plan_item_id": "AC40",
+      "execution_order": 40,
+      "issue_number": 230,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/230",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(planningops)",
+        "workflow_state(backlog)",
+        "loop_profile(l4_integration_reconcile)",
+        "plan_lane(m3_guardrails)"
+      ]
+    }
+  ],
+  "plan_id": "uap-runtime-infra-wave11",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave11-implementation-issue-pack.md",
+  "items_total": 4,
+  "open_issues_scanned": 8,
+  "closed_issues_scanned": 0,
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/runtime-infra-wave12-projection-report.json
+++ b/planningops/artifacts/validation/runtime-infra-wave12-projection-report.json
@@ -1,0 +1,106 @@
+{
+  "mode": "dry-run",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave12.execution-contract.json",
+  "validation_errors": [],
+  "results": [
+    {
+      "plan_item_id": "AD10",
+      "execution_order": 10,
+      "issue_number": 223,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/223",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(runtime)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l3_implementation_tdd)",
+        "plan_lane(m3_guardrails)"
+      ]
+    },
+    {
+      "plan_item_id": "AD20",
+      "execution_order": 20,
+      "issue_number": 225,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/225",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(provider_gateway)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l3_implementation_tdd)",
+        "plan_lane(m3_guardrails)"
+      ]
+    },
+    {
+      "plan_item_id": "AD30",
+      "execution_order": 30,
+      "issue_number": 227,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/227",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(observability_gateway)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l3_implementation_tdd)",
+        "plan_lane(m3_guardrails)"
+      ]
+    },
+    {
+      "plan_item_id": "AD40",
+      "execution_order": 40,
+      "issue_number": 229,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/229",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(planningops)",
+        "workflow_state(backlog)",
+        "loop_profile(l4_integration_reconcile)",
+        "plan_lane(m3_guardrails)"
+      ]
+    }
+  ],
+  "plan_id": "uap-runtime-infra-wave12",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave12-local-smoke-issue-pack.md",
+  "items_total": 4,
+  "open_issues_scanned": 8,
+  "closed_issues_scanned": 0,
+  "verdict": "pass"
+}


### PR DESCRIPTION
## Summary
- add runtime infra wave11 local wiring backlog pack
- add runtime infra wave12 federated local smoke backlog pack
- project both waves into planningops issues and validate backlog quality

## Scope
- planningops backlog and evidence only
- no execution repo code changes in this PR

## Linked Issues
- Related #223
- Related #224
- Related #225
- Related #226
- Related #227
- Related #228
- Related #229
- Related #230

## Validation
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave11.execution-contract.json --output planningops/artifacts/validation/runtime-infra-wave11-projection-report.json
- python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave12.execution-contract.json --output planningops/artifacts/validation/runtime-infra-wave12-projection-report.json
- python3 planningops/scripts/backfill_issue_labels.py --repo rather-not-work-on/platform-planningops --apply --output planningops/artifacts/validation/runtime-infra-backlog-label-backfill-report.json
- python3 planningops/scripts/validate_issue_quality.py --strict --output planningops/artifacts/validation/runtime-infra-backlog-issue-quality-report.json
- git diff --check

## Risks
- wave12 assumes wave11 lands first, but cross-wave dependency is currently documented textually rather than enforced by the projector

## Review Checklist
- [x] wave11 focuses on local profile wiring in composer layers
- [x] wave12 focuses on federated local smoke after wave11
- [x] all projected cards have labels and backlog-ready project metadata