### PR TITLE
docs(planningops): record wave14 oracle rehearsal review

### DIFF
--- a/planningops/artifacts/validation/runtime-infra-wave14-review.json
+++ b/planningops/artifacts/validation/runtime-infra-wave14-review.json
@@ -1,0 +1,50 @@
+{
+  "generated_at_utc": "2026-03-09T12:22:36.590340+00:00",
+  "wave_id": "uap-runtime-infra-wave14",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/fixtures/runtime-infra-wave14-review-spec.json",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 235,
+      "state": "CLOSED",
+      "title": "plan: [10] wave14 oracle rehearsal wrapper",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/235",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "gap_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave14-oracle-rehearsal-issue-pack.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass"
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/federation/run_wave14_oracle_rehearsal.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_wave14_oracle_rehearsal_contract.sh",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_wave14_oracle_rehearsal.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    }
+  ],
+  "check_count": 5,
+  "failure_count": 0,
+  "verdict": "pass"
+}

--- a/planningops/fixtures/runtime-infra-wave14-review-spec.json
+++ b/planningops/fixtures/runtime-infra-wave14-review-spec.json
@@ -1,0 +1,46 @@
+{
+  "wave_id": "uap-runtime-infra-wave14",
+  "issues_repo": "rather-not-work-on/platform-planningops",
+  "required_closed_issues": [235],
+  "gap_checks": [
+    {
+      "path": "docs/workbench/unified-personal-agent-platform/plans/runtime-infra-wave14-oracle-rehearsal-issue-pack.md",
+      "must_contain": [
+        "local remains the default execution profile",
+        "Oracle remains rehearsal-only",
+        "planningops owns portability evidence"
+      ]
+    }
+  ],
+  "file_checks": [
+    {
+      "repo": "rather-not-work-on/platform-planningops",
+      "repo_dir": "platform-planningops",
+      "path": "planningops/scripts/federation/run_wave14_oracle_rehearsal.py",
+      "must_contain": [
+        "run_local_runtime_stack_smoke.py",
+        "\"default_profile_preserved\"",
+        "\"oracle_rehearsal_only\""
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-planningops",
+      "repo_dir": "platform-planningops",
+      "path": "planningops/scripts/test_wave14_oracle_rehearsal_contract.sh",
+      "must_contain": [
+        "rehearsal_supported_components",
+        "shared_profile_components",
+        "wave14 oracle rehearsal contract ok"
+      ]
+    },
+    {
+      "repo": "rather-not-work-on/platform-planningops",
+      "repo_dir": "platform-planningops",
+      "path": "planningops/scripts/run_wave14_oracle_rehearsal.py",
+      "must_contain": [
+        "\"run_wave14_oracle_rehearsal.py\"",
+        "runpy.run_path"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the wave14 review spec for oracle rehearsal portability
- record deterministic review evidence after `#235` closed

## Scope
- planningops review spec and evidence only
- no runtime implementation changes

## Linked Issues
- Closes #237

## Validation
- `python3 planningops/scripts/federation/review_interface_adoption.py --spec planningops/fixtures/runtime-infra-wave14-review-spec.json --workspace-root .. --output planningops/artifacts/validation/runtime-infra-wave14-review.json`
- `git diff --check`

## Risks
- low; review artifact only

## Review Checklist
- [x] required predecessor issue is closed
- [x] review spec markers match the wave14 runner/wrapper/test files
- [x] output artifact records pass/fail deterministically

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required.
- Reason: review spec and evidence only.
