### PR TITLE
feat(planningops): auto-materialize backlog on supervisor replan

### DIFF
--- a/docs/initiatives/unified-personal-agent-platform/40-quality/uap-automation-operations-summary.quality.md
+++ b/docs/initiatives/unified-personal-agent-platform/40-quality/uap-automation-operations-summary.quality.md
@@ -88,7 +88,10 @@ The earlier local-only behavior was not caused by git permissions.
 4. If all repos are clean and no open issue is ready, regenerate or re-triage backlog from `planningops` instead of inventing repo-local work.
    - canonical command: `python3 planningops/scripts/core/backlog/materialize.py --contract-file <execution-contract.json>`
    - dry-run expectation: the command must project local issues first, then run label backfill / manifest / issue-quality against that projected issue set instead of depending on pre-existing live GitHub issues
-5. Keep durable conclusions in canonical docs or workbench audits; keep automation memory short and current.
+5. Supervisor runs may opt into automatic backlog regeneration on replanning paths.
+   - canonical command: `python3 planningops/scripts/autonomous_supervisor_loop.py --mode apply --auto-materialize-backlog --backlog-materialization-contract-file <execution-contract.json>`
+   - dry-run expectation: materialization reports should be attached to the supervisor cycle and surfaced as review guidance rather than being treated as a quality failure
+6. Keep durable conclusions in canonical docs or workbench audits; keep automation memory short and current.
 
 ## Reflected Outcomes
 - execution-repo remote reconciliation completed for:
@@ -105,4 +108,5 @@ The earlier local-only behavior was not caused by git permissions.
 - `git ls-remote --heads origin`
 - `gh issue list --state open` across the five managed repos
 - `python3 planningops/scripts/core/backlog/materialize.py --contract-file <execution-contract.json>`
+- `python3 planningops/scripts/autonomous_supervisor_loop.py --mode apply --auto-materialize-backlog --backlog-materialization-contract-file <execution-contract.json>`
 - `python3 planningops/scripts/backfill_issue_labels.py --repo rather-not-work-on/platform-planningops --issues-file /tmp/projected-issues.json --write-updated-issues-file /tmp/projected-issues.json --output /tmp/issue-label-backfill-report.json --apply`

--- a/planningops/README.md
+++ b/planningops/README.md
@@ -80,6 +80,7 @@ python3 planningops/scripts/validate_worker_task_pack.py --task-key issue-18 --i
 python3 planningops/scripts/verify_plan_projection.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --snapshot-file planningops/fixtures/plan-projection-snapshot-sample.json --strict
 python3 planningops/scripts/backlog_stock_replenishment_guard.py --items-file planningops/fixtures/backlog-stock-items-sample.json --candidate-file planningops/fixtures/backlog-replenishment-candidates-sample.json
 python3 planningops/scripts/autonomous_supervisor_loop.py --mode dry-run --max-cycles 3 --items-file planningops/fixtures/backlog-stock-items-sample.json --offline --loop-result-sequence-file planningops/fixtures/supervisor-loop-sequence-sample.json --run-id demo-supervisor-sequence
+python3 planningops/scripts/autonomous_supervisor_loop.py --mode apply --max-cycles 3 --auto-materialize-backlog --backlog-materialization-contract-file planningops/fixtures/plan-execution-contract-sample.json
 python3 planningops/scripts/supervisor_experiment_auto_executor.py --experiment-id demo-supervisor-exp --topic demo-cycle --options option-a,option-b --validation-pack-file planningops/config/supervisor-experiment-validation-pack.json
 bash planningops/scripts/test_compile_plan_to_backlog_contract.sh
 bash planningops/scripts/test_backfill_issue_labels_contract.sh

--- a/planningops/contracts/autonomous-supervisor-loop-contract.md
+++ b/planningops/contracts/autonomous-supervisor-loop-contract.md
@@ -64,6 +64,12 @@ Replan and replenishment are first-class outputs:
 - `replan_decision_path` (if present)
 - `replenishment_candidates_path`
 - `replenishment_candidates_count`
+- optional `backlog_materialization` result when `--auto-materialize-backlog` is enabled
+
+When auto materialization is enabled:
+1. `dry-run` may invoke `planningops/scripts/core/backlog/materialize.py` and attach its report as review evidence.
+2. `apply` may invoke backlog materialization and continue into the next cycle if materialization succeeds.
+3. materialization failure is terminal with stop reason `replan_materialization_failed`.
 
 ## Summary Artifact
 Run summary must include:

--- a/planningops/scripts/autonomous_supervisor_loop.py
+++ b/planningops/scripts/autonomous_supervisor_loop.py
@@ -191,11 +191,44 @@ def build_operator_report(summary: dict, summary_path: Path, run_dir: Path):
         return report
 
     if stop_reason == "replan_required":
+        materialization = stop_details.get("backlog_materialization") or {}
+        if materialization.get("enabled") and int(materialization.get("rc", 1)) == 0:
+            report.update(
+                {
+                    "status": "review_required",
+                    "headline": "Supervisor stopped after backlog materialization dry-run.",
+                    "operator_action": "review_materialized_backlog",
+                    "reason": "Backlog materialization succeeded, but no new live queue was consumed in this run.",
+                    "guidance": {
+                        **(report.get("guidance") or {}),
+                        "materialize_report_path": materialization.get("output_path"),
+                        "projected_issues_output": materialization.get("projected_issues_output"),
+                    },
+                }
+            )
+            return report
         report.update(
             {
                 "status": "review_required",
                 "headline": "Supervisor stopped because backlog selection requires replanning.",
                 "operator_action": "regenerate_backlog_or_reconcile_project",
+            }
+        )
+        return report
+
+    if stop_reason == "replan_materialization_failed":
+        materialization = stop_details.get("backlog_materialization") or {}
+        report.update(
+            {
+                "status": "blocked",
+                "headline": "Supervisor failed while materializing backlog on replanning.",
+                "operator_action": "inspect_materialization_failure",
+                "reason": materialization.get("stderr") or "Backlog materialization failed.",
+                "guidance": {
+                    **(report.get("guidance") or {}),
+                    "materialize_report_path": materialization.get("output_path"),
+                    "projected_issues_output": materialization.get("projected_issues_output"),
+                },
             }
         )
         return report
@@ -407,6 +440,39 @@ def run_experiment_auto_executor(args, run_id: str, cycle_index: int, loop_resul
     }
 
 
+def run_backlog_materializer(args, cycle_dir: Path):
+    if not args.auto_materialize_backlog or not args.backlog_materialization_contract_file:
+        return {"enabled": False}
+
+    report_path = cycle_dir / "backlog-materialize-report.json"
+    projected_issues_path = cycle_dir / "backlog-projected-issues.json"
+    cmd = [
+        sys.executable,
+        args.backlog_materializer_script,
+        "--contract-file",
+        args.backlog_materialization_contract_file,
+        "--output",
+        str(report_path),
+    ]
+    if args.mode == "apply":
+        cmd.append("--apply")
+    else:
+        cmd.extend(["--projected-issues-output", str(projected_issues_path)])
+
+    rc, out, err = run(cmd)
+    report = load_json(report_path, {})
+    return {
+        "enabled": True,
+        "rc": rc,
+        "command": cmd,
+        "stdout": out[-2000:],
+        "stderr": err[-2000:],
+        "output_path": str(report_path),
+        "projected_issues_output": str(projected_issues_path) if args.mode != "apply" else None,
+        "report": report if isinstance(report, dict) else {},
+    }
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Autonomous plan-work-review-replan supervisor loop")
     parser.add_argument("--mode", choices=["dry-run", "apply"], default="dry-run")
@@ -447,6 +513,12 @@ def parse_args():
     parser.add_argument("--experiment-artifacts-root", default="planningops/artifacts/experiments")
     parser.add_argument("--experiment-worktree-root", default="/tmp/planningops-supervisor-experiments")
     parser.add_argument("--keep-experiment-worktrees", action="store_true")
+    parser.add_argument("--auto-materialize-backlog", action="store_true")
+    parser.add_argument(
+        "--backlog-materializer-script",
+        default="planningops/scripts/core/backlog/materialize.py",
+    )
+    parser.add_argument("--backlog-materialization-contract-file", default=None)
     return parser.parse_args()
 
 
@@ -454,6 +526,9 @@ def main():
     args = parse_args()
     if args.max_cycles <= 0:
         print("max-cycles must be positive")
+        return 1
+    if args.auto_materialize_backlog and not args.backlog_materialization_contract_file:
+        print("backlog-materialization-contract-file is required when auto-materialize-backlog is enabled")
         return 1
 
     sequence_rows = None
@@ -495,6 +570,7 @@ def main():
         experiment = detect_experiment_trigger(loop_result)
         experiment_trigger_artifact = None
         experiment_executor = {"enabled": False}
+        backlog_materialization = {"enabled": False}
         if experiment["triggered"]:
             experiment_trigger_artifact = cycle_dir / "experiment-trigger.json"
             save_json(
@@ -547,6 +623,13 @@ def main():
                 "verdict": (experiment_executor.get("report") or {}).get("verdict"),
                 "selected_option": (experiment_executor.get("report") or {}).get("selected_option"),
             },
+            "backlog_materialization": {
+                "enabled": False,
+                "rc": None,
+                "output_path": None,
+                "projected_issues_output": None,
+                "verdict": None,
+            },
             "project_items_source": project_items_source,
             "project_items_rate_limit_fallback_used": project_items_rate_limit_fallback_used,
             "project_items_rate_limit_error": project_items_rate_limit_error,
@@ -589,8 +672,32 @@ def main():
             "dependency_blocked",
             "inventory_only_candidates_only",
         }:
+            backlog_materialization = run_backlog_materializer(args, cycle_dir)
+            cycle_record["backlog_materialization"] = {
+                "enabled": bool(backlog_materialization.get("enabled")),
+                "rc": backlog_materialization.get("rc"),
+                "output_path": backlog_materialization.get("output_path"),
+                "projected_issues_output": backlog_materialization.get("projected_issues_output"),
+                "verdict": (backlog_materialization.get("report") or {}).get("verdict"),
+            }
+            save_json(cycle_dir / "cycle-report.json", cycle_record)
+            if backlog_materialization.get("enabled") and int(backlog_materialization.get("rc", 1)) != 0:
+                stop_reason = "replan_materialization_failed"
+                stop_details = {
+                    "cycle": cycle_index,
+                    "reason_code": reason_code,
+                    "backlog_materialization": cycle_record["backlog_materialization"],
+                }
+                break
+            if backlog_materialization.get("enabled") and args.mode == "apply":
+                pass_streak = 0
+                continue
             stop_reason = "replan_required"
-            stop_details = {"cycle": cycle_index, "reason_code": reason_code}
+            stop_details = {
+                "cycle": cycle_index,
+                "reason_code": reason_code,
+                "backlog_materialization": cycle_record["backlog_materialization"],
+            }
             break
         if backlog_failed and not args.report_only_gates:
             stop_reason = "backlog_gate_fail"
@@ -631,6 +738,7 @@ def main():
         "backlog_gate_fail",
         "experiment_auto_executor_failed",
         "github_rate_limited",
+        "replan_materialization_failed",
     }:
         supervisor_verdict = "fail"
     elif stop_reason in {"experiment_triggered", "sequence_exhausted", "replan_required", "max_cycles_reached"}:
@@ -653,6 +761,7 @@ def main():
             "autonomous_run_policy": "planningops/contracts/autonomous-run-policy-contract.md",
             "worktree_experiment_protocol": "planningops/contracts/worktree-comparative-experiment-protocol.md",
             "backlog_replenishment": "planningops/contracts/backlog-stock-replenishment-contract.md",
+            "backlog_materialization": "planningops/contracts/backlog-materialization-contract.md",
         },
     }
 

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -356,5 +356,209 @@ with tempfile.TemporaryDirectory() as td:
     assert no_eligible_operator["status"] == "review_required", no_eligible_operator
     assert no_eligible_operator["operator_action"] == "regenerate_backlog_or_reconcile_project", no_eligible_operator
 
+    materialize_success = td_path / "materialize-success.py"
+    materialize_success.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import argparse",
+                "import json",
+                "from pathlib import Path",
+                "parser = argparse.ArgumentParser()",
+                "parser.add_argument('--contract-file', required=True)",
+                "parser.add_argument('--output', required=True)",
+                "parser.add_argument('--projected-issues-output', default=None)",
+                "parser.add_argument('--apply', action='store_true')",
+                "args = parser.parse_args()",
+                "report = {'verdict': 'pass', 'contract_file': args.contract_file, 'mode': 'apply' if args.apply else 'dry-run'}",
+                "Path(args.output).write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding='utf-8')",
+                "if args.projected_issues_output:",
+                "    Path(args.projected_issues_output).write_text('[]', encoding='utf-8')",
+                "print(json.dumps(report, ensure_ascii=True))",
+                "raise SystemExit(0)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    materialize_fail = td_path / "materialize-fail.py"
+    materialize_fail.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import argparse",
+                "import json",
+                "from pathlib import Path",
+                "parser = argparse.ArgumentParser()",
+                "parser.add_argument('--contract-file', required=True)",
+                "parser.add_argument('--output', required=True)",
+                "parser.add_argument('--projected-issues-output', default=None)",
+                "parser.add_argument('--apply', action='store_true')",
+                "args = parser.parse_args()",
+                "report = {'verdict': 'fail', 'contract_file': args.contract_file, 'mode': 'apply' if args.apply else 'dry-run'}",
+                "Path(args.output).write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding='utf-8')",
+                "if args.projected_issues_output:",
+                "    Path(args.projected_issues_output).write_text('[]', encoding='utf-8')",
+                "print(json.dumps(report, ensure_ascii=True))",
+                "raise SystemExit(1)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # 7) dry-run replanning can auto-materialize backlog and surface the materialized output for review.
+    out_replan_materialized = td_path / "supervisor-replan-materialized.json"
+    rc_replan_materialized, _, _ = run_supervisor(
+        [
+            "python3",
+            "planningops/scripts/autonomous_supervisor_loop.py",
+            "--mode",
+            "dry-run",
+            "--max-cycles",
+            "1",
+            "--continue-on-experiment",
+            "--loop-result-sequence-file",
+            str(no_eligible_sequence),
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
+            "--output",
+            str(out_replan_materialized),
+            "--auto-materialize-backlog",
+            "--backlog-materializer-script",
+            str(materialize_success),
+            "--backlog-materialization-contract-file",
+            "planningops/fixtures/plan-execution-contract-sample.json",
+        ]
+    )
+    assert rc_replan_materialized == 1, rc_replan_materialized
+    replan_materialized_doc = json.loads(out_replan_materialized.read_text(encoding="utf-8"))
+    assert replan_materialized_doc["supervisor_verdict"] == "inconclusive", replan_materialized_doc
+    assert replan_materialized_doc["stop_reason"] == "replan_required", replan_materialized_doc
+    materialization = replan_materialized_doc["cycles"][0]["backlog_materialization"]
+    assert materialization["enabled"] is True, replan_materialized_doc
+    assert materialization["rc"] == 0, materialization
+    assert materialization["verdict"] == "pass", materialization
+    assert materialization["projected_issues_output"].endswith("backlog-projected-issues.json"), materialization
+    replan_materialized_operator = json.loads(
+        Path(replan_materialized_doc["operator_report_last_path"]).read_text(encoding="utf-8")
+    )
+    assert replan_materialized_operator["operator_action"] == "review_materialized_backlog", replan_materialized_operator
+
+    # 8) apply-mode replanning can materialize backlog and continue into the next cycle.
+    apply_replan_sequence = td_path / "apply-replan-sequence.json"
+    apply_replan_sequence.write_text(
+        json.dumps(
+            {
+                "cycles": [
+                    {
+                        "rc": 2,
+                        "loop_result": {
+                            "result": "no_eligible_todo_issue",
+                            "reason_code": "no_eligible_todo_issue",
+                            "recommended_action": "retriage_backlog",
+                            "last_verdict": "inconclusive",
+                            "auto_paused": False,
+                            "replenishment_candidates_count": 0,
+                            "selection_trace": {
+                                "selected": None,
+                                "project_items_source": "live",
+                            },
+                        },
+                    },
+                    {
+                        "rc": 0,
+                        "loop_result": {
+                            "selected_issue": 501,
+                            "last_verdict": "pass",
+                            "reason_code": "ok",
+                            "auto_paused": False,
+                            "replenishment_candidates_count": 0,
+                            "selection_trace": {"selected": {"uncertainty_level": "low", "simulation_required": False}},
+                            "final_loop_profile": "L3 Implementation-TDD",
+                        },
+                    },
+                ]
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    out_apply_materialized = td_path / "supervisor-apply-materialized.json"
+    rc_apply_materialized, _, _ = run_supervisor(
+        [
+            "python3",
+            "planningops/scripts/autonomous_supervisor_loop.py",
+            "--mode",
+            "apply",
+            "--max-cycles",
+            "2",
+            "--convergence-pass-streak",
+            "1",
+            "--continue-on-experiment",
+            "--loop-result-sequence-file",
+            str(apply_replan_sequence),
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
+            "--output",
+            str(out_apply_materialized),
+            "--auto-materialize-backlog",
+            "--backlog-materializer-script",
+            str(materialize_success),
+            "--backlog-materialization-contract-file",
+            "planningops/fixtures/plan-execution-contract-sample.json",
+        ]
+    )
+    assert rc_apply_materialized == 0, rc_apply_materialized
+    apply_materialized_doc = json.loads(out_apply_materialized.read_text(encoding="utf-8"))
+    assert apply_materialized_doc["supervisor_verdict"] == "pass", apply_materialized_doc
+    assert apply_materialized_doc["stop_reason"] == "converged", apply_materialized_doc
+    assert apply_materialized_doc["executed_cycles"] == 2, apply_materialized_doc
+    assert apply_materialized_doc["cycles"][0]["backlog_materialization"]["enabled"] is True, apply_materialized_doc
+    assert apply_materialized_doc["cycles"][1]["last_verdict"] == "pass", apply_materialized_doc
+
+    # 9) materialization failure must become a dedicated supervisor failure.
+    out_materialize_fail = td_path / "supervisor-materialize-fail.json"
+    rc_materialize_fail, _, _ = run_supervisor(
+        [
+            "python3",
+            "planningops/scripts/autonomous_supervisor_loop.py",
+            "--mode",
+            "dry-run",
+            "--max-cycles",
+            "1",
+            "--continue-on-experiment",
+            "--loop-result-sequence-file",
+            str(no_eligible_sequence),
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
+            "--output",
+            str(out_materialize_fail),
+            "--auto-materialize-backlog",
+            "--backlog-materializer-script",
+            str(materialize_fail),
+            "--backlog-materialization-contract-file",
+            "planningops/fixtures/plan-execution-contract-sample.json",
+        ]
+    )
+    assert rc_materialize_fail == 1, rc_materialize_fail
+    materialize_fail_doc = json.loads(out_materialize_fail.read_text(encoding="utf-8"))
+    assert materialize_fail_doc["supervisor_verdict"] == "fail", materialize_fail_doc
+    assert materialize_fail_doc["stop_reason"] == "replan_materialization_failed", materialize_fail_doc
+    materialize_fail_operator = json.loads(Path(materialize_fail_doc["operator_report_last_path"]).read_text(encoding="utf-8"))
+    assert materialize_fail_operator["status"] == "blocked", materialize_fail_operator
+    assert materialize_fail_operator["operator_action"] == "inspect_materialization_failure", materialize_fail_operator
+
 print("autonomous supervisor loop contract tests ok")
 PY


### PR DESCRIPTION
## Summary
- let the supervisor invoke backlog materialization when replanning is required
- keep dry-run deterministic by attaching materialization evidence instead of treating empty queue as a hard failure
- let apply-mode supervisor continue to the next cycle after successful backlog materialization

## Scope
- Initiative docs:
  - `docs/initiatives/unified-personal-agent-platform/40-quality/uap-automation-operations-summary.quality.md`
- Workbench docs:
  - none
- `planningops/` scripts/contracts:
  - `planningops/scripts/autonomous_supervisor_loop.py`
  - `planningops/contracts/autonomous-supervisor-loop-contract.md`
  - `planningops/scripts/test_autonomous_supervisor_loop_contract.sh`
  - `planningops/README.md`
- `.github/` workflows:
  - none

## Linked Issues
- Closes #283
- Related #281

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`
  - `python3 -m py_compile planningops/scripts/autonomous_supervisor_loop.py planningops/scripts/core/backlog/materialize.py planningops/scripts/backfill_issue_labels.py`
  - `git diff --check`

## Risks
- Risk:
  - apply-mode supervisor can now mutate backlog state indirectly through materialization, so callers must provide the intended execution contract file explicitly
- Rollback:
  - revert this PR to restore operator-only replanning behavior

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
