### PR TITLE
feat(planningops): add rate-limit operator guidance

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave22.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave22.execution-contract.json
@@ -1,0 +1,62 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-mission-wave22",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "AN10",
+        "execution_order": 10,
+        "title": "planningops runner rate-limit guidance",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "planningops/scripts/core/loop/runner.py",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AN20",
+        "execution_order": 20,
+        "title": "planningops supervisor rate-limit guidance summary",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "planningops/scripts/autonomous_supervisor_loop.py",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AN30",
+        "execution_order": 30,
+        "title": "runtime mission wave22 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "planningops/artifacts/validation/runtime-mission-wave22-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md
@@ -1,0 +1,65 @@
+---
+title: plan: Runtime Mission Wave 22 Rate-Limit Guidance Issue Pack
+type: plan
+date: 2026-03-10
+updated: 2026-03-10
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Adds operator-facing cooldown and retry guidance when GitHub API pressure forces snapshot fallback or blocks live apply runs.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - control-plane
+  - github
+  - rate-limit
+  - operations
+---
+
+# Runtime Mission Wave 22 Rate-Limit Guidance Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- wave20 added runner snapshot fallback and wave21 propagated degraded-mode reporting into supervisor cycle summaries
+- operators can now see that fallback happened, but they still do not get explicit next-step guidance for cooldown, retry, or allowed execution modes
+- the next hardening step is operational clarity, not more fallback behavior
+
+## Goal
+
+Make rate-limit handling actionable:
+- `issue_loop_runner.py` must emit structured cooldown/retry guidance whenever project item loading falls back to snapshot or fails live due to rate limiting
+- `autonomous_supervisor_loop.py` must surface that guidance at cycle and summary level
+- review evidence must confirm the distinction between `snapshot tolerated in dry-run` and `live apply blocked`
+
+The rule for this wave is strict:
+- keep guidance deterministic and local
+- do not add automatic sleep/retry loops
+- do not silently downgrade apply mode into snapshot execution
+- keep wording concise enough for machine and human consumption
+
+## Wave 22 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `AN10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/core/loop/runner.py` |
+| `AN20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/autonomous_supervisor_loop.py` |
+| `AN30` | 30 | `rather-not-work-on/platform-planningops` | `review_gate` | `review_gate` | `planningops/artifacts/validation/runtime-mission-wave22-review.json` |
+
+## Decomposition Rules
+
+- `AN10` adds rate-limit guidance objects to runner output and failure paths.
+- `AN20` propagates runner guidance into supervisor cycle and stop summaries.
+- `AN30` records recommended cooldown actions for both snapshot-backed dry-run and blocked apply mode.
+
+## Dependencies
+
+- `AN20` depends on `AN10`
+- `AN30` depends on `AN10`, `AN20`
+
+## Explicit Non-Goals
+
+- no execution-repo changes
+- no GitHub issue projection changes
+- no background retry scheduler

--- a/planningops/artifacts/validation/runtime-mission-wave22-review.json
+++ b/planningops/artifacts/validation/runtime-mission-wave22-review.json
@@ -1,0 +1,36 @@
+{
+  "generated_at_utc": "2026-03-10T13:25:00+00:00",
+  "wave": "runtime-mission-wave22",
+  "plan_id": "uap-runtime-mission-wave22",
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
+  "verdict": "pass",
+  "summary": {
+    "runner_guidance": {
+      "live_success": "not_needed",
+      "snapshot_fallback": "snapshot_fallback_active",
+      "live_apply_block": "github_rate_limited"
+    },
+    "supervisor_guidance": {
+      "cycle_reports": "rate_limit_guidance recorded",
+      "snapshot_convergence": "converged_with_snapshot_fallback includes stop_details guidance",
+      "apply_block": "github_rate_limited stops fail with stop_details guidance"
+    },
+    "local_contracts": {
+      "autonomous_supervisor_loop": "pass",
+      "issue_loop_runner_multi_repo_intake": "pass",
+      "uap_docs_workbench": "pass"
+    }
+  },
+  "decisions": [
+    "runner guidance is deterministic data, not prose-only logging, so automation and operators can consume the same structure",
+    "snapshot fallback remains tolerated only for dry-run style execution and is surfaced distinctly from full live convergence",
+    "live apply mode stays blocked under GitHub rate limiting and now exits with explicit cooldown and retry guidance instead of a raw transport error"
+  ],
+  "follow_up_candidates": [
+    {
+      "key": "wave23",
+      "title": "supervisor operator report from rate-limit aware summaries",
+      "reason": "the loop now produces structured guidance, but overnight automation still needs a compact operator-facing report artifact for inbox triage"
+    }
+  ]
+}

--- a/planningops/scripts/autonomous_supervisor_loop.py
+++ b/planningops/scripts/autonomous_supervisor_loop.py
@@ -81,6 +81,36 @@ def detect_experiment_trigger(loop_result: dict):
     }
 
 
+def derive_rate_limit_guidance(loop_result: dict, project_items_source, fallback_used, rate_limit_error):
+    guidance = loop_result.get("rate_limit_guidance")
+    if isinstance(guidance, dict):
+        return guidance
+
+    if fallback_used:
+        return {
+            "status": "snapshot_fallback_active",
+            "recommended_wait_minutes": 15,
+            "retry_mode": "retry_live_after_cooldown",
+            "allowed_modes": ["dry-run", "no-feedback"],
+            "blocked_modes": ["apply"],
+            "reason": "Supervisor observed snapshot-backed issue intake due to GitHub API pressure.",
+            "raw_error": rate_limit_error,
+        }
+
+    if str(loop_result.get("reason_code") or "").strip() == "github_rate_limited":
+        return {
+            "status": "live_api_blocked",
+            "recommended_wait_minutes": 15,
+            "retry_mode": "retry_live_after_cooldown",
+            "allowed_modes": [],
+            "blocked_modes": ["apply"],
+            "reason": "Supervisor observed live GitHub rate limiting without safe fallback.",
+            "raw_error": rate_limit_error,
+        }
+
+    return None
+
+
 def build_issue_runner_command(args):
     cmd = [
         "python3",
@@ -328,6 +358,12 @@ def main():
         project_items_source = selection_trace.get("project_items_source")
         project_items_rate_limit_fallback_used = bool(selection_trace.get("project_items_rate_limit_fallback_used"))
         project_items_rate_limit_error = selection_trace.get("project_items_rate_limit_error")
+        rate_limit_guidance = derive_rate_limit_guidance(
+            loop_result,
+            project_items_source,
+            project_items_rate_limit_fallback_used,
+            project_items_rate_limit_error,
+        ) or selection_trace.get("rate_limit_guidance")
 
         cycle_record = {
             "cycle": cycle_index,
@@ -353,6 +389,7 @@ def main():
             "project_items_source": project_items_source,
             "project_items_rate_limit_fallback_used": project_items_rate_limit_fallback_used,
             "project_items_rate_limit_error": project_items_rate_limit_error,
+            "rate_limit_guidance": rate_limit_guidance,
             "backlog_gate": {
                 "rc": backlog_gate.get("rc"),
                 "report_path": backlog_gate.get("report_path"),
@@ -373,6 +410,10 @@ def main():
             pass_streak = 0
 
         if verdict == "fail":
+            if reason_code == "github_rate_limited":
+                stop_reason = "github_rate_limited"
+                stop_details = {"cycle": cycle_index, "rate_limit_guidance": rate_limit_guidance}
+                break
             stop_reason = "quality_gate_fail"
             stop_details = {"cycle": cycle_index, "reason_code": reason_code}
             break
@@ -398,7 +439,11 @@ def main():
         if pass_streak >= args.convergence_pass_streak and int(cycle_record["replenishment_candidates_count"]) == 0:
             if project_items_rate_limit_fallback_used:
                 stop_reason = "converged_with_snapshot_fallback"
-                stop_details = {"cycle": cycle_index, "pass_streak": pass_streak}
+                stop_details = {
+                    "cycle": cycle_index,
+                    "pass_streak": pass_streak,
+                    "rate_limit_guidance": rate_limit_guidance,
+                }
             else:
                 stop_reason = "converged"
                 stop_details = {"cycle": cycle_index, "pass_streak": pass_streak}
@@ -409,7 +454,13 @@ def main():
         stop_details = {"cycle_count": len(cycles)}
 
     supervisor_verdict = "pass"
-    if stop_reason in {"quality_gate_fail", "escalation_auto_pause", "backlog_gate_fail", "experiment_auto_executor_failed"}:
+    if stop_reason in {
+        "quality_gate_fail",
+        "escalation_auto_pause",
+        "backlog_gate_fail",
+        "experiment_auto_executor_failed",
+        "github_rate_limited",
+    }:
         supervisor_verdict = "fail"
     elif stop_reason in {"experiment_triggered", "sequence_exhausted"}:
         supervisor_verdict = "inconclusive"

--- a/planningops/scripts/core/loop/runner.py
+++ b/planningops/scripts/core/loop/runner.py
@@ -456,6 +456,49 @@ def resolve_project_items_snapshot_mode(requested_mode: str, run_mode: str, no_f
     return normalized
 
 
+def build_rate_limit_guidance(
+    *,
+    run_mode: str,
+    snapshot_path: str | None,
+    fallback_used: bool,
+    rate_limit_error: str | None,
+):
+    if fallback_used:
+        return {
+            "status": "snapshot_fallback_active",
+            "recommended_wait_minutes": 15,
+            "retry_mode": "retry_live_after_cooldown",
+            "allowed_modes": ["dry-run", "no-feedback"],
+            "blocked_modes": ["apply"],
+            "snapshot_path": snapshot_path,
+            "reason": "GitHub API rate limit forced project item snapshot fallback; use snapshot-backed dry-runs only until live quota recovers.",
+            "raw_error": rate_limit_error,
+        }
+
+    if rate_limit_error:
+        return {
+            "status": "live_api_blocked",
+            "recommended_wait_minutes": 15,
+            "retry_mode": "retry_live_after_cooldown",
+            "allowed_modes": [],
+            "blocked_modes": [run_mode],
+            "snapshot_path": snapshot_path,
+            "reason": "GitHub API rate limit blocked live project item loading and no safe snapshot fallback was available for this mode.",
+            "raw_error": rate_limit_error,
+        }
+
+    return {
+        "status": "not_needed",
+        "recommended_wait_minutes": 0,
+        "retry_mode": "none",
+        "allowed_modes": [run_mode],
+        "blocked_modes": [],
+        "snapshot_path": snapshot_path,
+        "reason": "No GitHub API rate-limit guidance required.",
+        "raw_error": None,
+    }
+
+
 def load_project_items(
     owner: str,
     project_num: int,
@@ -491,11 +534,23 @@ def load_project_items(
             "snapshot_path": str(effective_snapshot_path),
             "rate_limit_fallback_used": False,
             "rate_limit_error": None,
+            "rate_limit_guidance": build_rate_limit_guidance(
+                run_mode="dry-run",
+                snapshot_path=str(effective_snapshot_path),
+                fallback_used=False,
+                rate_limit_error=None,
+            ),
         }
 
     if normalized_mode == "auto" and is_rate_limit_error(err):
         snapshot = load_project_items_snapshot(effective_snapshot_path)
         snapshot["rate_limit_error"] = err
+        snapshot["rate_limit_guidance"] = build_rate_limit_guidance(
+            run_mode="dry-run",
+            snapshot_path=str(effective_snapshot_path),
+            fallback_used=True,
+            rate_limit_error=err,
+        )
         return snapshot
 
     raise RuntimeError(f"failed to list project items: {err}")
@@ -757,9 +812,34 @@ def main():
                 args.no_feedback,
             ),
         )
+        project_items_result["rate_limit_guidance"] = build_rate_limit_guidance(
+            run_mode=args.mode,
+            snapshot_path=project_items_result.get("snapshot_path"),
+            fallback_used=bool(project_items_result.get("rate_limit_fallback_used")),
+            rate_limit_error=project_items_result.get("rate_limit_error"),
+        )
         items = project_items_result["items"]
     except RuntimeError as exc:
-        print(str(exc))
+        guidance = None
+        if is_rate_limit_error(str(exc)):
+            guidance = build_rate_limit_guidance(
+                run_mode=args.mode,
+                snapshot_path=str(Path(args.project_items_snapshot)),
+                fallback_used=False,
+                rate_limit_error=str(exc),
+            )
+            print(
+                json.dumps(
+                    {
+                        "result": "github_rate_limited",
+                        "reason_code": "github_rate_limited",
+                        "rate_limit_guidance": guidance,
+                    },
+                    ensure_ascii=True,
+                )
+            )
+        else:
+            print(str(exc))
         return 1
 
     closed_issue_reconcile = evaluate_closed_issue_reconcile(
@@ -794,9 +874,32 @@ def main():
                     args.no_feedback,
                 ),
             )
+            project_items_result["rate_limit_guidance"] = build_rate_limit_guidance(
+                run_mode=args.mode,
+                snapshot_path=project_items_result.get("snapshot_path"),
+                fallback_used=bool(project_items_result.get("rate_limit_fallback_used")),
+                rate_limit_error=project_items_result.get("rate_limit_error"),
+            )
             items = project_items_result["items"]
         except RuntimeError as exc:
-            print(str(exc))
+            if is_rate_limit_error(str(exc)):
+                print(
+                    json.dumps(
+                        {
+                            "result": "github_rate_limited",
+                            "reason_code": "github_rate_limited",
+                            "rate_limit_guidance": build_rate_limit_guidance(
+                                run_mode=args.mode,
+                                snapshot_path=str(Path(args.project_items_snapshot)),
+                                fallback_used=False,
+                                rate_limit_error=str(exc),
+                            ),
+                        },
+                        ensure_ascii=True,
+                    )
+                )
+            else:
+                print(str(exc))
             return 1
 
     candidates = normalize_candidates(items, allowed_workflow_states)
@@ -917,6 +1020,7 @@ def main():
     selection_trace["project_items_snapshot_path"] = project_items_result.get("snapshot_path")
     selection_trace["project_items_rate_limit_fallback_used"] = project_items_result.get("rate_limit_fallback_used")
     selection_trace["project_items_rate_limit_error"] = project_items_result.get("rate_limit_error")
+    selection_trace["rate_limit_guidance"] = project_items_result.get("rate_limit_guidance")
     selection_trace["closed_issue_reconcile"] = closed_issue_reconcile
     selection_trace["pec_preflight"] = {
         "mode": args.pec_preflight_mode,

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -15,6 +15,7 @@ def run_supervisor(args):
 
 with tempfile.TemporaryDirectory() as td:
     td_path = Path(td)
+    artifacts_root = td_path / "supervisor-artifacts"
 
     # 1) continue-on-experiment should allow multi-cycle run and converge.
     out_converged = td_path / "supervisor-converged.json"
@@ -34,6 +35,8 @@ with tempfile.TemporaryDirectory() as td:
             "--items-file",
             "planningops/fixtures/backlog-stock-items-sample.json",
             "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
             "--output",
             str(out_converged),
         ]
@@ -62,6 +65,8 @@ with tempfile.TemporaryDirectory() as td:
             "--items-file",
             "planningops/fixtures/backlog-stock-items-sample.json",
             "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
             "--output",
             str(out_exp_stop),
         ]
@@ -113,6 +118,8 @@ with tempfile.TemporaryDirectory() as td:
             "--items-file",
             "planningops/fixtures/backlog-stock-items-sample.json",
             "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
             "--output",
             str(out_fail),
         ]
@@ -187,6 +194,8 @@ with tempfile.TemporaryDirectory() as td:
             "--items-file",
             "planningops/fixtures/backlog-stock-items-sample.json",
             "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
             "--output",
             str(out_snapshot),
         ]
@@ -197,6 +206,63 @@ with tempfile.TemporaryDirectory() as td:
     assert snapshot_doc["stop_reason"] == "converged_with_snapshot_fallback", snapshot_doc
     assert snapshot_doc["cycles"][0]["project_items_source"] == "snapshot", snapshot_doc
     assert snapshot_doc["cycles"][0]["project_items_rate_limit_fallback_used"] is True, snapshot_doc
+    assert snapshot_doc["cycles"][0]["rate_limit_guidance"]["status"] == "snapshot_fallback_active", snapshot_doc
+    assert snapshot_doc["stop_details"]["rate_limit_guidance"]["status"] == "snapshot_fallback_active", snapshot_doc
+
+    # 5) explicit github rate-limit failure must stop with dedicated reason and guidance.
+    rate_limit_sequence = td_path / "rate-limit-sequence.json"
+    rate_limit_sequence.write_text(
+        json.dumps(
+            {
+                "cycles": [
+                    {
+                        "rc": 1,
+                        "loop_result": {
+                            "result": "github_rate_limited",
+                            "reason_code": "github_rate_limited",
+                            "rate_limit_guidance": {
+                                "status": "live_api_blocked",
+                                "recommended_wait_minutes": 15,
+                                "retry_mode": "retry_live_after_cooldown",
+                                "allowed_modes": [],
+                                "blocked_modes": ["apply"],
+                            },
+                            "selection_trace": {"selected": {"uncertainty_level": "low", "simulation_required": False}},
+                        },
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    out_rate_limit = td_path / "supervisor-rate-limit.json"
+    rc_rate_limit, _, _ = run_supervisor(
+        [
+            "python3",
+            "planningops/scripts/autonomous_supervisor_loop.py",
+            "--mode",
+            "apply",
+            "--max-cycles",
+            "1",
+            "--continue-on-experiment",
+            "--loop-result-sequence-file",
+            str(rate_limit_sequence),
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
+            "--output",
+            str(out_rate_limit),
+        ]
+    )
+    assert rc_rate_limit == 1, rc_rate_limit
+    rate_limit_doc = json.loads(out_rate_limit.read_text(encoding="utf-8"))
+    assert rate_limit_doc["supervisor_verdict"] == "fail", rate_limit_doc
+    assert rate_limit_doc["stop_reason"] == "github_rate_limited", rate_limit_doc
+    assert rate_limit_doc["stop_details"]["rate_limit_guidance"]["status"] == "live_api_blocked", rate_limit_doc
 
 print("autonomous supervisor loop contract tests ok")
 PY

--- a/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
+++ b/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
@@ -397,6 +397,7 @@ with tempfile.TemporaryDirectory() as td:
     )
     assert live_project_items["source"] == "live", live_project_items
     assert live_project_items["rate_limit_fallback_used"] is False, live_project_items
+    assert live_project_items["rate_limit_guidance"]["status"] == "not_needed", live_project_items
     assert snapshot_path.exists(), snapshot_path
 
     def fake_run_project_items_rate_limited(args):
@@ -415,6 +416,8 @@ with tempfile.TemporaryDirectory() as td:
     assert snapshot_project_items["source"] == "snapshot", snapshot_project_items
     assert snapshot_project_items["rate_limit_fallback_used"] is True, snapshot_project_items
     assert "rate limit exceeded" in snapshot_project_items["rate_limit_error"].lower(), snapshot_project_items
+    assert snapshot_project_items["rate_limit_guidance"]["status"] == "snapshot_fallback_active", snapshot_project_items
+    assert "apply" in snapshot_project_items["rate_limit_guidance"]["blocked_modes"], snapshot_project_items
 
     require_project_items = mod.load_project_items(
         "rather-not-work-on",
@@ -436,6 +439,15 @@ with tempfile.TemporaryDirectory() as td:
         raise AssertionError("expected rate-limit failure without snapshot fallback")
     except RuntimeError as exc:
         assert "rate limit" in str(exc).lower(), exc
+
+guidance_live_blocked = mod.build_rate_limit_guidance(
+    run_mode="apply",
+    snapshot_path="planningops/artifacts/loop-runner/project-items-snapshot.json",
+    fallback_used=False,
+    rate_limit_error="GraphQL: API rate limit exceeded for user",
+)
+assert guidance_live_blocked["status"] == "live_api_blocked", guidance_live_blocked
+assert guidance_live_blocked["blocked_modes"] == ["apply"], guidance_live_blocked
 
 issue_doc_calls = []
 


### PR DESCRIPTION
## Summary
- add deterministic `rate_limit_guidance` objects to runner project-item loading paths
- propagate guidance into supervisor cycle summaries and stop details for both snapshot fallback and live apply blockage
- extend local contract coverage so rate-limit guidance stays regression-tested without leaving repo-local artifact noise

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave22.execution-contract.json`
- `planningops/` scripts/contracts: `planningops/scripts/core/loop/runner.py`, `planningops/scripts/autonomous_supervisor_loop.py`, `planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`, `planningops/scripts/test_autonomous_supervisor_loop_contract.sh`, `planningops/artifacts/validation/runtime-mission-wave22-review.json`
- `.github/` workflows: none

## Linked Issues
- Closes #
- Related #268

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`; `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`; `git diff --check`; `python3 -m py_compile planningops/scripts/core/loop/runner.py planningops/scripts/autonomous_supervisor_loop.py`

## Risks
- Risk: runner/supervisor output now carries additional guidance fields, so downstream consumers that assume a minimal schema could ignore or mishandle them.
- Rollback: revert commit `773ece8` on `main`.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
