### PR TITLE
feat(planningops): reconcile closed project items for wave18

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-mission-wave18.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-mission-wave18.execution-contract.json
@@ -1,0 +1,62 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-mission-wave18",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave18-project-close-state-reconcile-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "AJ10",
+        "execution_order": 10,
+        "title": "planningops closed issue project reconcile scan mode",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "planningops/scripts/sync_project_fields_after_issue_create.py",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AJ20",
+        "execution_order": 20,
+        "title": "planningops project close-state reconcile report",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "planningops/artifacts/validation/project-close-state-reconcile-report.json",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AJ30",
+        "execution_order": 30,
+        "title": "runtime mission wave18 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "planningops/artifacts/validation/runtime-mission-wave18-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave18-project-close-state-reconcile-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave18-project-close-state-reconcile-issue-pack.md
@@ -1,0 +1,63 @@
+---
+title: plan: Runtime Mission Wave 18 Project Close-State Reconcile Issue Pack
+type: plan
+date: 2026-03-09
+updated: 2026-03-09
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Adds a control-plane reconcile path that backfills Project status/workflow_state for issues already closed in GitHub but still left in executable states inside the planningops project.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - control-plane
+  - reconcile
+  - backlog
+---
+
+# Runtime Mission Wave 18 Project Close-State Reconcile Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- wave17 proved that compile-projected ready items can now be selected by the live issue loop
+- the live pilot also exposed historical project drift: many issues are already closed in GitHub but still appear as `Todo`/`ready-implementation` in the project view
+- this drift does not block correctness anymore, but it inflates candidate scans and weakens the reliability of the control plane
+
+## Goal
+
+Make project state converge after issue closure:
+- `sync_project_fields_after_issue_create.py` must support scanning issues beyond currently-open cards so closed items can be reconciled
+- planningops must be able to produce a deterministic drift report and, in apply mode, move closed cards to `done`
+- the live issue loop should no longer waste intake attempts on already-closed cards once reconcile has run
+
+The rule for this wave is strict:
+- keep the fix inside planningops
+- reuse existing project-field sync logic instead of creating a second competing reconcile script
+- record one compact review artifact after live reconcile
+
+## Wave 18 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `AJ10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/sync_project_fields_after_issue_create.py` |
+| `AJ20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/artifacts/validation/project-close-state-reconcile-report.json` |
+| `AJ30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/runtime-mission-wave18-review.json` |
+
+## Decomposition Rules
+
+- `AJ10` adds a repo scan mode that can include `open`, `closed`, or `all` issue states without breaking the existing issue-ref and open-only behavior.
+- `AJ20` adds contract coverage for close-state reconcile and runs a live planningops reconcile pass that writes a deterministic report.
+- `AJ30` records whether the reconcile reduced issue-loop candidate noise and whether project states now converge with GitHub issue states.
+
+## Dependencies
+
+- `AJ20` depends on `AJ10`
+- `AJ30` depends on `AJ10`, `AJ20`
+
+## Explicit Non-Goals
+
+- no execution-repo changes
+- no new scheduler behavior
+- no deletion of historical issues or project items

--- a/planningops/artifacts/validation/project-close-state-reconcile-report.json
+++ b/planningops/artifacts/validation/project-close-state-reconcile-report.json
@@ -1,0 +1,211 @@
+{
+  "generated_at_utc": "2026-03-09T14:18:21.239250+00:00",
+  "mode": "apply",
+  "issues_total": 10,
+  "updated_count": 10,
+  "error_count": 0,
+  "results": [
+    {
+      "plan_item_id": "W10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 180,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/180",
+      "issue_state": "closed",
+      "component": "runtime",
+      "workflow_state": "done",
+      "plan_lane": "m2_sync_core",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    },
+    {
+      "plan_item_id": "X10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 190,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/190",
+      "issue_state": "closed",
+      "component": "runtime",
+      "workflow_state": "done",
+      "plan_lane": "m2_sync_core",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    },
+    {
+      "plan_item_id": "G10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 207,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/207",
+      "issue_state": "closed",
+      "component": "runtime",
+      "workflow_state": "done",
+      "plan_lane": "m3_guardrails",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    },
+    {
+      "plan_item_id": "AA10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 213,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/213",
+      "issue_state": "closed",
+      "component": "runtime",
+      "workflow_state": "done",
+      "plan_lane": "m2_sync_core",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    },
+    {
+      "plan_item_id": "AB10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 218,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/218",
+      "issue_state": "closed",
+      "component": "runtime",
+      "workflow_state": "done",
+      "plan_lane": "m2_sync_core",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    },
+    {
+      "plan_item_id": "AD10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 223,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/223",
+      "issue_state": "closed",
+      "component": "runtime",
+      "workflow_state": "done",
+      "plan_lane": "m3_guardrails",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    },
+    {
+      "plan_item_id": "AC10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 224,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/224",
+      "issue_state": "closed",
+      "component": "runtime",
+      "workflow_state": "done",
+      "plan_lane": "m3_guardrails",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    },
+    {
+      "plan_item_id": "AE10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 234,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/234",
+      "issue_state": "closed",
+      "component": "planningops",
+      "workflow_state": "done",
+      "plan_lane": "m3_guardrails",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    },
+    {
+      "plan_item_id": "AG10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 244,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/244",
+      "issue_state": "closed",
+      "component": "runtime",
+      "workflow_state": "done",
+      "plan_lane": "m2_sync_core",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    },
+    {
+      "plan_item_id": "AH10",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 251,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/251",
+      "issue_state": "closed",
+      "component": "planningops",
+      "workflow_state": "done",
+      "plan_lane": "m3_guardrails",
+      "field_updates": [
+        "initiative",
+        "target_repo",
+        "execution_order",
+        "status",
+        "component",
+        "workflow_state",
+        "plan_lane",
+        "loop_profile"
+      ]
+    }
+  ],
+  "errors": [],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/runtime-mission-wave18-review.json
+++ b/planningops/artifacts/validation/runtime-mission-wave18-review.json
@@ -1,0 +1,56 @@
+{
+  "generated_at_utc": "2026-03-09T14:18:44.836698+00:00",
+  "wave": "runtime-mission-wave18",
+  "plan_id": "uap-runtime-mission-wave18",
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave18-project-close-state-reconcile-issue-pack.md",
+  "verdict": "pass",
+  "summary": {
+    "close_state_reconcile": {
+      "verdict": "pass",
+      "issues_total": 10,
+      "updated_count": 10,
+      "error_count": 0,
+      "done_issue_numbers": [
+        180,
+        190,
+        207,
+        213,
+        218,
+        223,
+        224,
+        234,
+        244,
+        251
+      ]
+    },
+    "live_projection_gate": {
+      "verdict": "pass",
+      "project_items_scanned": 210,
+      "project_items_limit_hit": false,
+      "missing_count": 0,
+      "mismatch_count": 0
+    },
+    "live_issue_loop_pilot": {
+      "selected_issue": 260,
+      "selected_plan_item_id": "AJ10",
+      "candidate_count_after_reconcile": 35,
+      "candidate_count_before_reconcile": 46,
+      "candidate_count_delta": 11,
+      "first_attempt_result": "issue_not_open",
+      "last_verdict": "pass",
+      "reason_code": "ok"
+    }
+  },
+  "decisions": [
+    "close-state drift reuses the existing project-field sync path instead of introducing a second reconcile implementation",
+    "targeted reconcile of known closed candidates is sufficient to reduce current live-intake noise immediately",
+    "remaining stale cards should be handled by an automatic close-event sync or scheduled full reconcile, not by repeated manual wave-specific repair"
+  ],
+  "follow_up_candidates": [
+    {
+      "key": "wave19",
+      "title": "automatic close-event project sync or scheduled full reconcile",
+      "reason": "candidate_count dropped from 46 to 35, but newly closed cards like #256 remain noise until another reconcile pass runs"
+    }
+  ]
+}

--- a/planningops/scripts/sync_project_fields_after_issue_create.py
+++ b/planningops/scripts/sync_project_fields_after_issue_create.py
@@ -24,6 +24,7 @@ DEFAULT_REPOS = [
     "rather-not-work-on/monday",
 ]
 DEFAULT_PLAN_ITEM_REGEX = r"^[A-Z][0-9]{2}$"
+ISSUE_STATE_CHOICES = {"open", "closed", "all"}
 WORKFLOW_TO_STATUS = {
     "backlog": "todo",
     "ready_contract": "todo",
@@ -72,8 +73,25 @@ def parse_issue_ref(raw: str):
     return match.group(1), int(match.group(2))
 
 
-def list_open_issues(repo: str):
-    rc, out, err = run(["gh", "issue", "list", "--repo", repo, "--state", "open", "--limit", "200", "--json", "number,title,url,body,state"])
+def list_issues(repo: str, issue_state: str):
+    normalized_state = normalize_option_key(issue_state) or "open"
+    if normalized_state not in ISSUE_STATE_CHOICES:
+        raise ValueError(f"unsupported issue_state: {issue_state}")
+    rc, out, err = run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            normalized_state,
+            "--limit",
+            "400",
+            "--json",
+            "number,title,url,body,state",
+        ]
+    )
     if rc != 0:
         raise RuntimeError(f"failed to list issues for {repo}: {err}")
     rows = json.loads(out)
@@ -278,7 +296,7 @@ def collect_candidates(args):
     repos = [x.strip() for x in args.repos.split(",") if x.strip()]
     rows = []
     for repo in repos:
-        for issue in list_open_issues(repo):
+        for issue in list_issues(repo, args.issue_state):
             metadata = parse_metadata(issue["body"])
             plan_item_id = metadata.get("plan_item_id", "")
             if not plan_item_id:
@@ -414,6 +432,12 @@ def main():
         default=[],
         help="Explicit issue refs (owner/repo#number). Can be repeated.",
     )
+    parser.add_argument(
+        "--issue-state",
+        default="open",
+        choices=sorted(ISSUE_STATE_CHOICES),
+        help="Issue state scope for repo scan when --issue-ref is not used",
+    )
     args = parser.parse_args()
 
     project = load_config(Path(args.config))
@@ -423,6 +447,7 @@ def main():
         "project_number": project["project_number"],
         "project_id": project["project_id"],
         "plan_item_regex": args.plan_item_regex,
+        "issue_state": args.issue_state,
         "issues_total": 0,
         "updated_count": 0,
         "error_count": 0,

--- a/planningops/scripts/test_sync_project_fields_after_issue_create_contract.sh
+++ b/planningops/scripts/test_sync_project_fields_after_issue_create_contract.sh
@@ -106,5 +106,38 @@ assert "O_COMPONENT_PROVIDER" in select_option_ids, select_calls
 assert "O_WF_READY_IMPL" in select_option_ids, select_calls
 assert "O_LANE_M2" in select_option_ids, select_calls
 
+listed_states = []
+
+
+def fake_list_issues(repo, issue_state):
+    listed_states.append((repo, issue_state))
+    return [
+        {
+            "repo": repo,
+            "number": 44,
+            "title": "closed card",
+            "url": f"https://github.com/{repo}/issues/44",
+            "body": body,
+            "state": "CLOSED",
+        }
+    ]
+
+
+mod.list_issues = fake_list_issues
+
+
+class Args:
+    issue_ref = []
+    repos = "rather-not-work-on/platform-provider-gateway"
+    plan_item_regex = r"^B21$"
+    issue_state = "all"
+
+
+candidates = mod.collect_candidates(Args())
+assert listed_states == [("rather-not-work-on/platform-provider-gateway", "all")], listed_states
+assert len(candidates) == 1, candidates
+assert candidates[0]["state"] == "CLOSED", candidates
+assert candidates[0]["metadata"]["plan_item_id"] == "B21", candidates
+
 print("sync_project_fields_after_issue_create contract tests ok")
 PY


### PR DESCRIPTION
## Summary
- extend `sync_project_fields_after_issue_create.py` so repo scans can include `open`, `closed`, or `all` issue states
- use that reconcile path to move known closed planningops cards from executable project states into `done`
- record a compact review showing live intake noise dropped after reconcile (`candidate_count` 46 -> 35)

## Scope
- Initiative docs:
  - `none`
- Workbench docs:
  - `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave18-project-close-state-reconcile-issue-pack.md`
  - `docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-mission-wave18.execution-contract.json`
- `planningops/` scripts/contracts:
  - `planningops/scripts/sync_project_fields_after_issue_create.py`
  - `planningops/scripts/test_sync_project_fields_after_issue_create_contract.sh`
  - `planningops/artifacts/validation/project-close-state-reconcile-report.json`
  - `planningops/artifacts/validation/runtime-mission-wave18-review.json`
- `.github/` workflows:
  - `none`

## Linked Issues
- Closes #260
- Closes #261
- Closes #262
- Related #259

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_sync_project_fields_after_issue_create_contract.sh`
  - `python3 planningops/scripts/validate_issue_quality.py --strict`
  - `python3 planningops/scripts/verify_plan_projection.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-mission-wave18.execution-contract.json --strict --output planningops/artifacts/validation/runtime-mission-wave18-live-projection-report.json`
  - `python3 planningops/scripts/issue_loop_runner.py --mode dry-run --no-feedback --pull-workflow-states ready-implementation --pec-preflight-mode strict-pec --pec-contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-09-runtime-mission-wave18.execution-contract.json --runtime-profile-file planningops/config/runtime-profiles.json --project-item-limit 1000`

## Risks
- Risk:
  - current reconcile run is targeted; future closed cards still need either periodic reconcile or close-event automation
- Rollback:
  - revert this commit and re-run project field sync for the affected issue refs if needed

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
