### PR TITLE
feat(planningops): stack runtime infra wave13 and wave14 backlog

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave13.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave13.execution-contract.json
@@ -1,0 +1,63 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-infra-wave13",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave13-federated-smoke-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "AE10",
+        "execution_order": 10,
+        "title": "federated local runtime stack smoke runner",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "planningops/scripts/federation/run_local_runtime_stack_smoke.py",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AE20",
+        "execution_order": 20,
+        "title": "federated local runtime stack smoke contract test",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "planningops/scripts/test_local_runtime_stack_smoke_contract.sh",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AE30",
+        "execution_order": 30,
+        "title": "runtime infra wave13 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "backlog",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "planningops/artifacts/validation/runtime-infra-wave13-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}
+

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave14.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave14.execution-contract.json
@@ -1,0 +1,43 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-infra-wave14",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave14-oracle-rehearsal-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "AF10",
+        "execution_order": 10,
+        "title": "wave14 oracle rehearsal wrapper",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "backlog",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "planningops/scripts/federation/run_wave14_oracle_rehearsal.py",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AF20",
+        "execution_order": 20,
+        "title": "runtime infra wave14 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "backlog",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "planningops/artifacts/validation/runtime-infra-wave14-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave13-federated-smoke-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave13-federated-smoke-issue-pack.md
@@ -1,0 +1,61 @@
+---
+title: plan: Runtime Infra Wave 13 Federated Smoke Issue Pack
+type: plan
+date: 2026-03-09
+updated: 2026-03-09
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the next executable issue pack that lifts the repo-local wave12 smoke entrypoints into a single planningops-owned federated local stack smoke runner and review gate.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - smoke
+  - federated
+  - backlog
+---
+
+# Runtime Infra Wave 13 Federated Smoke Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- runtime infra wave12 is merged and its review recorded `verdict=pass`
+- repo-local smoke entrypoints now exist in monday, provider, and observability
+- the next missing capability is a planningops-owned one-command smoke that coordinates the three repos without collapsing ownership
+
+## Goal
+
+Create a planningops-owned federated smoke runner that executes the monday/provider/observability local smoke entrypoints and writes a deterministic aggregate report.
+
+The rule for this wave is strict:
+- planningops owns orchestration and aggregate evidence only
+- monday/provider/observability continue to own their repo-local smoke entrypoints
+- aggregate output must reference repo-owned evidence rather than re-encoding the same logic in planningops
+
+## Wave 13 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `AE10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/federation/run_local_runtime_stack_smoke.py` |
+| `AE20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/test_local_runtime_stack_smoke_contract.sh` |
+| `AE30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `backlog` | `planningops/artifacts/validation/runtime-infra-wave13-review.json` |
+
+## Decomposition Rules
+
+- `AE10` adds a planningops-owned federated local smoke runner that shells into repo-owned monday/provider/observability smoke entrypoints and records stable aggregate evidence without rewriting repo-local smoke logic.
+- `AE20` adds a contract test for the new federated local smoke runner so orchestration shape and evidence expectations do not drift silently.
+- `AE30` validates that planningops now owns only the aggregate smoke path and that repo-local evidence remains the source for each execution domain.
+
+## Dependencies
+
+- `AE20` depends on `AE10`
+- `AE30` depends on `AE10`, `AE20`
+
+## Explicit Non-Goals
+
+- no Oracle Cloud rehearsal yet
+- no long-running daemon or scheduler soak
+- no GitHub issue execution loop wired onto the federated smoke path yet
+

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave14-oracle-rehearsal-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave14-oracle-rehearsal-issue-pack.md
@@ -1,0 +1,58 @@
+---
+title: plan: Runtime Infra Wave 14 Oracle Rehearsal Issue Pack
+type: plan
+date: 2026-03-09
+updated: 2026-03-09
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the follow-up issue pack that reuses the wave13 federated smoke runner to validate local-to-OCI profile portability without promoting Oracle execution to the default path.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - oracle
+  - rehearsal
+  - backlog
+---
+
+# Runtime Infra Wave 14 Oracle Rehearsal Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- wave13 is the immediate predecessor and must produce a planningops-owned federated local smoke runner
+- `planningops/scripts/federation/run_local_oracle_rehearsal.py` already exists as a rehearsal boundary candidate
+- the next missing evidence after federated local smoke is profile portability from local to OCI-shaped targets
+
+## Goal
+
+Reuse the planningops-owned federated smoke path to classify whether runtime profiles remain portable when rehearsed against the oracle_cloud profile.
+
+The rule for this wave is strict:
+- local remains the default execution profile
+- Oracle remains rehearsal-only until explicit user approval
+- planningops owns portability evidence, not runtime service code
+
+## Wave 14 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `AF10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `backlog` | `planningops/scripts/federation/run_wave14_oracle_rehearsal.py` |
+| `AF20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `backlog` | `planningops/artifacts/validation/runtime-infra-wave14-review.json` |
+
+## Decomposition Rules
+
+- `AF10` wraps the existing local/oracle rehearsal boundary into a wave-owned entrypoint that consumes the wave13 federated smoke runner outputs and classifies portability gaps.
+- `AF20` validates that rehearsal stays non-destructive, local remains default, and OCI profile drift is surfaced as evidence instead of silently changing runtime defaults.
+
+## Dependencies
+
+- `AF20` depends on `AF10`
+
+## Explicit Non-Goals
+
+- no Oracle production cutover
+- no default profile switch away from local
+- no secrets bootstrap or infrastructure provisioning
+

--- a/planningops/artifacts/validation/runtime-infra-wave13-14-issue-quality-report.json
+++ b/planningops/artifacts/validation/runtime-infra-wave13-14-issue-quality-report.json
@@ -1,0 +1,10 @@
+{
+  "generated_at_utc": "2026-03-09T11:22:56.896606+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_scanned": 5,
+  "issues_in_scope": 5,
+  "violation_count": 0,
+  "violations": [],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/runtime-infra-wave13-14-label-backfill-report.json
+++ b/planningops/artifacts/validation/runtime-infra-wave13-14-label-backfill-report.json
@@ -1,0 +1,81 @@
+{
+  "generated_at_utc": "2026-03-09T11:22:46.674485+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "mode": "apply",
+  "issues_in_scope": 5,
+  "issues_with_missing_labels": 5,
+  "issues_applied": 5,
+  "rows": [
+    {
+      "number": 238,
+      "title": "plan: [30] runtime infra wave13 review",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/238",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/governance"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 237,
+      "title": "plan: [20] runtime infra wave14 review",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/237",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/governance"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 236,
+      "title": "plan: [20] federated local runtime stack smoke contract test",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/236",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 235,
+      "title": "plan: [10] wave14 oracle rehearsal wrapper",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/235",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    },
+    {
+      "number": 234,
+      "title": "plan: [10] federated local runtime stack smoke runner",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/234",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied",
+      "error": ""
+    }
+  ]
+}

--- a/planningops/artifacts/validation/runtime-infra-wave13-projection-report.json
+++ b/planningops/artifacts/validation/runtime-infra-wave13-projection-report.json
@@ -1,0 +1,83 @@
+{
+  "mode": "apply",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave13.execution-contract.json",
+  "validation_errors": [],
+  "results": [
+    {
+      "plan_item_id": "AE10",
+      "execution_order": 10,
+      "issue_number": 234,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/234",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    },
+    {
+      "plan_item_id": "AE20",
+      "execution_order": 20,
+      "issue_number": 236,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/236",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    },
+    {
+      "plan_item_id": "AE30",
+      "execution_order": 30,
+      "issue_number": 238,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/238",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    }
+  ],
+  "plan_id": "uap-runtime-infra-wave13",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave13-federated-smoke-issue-pack.md",
+  "items_total": 3,
+  "open_issues_scanned": 0,
+  "closed_issues_scanned": 0,
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/runtime-infra-wave14-projection-report.json
+++ b/planningops/artifacts/validation/runtime-infra-wave14-projection-report.json
@@ -1,0 +1,60 @@
+{
+  "mode": "apply",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave14.execution-contract.json",
+  "validation_errors": [],
+  "results": [
+    {
+      "plan_item_id": "AF10",
+      "execution_order": 10,
+      "issue_number": 235,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/235",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    },
+    {
+      "plan_item_id": "AF20",
+      "execution_order": 20,
+      "issue_number": 237,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/237",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "loop_profile",
+        "plan_lane"
+      ]
+    }
+  ],
+  "plan_id": "uap-runtime-infra-wave14",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave14-oracle-rehearsal-issue-pack.md",
+  "items_total": 2,
+  "open_issues_scanned": 0,
+  "closed_issues_scanned": 0,
+  "verdict": "pass"
+}


### PR DESCRIPTION
## Summary
- stack the next planningops-only runtime infra backlog waves after wave12 completion
- project wave13 federated local smoke work and wave14 oracle rehearsal work into executable planningops issues
- record projection, label backfill, and issue-quality evidence for the new backlog pack

## Scope
- Runtime/packages: none
- Scripts/contracts/docs: `docs/workbench/.../plans`, `planningops/artifacts/validation`
- `.github/` workflows: none

## Linked Issues
- Related #234
- Related #235
- Related #236
- Related #237
- Related #238

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- [x] `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave13.execution-contract.json --apply --output planningops/artifacts/validation/runtime-infra-wave13-projection-report.json`
- [x] `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-infra-wave14.execution-contract.json --apply --output planningops/artifacts/validation/runtime-infra-wave14-projection-report.json`
- [x] Additional checks (if any): `python3 planningops/scripts/backfill_issue_labels.py --repo rather-not-work-on/platform-planningops --apply --output planningops/artifacts/validation/runtime-infra-wave13-14-label-backfill-report.json`; `python3 planningops/scripts/validate_issue_quality.py --strict --output planningops/artifacts/validation/runtime-infra-wave13-14-issue-quality-report.json`

## Risks
- Risk: this PR only queues the next waves; it does not yet prove the federated smoke runner or oracle rehearsal wrapper behavior.
- Rollback: revert this PR to remove the newly stacked backlog waves and their projection evidence.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] Evidence paths remain inside canonical planningops validation artifacts.
- [x] Validation commands were run locally.
