### PR TITLE
feat(planningops): make backlog materializer self-contained

### DIFF
--- a/docs/initiatives/unified-personal-agent-platform/40-quality/uap-automation-operations-summary.quality.md
+++ b/docs/initiatives/unified-personal-agent-platform/40-quality/uap-automation-operations-summary.quality.md
@@ -5,7 +5,7 @@ doc_type: quality
 domain: quality
 status: active
 date: 2026-03-11
-updated: 2026-03-11
+updated: 2026-03-13
 initiative: unified-personal-agent-platform
 memory_tier: L1
 tags:
@@ -86,6 +86,8 @@ The earlier local-only behavior was not caused by git permissions.
    - feature branch cleanup
    - issue/project field sync
 4. If all repos are clean and no open issue is ready, regenerate or re-triage backlog from `planningops` instead of inventing repo-local work.
+   - canonical command: `python3 planningops/scripts/core/backlog/materialize.py --contract-file <execution-contract.json>`
+   - dry-run expectation: the command must project local issues first, then run label backfill / manifest / issue-quality against that projected issue set instead of depending on pre-existing live GitHub issues
 5. Keep durable conclusions in canonical docs or workbench audits; keep automation memory short and current.
 
 ## Reflected Outcomes
@@ -102,3 +104,5 @@ The earlier local-only behavior was not caused by git permissions.
 - `gh api rate_limit`
 - `git ls-remote --heads origin`
 - `gh issue list --state open` across the five managed repos
+- `python3 planningops/scripts/core/backlog/materialize.py --contract-file <execution-contract.json>`
+- `python3 planningops/scripts/backfill_issue_labels.py --repo rather-not-work-on/platform-planningops --issues-file /tmp/projected-issues.json --write-updated-issues-file /tmp/projected-issues.json --output /tmp/issue-label-backfill-report.json --apply`

--- a/planningops/README.md
+++ b/planningops/README.md
@@ -72,6 +72,8 @@ python3 planningops/scripts/issue_loop_runner.py --mode apply --closed-issue-rec
 python3 planningops/scripts/issue_loop_runner.py --mode dry-run --project-items-snapshot-fallback auto
 python3 planningops/scripts/issue_loop_runner.py --mode dry-run --pec-preflight-mode strict-pec --pec-contract-file planningops/fixtures/plan-execution-contract-sample.json --no-feedback
 python3 planningops/scripts/compile_plan_to_backlog.py --contract-file planningops/fixtures/plan-execution-contract-sample.json
+python3 planningops/scripts/core/backlog/materialize.py --contract-file planningops/fixtures/plan-execution-contract-sample.json
+python3 planningops/scripts/backfill_issue_labels.py --repo rather-not-work-on/platform-planningops --issues-file /tmp/projected-issues.json --write-updated-issues-file /tmp/projected-issues.json --output /tmp/issue-label-backfill-report.json --apply
 python3 planningops/scripts/build_meta_plan_graph.py --contract-file planningops/fixtures/meta-plan-graph-sample.json --strict
 python3 planningops/scripts/meta_plan_orchestrator.py --meta-graph-contract planningops/fixtures/meta-plan-graph-sample.json --mode dry-run --strict
 python3 planningops/scripts/validate_worker_task_pack.py --task-key issue-18 --issue-number 18 --mode dry-run --loop-profile "L3 Implementation-TDD" --strict
@@ -80,6 +82,8 @@ python3 planningops/scripts/backlog_stock_replenishment_guard.py --items-file pl
 python3 planningops/scripts/autonomous_supervisor_loop.py --mode dry-run --max-cycles 3 --items-file planningops/fixtures/backlog-stock-items-sample.json --offline --loop-result-sequence-file planningops/fixtures/supervisor-loop-sequence-sample.json --run-id demo-supervisor-sequence
 python3 planningops/scripts/supervisor_experiment_auto_executor.py --experiment-id demo-supervisor-exp --topic demo-cycle --options option-a,option-b --validation-pack-file planningops/config/supervisor-experiment-validation-pack.json
 bash planningops/scripts/test_compile_plan_to_backlog_contract.sh
+bash planningops/scripts/test_backfill_issue_labels_contract.sh
+bash planningops/scripts/test_backlog_materialization_contract.sh
 bash planningops/scripts/test_build_meta_plan_graph_contract.sh
 bash planningops/scripts/test_verify_plan_projection_contract.sh
 bash planningops/scripts/test_meta_plan_graph_schema_contract.sh

--- a/planningops/contracts/backlog-materialization-contract.md
+++ b/planningops/contracts/backlog-materialization-contract.md
@@ -1,0 +1,31 @@
+# Backlog Materialization Contract
+
+## Purpose
+Provide one recurring control-plane command that materializes executable backlog from an execution contract without relying on ad hoc shell choreography.
+
+## Canonical Entrypoint
+- `planningops/scripts/core/backlog/materialize.py`
+
+## Required Sequence
+1. Compile issue/project mutations from the execution contract.
+2. In dry-run mode, project deterministic local issues from the execution contract and use them as the offline input set for downstream steps.
+3. Backfill required issue labels against the active issue input set.
+4. Rebuild the program manifest from the active issue input set.
+5. Re-validate PlanningOps issue quality against the active issue input set.
+
+## Execution Rules
+- The command must accept an explicit execution contract file.
+- Dry-run mode must preserve the full command plan without GitHub mutations.
+- Dry-run mode must not require pre-existing live GitHub issues for the selected plan.
+- Apply mode may use live GitHub issues, but only through the existing helper scripts.
+- Apply mode must pass through issue creation/reopen behavior only via existing helper scripts.
+- The runner must emit a deterministic JSON report under `planningops/artifacts/backlog/`.
+- Dry-run mode must emit a projected issues artifact under `planningops/artifacts/backlog/`.
+
+## Failure Rules
+- Fail fast on the first step that returns non-zero.
+- Preserve each executed step command, rc, and truncated stdout/stderr in the report.
+- Do not invent fallback mutations outside the composed helper scripts.
+
+## Validation
+- `planningops/scripts/test_backlog_materialization_contract.sh`

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -8,6 +8,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `core/loop/runner.py`
   - `core/loop/checkpoint_lock.py`
   - `core/loop/selection.py`
+  - `core/backlog/materialize.py`
 - Federation entrypoints (canonical location):
   - `federation/federated_python_env.py`
   - `federation/adapter_registry.py`
@@ -75,6 +76,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `cross_repo_conformance_check.py`
   - `multi_repo_projection_report.py`
 - Backlog/bootstrap helpers:
+  - `core/backlog/materialize.py`
   - `bootstrap_two_track_backlog.py`
   - `compile_plan_to_backlog.py`
   - `build_program_manifest.py`
@@ -82,6 +84,8 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `planning_context.py`
   - `build_meta_plan_graph.py`
   - `test_planning_context_contract.sh`
+  - `test_backfill_issue_labels_contract.sh`
+  - `test_backlog_materialization_contract.sh`
   - `test_build_program_manifest_contract.sh`
   - `test_compile_plan_to_backlog_contract.sh`
   - `test_sync_project_fields_after_issue_create_contract.sh`
@@ -133,6 +137,8 @@ Host executable runners, validators, and contract tests for planningops loops.
 - Commands must run from repo root with repo-relative paths.
 - New non-recurring scripts must be placed under `planningops/scripts/oneoff` with a root wrapper only if needed.
 - New recurring control-plane logic must move into `planningops/scripts/core/` and keep root wrappers thin while compatibility is required.
+- Recurring backlog regeneration should use `core/backlog/materialize.py` as the canonical orchestration entrypoint.
+- `core/backlog/materialize.py` dry-run must remain self-contained via projected issues, not pre-existing live GitHub state.
 - Federation mappings must live under `planningops/scripts/federation/`; root compatibility wrappers must be registered in `planningops/config/script-role-map.json` and `planningops/config/wrapper-deprecation-map.json`.
 - Backlog issue creation/update flows must satisfy `planningops/contracts/issue-quality-contract.md`.
 - Validators must ignore filesystem metadata files (`._*`, `.DS_Store`, `Thumbs.db`) to prevent false CI failures.

--- a/planningops/scripts/backfill_issue_labels.py
+++ b/planningops/scripts/backfill_issue_labels.py
@@ -26,6 +26,11 @@ def load_json(path: Path):
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def write_json(path: Path, doc):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
 def fetch_open_issues(repo: str):
     rc, out, err = run(
         [
@@ -52,6 +57,8 @@ def label_names(issue: dict):
     for row in issue.get("labels", []):
         if isinstance(row, dict) and row.get("name"):
             names.append(row["name"])
+        elif isinstance(row, str) and row:
+            names.append(row)
     return names
 
 
@@ -125,11 +132,28 @@ def infer_type_label(issue: dict):
     return "type/hardening"
 
 
+def load_issues(path: Path):
+    doc = load_json(path)
+    if not isinstance(doc, list):
+        raise RuntimeError("issues-file must contain JSON array")
+    return doc
+
+
+def set_issue_labels(issue: dict, labels):
+    issue["labels"] = [{"name": label} for label in sorted(set(labels))]
+
+
 def main():
     parser = argparse.ArgumentParser(description="Backfill required label taxonomy on open planning issues")
     parser.add_argument("--repo", default="rather-not-work-on/platform-planningops")
     parser.add_argument("--rules", default=str(DEFAULT_RULES))
     parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--issues-file", default=None, help="Optional local issues JSON array")
+    parser.add_argument(
+        "--write-updated-issues-file",
+        default=None,
+        help="Optional output path for local issues JSON after label application",
+    )
     parser.add_argument("--apply", action="store_true", help="Apply missing labels via gh issue edit")
     args = parser.parse_args()
 
@@ -139,7 +163,7 @@ def main():
     required_prefixes = rules.get("required_label_prefixes", [])
     default_priority = "p2"
 
-    issues = fetch_open_issues(args.repo)
+    issues = load_issues(Path(args.issues_file)) if args.issues_file else fetch_open_issues(args.repo)
     rows = []
     applied_count = 0
 
@@ -171,24 +195,29 @@ def main():
         error = ""
 
         if args.apply and to_add:
-            rc, out, err = run(
-                [
-                    "gh",
-                    "issue",
-                    "edit",
-                    str(issue.get("number")),
-                    "--repo",
-                    args.repo,
-                    "--add-label",
-                    ",".join(to_add),
-                ]
-            )
-            if rc == 0:
-                apply_status = "applied"
+            if args.issues_file:
+                set_issue_labels(issue, names + to_add)
+                apply_status = "applied_local"
                 applied_count += 1
             else:
-                apply_status = "error"
-                error = err or out
+                rc, out, err = run(
+                    [
+                        "gh",
+                        "issue",
+                        "edit",
+                        str(issue.get("number")),
+                        "--repo",
+                        args.repo,
+                        "--add-label",
+                        ",".join(to_add),
+                    ]
+                )
+                if rc == 0:
+                    apply_status = "applied"
+                    applied_count += 1
+                else:
+                    apply_status = "error"
+                    error = err or out
 
         rows.append(
             {
@@ -206,6 +235,8 @@ def main():
         "generated_at_utc": now_utc(),
         "repo": args.repo,
         "rules_path": str(Path(args.rules)),
+        "issues_file": args.issues_file,
+        "write_updated_issues_file": args.write_updated_issues_file,
         "mode": "apply" if args.apply else "dry-run",
         "issues_in_scope": len(rows),
         "issues_with_missing_labels": len([r for r in rows if r["planned_labels"]]),
@@ -214,8 +245,9 @@ def main():
     }
 
     out = Path(args.output)
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding="utf-8")
+    write_json(out, report)
+    if args.issues_file and args.write_updated_issues_file:
+        write_json(Path(args.write_updated_issues_file), issues)
 
     print(f"report written: {out}")
     print(

--- a/planningops/scripts/build_program_manifest.py
+++ b/planningops/scripts/build_program_manifest.py
@@ -187,8 +187,14 @@ def dedupe_manifest_items(candidates):
 def build_manifest(source_rows, args):
     plan_item_re = re.compile(args.plan_item_regex)
     items = []
+    filtered_out_count = 0
     for row in source_rows:
-        metadata = parse_metadata(row["body"])
+        metadata = parse_metadata(row["body"], keys=["plan_item_id", "target_repo", "component", "workflow_state", "loop_profile", "execution_order", "depends_on", "plan_lane", "plan_doc", "plan_id"])
+        plan_doc = normalize_value(metadata.get("plan_doc"))
+        if args.scope_source_plan:
+            if not plan_doc or plan_doc != args.source_plan:
+                filtered_out_count += 1
+                continue
         plan_item_id = normalize_value(metadata.get("plan_item_id"))
         if not plan_item_id or not plan_item_re.search(plan_item_id):
             continue
@@ -219,12 +225,13 @@ def build_manifest(source_rows, args):
         "program_id": args.program_id,
         "initiative": args.initiative,
         "source_plan": args.source_plan,
+        "scope_source_plan": bool(args.scope_source_plan),
         "generated_at_utc": now_utc(),
         "selection_policy": "dedupe_by_plan_item_id_and_target_repo_open_first_then_latest_update",
         "item_count": len(items),
         "items": items,
     }
-    return manifest, duplicate_groups
+    return manifest, duplicate_groups, filtered_out_count
 
 
 def validate_manifest(manifest):
@@ -304,6 +311,7 @@ def main():
     parser.add_argument("--program-id", default="uap-po-ct-program", help="Program identifier")
     parser.add_argument("--initiative", default=DEFAULT_INITIATIVE, help="Initiative id")
     parser.add_argument("--source-plan", default=DEFAULT_SOURCE_PLAN, help="Primary source plan path")
+    parser.add_argument("--scope-source-plan", action="store_true", help="Include only issues whose plan_doc matches --source-plan")
     parser.add_argument("--output", default=str(DEFAULT_OUTPUT), help="Manifest output path")
     parser.add_argument("--report-output", default=str(DEFAULT_REPORT), help="Validation report output path")
     parser.add_argument("--strict", action="store_true", help="Exit non-zero on validation failure")
@@ -322,9 +330,10 @@ def main():
 
     try:
         source_rows = load_source_issues(args)
-        manifest, duplicate_groups = build_manifest(source_rows, args)
+        manifest, duplicate_groups, filtered_out_count = build_manifest(source_rows, args)
         errors = validate_manifest(manifest)
         report["issues_scanned"] = len(source_rows)
+        report["filtered_out_count"] = filtered_out_count
         report["item_count"] = manifest["item_count"]
         report["duplicate_group_count"] = len(duplicate_groups)
         report["duplicate_groups"] = duplicate_groups

--- a/planningops/scripts/core/backlog/README.md
+++ b/planningops/scripts/core/backlog/README.md
@@ -1,0 +1,14 @@
+# planningops/scripts/core/backlog
+
+## Purpose
+Hold recurring control-plane backlog materialization logic.
+
+## Contents
+- `materialize.py`
+  - Canonical steady-state entrypoint for `execution contract -> issue materialization -> label backfill -> manifest refresh -> issue quality validation`.
+  - Dry-run uses projected local issues so backlog regeneration stays deterministic before GitHub mutations are applied.
+
+## Rules
+- Keep backlog creation deterministic and contract-driven.
+- Prefer composing existing backlog helpers over re-implementing GitHub mutation logic here.
+- Write a regression test whenever the orchestration sequence or failure handling changes.

--- a/planningops/scripts/core/backlog/materialize.py
+++ b/planningops/scripts/core/backlog/materialize.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPTS_ROOT = Path(__file__).resolve().parents[2]
+if str(SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_ROOT))
+
+from compile_plan_to_backlog import issue_body
+
+
+DEFAULT_REPO = "rather-not-work-on/platform-planningops"
+DEFAULT_INITIATIVE = "unified-personal-agent-platform"
+DEFAULT_MANIFEST_REPOS = ",".join(
+    [
+        "rather-not-work-on/platform-planningops",
+        "rather-not-work-on/platform-contracts",
+        "rather-not-work-on/platform-provider-gateway",
+        "rather-not-work-on/platform-observability-gateway",
+        "rather-not-work-on/monday",
+    ]
+)
+DEFAULT_OUTPUT = Path("planningops/artifacts/backlog/materialize-report.json")
+DEFAULT_PROJECTED_ISSUES = Path("planningops/artifacts/backlog/projected-issues.json")
+DEFAULT_COMPILE_OUTPUT = Path("planningops/artifacts/validation/plan-compile-report.json")
+DEFAULT_LABEL_OUTPUT = Path("planningops/artifacts/validation/issue-label-backfill-report.json")
+DEFAULT_MANIFEST_OUTPUT = Path("planningops/artifacts/program/program-manifest.json")
+DEFAULT_MANIFEST_REPORT = Path("planningops/artifacts/validation/program-manifest-report.json")
+DEFAULT_QUALITY_OUTPUT = Path("planningops/artifacts/validation/issue-quality-report.json")
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def run(cmd):
+    cp = subprocess.run(cmd, capture_output=True, text=True)
+    return cp.returncode, cp.stdout.strip(), cp.stderr.strip()
+
+
+def load_execution_contract(path: Path):
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    execution_contract = doc.get("execution_contract")
+    if not isinstance(execution_contract, dict):
+        raise RuntimeError("execution_contract object is required")
+    for key in ["plan_id", "plan_revision", "source_of_truth", "items"]:
+        if key not in execution_contract:
+            raise RuntimeError(f"execution_contract.{key} is required")
+    if not isinstance(execution_contract.get("items"), list) or not execution_contract["items"]:
+        raise RuntimeError("execution_contract.items must be non-empty list")
+    return execution_contract
+
+
+def build_projected_issues(execution_contract, repo: str, source_plan_override: str | None = None):
+    source_plan = str(source_plan_override or execution_contract.get("source_of_truth") or "").strip()
+    if not source_plan:
+        raise RuntimeError("source_of_truth is required for projected backlog issues")
+
+    plan_id = execution_contract["plan_id"]
+    plan_revision = execution_contract["plan_revision"]
+    items = sorted(
+        execution_contract["items"],
+        key=lambda item: (int(item.get("execution_order", 0) or 0), str(item.get("plan_item_id") or "")),
+    )
+    order_to_plan_item_id = {
+        int(item["execution_order"]): str(item["plan_item_id"])
+        for item in items
+        if isinstance(item.get("execution_order"), int) and item.get("plan_item_id")
+    }
+
+    projected_issues = []
+    generated_at = now_utc()
+    for item in items:
+        synthetic_number = int(item["execution_order"])
+        projected_item = dict(item)
+        projected_item["depends_on"] = [
+            order_to_plan_item_id.get(dep, str(dep)) for dep in (item.get("depends_on") or [])
+        ]
+        projected_issues.append(
+            {
+                "repo": repo,
+                "number": synthetic_number,
+                "state": "open",
+                "updated_at": generated_at,
+                "title": f"plan: [{item['execution_order']}] {item['title']}",
+                "url": f"https://github.com/{repo}/issues/{synthetic_number}",
+                "body": issue_body(source_plan, plan_id, plan_revision, projected_item),
+                "labels": [],
+            }
+        )
+    return projected_issues
+
+
+def build_plan_item_regex(execution_contract):
+    plan_item_ids = sorted(
+        {
+            str(item.get("plan_item_id")).strip()
+            for item in execution_contract.get("items", [])
+            if str(item.get("plan_item_id") or "").strip()
+        }
+    )
+    if not plan_item_ids:
+        raise RuntimeError("execution_contract.items must provide non-empty plan_item_id values")
+    return "^(?:" + "|".join(re.escape(plan_item_id) for plan_item_id in plan_item_ids) + ")$"
+
+
+def build_steps(args, execution_contract, projected_issues_file: str | None = None):
+    source_plan = str(args.source_plan or execution_contract.get("source_of_truth") or "").strip()
+    if not source_plan:
+        raise RuntimeError("source_of_truth is required for backlog materialization")
+
+    compile_cmd = [
+        "python3",
+        "planningops/scripts/compile_plan_to_backlog.py",
+        "--contract-file",
+        args.contract_file,
+        "--config",
+        args.compile_config,
+        "--blueprint-defaults-config",
+        args.blueprint_defaults_config,
+        "--output",
+        args.compile_output,
+    ]
+    if args.apply:
+        compile_cmd.append("--apply")
+    if args.allow_reopen_closed:
+        compile_cmd.append("--allow-reopen-closed")
+
+    label_cmd = [
+        "python3",
+        "planningops/scripts/backfill_issue_labels.py",
+        "--output",
+        args.label_output,
+    ]
+    if projected_issues_file:
+        label_cmd.extend(
+            [
+                "--repo",
+                args.repo,
+                "--issues-file",
+                projected_issues_file,
+                "--write-updated-issues-file",
+                projected_issues_file,
+                "--apply",
+            ]
+        )
+    else:
+        label_cmd.extend(["--repo", args.repo])
+    if args.apply and not projected_issues_file:
+        label_cmd.append("--apply")
+
+    manifest_cmd = [
+        "python3",
+        "planningops/scripts/build_program_manifest.py",
+        "--plan-item-regex",
+        build_plan_item_regex(execution_contract),
+        "--initiative",
+        args.initiative,
+        "--source-plan",
+        source_plan,
+        "--scope-source-plan",
+        "--output",
+        args.manifest_output,
+        "--report-output",
+        args.manifest_report,
+        "--strict",
+    ]
+    if projected_issues_file:
+        manifest_cmd.extend(["--issues-file", projected_issues_file])
+    else:
+        manifest_cmd.extend(["--repos", args.manifest_repos])
+
+    quality_cmd = [
+        "python3",
+        "planningops/scripts/validate_issue_quality.py",
+        "--output",
+        args.quality_output,
+        "--strict",
+    ]
+    if projected_issues_file:
+        quality_cmd.extend(["--issues-file", projected_issues_file, "--repo", args.repo])
+    else:
+        quality_cmd.extend(["--repo", args.repo])
+
+    return [
+        {"name": "compile_plan_to_backlog", "command": compile_cmd, "output_path": args.compile_output},
+        {"name": "backfill_issue_labels", "command": label_cmd, "output_path": args.label_output},
+        {"name": "build_program_manifest", "command": manifest_cmd, "output_path": args.manifest_report},
+        {"name": "validate_issue_quality", "command": quality_cmd, "output_path": args.quality_output},
+    ]
+
+
+def execute_steps(steps, run_fn=run):
+    results = []
+    verdict = "pass"
+    for step in steps:
+        rc, out, err = run_fn(step["command"])
+        result = {
+            "name": step["name"],
+            "command": step["command"],
+            "output_path": step["output_path"],
+            "rc": rc,
+            "stdout": out[-2000:],
+            "stderr": err[-2000:],
+            "verdict": "pass" if rc == 0 else "fail",
+        }
+        results.append(result)
+        if rc != 0:
+            verdict = "fail"
+            break
+    return results, verdict
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Materialize planningops backlog from an execution contract")
+    parser.add_argument("--contract-file", required=True, help="Execution contract JSON file path")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--initiative", default=DEFAULT_INITIATIVE)
+    parser.add_argument("--manifest-repos", default=DEFAULT_MANIFEST_REPOS)
+    parser.add_argument("--source-plan", default=None, help="Optional manifest source-plan override")
+    parser.add_argument("--compile-config", default="planningops/config/project-field-ids.json")
+    parser.add_argument(
+        "--blueprint-defaults-config",
+        default="planningops/config/ready-implementation-blueprint-defaults.json",
+    )
+    parser.add_argument("--compile-output", default=str(DEFAULT_COMPILE_OUTPUT))
+    parser.add_argument("--label-output", default=str(DEFAULT_LABEL_OUTPUT))
+    parser.add_argument("--manifest-output", default=str(DEFAULT_MANIFEST_OUTPUT))
+    parser.add_argument("--manifest-report", default=str(DEFAULT_MANIFEST_REPORT))
+    parser.add_argument("--quality-output", default=str(DEFAULT_QUALITY_OUTPUT))
+    parser.add_argument("--projected-issues-output", default=str(DEFAULT_PROJECTED_ISSUES))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--apply", action="store_true", help="Apply GitHub mutations during materialization")
+    parser.add_argument("--allow-reopen-closed", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    report = {
+        "generated_at_utc": now_utc(),
+        "mode": "apply" if args.apply else "dry-run",
+        "contract_file": args.contract_file,
+        "repo": args.repo,
+        "initiative": args.initiative,
+        "steps": [],
+    }
+
+    try:
+        execution_contract = load_execution_contract(Path(args.contract_file))
+        report["plan_id"] = execution_contract["plan_id"]
+        report["plan_revision"] = execution_contract["plan_revision"]
+        report["source_of_truth"] = execution_contract["source_of_truth"]
+        report["items_total"] = len(execution_contract["items"])
+        projected_issues_file = None
+        if not args.apply:
+            projected_issues_path = Path(args.projected_issues_output)
+            projected_issues_path.parent.mkdir(parents=True, exist_ok=True)
+            projected_issues = build_projected_issues(
+                execution_contract,
+                repo=args.repo,
+                source_plan_override=args.source_plan,
+            )
+            projected_issues_path.write_text(
+                json.dumps(projected_issues, ensure_ascii=True, indent=2),
+                encoding="utf-8",
+            )
+            projected_issues_file = str(projected_issues_path)
+            report["projected_issues_output"] = projected_issues_file
+            report["projected_issue_count"] = len(projected_issues)
+        steps = build_steps(args, execution_contract, projected_issues_file=projected_issues_file)
+        report["step_count"] = len(steps)
+        report["steps"], report["verdict"] = execute_steps(steps)
+    except Exception as exc:  # noqa: BLE001
+        report["verdict"] = "fail"
+        report["error"] = str(exc)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    return 0 if report["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/test_backfill_issue_labels_contract.sh
+++ b/planningops/scripts/test_backfill_issue_labels_contract.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+issues_file="$tmpdir/issues.json"
+report_file="$tmpdir/report.json"
+
+cat >"$issues_file" <<'JSON'
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 60,
+    "state": "open",
+    "updated_at": "2026-03-12T00:00:00+00:00",
+    "title": "plan: [60] Add recurring backlog materialization runner",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/60",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- plan_id: `uap-backlog-wave26`\n- plan_revision: `1`\n- plan_item_id: `A60`\n- execution_order: `60`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `-`\n- primary_output: `planningops/scripts/core/backlog/materialize.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- `planningops/scripts/core/backlog/materialize.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
+    "labels": []
+  }
+]
+JSON
+
+python3 planningops/scripts/backfill_issue_labels.py \
+  --repo rather-not-work-on/platform-planningops \
+  --issues-file "$issues_file" \
+  --write-updated-issues-file "$issues_file" \
+  --output "$report_file" \
+  --apply
+
+python3 - <<'PY' "$issues_file" "$report_file"
+import json
+import sys
+from pathlib import Path
+
+issues = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+report = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+
+assert len(issues) == 1, issues
+labels = sorted(label["name"] for label in issues[0]["labels"])
+assert labels == ["area/planningops", "p2", "task", "type/hardening"], labels
+
+assert report["mode"] == "apply", report
+assert report["issues_in_scope"] == 1, report
+assert report["issues_applied"] == 1, report
+assert report["rows"][0]["apply_status"] == "applied_local", report["rows"][0]
+
+print("backfill_issue_labels offline contract ok")
+PY

--- a/planningops/scripts/test_backlog_materialization_contract.sh
+++ b/planningops/scripts/test_backlog_materialization_contract.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+module_path = Path("planningops/scripts/core/backlog/materialize.py")
+spec = importlib.util.spec_from_file_location("backlog_materialize_core", module_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+with tempfile.TemporaryDirectory() as td:
+    td_path = Path(td)
+    contract_path = td_path / "execution-contract.json"
+    contract_path.write_text(
+        json.dumps(
+            {
+                "execution_contract": {
+                    "plan_id": "uap-backlog-wave26",
+                    "plan_revision": 1,
+                    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md",
+                    "items": [
+                        {
+                            "plan_item_id": "A60",
+                            "execution_order": 60,
+                            "title": "Add recurring backlog materialization runner",
+                            "target_repo": "rather-not-work-on/platform-planningops",
+                            "component": "planningops",
+                            "workflow_state": "ready_implementation",
+                            "loop_profile": "l4_integration_reconcile",
+                            "plan_lane": "m3_guardrails",
+                            "depends_on": [],
+                            "primary_output": "planningops/scripts/core/backlog/materialize.py",
+                        }
+                    ],
+                }
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    execution_contract = mod.load_execution_contract(contract_path)
+    assert execution_contract["plan_id"] == "uap-backlog-wave26", execution_contract
+
+    dry_args = SimpleNamespace(
+        contract_file=str(contract_path),
+        repo="rather-not-work-on/platform-planningops",
+        initiative="unified-personal-agent-platform",
+        manifest_repos="rather-not-work-on/platform-planningops,rather-not-work-on/monday",
+        source_plan=None,
+        compile_config="planningops/config/project-field-ids.json",
+        blueprint_defaults_config="planningops/config/ready-implementation-blueprint-defaults.json",
+        compile_output=str(td_path / "compile.json"),
+        label_output=str(td_path / "labels.json"),
+        manifest_output=str(td_path / "manifest.json"),
+        manifest_report=str(td_path / "manifest-report.json"),
+        quality_output=str(td_path / "quality.json"),
+        projected_issues_output=str(td_path / "projected-issues.json"),
+        output=str(td_path / "materialize.json"),
+        apply=False,
+        allow_reopen_closed=False,
+    )
+    projected_issues = mod.build_projected_issues(
+        execution_contract,
+        repo=dry_args.repo,
+        source_plan_override=dry_args.source_plan,
+    )
+    projected_issues_path = Path(dry_args.projected_issues_output)
+    projected_issues_path.write_text(json.dumps(projected_issues, ensure_ascii=True, indent=2), encoding="utf-8")
+    assert len(projected_issues) == 1, projected_issues
+    assert projected_issues[0]["number"] == 60, projected_issues[0]
+    assert "depends_on: `-`" in projected_issues[0]["body"], projected_issues[0]["body"]
+
+    dry_steps = mod.build_steps(dry_args, execution_contract, projected_issues_file=str(projected_issues_path))
+    assert [step["name"] for step in dry_steps] == [
+        "compile_plan_to_backlog",
+        "backfill_issue_labels",
+        "build_program_manifest",
+        "validate_issue_quality",
+    ], dry_steps
+    assert "--apply" not in dry_steps[0]["command"], dry_steps[0]
+    assert "--apply" in dry_steps[1]["command"], dry_steps[1]
+    assert "--issues-file" in dry_steps[1]["command"], dry_steps[1]
+    assert "--write-updated-issues-file" in dry_steps[1]["command"], dry_steps[1]
+    assert "--plan-item-regex" in dry_steps[2]["command"], dry_steps[2]
+    assert "^(?:A60)$" in dry_steps[2]["command"], dry_steps[2]
+    assert "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md" in dry_steps[2]["command"], dry_steps[2]
+    assert "--issues-file" in dry_steps[2]["command"], dry_steps[2]
+    assert "--strict" in dry_steps[2]["command"], dry_steps[2]
+    assert "--issues-file" in dry_steps[3]["command"], dry_steps[3]
+    assert "--strict" in dry_steps[3]["command"], dry_steps[3]
+
+    apply_args = SimpleNamespace(**{**dry_args.__dict__, "apply": True, "allow_reopen_closed": True})
+    apply_steps = mod.build_steps(apply_args, execution_contract)
+    assert "--apply" in apply_steps[0]["command"], apply_steps[0]
+    assert "--allow-reopen-closed" in apply_steps[0]["command"], apply_steps[0]
+    assert "--apply" in apply_steps[1]["command"], apply_steps[1]
+
+    seen = []
+
+    def fake_run(cmd):
+        seen.append(cmd)
+        if "backfill_issue_labels.py" in cmd[1]:
+            return 1, "", "label-backfill-failed"
+        return 0, "ok", ""
+
+    results, verdict = mod.execute_steps(apply_steps, run_fn=fake_run)
+    assert verdict == "fail", results
+    assert len(results) == 2, results
+    assert results[0]["name"] == "compile_plan_to_backlog", results
+    assert results[1]["name"] == "backfill_issue_labels", results
+    assert results[1]["stderr"] == "label-backfill-failed", results[1]
+
+print("backlog materialization contract ok")
+PY

--- a/planningops/scripts/test_build_program_manifest_contract.sh
+++ b/planningops/scripts/test_build_program_manifest_contract.sh
@@ -30,6 +30,7 @@ with tempfile.TemporaryDirectory() as td:
             "body": "\n".join(
                 [
                     "## Planning Context",
+                    "- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`",
                     "- plan_item_id: `A00`",
                     "- target_repo: `rather-not-work-on/platform-planningops`",
                     "- component: `orchestrator`",
@@ -51,6 +52,7 @@ with tempfile.TemporaryDirectory() as td:
             "body": "\n".join(
                 [
                     "## Planning Context",
+                    "- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`",
                     "- plan_item_id: `A10`",
                     "- target_repo: `rather-not-work-on/platform-planningops`",
                     "- component: `planningops`",
@@ -72,6 +74,7 @@ with tempfile.TemporaryDirectory() as td:
             "body": "\n".join(
                 [
                     "## Planning Context",
+                    "- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`",
                     "- plan_item_id: `B10`",
                     "- target_repo: `rather-not-work-on/platform-contracts`",
                     "- component: `contracts`",
@@ -156,6 +159,56 @@ with tempfile.TemporaryDirectory() as td:
     assert dup_report["duplicate_group_count"] == 1, dup_report
     assert dup_report["duplicate_groups"][0]["winner"]["issue_number"] == 96, dup_report
     assert [row["issue_number"] for row in dup_report["duplicate_groups"][0]["losers"]] == [95, 80], dup_report
+
+    # Source-plan scoping should ignore unrelated wave items with colliding plan_item_id values.
+    scoped_issues = json.loads(json.dumps(base_issues))
+    scoped_issues.append(
+        {
+            "repo": "rather-not-work-on/platform-planningops",
+            "number": 163,
+            "state": "closed",
+            "updated_at": "2026-03-11T12:00:00Z",
+            "title": "old wave B10",
+            "url": "https://github.com/rather-not-work-on/platform-planningops/issues/163",
+            "body": "\n".join(
+                [
+                    "## Planning Context",
+                    "- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-skeleton-wave3-build-baseline-issue-pack.md`",
+                    "- plan_item_id: `B10`",
+                    "- target_repo: `rather-not-work-on/platform-planningops`",
+                    "- component: `planningops`",
+                    "- workflow_state: `done`",
+                    "- loop_profile: `l4_integration_reconcile`",
+                    "- execution_order: `10`",
+                    "- depends_on: `-`",
+                    "- plan_lane: `M3 Guardrails`",
+                ]
+            ),
+        }
+    )
+    issues_path.write_text(json.dumps(scoped_issues, ensure_ascii=True, indent=2), encoding="utf-8")
+    rc_scoped, out_scoped, err_scoped = run(
+        [
+            "python3",
+            "planningops/scripts/build_program_manifest.py",
+            "--issues-file",
+            str(issues_path),
+            "--source-plan",
+            "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md",
+            "--scope-source-plan",
+            "--output",
+            str(output_path),
+            "--report-output",
+            str(report_path),
+            "--strict",
+        ]
+    )
+    assert rc_scoped == 0, (rc_scoped, out_scoped, err_scoped)
+    scoped_manifest = json.loads(output_path.read_text(encoding="utf-8"))
+    scoped_report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert scoped_report["verdict"] == "pass", scoped_report
+    assert scoped_report["filtered_out_count"] == 1, scoped_report
+    assert [row["issue_number"] for row in scoped_manifest["items"] if row["plan_item_id"] == "B10"] == [2], scoped_manifest
 
     # Invalid graph: dependency points to unknown key.
     bad = json.loads(json.dumps(base_issues))


### PR DESCRIPTION
## Summary
- add a canonical recurring backlog materialization runner under `planningops/scripts/core/backlog/`
- make dry-run self-contained by projecting local issues before label backfill, manifest build, and issue-quality validation
- add offline label backfill coverage and source-plan scoped manifest regression coverage

## Scope
- Initiative docs:
  - `docs/initiatives/unified-personal-agent-platform/40-quality/uap-automation-operations-summary.quality.md`
- Workbench docs:
  - none
- `planningops/` scripts/contracts:
  - `planningops/contracts/backlog-materialization-contract.md`
  - `planningops/scripts/core/backlog/materialize.py`
  - `planningops/scripts/core/backlog/README.md`
  - `planningops/scripts/backfill_issue_labels.py`
  - `planningops/scripts/build_program_manifest.py`
  - `planningops/scripts/test_backfill_issue_labels_contract.sh`
  - `planningops/scripts/test_backlog_materialization_contract.sh`
  - `planningops/scripts/test_build_program_manifest_contract.sh`
  - `planningops/scripts/README.md`
  - `planningops/README.md`
- `.github/` workflows:
  - none

## Linked Issues
- Closes #281
- Related #279

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_backfill_issue_labels_contract.sh`
  - `bash planningops/scripts/test_backlog_materialization_contract.sh`
  - `bash planningops/scripts/test_build_program_manifest_contract.sh`
  - `python3 planningops/scripts/core/backlog/materialize.py --contract-file planningops/fixtures/plan-execution-contract-sample.json`
  - `python3 -m py_compile planningops/scripts/core/backlog/materialize.py planningops/scripts/backfill_issue_labels.py planningops/scripts/build_program_manifest.py`
  - `git diff --check`

## Risks
- Risk:
  - dry-run now writes projected issues to `planningops/artifacts/backlog/projected-issues.json`; callers must treat it as ephemeral validation output, not canonical source data
- Rollback:
  - revert this PR to restore the previous live-state dependent materializer path

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
