### PR TITLE
docs(planningops): record wave13 federated smoke review

### DIFF
--- a/planningops/artifacts/validation/runtime-infra-wave13-review.json
+++ b/planningops/artifacts/validation/runtime-infra-wave13-review.json
@@ -1,0 +1,58 @@
+{
+  "generated_at_utc": "2026-03-09T12:13:26.612471+00:00",
+  "wave_id": "uap-runtime-infra-wave13",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/fixtures/runtime-infra-wave13-review-spec.json",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 234,
+      "state": "CLOSED",
+      "title": "plan: [10] federated local runtime stack smoke runner",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/234",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 236,
+      "state": "CLOSED",
+      "title": "plan: [20] federated local runtime stack smoke contract test",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/236",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "gap_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave13-federated-smoke-issue-pack.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass"
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/federation/run_local_runtime_stack_smoke.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_local_runtime_stack_smoke_contract.sh",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_local_runtime_stack_smoke.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    }
+  ],
+  "check_count": 6,
+  "failure_count": 0,
+  "verdict": "pass"
+}

--- a/planningops/fixtures/runtime-infra-wave13-review-spec.json
+++ b/planningops/fixtures/runtime-infra-wave13-review-spec.json
@@ -1,0 +1,47 @@
+{
+  "wave_id": "uap-runtime-infra-wave13",
+  "issues_repo": "rather-not-work-on/platform-planningops",
+  "required_closed_issues": [234, 236],
+  "gap_checks": [
+    {
+      "path": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave13-federated-smoke-issue-pack.md",
+      "must_contain": [
+        "planningops owns orchestration and aggregate evidence only",
+        "monday/provider/observability continue to own their repo-local smoke entrypoints",
+        "aggregate output must reference repo-owned evidence"
+      ]
+    }
+  ],
+  "file_checks": [
+    {
+      "repo": "rather-not-work-on/platform-planningops",
+      "repo_dir": "platform-planningops",
+      "path": "planningops/scripts/federation/run_local_runtime_stack_smoke.py",
+      "must_contain": [
+        "\"scripts/run_local_runtime_smoke.py\"",
+        "\"scripts/litellm_live_smoke.py\"",
+        "\"scripts/langfuse_live_smoke.py\"",
+        "\"component_runs\""
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-planningops",
+      "repo_dir": "platform-planningops",
+      "path": "planningops/scripts/test_local_runtime_stack_smoke_contract.sh",
+      "must_contain": [
+        "component_runs",
+        "report_summary",
+        "local runtime stack smoke contract ok"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-planningops",
+      "repo_dir": "platform-planningops",
+      "path": "planningops/scripts/run_local_runtime_stack_smoke.py",
+      "must_contain": [
+        "\"run_local_runtime_stack_smoke.py\"",
+        "runpy.run_path"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the wave13 review spec for federated local runtime stack smoke
- record deterministic review evidence after `#234` and `#236` closed

## Scope
- planningops review spec and evidence only
- no runtime implementation changes

## Linked Issues
- Closes #238

## Validation
- `python3 planningops/scripts/federation/review_interface_adoption.py --spec planningops/fixtures/runtime-infra-wave13-review-spec.json --workspace-root .. --output planningops/artifacts/validation/runtime-infra-wave13-review.json`
- `git diff --check`

## Risks
- low; review artifact only

## Review Checklist
- [x] required predecessor issues are closed
- [x] review spec markers match actual wave13 runner/test files
- [x] output artifact records pass/fail deterministically

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required.
- Reason: review spec and evidence only.
