### PR TITLE
feat(planningops): review runtime infra wave11

### DIFF
--- a/planningops/artifacts/validation/runtime-infra-wave11-review.json
+++ b/planningops/artifacts/validation/runtime-infra-wave11-review.json
@@ -1,0 +1,80 @@
+{
+  "generated_at_utc": "2026-03-09T11:12:46.111151+00:00",
+  "wave_id": "uap-runtime-infra-wave11",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/fixtures/runtime-infra-wave11-review-spec.json",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 224,
+      "state": "CLOSED",
+      "title": "plan: [10] monday local runtime composition baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/224",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 226,
+      "state": "CLOSED",
+      "title": "plan: [20] provider LiteLLM local composer baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/226",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 228,
+      "state": "CLOSED",
+      "title": "plan: [30] observability Langfuse local composer baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/228",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "gap_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave11-implementation-issue-pack.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass"
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/orchestrator/src/default_local_runtime.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/packages/provider-client-adapter/src/provider_client.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/services/provider-gateway-composer/src/default_litellm_runtime.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/services/telemetry-gateway-composer/src/default_langfuse_gateway.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/sinks/langfuse-sink/src/langfuse_sink.ts",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    }
+  ],
+  "check_count": 9,
+  "failure_count": 0,
+  "verdict": "pass"
+}

--- a/planningops/fixtures/runtime-infra-wave11-review-spec.json
+++ b/planningops/fixtures/runtime-infra-wave11-review-spec.json
@@ -1,0 +1,66 @@
+{
+  "wave_id": "uap-runtime-infra-wave11",
+  "issues_repo": "rather-not-work-on/platform-planningops",
+  "required_closed_issues": [224, 226, 228],
+  "gap_checks": [
+    {
+      "path": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave11-implementation-issue-pack.md",
+      "must_contain": [
+        "monday owns local runtime composition that binds profiled provider and telemetry clients without knowing launcher internals",
+        "platform-provider-gateway owns LiteLLM local composer wiring on top of the existing launcher/profile drill",
+        "platform-observability-gateway owns Langfuse local composer wiring on top of the existing launcher/replay drill"
+      ]
+    }
+  ],
+  "file_checks": [
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/orchestrator/src/default_local_runtime.ts",
+      "must_contain": [
+        "resolveLocalRuntimeProfile",
+        "buildDefaultLocalRuntimeDependencies",
+        "new ProviderClient(providerOptions)",
+        "new TimelineEmitterClient(telemetryOptions)"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "packages/provider-client-adapter/src/provider_client.ts",
+      "must_contain": [
+        "ProviderClientProfile",
+        "provider_client_profiled"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "services/provider-gateway-composer/src/default_litellm_runtime.ts",
+      "must_contain": [
+        "resolveLiteLLMRuntimeProfile",
+        "createDefaultLiteLLMRuntime",
+        "new ProviderLocalLlmDriver"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "services/telemetry-gateway-composer/src/default_langfuse_gateway.ts",
+      "must_contain": [
+        "resolveLangfuseRuntimeProfile",
+        "createDefaultLangfuseGateway",
+        "new LangfuseSink"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "sinks/langfuse-sink/src/langfuse_sink.ts",
+      "must_contain": [
+        "LangfuseSinkProfile",
+        "this.options.profile"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the wave11 review spec for local runtime profile wiring
- record review evidence after monday/provider/observability wave11 merges
- close out the planningops review item for runtime infra wave11

## Scope
- Runtime/packages: none
- Scripts/contracts/docs: `planningops/fixtures`, `planningops/artifacts/validation`
- `.github/` workflows: none

## Linked Issues
- Closes #230
- Related #224
- Related #226
- Related #228

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- [x] `python3 planningops/scripts/federation/review_interface_adoption.py --spec planningops/fixtures/runtime-infra-wave11-review-spec.json --workspace-root .. --output planningops/artifacts/validation/runtime-infra-wave11-review.json`
- [x] Additional checks (if any): external repo issues `#224/#226/#228` auto-closed via repo-qualified PR refs

## Risks
- Risk: the review is marker-driven, so it proves boundary placement and issue closure but not yet a live local mission path.
- Rollback: revert this PR to remove the review artifact and keep wave11 open for re-review.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] Evidence paths remain inside canonical planningops validation artifacts.
- [x] Validation commands were run locally.
