### PR TITLE
fix(planningops): treat empty issue intake as replanning

### DIFF
--- a/planningops/scripts/autonomous_supervisor_loop.py
+++ b/planningops/scripts/autonomous_supervisor_loop.py
@@ -51,6 +51,11 @@ def parse_json_doc(raw: str):
 def extract_verdict_reason(loop_result: dict, rc: int):
     verdict = str(loop_result.get("last_verdict", "")).strip().lower()
     reason_code = str(loop_result.get("reason_code", "")).strip()
+    result_name = str(loop_result.get("result", "")).strip().lower()
+    if verdict not in {"pass", "fail", "inconclusive"} and result_name == "no_eligible_todo_issue":
+        verdict = "inconclusive"
+        if not reason_code:
+            reason_code = "no_eligible_todo_issue"
     if verdict not in {"pass", "fail", "inconclusive"}:
         verdict = "pass" if rc == 0 else "fail"
     if not reason_code:
@@ -181,6 +186,16 @@ def build_operator_report(summary: dict, summary_path: Path, run_dir: Path):
                 "status": "review_required",
                 "headline": "Supervisor paused on experiment trigger.",
                 "operator_action": "review_experiment_trigger",
+            }
+        )
+        return report
+
+    if stop_reason == "replan_required":
+        report.update(
+            {
+                "status": "review_required",
+                "headline": "Supervisor stopped because backlog selection requires replanning.",
+                "operator_action": "regenerate_backlog_or_reconcile_project",
             }
         )
         return report
@@ -567,6 +582,16 @@ def main():
             stop_reason = "escalation_auto_pause"
             stop_details = {"cycle": cycle_index, "reason_code": reason_code}
             break
+        if verdict == "inconclusive" and reason_code in {
+            "no_eligible_todo_issue",
+            "no_candidate_project_items",
+            "closed_issue_project_drift",
+            "dependency_blocked",
+            "inventory_only_candidates_only",
+        }:
+            stop_reason = "replan_required"
+            stop_details = {"cycle": cycle_index, "reason_code": reason_code}
+            break
         if backlog_failed and not args.report_only_gates:
             stop_reason = "backlog_gate_fail"
             stop_details = {"cycle": cycle_index}
@@ -608,7 +633,7 @@ def main():
         "github_rate_limited",
     }:
         supervisor_verdict = "fail"
-    elif stop_reason in {"experiment_triggered", "sequence_exhausted"}:
+    elif stop_reason in {"experiment_triggered", "sequence_exhausted", "replan_required", "max_cycles_reached"}:
         supervisor_verdict = "inconclusive"
 
     summary = {

--- a/planningops/scripts/core/loop/runner.py
+++ b/planningops/scripts/core/loop/runner.py
@@ -64,6 +64,7 @@ WATCHDOG_DIR = Path("planningops/artifacts/loop-runner/watchdog")
 ESCALATION_HISTORY_PATH = Path("planningops/artifacts/loop-runner/escalation-history.json")
 PROJECT_ITEMS_SNAPSHOT_PATH = Path("planningops/artifacts/loop-runner/project-items-snapshot.json")
 PROGRAM_MANIFEST_PATH = Path("planningops/artifacts/program/program-manifest.json")
+LAST_RUN_PATH = Path("planningops/artifacts/loop-runner/last-run.json")
 DEFAULT_ATTEMPT_BUDGET = {
     "max_attempts": 3,
     "max_duration_minutes": 30,
@@ -808,6 +809,56 @@ def evaluate_closed_issue_reconcile(requested_mode, run_mode, no_feedback, items
     return result
 
 
+def derive_no_eligible_reason(candidates, selection_attempts, closed_issue_reconcile):
+    if not candidates:
+        return {
+            "reason_code": "no_candidate_project_items",
+            "recommended_action": "retriage_backlog",
+        }
+
+    attempt_results = [str(attempt.get("result") or "").strip() for attempt in selection_attempts if attempt.get("result")]
+    if (
+        closed_issue_reconcile.get("issues_total", 0) > 0
+        and attempt_results
+        and all(result == "issue_not_open" for result in attempt_results)
+    ):
+        return {
+            "reason_code": "closed_issue_project_drift",
+            "recommended_action": "rerun_apply_closed_issue_reconcile",
+        }
+    if attempt_results and all(result == "dependency_blocked" for result in attempt_results):
+        return {
+            "reason_code": "dependency_blocked",
+            "recommended_action": "wait_for_dependencies",
+        }
+    if attempt_results and all(result == "inventory_only" for result in attempt_results):
+        return {
+            "reason_code": "inventory_only_candidates_only",
+            "recommended_action": "promote_executable_backlog",
+        }
+    return {
+        "reason_code": "no_eligible_todo_issue",
+        "recommended_action": "retriage_backlog",
+    }
+
+
+def build_no_eligible_result(selection_trace, candidates, selection_attempts, closed_issue_reconcile, no_feedback):
+    derived = derive_no_eligible_reason(candidates, selection_attempts, closed_issue_reconcile)
+    return {
+        "result": "no_eligible_todo_issue",
+        "reason_code": derived["reason_code"],
+        "recommended_action": derived["recommended_action"],
+        "last_verdict": "inconclusive",
+        "auto_paused": False,
+        "selection_trace": selection_trace,
+        "candidate_count": len(candidates),
+        "replenishment_candidates_path": None,
+        "replenishment_candidates_count": 0,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "no_feedback": no_feedback,
+    }
+
+
 def issue_is_closed(issue_num: int, repo: str):
     try:
         issue_doc = load_issue_doc(issue_num, repo)
@@ -1161,7 +1212,15 @@ def main():
     }
 
     if selected is None:
-        print(json.dumps({"result": "no_eligible_todo_issue", "selection_trace": selection_trace}, ensure_ascii=True))
+        no_eligible_result = build_no_eligible_result(
+            selection_trace,
+            candidates,
+            selection_attempts,
+            closed_issue_reconcile,
+            args.no_feedback,
+        )
+        save_json(LAST_RUN_PATH, no_eligible_result)
+        print(json.dumps(no_eligible_result, ensure_ascii=True, indent=2))
         return 2
 
     pec_preflight = evaluate_pec_preflight(
@@ -1911,8 +1970,7 @@ def main():
             adapter_artifact_dir=adapter_artifact_dir,
             transition_log=transition_log,
         )
-        out_path = Path("planningops/artifacts/loop-runner/last-run.json")
-        save_json(out_path, failure_result)
+        save_json(LAST_RUN_PATH, failure_result)
         print(json.dumps(failure_result, ensure_ascii=True, indent=2))
         return 1
 
@@ -2024,8 +2082,7 @@ def main():
         adapter_artifact_dir=adapter_artifact_dir,
         transition_log=transition_log,
     )
-    out_path = Path("planningops/artifacts/loop-runner/last-run.json")
-    save_json(out_path, result)
+    save_json(LAST_RUN_PATH, result)
     print(json.dumps(result, ensure_ascii=True, indent=2))
     return 0
 

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -293,5 +293,68 @@ with tempfile.TemporaryDirectory() as td:
     assert rate_limit_inbox["status"] == "blocked", rate_limit_inbox
     assert rate_limit_inbox["attachments"][0].endswith("-operator-summary.md"), rate_limit_inbox
 
+    # 6) no-eligible issue results must become replanning signals, not quality failures.
+    no_eligible_sequence = td_path / "no-eligible-sequence.json"
+    no_eligible_sequence.write_text(
+        json.dumps(
+            {
+                "cycles": [
+                    {
+                        "rc": 2,
+                        "loop_result": {
+                            "result": "no_eligible_todo_issue",
+                            "reason_code": "closed_issue_project_drift",
+                            "recommended_action": "rerun_apply_closed_issue_reconcile",
+                            "last_verdict": "inconclusive",
+                            "auto_paused": False,
+                            "replenishment_candidates_count": 0,
+                            "selection_trace": {
+                                "selected": None,
+                                "project_items_source": "live",
+                                "closed_issue_reconcile": {
+                                    "status": "pass",
+                                    "effective_mode": "check",
+                                    "issues_total": 3,
+                                },
+                            },
+                        },
+                    }
+                ]
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    out_no_eligible = td_path / "supervisor-no-eligible.json"
+    rc_no_eligible, _, _ = run_supervisor(
+        [
+            "python3",
+            "planningops/scripts/autonomous_supervisor_loop.py",
+            "--mode",
+            "dry-run",
+            "--max-cycles",
+            "1",
+            "--continue-on-experiment",
+            "--loop-result-sequence-file",
+            str(no_eligible_sequence),
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
+            "--output",
+            str(out_no_eligible),
+        ]
+    )
+    assert rc_no_eligible == 1, rc_no_eligible
+    no_eligible_doc = json.loads(out_no_eligible.read_text(encoding="utf-8"))
+    assert no_eligible_doc["supervisor_verdict"] == "inconclusive", no_eligible_doc
+    assert no_eligible_doc["stop_reason"] == "replan_required", no_eligible_doc
+    assert no_eligible_doc["stop_details"]["reason_code"] == "closed_issue_project_drift", no_eligible_doc
+    no_eligible_operator = json.loads(Path(no_eligible_doc["operator_report_last_path"]).read_text(encoding="utf-8"))
+    assert no_eligible_operator["status"] == "review_required", no_eligible_operator
+    assert no_eligible_operator["operator_action"] == "regenerate_backlog_or_reconcile_project", no_eligible_operator
+
 print("autonomous supervisor loop contract tests ok")
 PY

--- a/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
+++ b/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
@@ -377,6 +377,43 @@ with tempfile.TemporaryDirectory() as td:
     assert reconcile_fail["status"] == "fail", reconcile_fail
     assert reconcile_fail["reason_code"] == "closed_issue_reconcile_failed", reconcile_fail
 
+    closed_only_attempts = [
+        {
+            "number": 301,
+            "issue_repo": "rather-not-work-on/platform-planningops",
+            "result": "issue_not_open",
+            "state": "CLOSED",
+        }
+    ]
+    closed_only_trace = mod.build_selection_trace(
+        mod.normalize_candidates(reconcile_items, {"ready-implementation"}),
+        None,
+        closed_only_attempts,
+        {"ready-implementation"},
+    )
+    closed_only_trace["closed_issue_reconcile"] = reconcile_check
+    no_eligible_closed = mod.build_no_eligible_result(
+        closed_only_trace,
+        mod.normalize_candidates(reconcile_items, {"ready-implementation"}),
+        closed_only_attempts,
+        reconcile_check,
+        True,
+    )
+    assert no_eligible_closed["result"] == "no_eligible_todo_issue", no_eligible_closed
+    assert no_eligible_closed["last_verdict"] == "inconclusive", no_eligible_closed
+    assert no_eligible_closed["reason_code"] == "closed_issue_project_drift", no_eligible_closed
+    assert no_eligible_closed["recommended_action"] == "rerun_apply_closed_issue_reconcile", no_eligible_closed
+
+    no_eligible_empty = mod.build_no_eligible_result(
+        {"candidate_count": 0},
+        [],
+        [],
+        {"issues_total": 0},
+        True,
+    )
+    assert no_eligible_empty["reason_code"] == "no_candidate_project_items", no_eligible_empty
+    assert no_eligible_empty["recommended_action"] == "retriage_backlog", no_eligible_empty
+
 with tempfile.TemporaryDirectory() as td:
     snapshot_path = Path(td) / "project-items-snapshot.json"
     project_item_calls = []


### PR DESCRIPTION
## Summary
- emit a structured inconclusive result when issue intake finds only closed or otherwise non-executable project items
- treat replanning/no-eligible loop results as supervisor replanning stops instead of quality failures
- add contract coverage for closed-only selection drift and supervisor handling

## Scope
- `planningops/scripts/core/loop/runner.py`
- `planningops/scripts/autonomous_supervisor_loop.py`
- `planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
- `planningops/scripts/test_autonomous_supervisor_loop_contract.sh`

## Linked Issues
- Closes rather-not-work-on/platform-planningops#279

## Validation
- `bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
- `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`
- `python3 -m py_compile planningops/scripts/core/loop/runner.py planningops/scripts/autonomous_supervisor_loop.py`
- `git diff --check`

## Risks
- `no_eligible_todo_issue` now carries `last_verdict=inconclusive`; any caller that treated exit code `2` as hard failure but ignored payload semantics may need to read the richer JSON fields.
- Supervisor now stops with `replan_required` instead of silently aging into `quality_gate_fail`; downstream summaries should expect the new stop reason.

## Review Checklist
- [x] no-eligible selection produces a concrete `reason_code` and `recommended_action`
- [x] closed-only project drift becomes `closed_issue_project_drift`
- [x] supervisor maps no-eligible outcomes to `replan_required`
- [x] contract coverage added for runner and supervisor

## Post-Deploy Monitoring & Validation
- Run `python3 planningops/scripts/issue_loop_runner.py --mode dry-run --project-items-snapshot-fallback auto` and confirm `result=no_eligible_todo_issue` returns `last_verdict=inconclusive` plus a concrete `reason_code` when only closed project items remain.
- Run `python3 planningops/scripts/autonomous_supervisor_loop.py --mode dry-run --max-cycles 1 --continue-on-experiment --loop-result-sequence-file <sequence>` against a no-eligible sequence and confirm `stop_reason=replan_required`, not `quality_gate_fail`.
- Healthy signal: operator report status is `review_required` with `operator_action=regenerate_backlog_or_reconcile_project`.
- Failure signal: supervisor reports `quality_gate_fail` for no-eligible intake or runner omits `last_verdict`/`recommended_action`.
- Validation window: first live automation run after merge. Owner: Codex automation / planningops maintainer.