### PR TITLE
feat(planningops): add supervisor inbox summaries

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave24.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave24.execution-contract.json
@@ -1,0 +1,57 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-runtime-mission-wave24",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave24-supervisor-inbox-summary-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "AP10",
+        "execution_order": 10,
+        "title": "planningops supervisor markdown inbox summary",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "planningops/scripts/autonomous_supervisor_loop.py",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AP20",
+        "execution_order": 20,
+        "title": "planningops supervisor contract markdown summary output",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [10],
+        "primary_output": "planningops/contracts/autonomous-supervisor-loop-contract.md",
+        "required_checks": [
+          "validate-and-dry-run",
+          "federated-conformance"
+        ]
+      },
+      {
+        "plan_item_id": "AP30",
+        "execution_order": 30,
+        "title": "runtime mission wave24 review",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [10, 20],
+        "primary_output": "planningops/artifacts/validation/runtime-mission-wave24-review.json",
+        "required_checks": [
+          "federated-conformance",
+          "issue-quality"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave24-supervisor-inbox-summary-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave24-supervisor-inbox-summary-issue-pack.md
@@ -1,0 +1,65 @@
+---
+title: plan: Runtime Mission Wave 24 Supervisor Inbox Summary Issue Pack
+type: plan
+date: 2026-03-10
+updated: 2026-03-10
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Projects the supervisor operator report into a compact markdown summary artifact suitable for inbox delivery and quick human review.
+tags:
+  - uap
+  - implementation
+  - runtime
+  - control-plane
+  - supervisor
+  - inbox
+  - reporting
+---
+
+# Runtime Mission Wave 24 Supervisor Inbox Summary Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+- wave23 emits structured `operator-report.json` sidecars for supervisor runs
+- recurring automation still benefits from a concise markdown artifact that can be attached or pasted without parsing JSON
+- the next step is formatting and projection, not new supervisor decisions
+
+## Goal
+
+Emit an inbox-ready markdown summary per supervisor run:
+- `autonomous_supervisor_loop.py` must render a compact markdown summary from the operator report
+- the summary must highlight status, action, cooldown, and evidence paths
+- the summary must be written alongside the JSON sidecar for both run-specific and last-run paths
+
+The rule for this wave is strict:
+- keep markdown deterministic and compact
+- do not duplicate full cycle logs
+- do not change stop logic or retry logic
+- keep execution inside planningops
+
+## Wave 24 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `AP10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/autonomous_supervisor_loop.py` |
+| `AP20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/contracts/autonomous-supervisor-loop-contract.md` |
+| `AP30` | 30 | `rather-not-work-on/platform-planningops` | `review_gate` | `review_gate` | `planningops/artifacts/validation/runtime-mission-wave24-review.json` |
+
+## Decomposition Rules
+
+- `AP10` renders and persists markdown summaries from the operator report.
+- `AP20` extends the supervisor contract to include markdown summary outputs.
+- `AP30` records how degraded and blocked runs are represented for inbox consumption.
+
+## Dependencies
+
+- `AP20` depends on `AP10`
+- `AP30` depends on `AP10`, `AP20`
+
+## Explicit Non-Goals
+
+- no execution-repo changes
+- no new automation scheduler behavior
+- no additional retry/backoff logic

--- a/planningops/artifacts/validation/runtime-mission-wave24-review.json
+++ b/planningops/artifacts/validation/runtime-mission-wave24-review.json
@@ -1,0 +1,35 @@
+{
+  "generated_at_utc": "2026-03-10T13:48:00+00:00",
+  "wave": "runtime-mission-wave24",
+  "plan_id": "uap-runtime-mission-wave24",
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave24-supervisor-inbox-summary-issue-pack.md",
+  "verdict": "pass",
+  "summary": {
+    "operator_summary_outputs": {
+      "run_markdown_sidecar": "implemented",
+      "last_run_markdown_sidecar": "implemented",
+      "status_action_lines": "implemented"
+    },
+    "representation_matrix": {
+      "ok": "Action: none",
+      "degraded": "Action: retry_live_after_cooldown",
+      "blocked": "Action: wait_for_cooldown_then_retry_live"
+    },
+    "local_contracts": {
+      "autonomous_supervisor_loop": "pass",
+      "uap_docs_workbench": "pass"
+    }
+  },
+  "decisions": [
+    "markdown summary is emitted from the operator report, not from raw cycle data, so human-facing presentation stays downstream of the machine contract",
+    "the summary stays intentionally compact and links back to the full summary and cycle evidence instead of duplicating logs",
+    "status and action are the first two human-readable fields because they are the minimum needed for inbox triage"
+  ],
+  "follow_up_candidates": [
+    {
+      "key": "wave25",
+      "title": "issue-loop inbox payload projection from operator summary",
+      "reason": "the markdown summary now exists, so the next step is a deterministic payload that recurring automation can emit directly into its inbox item"
+    }
+  ]
+}

--- a/planningops/contracts/autonomous-supervisor-loop-contract.md
+++ b/planningops/contracts/autonomous-supervisor-loop-contract.md
@@ -15,6 +15,8 @@ Cycle report artifact:
 - `planningops/artifacts/supervisor/<run-id>/cycle-<nn>/cycle-report.json`
 Operator report artifact:
 - `planningops/artifacts/supervisor/<run-id>/operator-report.json`
+Operator summary artifact:
+- `planningops/artifacts/supervisor/<run-id>/operator-summary.md`
 
 ## Required Decisions Per Cycle
 1. `last_verdict` and `reason_code`
@@ -72,6 +74,7 @@ Run summary must include:
 Output:
 - `planningops/artifacts/supervisor/last-run.json`
 - `planningops/artifacts/supervisor/last-run-operator-report.json`
+- `planningops/artifacts/supervisor/last-run-operator-summary.md`
 
 ## Testability Mapping
 - implementation:

--- a/planningops/scripts/autonomous_supervisor_loop.py
+++ b/planningops/scripts/autonomous_supervisor_loop.py
@@ -198,6 +198,31 @@ def build_operator_report(summary: dict, summary_path: Path, run_dir: Path):
     return report
 
 
+def build_operator_summary_markdown(operator_report: dict):
+    allowed_modes = operator_report.get("allowed_modes") or []
+    blocked_modes = operator_report.get("blocked_modes") or []
+    lines = [
+        "# Supervisor Operator Summary",
+        "",
+        f"- Status: {operator_report.get('status')}",
+        f"- Headline: {operator_report.get('headline')}",
+        f"- Action: {operator_report.get('operator_action')}",
+        f"- Wait Minutes: {operator_report.get('recommended_wait_minutes')}",
+        f"- Retry Mode: {operator_report.get('retry_mode')}",
+        f"- Allowed Modes: {', '.join(allowed_modes) if allowed_modes else 'none'}",
+        f"- Blocked Modes: {', '.join(blocked_modes) if blocked_modes else 'none'}",
+        f"- Needs Human Attention: {'yes' if operator_report.get('needs_human_attention') else 'no'}",
+        f"- Summary Path: {operator_report.get('summary_path')}",
+    ]
+    cycle_report_path = operator_report.get("cycle_report_path")
+    if cycle_report_path:
+        lines.append(f"- Cycle Report Path: {cycle_report_path}")
+    reason = operator_report.get("reason")
+    if reason:
+        lines.extend(["", "## Reason", "", reason])
+    return "\n".join(lines) + "\n"
+
+
 def build_issue_runner_command(args):
     cmd = [
         "python3",
@@ -575,13 +600,20 @@ def main():
     output_path = Path(args.output)
     operator_report_path = run_dir / "operator-report.json"
     last_operator_report_path = output_path.with_name(f"{output_path.stem}-operator-report.json")
+    operator_summary_path = run_dir / "operator-summary.md"
+    last_operator_summary_path = output_path.with_name(f"{output_path.stem}-operator-summary.md")
     summary["operator_report_path"] = str(operator_report_path)
     summary["operator_report_last_path"] = str(last_operator_report_path)
+    summary["operator_summary_path"] = str(operator_summary_path)
+    summary["operator_summary_last_path"] = str(last_operator_summary_path)
     save_json(output_path, summary)
     save_json(run_dir / "summary.json", summary)
     operator_report = build_operator_report(summary, output_path, run_dir)
     save_json(operator_report_path, operator_report)
     save_json(last_operator_report_path, operator_report)
+    operator_summary = build_operator_summary_markdown(operator_report)
+    operator_summary_path.write_text(operator_summary, encoding="utf-8")
+    last_operator_summary_path.write_text(operator_summary, encoding="utf-8")
     print(json.dumps(summary, ensure_ascii=True, indent=2))
     return 0 if supervisor_verdict == "pass" else 1
 

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -52,6 +52,9 @@ with tempfile.TemporaryDirectory() as td:
     converged_operator = json.loads(Path(converged["operator_report_last_path"]).read_text(encoding="utf-8"))
     assert converged_operator["status"] == "ok", converged_operator
     assert converged_operator["operator_action"] == "none", converged_operator
+    converged_summary = Path(converged["operator_summary_last_path"]).read_text(encoding="utf-8")
+    assert "# Supervisor Operator Summary" in converged_summary, converged_summary
+    assert "Action: none" in converged_summary, converged_summary
 
     # 2) default behavior should stop when experiment trigger is detected.
     out_exp_stop = td_path / "supervisor-experiment-stop.json"
@@ -215,6 +218,9 @@ with tempfile.TemporaryDirectory() as td:
     assert snapshot_operator["status"] == "degraded", snapshot_operator
     assert snapshot_operator["operator_action"] == "retry_live_after_cooldown", snapshot_operator
     assert "dry-run" in snapshot_operator["allowed_modes"], snapshot_operator
+    snapshot_summary = Path(snapshot_doc["operator_summary_last_path"]).read_text(encoding="utf-8")
+    assert "Status: degraded" in snapshot_summary, snapshot_summary
+    assert "Action: retry_live_after_cooldown" in snapshot_summary, snapshot_summary
 
     # 5) explicit github rate-limit failure must stop with dedicated reason and guidance.
     rate_limit_sequence = td_path / "rate-limit-sequence.json"
@@ -274,6 +280,9 @@ with tempfile.TemporaryDirectory() as td:
     assert rate_limit_operator["status"] == "blocked", rate_limit_operator
     assert rate_limit_operator["operator_action"] == "wait_for_cooldown_then_retry_live", rate_limit_operator
     assert rate_limit_operator["blocked_modes"] == ["apply"], rate_limit_operator
+    rate_limit_summary = Path(rate_limit_doc["operator_summary_last_path"]).read_text(encoding="utf-8")
+    assert "Status: blocked" in rate_limit_summary, rate_limit_summary
+    assert "Action: wait_for_cooldown_then_retry_live" in rate_limit_summary, rate_limit_summary
 
 print("autonomous supervisor loop contract tests ok")
 PY


### PR DESCRIPTION
## Summary
- emit compact markdown inbox summaries alongside supervisor operator reports
- persist both run-scoped and last-run markdown sidecars for recurring automation handoff
- extend the supervisor contract and deterministic tests to cover human-facing summary output

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave24-supervisor-inbox-summary-issue-pack.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave24.execution-contract.json`
- `planningops/` scripts/contracts: `planningops/scripts/autonomous_supervisor_loop.py`, `planningops/scripts/test_autonomous_supervisor_loop_contract.sh`, `planningops/contracts/autonomous-supervisor-loop-contract.md`, `planningops/artifacts/validation/runtime-mission-wave24-review.json`
- `.github/` workflows: none

## Linked Issues
- Closes #
- Related #270

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`; `python3 -m py_compile planningops/scripts/autonomous_supervisor_loop.py`; `git diff --check`

## Risks
- Risk: downstream automation may start relying on markdown phrasing before an explicit inbox-payload contract exists.
- Rollback: revert commit `e5fc3e2` on `main`.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
