### PR TITLE
feat(planningops): review runtime infra wave12

### DIFF
--- a/planningops/artifacts/validation/runtime-infra-wave12-review.json
+++ b/planningops/artifacts/validation/runtime-infra-wave12-review.json
@@ -1,0 +1,80 @@
+{
+  "generated_at_utc": "2026-03-09T11:19:06.205897+00:00",
+  "wave_id": "uap-runtime-infra-wave12",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/fixtures/runtime-infra-wave12-review-spec.json",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 223,
+      "state": "CLOSED",
+      "title": "plan: [10] monday local mission smoke baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/223",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 225,
+      "state": "CLOSED",
+      "title": "plan: [20] provider live local smoke baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/225",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 227,
+      "state": "CLOSED",
+      "title": "plan: [30] observability live local smoke baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/227",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "gap_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave12-local-smoke-issue-pack.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass"
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/run_local_runtime_smoke.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/scripts/litellm_live_smoke.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-provider-gateway/scripts/litellm_stack_launcher.sh",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-provider-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/scripts/langfuse_live_smoke.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-observability-gateway/scripts/langfuse_stack_launcher.sh",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-observability-gateway"
+    }
+  ],
+  "check_count": 9,
+  "failure_count": 0,
+  "verdict": "pass"
+}

--- a/planningops/fixtures/runtime-infra-wave12-review-spec.json
+++ b/planningops/fixtures/runtime-infra-wave12-review-spec.json
@@ -1,0 +1,65 @@
+{
+  "wave_id": "uap-runtime-infra-wave12",
+  "issues_repo": "rather-not-work-on/platform-planningops",
+  "required_closed_issues": [223, 225, 227],
+  "gap_checks": [
+    {
+      "path": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave12-local-smoke-issue-pack.md",
+      "must_contain": [
+        "monday owns the local mission smoke entrypoint",
+        "platform-provider-gateway owns the launcher-backed provider smoke path",
+        "platform-observability-gateway owns the launcher-backed ingest smoke path"
+      ]
+    }
+  ],
+  "file_checks": [
+    {
+      "repo": "rather-not-work-on/monday",
+      "repo_dir": "monday",
+      "path": "scripts/run_local_runtime_smoke.py",
+      "must_contain": [
+        "buildDefaultLocalExecutor",
+        "runtime-artifacts/smoke",
+        "local_runtime_smoke_failed"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "scripts/litellm_live_smoke.py",
+      "must_contain": [
+        "scripts/litellm_stack_launcher.sh",
+        "scripts/litellm_gateway_smoke.py",
+        "runtime-artifacts/live"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-provider-gateway",
+      "repo_dir": "platform-provider-gateway",
+      "path": "scripts/litellm_stack_launcher.sh",
+      "must_contain": [
+        "PYTHON_BIN",
+        "\"$PYTHON_BIN\" scripts/litellm_profile_drill.py"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "scripts/langfuse_live_smoke.py",
+      "must_contain": [
+        "scripts/langfuse_stack_launcher.sh",
+        "validate_ingest_smoke_evidence.py",
+        "runtime-artifacts/live"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-observability-gateway",
+      "repo_dir": "platform-observability-gateway",
+      "path": "scripts/langfuse_stack_launcher.sh",
+      "must_contain": [
+        "PYTHON_BIN",
+        "\"$PYTHON_BIN\" scripts/langfuse_ingest_smoke.py"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the wave12 review spec for local smoke entrypoints and launcher interpreter wiring
- record review evidence after monday/provider/observability wave12 merges
- close out the planningops review item for runtime infra wave12

## Scope
- Runtime/packages: none
- Scripts/contracts/docs: `planningops/fixtures`, `planningops/artifacts/validation`
- `.github/` workflows: none

## Linked Issues
- Closes #229
- Related #223
- Related #225
- Related #227

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- [x] `python3 planningops/scripts/federation/review_interface_adoption.py --spec planningops/fixtures/runtime-infra-wave12-review-spec.json --workspace-root .. --output planningops/artifacts/validation/runtime-infra-wave12-review.json`
- [x] Additional checks (if any): external repo issues `#223/#225/#227` auto-closed via repo-qualified PR refs

## Risks
- Risk: the review is still marker-driven, so it confirms smoke entrypoint ownership and launcher wiring but not a full planningops-driven federated one-command run yet.
- Rollback: revert this PR to remove the review artifact and keep wave12 open for re-review.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] Evidence paths remain inside canonical planningops validation artifacts.
- [x] Validation commands were run locally.
