### PR TITLE
feat(planningops): surface rate-limit fallback in supervisor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave21.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave21.execution-contract.json
@@ -1,0 +1,43 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-mission-wave21",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave21-supervisor-rate-limit-reporting-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "AM10",
+        "execution_order": 10,
+        "title": "planningops supervisor rate-limit aware runner passthrough",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "planningops/scripts/autonomous_supervisor_loop.py",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AM20",
+        "execution_order": 20,
+        "title": "runtime mission wave21 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "planningops/artifacts/validation/runtime-mission-wave21-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave21-supervisor-rate-limit-reporting-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave21-supervisor-rate-limit-reporting-issue-pack.md
@@ -1,0 +1,62 @@
+---
+title: plan: Runtime Mission Wave 21 Supervisor Rate-Limit Reporting Issue Pack
+type: plan
+date: 2026-03-10
+updated: 2026-03-10
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Propagates rate-limit fallback signals from issue-loop intake into supervisor commands, per-cycle reports, and convergence stop reasons.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - control-plane
+  - supervisor
+  - rate-limit
+  - backlog
+---
+
+# Runtime Mission Wave 21 Supervisor Rate-Limit Reporting Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- wave20 hardened `issue_loop_runner.py` with snapshot fallback and issue-doc caching
+- the supervisor currently treats the runner as an opaque black box and does not record whether a cycle used live or snapshot project data
+- overnight automation needs explicit degraded-mode evidence, otherwise operators cannot tell a true live convergence from a snapshot-backed one
+
+## Goal
+
+Make supervisor reports rate-limit aware:
+- `autonomous_supervisor_loop.py` must pass project-item snapshot controls through to `issue_loop_runner.py`
+- supervisor cycle reports must surface `project_items_source`, snapshot fallback usage, and any runner-reported rate-limit error
+- convergence under snapshot fallback must remain explicit in the final stop reason
+
+The rule for this wave is strict:
+- keep the change inside planningops
+- do not change execution-repo behavior
+- do not introduce retry sleeps or background wait loops
+- preserve pass/fail semantics while making degraded convergence visible
+
+## Wave 21 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `AM10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/autonomous_supervisor_loop.py` |
+| `AM20` | 20 | `rather-not-work-on/platform-planningops` | `review_gate` | `review_gate` | `planningops/artifacts/validation/runtime-mission-wave21-review.json` |
+
+## Decomposition Rules
+
+- `AM10` threads snapshot controls into the runner command and records rate-limit fallback signals in cycle reports.
+- `AM20` records whether convergence stayed fully live or used snapshot fallback, and what stop reason was emitted.
+
+## Dependencies
+
+- `AM20` depends on `AM10`
+
+## Explicit Non-Goals
+
+- no new GitHub issue projection
+- no backoff/retry timing policy
+- no apply-mode fallback beyond what wave20 already defined

--- a/planningops/artifacts/validation/runtime-mission-wave21-review.json
+++ b/planningops/artifacts/validation/runtime-mission-wave21-review.json
@@ -1,0 +1,31 @@
+{
+  "generated_at_utc": "2026-03-10T12:45:00+00:00",
+  "wave": "runtime-mission-wave21",
+  "plan_id": "uap-runtime-mission-wave21",
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave21-supervisor-rate-limit-reporting-issue-pack.md",
+  "verdict": "pass",
+  "summary": {
+    "supervisor_passthrough": {
+      "project_items_snapshot": "implemented",
+      "project_items_snapshot_fallback": "implemented",
+      "degraded_convergence_reason": "converged_with_snapshot_fallback"
+    },
+    "local_contracts": {
+      "autonomous_supervisor_loop": "pass",
+      "issue_loop_runner_multi_repo_intake": "pass",
+      "uap_docs_workbench": "pass"
+    }
+  },
+  "decisions": [
+    "supervisor forwards runner snapshot controls instead of hardcoding live-only intake assumptions",
+    "per-cycle reports now surface project item data source and fallback usage so degraded runs are inspectable",
+    "snapshot-backed convergence stays pass but uses a distinct stop reason to avoid being mistaken for full live convergence"
+  ],
+  "follow_up_candidates": [
+    {
+      "key": "wave22",
+      "title": "operator-facing cooldown and retry guidance for GitHub API pressure",
+      "reason": "the supervisor now reports degraded convergence, but operators still need a compact cooldown / retry recommendation artifact"
+    }
+  ]
+}

--- a/planningops/scripts/autonomous_supervisor_loop.py
+++ b/planningops/scripts/autonomous_supervisor_loop.py
@@ -93,6 +93,10 @@ def build_issue_runner_command(args):
         str(args.project_num),
         "--initiative",
         args.initiative,
+        "--project-items-snapshot",
+        args.issue_runner_project_items_snapshot,
+        "--project-items-snapshot-fallback",
+        args.issue_runner_project_items_snapshot_fallback,
     ]
     if args.mode == "dry-run":
         cmd.append("--no-feedback")
@@ -227,6 +231,15 @@ def parse_args():
     parser.add_argument("--offline", action="store_true")
     parser.add_argument("--issue-runner-script", default="planningops/scripts/issue_loop_runner.py")
     parser.add_argument(
+        "--issue-runner-project-items-snapshot",
+        default="planningops/artifacts/loop-runner/project-items-snapshot.json",
+    )
+    parser.add_argument(
+        "--issue-runner-project-items-snapshot-fallback",
+        choices=["off", "auto", "require"],
+        default="auto",
+    )
+    parser.add_argument(
         "--loop-result-sequence-file",
         default=None,
         help="Optional simulation sequence file with loop_result rows for deterministic contract tests",
@@ -311,6 +324,10 @@ def main():
         backlog_gate = run_backlog_gate(args, cycle_dir, candidate_file)
         backlog_verdict = str((backlog_gate.get("report") or {}).get("verdict", "")).lower()
         backlog_failed = backlog_gate.get("rc", 1) != 0 or backlog_verdict == "fail"
+        selection_trace = loop_result.get("selection_trace") or {}
+        project_items_source = selection_trace.get("project_items_source")
+        project_items_rate_limit_fallback_used = bool(selection_trace.get("project_items_rate_limit_fallback_used"))
+        project_items_rate_limit_error = selection_trace.get("project_items_rate_limit_error")
 
         cycle_record = {
             "cycle": cycle_index,
@@ -333,6 +350,9 @@ def main():
                 "verdict": (experiment_executor.get("report") or {}).get("verdict"),
                 "selected_option": (experiment_executor.get("report") or {}).get("selected_option"),
             },
+            "project_items_source": project_items_source,
+            "project_items_rate_limit_fallback_used": project_items_rate_limit_fallback_used,
+            "project_items_rate_limit_error": project_items_rate_limit_error,
             "backlog_gate": {
                 "rc": backlog_gate.get("rc"),
                 "report_path": backlog_gate.get("report_path"),
@@ -376,8 +396,12 @@ def main():
             stop_details = {"cycle": cycle_index, "reasons": experiment["reasons"]}
             break
         if pass_streak >= args.convergence_pass_streak and int(cycle_record["replenishment_candidates_count"]) == 0:
-            stop_reason = "converged"
-            stop_details = {"cycle": cycle_index, "pass_streak": pass_streak}
+            if project_items_rate_limit_fallback_used:
+                stop_reason = "converged_with_snapshot_fallback"
+                stop_details = {"cycle": cycle_index, "pass_streak": pass_streak}
+            else:
+                stop_reason = "converged"
+                stop_details = {"cycle": cycle_index, "pass_streak": pass_streak}
             break
 
     if stop_reason is None:

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -45,6 +45,7 @@ with tempfile.TemporaryDirectory() as td:
     assert converged["executed_cycles"] == 2, converged
     assert converged["cycles"][0]["experiment_trigger"]["triggered"] is True, converged
     assert converged["cycles"][1]["replenishment_candidates_count"] == 0, converged
+    assert converged["cycles"][0]["project_items_rate_limit_fallback_used"] is False, converged
 
     # 2) default behavior should stop when experiment trigger is detected.
     out_exp_stop = td_path / "supervisor-experiment-stop.json"
@@ -121,6 +122,81 @@ with tempfile.TemporaryDirectory() as td:
     assert fail_doc["supervisor_verdict"] == "fail", fail_doc
     assert fail_doc["stop_reason"] == "quality_gate_fail", fail_doc
     assert fail_doc["cycles"][0]["reason_code"] == "verdict_consistency_error", fail_doc
+
+    # 4) snapshot-backed convergence must remain explicit in the stop reason.
+    snapshot_sequence = td_path / "snapshot-sequence.json"
+    snapshot_sequence.write_text(
+        json.dumps(
+            {
+                "cycles": [
+                    {
+                        "rc": 0,
+                        "loop_result": {
+                            "selected_issue": 401,
+                            "last_verdict": "pass",
+                            "reason_code": "ok",
+                            "auto_paused": False,
+                            "replenishment_candidates_count": 0,
+                            "selection_trace": {
+                                "selected": {"uncertainty_level": "low", "simulation_required": False},
+                                "project_items_source": "snapshot",
+                                "project_items_rate_limit_fallback_used": True,
+                                "project_items_rate_limit_error": "GraphQL: API rate limit exceeded for user",
+                            },
+                            "final_loop_profile": "L3 Implementation-TDD",
+                        },
+                    },
+                    {
+                        "rc": 0,
+                        "loop_result": {
+                            "selected_issue": 402,
+                            "last_verdict": "pass",
+                            "reason_code": "ok",
+                            "auto_paused": False,
+                            "replenishment_candidates_count": 0,
+                            "selection_trace": {
+                                "selected": {"uncertainty_level": "low", "simulation_required": False},
+                                "project_items_source": "snapshot",
+                                "project_items_rate_limit_fallback_used": True,
+                                "project_items_rate_limit_error": "GraphQL: API rate limit exceeded for user",
+                            },
+                            "final_loop_profile": "L3 Implementation-TDD",
+                        },
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    out_snapshot = td_path / "supervisor-snapshot.json"
+    rc_snapshot, _, _ = run_supervisor(
+        [
+            "python3",
+            "planningops/scripts/autonomous_supervisor_loop.py",
+            "--mode",
+            "dry-run",
+            "--max-cycles",
+            "3",
+            "--convergence-pass-streak",
+            "2",
+            "--continue-on-experiment",
+            "--loop-result-sequence-file",
+            str(snapshot_sequence),
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--offline",
+            "--output",
+            str(out_snapshot),
+        ]
+    )
+    assert rc_snapshot == 0, rc_snapshot
+    snapshot_doc = json.loads(out_snapshot.read_text(encoding="utf-8"))
+    assert snapshot_doc["supervisor_verdict"] == "pass", snapshot_doc
+    assert snapshot_doc["stop_reason"] == "converged_with_snapshot_fallback", snapshot_doc
+    assert snapshot_doc["cycles"][0]["project_items_source"] == "snapshot", snapshot_doc
+    assert snapshot_doc["cycles"][0]["project_items_rate_limit_fallback_used"] is True, snapshot_doc
 
 print("autonomous supervisor loop contract tests ok")
 PY


### PR DESCRIPTION
## Summary
- add wave21 supervisor reporting for issue-loop snapshot fallback / rate-limit degradation
- thread runner snapshot controls through `autonomous_supervisor_loop.py`
- distinguish `converged` from `converged_with_snapshot_fallback` in supervisor outputs

## Scope
- Initiative docs:
  - `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave21-supervisor-rate-limit-reporting-issue-pack.md`
  - `docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave21.execution-contract.json`
- Workbench docs:
  - `planningops/artifacts/validation/runtime-mission-wave21-review.json`
- `planningops/` scripts/contracts:
  - `planningops/scripts/autonomous_supervisor_loop.py`
  - `planningops/scripts/test_autonomous_supervisor_loop_contract.sh`
- `.github/` workflows:
  - none

## Linked Issues
- Related #264

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`
  - `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
  - `git diff --check`

## Risks
- Risk:
  - This wave changes reporting and stop-reason semantics; dashboards or downstream scripts that assume only `converged` may need adjustment.
- Rollback:
  - Revert commit `e37231b`.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
