### PR TITLE
feat(planningops): emit supervisor operator reports

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave23.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave23.execution-contract.json
@@ -1,0 +1,57 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-mission-wave23",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave23-supervisor-operator-report-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "AO10",
+        "execution_order": 10,
+        "title": "planningops supervisor operator report sidecar",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "planningops/scripts/autonomous_supervisor_loop.py",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AO20",
+        "execution_order": 20,
+        "title": "planningops supervisor contract operator report output",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [10],
+        "primary_output": "planningops/contracts/autonomous-supervisor-loop-contract.md",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AO30",
+        "execution_order": 30,
+        "title": "runtime mission wave23 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [10, 20],
+        "primary_output": "planningops/artifacts/validation/runtime-mission-wave23-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave23-supervisor-operator-report-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave23-supervisor-operator-report-issue-pack.md
@@ -1,0 +1,65 @@
+---
+title: plan: Runtime Mission Wave 23 Supervisor Operator Report Issue Pack
+type: plan
+date: 2026-03-10
+updated: 2026-03-10
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Emits a compact operator-facing supervisor report so overnight automation can surface cooldown, retry, and attention guidance without parsing the full run summary.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - control-plane
+  - supervisor
+  - operations
+  - reporting
+---
+
+# Runtime Mission Wave 23 Supervisor Operator Report Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- wave22 added structured rate-limit guidance to runner and supervisor outputs
+- overnight automation still has to parse the full supervisor summary to extract the next operator action
+- the next hardening step is a compact sidecar report, not a new retry mechanism
+
+## Goal
+
+Emit a deterministic operator report for each supervisor run:
+- `autonomous_supervisor_loop.py` must derive a compact operator report from the final run summary
+- the report must distinguish `converged`, `converged_with_snapshot_fallback`, `github_rate_limited`, and review-required stops
+- the report must be written next to run summaries so automations can attach it directly
+
+The rule for this wave is strict:
+- keep the report machine-readable and compact
+- do not introduce new background retries or wait loops
+- do not duplicate the full cycle log in the report
+- keep execution inside planningops
+
+## Wave 23 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `AO10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/autonomous_supervisor_loop.py` |
+| `AO20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/contracts/autonomous-supervisor-loop-contract.md` |
+| `AO30` | 30 | `rather-not-work-on/platform-planningops` | `review_gate` | `review_gate` | `planningops/artifacts/validation/runtime-mission-wave23-review.json` |
+
+## Decomposition Rules
+
+- `AO10` derives and writes the operator report sidecar from final supervisor state.
+- `AO20` updates the supervisor contract so report outputs are part of the stable interface.
+- `AO30` records the decision matrix for normal convergence, snapshot-backed convergence, and live API block.
+
+## Dependencies
+
+- `AO20` depends on `AO10`
+- `AO30` depends on `AO10`, `AO20`
+
+## Explicit Non-Goals
+
+- no execution-repo changes
+- no new GitHub project mutation logic
+- no automatic backoff scheduler

--- a/planningops/artifacts/validation/runtime-mission-wave23-review.json
+++ b/planningops/artifacts/validation/runtime-mission-wave23-review.json
@@ -1,0 +1,36 @@
+{
+  "generated_at_utc": "2026-03-10T13:40:00+00:00",
+  "wave": "runtime-mission-wave23",
+  "plan_id": "uap-runtime-mission-wave23",
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave23-supervisor-operator-report-issue-pack.md",
+  "verdict": "pass",
+  "summary": {
+    "operator_report_outputs": {
+      "run_sidecar": "implemented",
+      "last_run_sidecar": "implemented",
+      "summary_links": "operator_report_path and operator_report_last_path recorded"
+    },
+    "decision_matrix": {
+      "converged": "status=ok action=none",
+      "converged_with_snapshot_fallback": "status=degraded action=retry_live_after_cooldown",
+      "github_rate_limited": "status=blocked action=wait_for_cooldown_then_retry_live",
+      "gate_failures": "status=review_required action=inspect_failure_and_replan"
+    },
+    "local_contracts": {
+      "autonomous_supervisor_loop": "pass",
+      "uap_docs_workbench": "pass"
+    }
+  },
+  "decisions": [
+    "operator-facing reporting is emitted as a compact sidecar so inbox automation does not need to parse full cycle history",
+    "the sidecar stays machine-readable JSON and links back to the full summary and last cycle evidence instead of duplicating them",
+    "snapshot-backed convergence remains pass but is explicitly degraded in the operator report so live apply is not implied"
+  ],
+  "follow_up_candidates": [
+    {
+      "key": "wave24",
+      "title": "issue-loop inbox summary from supervisor operator report",
+      "reason": "the operator report now exists, so the next step is projecting it into a compact inbox-ready summary for recurring automation"
+    }
+  ]
+}

--- a/planningops/contracts/autonomous-supervisor-loop-contract.md
+++ b/planningops/contracts/autonomous-supervisor-loop-contract.md
@@ -13,6 +13,8 @@ Each cycle must run in this order:
 
 Cycle report artifact:
 - `planningops/artifacts/supervisor/<run-id>/cycle-<nn>/cycle-report.json`
+Operator report artifact:
+- `planningops/artifacts/supervisor/<run-id>/operator-report.json`
 
 ## Required Decisions Per Cycle
 1. `last_verdict` and `reason_code`
@@ -65,9 +67,11 @@ Run summary must include:
 2. `stop_reason` + `stop_details`
 3. full `cycles[]` records
 4. referenced contracts
+5. operator report sidecar paths when generated
 
 Output:
 - `planningops/artifacts/supervisor/last-run.json`
+- `planningops/artifacts/supervisor/last-run-operator-report.json`
 
 ## Testability Mapping
 - implementation:

--- a/planningops/scripts/autonomous_supervisor_loop.py
+++ b/planningops/scripts/autonomous_supervisor_loop.py
@@ -111,6 +111,93 @@ def derive_rate_limit_guidance(loop_result: dict, project_items_source, fallback
     return None
 
 
+def build_operator_report(summary: dict, summary_path: Path, run_dir: Path):
+    cycles = summary.get("cycles") or []
+    last_cycle = cycles[-1] if cycles else {}
+    stop_reason = str(summary.get("stop_reason") or "")
+    stop_details = summary.get("stop_details") or {}
+    guidance = stop_details.get("rate_limit_guidance") or last_cycle.get("rate_limit_guidance") or {}
+    cycle_number = stop_details.get("cycle") or last_cycle.get("cycle")
+    cycle_report_path = None
+    if cycle_number:
+        cycle_report_path = str(run_dir / f"cycle-{int(cycle_number):02d}" / "cycle-report.json")
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "run_id": summary.get("run_id"),
+        "summary_path": str(summary_path),
+        "cycle_report_path": cycle_report_path,
+        "supervisor_verdict": summary.get("supervisor_verdict"),
+        "stop_reason": stop_reason,
+        "status": "review_required",
+        "headline": "Supervisor run requires review.",
+        "operator_action": "inspect_supervisor_summary",
+        "recommended_wait_minutes": int(guidance.get("recommended_wait_minutes") or 0),
+        "retry_mode": guidance.get("retry_mode") or "none",
+        "allowed_modes": list(guidance.get("allowed_modes") or []),
+        "blocked_modes": list(guidance.get("blocked_modes") or []),
+        "needs_human_attention": True,
+        "reason": guidance.get("reason") or stop_reason,
+        "guidance": guidance if isinstance(guidance, dict) else {},
+    }
+
+    if stop_reason == "converged":
+        report.update(
+            {
+                "status": "ok",
+                "headline": "Supervisor run converged with live project data.",
+                "operator_action": "none",
+                "needs_human_attention": False,
+                "reason": "No cooldown or retry guidance required.",
+            }
+        )
+        return report
+
+    if stop_reason == "converged_with_snapshot_fallback":
+        report.update(
+            {
+                "status": "degraded",
+                "headline": "Supervisor converged with snapshot-backed GitHub intake.",
+                "operator_action": "retry_live_after_cooldown",
+                "needs_human_attention": False,
+            }
+        )
+        return report
+
+    if stop_reason == "github_rate_limited":
+        report.update(
+            {
+                "status": "blocked",
+                "headline": "Live GitHub intake is blocked by API rate limiting.",
+                "operator_action": "wait_for_cooldown_then_retry_live",
+                "needs_human_attention": False,
+            }
+        )
+        return report
+
+    if stop_reason == "experiment_triggered":
+        report.update(
+            {
+                "status": "review_required",
+                "headline": "Supervisor paused on experiment trigger.",
+                "operator_action": "review_experiment_trigger",
+            }
+        )
+        return report
+
+    if stop_reason in {"quality_gate_fail", "backlog_gate_fail", "escalation_auto_pause", "experiment_auto_executor_failed"}:
+        report.update(
+            {
+                "status": "review_required",
+                "headline": "Supervisor stopped on a blocking gate failure.",
+                "operator_action": "inspect_failure_and_replan",
+            }
+        )
+        return report
+
+    return report
+
+
 def build_issue_runner_command(args):
     cmd = [
         "python3",
@@ -486,8 +573,15 @@ def main():
     }
 
     output_path = Path(args.output)
+    operator_report_path = run_dir / "operator-report.json"
+    last_operator_report_path = output_path.with_name(f"{output_path.stem}-operator-report.json")
+    summary["operator_report_path"] = str(operator_report_path)
+    summary["operator_report_last_path"] = str(last_operator_report_path)
     save_json(output_path, summary)
     save_json(run_dir / "summary.json", summary)
+    operator_report = build_operator_report(summary, output_path, run_dir)
+    save_json(operator_report_path, operator_report)
+    save_json(last_operator_report_path, operator_report)
     print(json.dumps(summary, ensure_ascii=True, indent=2))
     return 0 if supervisor_verdict == "pass" else 1
 

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -49,6 +49,9 @@ with tempfile.TemporaryDirectory() as td:
     assert converged["cycles"][0]["experiment_trigger"]["triggered"] is True, converged
     assert converged["cycles"][1]["replenishment_candidates_count"] == 0, converged
     assert converged["cycles"][0]["project_items_rate_limit_fallback_used"] is False, converged
+    converged_operator = json.loads(Path(converged["operator_report_last_path"]).read_text(encoding="utf-8"))
+    assert converged_operator["status"] == "ok", converged_operator
+    assert converged_operator["operator_action"] == "none", converged_operator
 
     # 2) default behavior should stop when experiment trigger is detected.
     out_exp_stop = td_path / "supervisor-experiment-stop.json"
@@ -208,6 +211,10 @@ with tempfile.TemporaryDirectory() as td:
     assert snapshot_doc["cycles"][0]["project_items_rate_limit_fallback_used"] is True, snapshot_doc
     assert snapshot_doc["cycles"][0]["rate_limit_guidance"]["status"] == "snapshot_fallback_active", snapshot_doc
     assert snapshot_doc["stop_details"]["rate_limit_guidance"]["status"] == "snapshot_fallback_active", snapshot_doc
+    snapshot_operator = json.loads(Path(snapshot_doc["operator_report_last_path"]).read_text(encoding="utf-8"))
+    assert snapshot_operator["status"] == "degraded", snapshot_operator
+    assert snapshot_operator["operator_action"] == "retry_live_after_cooldown", snapshot_operator
+    assert "dry-run" in snapshot_operator["allowed_modes"], snapshot_operator
 
     # 5) explicit github rate-limit failure must stop with dedicated reason and guidance.
     rate_limit_sequence = td_path / "rate-limit-sequence.json"
@@ -263,6 +270,10 @@ with tempfile.TemporaryDirectory() as td:
     assert rate_limit_doc["supervisor_verdict"] == "fail", rate_limit_doc
     assert rate_limit_doc["stop_reason"] == "github_rate_limited", rate_limit_doc
     assert rate_limit_doc["stop_details"]["rate_limit_guidance"]["status"] == "live_api_blocked", rate_limit_doc
+    rate_limit_operator = json.loads(Path(rate_limit_doc["operator_report_last_path"]).read_text(encoding="utf-8"))
+    assert rate_limit_operator["status"] == "blocked", rate_limit_operator
+    assert rate_limit_operator["operator_action"] == "wait_for_cooldown_then_retry_live", rate_limit_operator
+    assert rate_limit_operator["blocked_modes"] == ["apply"], rate_limit_operator
 
 print("autonomous supervisor loop contract tests ok")
 PY


### PR DESCRIPTION
## Summary
- emit a compact operator-report sidecar for every supervisor run and last-run summary
- classify supervisor outcomes into actionable statuses like `ok`, `degraded`, `blocked`, and `review_required`
- update the supervisor contract and deterministic tests so operator-facing reporting stays stable

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave23-supervisor-operator-report-issue-pack.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave23.execution-contract.json`
- `planningops/` scripts/contracts: `planningops/scripts/autonomous_supervisor_loop.py`, `planningops/scripts/test_autonomous_supervisor_loop_contract.sh`, `planningops/contracts/autonomous-supervisor-loop-contract.md`, `planningops/artifacts/validation/runtime-mission-wave23-review.json`
- `.github/` workflows: none

## Linked Issues
- Closes #
- Related #269

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`; `python3 -m py_compile planningops/scripts/autonomous_supervisor_loop.py`; `git diff --check`

## Risks
- Risk: consumers may start depending on operator report field names before the sidecar format is fully proven in recurring automation.
- Rollback: revert commit `9c6d2d8` on `main`.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
