### PR TITLE
feat(planningops): guard materialization against exhausted contracts

### DIFF
--- a/docs/initiatives/unified-personal-agent-platform/40-quality/uap-automation-operations-summary.quality.md
+++ b/docs/initiatives/unified-personal-agent-platform/40-quality/uap-automation-operations-summary.quality.md
@@ -88,6 +88,7 @@ The earlier local-only behavior was not caused by git permissions.
 4. If all repos are clean and no open issue is ready, regenerate or re-triage backlog from `planningops` instead of inventing repo-local work.
    - canonical command: `python3 planningops/scripts/core/backlog/materialize.py --contract-file <execution-contract.json>`
    - dry-run expectation: the command must project local issues first, then run label backfill / manifest / issue-quality against that projected issue set instead of depending on pre-existing live GitHub issues
+   - apply expectation: the command must fail preflight when the selected execution contract only matches closed historical issues unless reopen is explicitly enabled
 5. Supervisor runs may opt into automatic backlog regeneration on replanning paths.
    - canonical command: `python3 planningops/scripts/autonomous_supervisor_loop.py --mode apply --auto-materialize-backlog --backlog-materialization-contract-file <execution-contract.json>`
    - dry-run expectation: materialization reports should be attached to the supervisor cycle and surfaced as review guidance rather than being treated as a quality failure

--- a/planningops/contracts/backlog-materialization-contract.md
+++ b/planningops/contracts/backlog-materialization-contract.md
@@ -19,6 +19,7 @@ Provide one recurring control-plane command that materializes executable backlog
 - Dry-run mode must not require pre-existing live GitHub issues for the selected plan.
 - Apply mode may use live GitHub issues, but only through the existing helper scripts.
 - Apply mode must pass through issue creation/reopen behavior only via existing helper scripts.
+- Apply mode must preflight exact closed matches and fail before creating duplicate issues from an exhausted execution contract unless `--allow-reopen-closed` is explicit.
 - The runner must emit a deterministic JSON report under `planningops/artifacts/backlog/`.
 - Dry-run mode must emit a projected issues artifact under `planningops/artifacts/backlog/`.
 

--- a/planningops/scripts/compile_plan_to_backlog.py
+++ b/planningops/scripts/compile_plan_to_backlog.py
@@ -515,6 +515,7 @@ def compile_item(
     project_item_issue_index,
     blueprint_defaults_doc=None,
     execution_order_issue_index=None,
+    detect_closed_matches=False,
 ):
     desired_title = f"plan: [{item['execution_order']}] {item['title']}"
     desired_body = issue_body(
@@ -528,19 +529,24 @@ def compile_item(
     issue, dedup_strategy = find_issue_for_item(open_issues, plan_id, item["plan_item_id"], item["target_repo"])
     reused_closed_issue = False
     reopened_closed_issue = False
+    closed_match_detected = False
+    closed_match_issue_number = None
     dedup_match_state = "open" if issue else None
 
-    if issue is None and allow_reopen_closed:
+    if issue is None and (detect_closed_matches or allow_reopen_closed):
         closed_issue, dedup_strategy = find_issue_for_item(closed_issues, plan_id, item["plan_item_id"], item["target_repo"])
         if closed_issue:
-            issue = dict(closed_issue)
-            reused_closed_issue = True
-            dedup_match_state = "closed"
-            if apply_mode:
-                reopen_issue(CONTROL_REPO, issue["number"])
-                reopened_closed_issue = True
-                issue["state"] = "open"
-            open_issues.append(issue)
+            closed_match_detected = True
+            closed_match_issue_number = int(closed_issue["number"])
+            if allow_reopen_closed:
+                issue = dict(closed_issue)
+                reused_closed_issue = True
+                dedup_match_state = "closed"
+                if apply_mode:
+                    reopen_issue(CONTROL_REPO, issue["number"])
+                    reopened_closed_issue = True
+                    issue["state"] = "open"
+                open_issues.append(issue)
 
     created = False
     if issue:
@@ -588,6 +594,8 @@ def compile_item(
         "dedup_strategy": dedup_strategy,
         "reused_closed_issue": reused_closed_issue,
         "reopened_closed_issue": reopened_closed_issue,
+        "closed_match_detected": closed_match_detected,
+        "closed_match_issue_number": closed_match_issue_number,
         "metadata_sync_required": metadata_sync_required,
         "metadata_sync_action": metadata_sync_action,
         "field_updates": [],
@@ -648,6 +656,11 @@ def main():
     )
     parser.add_argument("--apply", action="store_true", help="Apply GitHub mutations (default dry-run)")
     parser.add_argument("--allow-reopen-closed", action="store_true", help="Allow closed dedup matches and reopen in apply mode")
+    parser.add_argument(
+        "--detect-closed-match",
+        action="store_true",
+        help="Scan closed issues and report exact matches even when reopen is disabled",
+    )
     parser.add_argument("--output", default="planningops/artifacts/validation/plan-compile-report.json", help="Output report path")
     args = parser.parse_args()
 
@@ -672,7 +685,7 @@ def main():
     project = load_project_config(Path(args.config))
     blueprint_defaults_doc = load_blueprint_defaults(Path(args.blueprint_defaults_config))
     open_issues = list_existing_issues(CONTROL_REPO, "open")
-    closed_issues = list_existing_issues(CONTROL_REPO, "closed") if args.allow_reopen_closed else []
+    closed_issues = list_existing_issues(CONTROL_REPO, "closed") if (args.allow_reopen_closed or args.detect_closed_match) else []
     project_item_issue_index = {}
     execution_order_issue_index = {}
 
@@ -703,6 +716,7 @@ def main():
                     project_item_issue_index,
                     blueprint_defaults_doc,
                     execution_order_issue_index,
+                    detect_closed_matches=(args.detect_closed_match or args.allow_reopen_closed),
                 )
             )
     except Exception as exc:

--- a/planningops/scripts/core/backlog/materialize.py
+++ b/planningops/scripts/core/backlog/materialize.py
@@ -198,6 +198,56 @@ def build_steps(args, execution_contract, projected_issues_file: str | None = No
     ]
 
 
+def collect_closed_match_violations(compile_report):
+    violations = []
+    for row in compile_report.get("results", []):
+        if not row.get("closed_match_detected"):
+            continue
+        if row.get("reused_closed_issue"):
+            continue
+        violations.append(
+            {
+                "plan_item_id": row.get("plan_item_id"),
+                "execution_order": row.get("execution_order"),
+                "closed_match_issue_number": row.get("closed_match_issue_number"),
+            }
+        )
+    return violations
+
+
+def run_apply_preflight(args, run_fn=run):
+    preflight_cmd = [
+        "python3",
+        "planningops/scripts/compile_plan_to_backlog.py",
+        "--contract-file",
+        args.contract_file,
+        "--config",
+        args.compile_config,
+        "--blueprint-defaults-config",
+        args.blueprint_defaults_config,
+        "--output",
+        args.compile_output,
+        "--detect-closed-match",
+    ]
+    if args.allow_reopen_closed:
+        preflight_cmd.append("--allow-reopen-closed")
+
+    rc, out, err = run_fn(preflight_cmd)
+    compile_report = {}
+    compile_output_path = Path(args.compile_output)
+    if compile_output_path.exists():
+        compile_report = json.loads(compile_output_path.read_text(encoding="utf-8"))
+    violations = collect_closed_match_violations(compile_report if isinstance(compile_report, dict) else {})
+    return {
+        "command": preflight_cmd,
+        "rc": rc,
+        "stdout": out[-2000:],
+        "stderr": err[-2000:],
+        "compile_report": compile_report if isinstance(compile_report, dict) else {},
+        "closed_match_violations": violations,
+    }
+
+
 def execute_steps(steps, run_fn=run):
     results = []
     verdict = "pass"
@@ -276,6 +326,22 @@ def main():
             projected_issues_file = str(projected_issues_path)
             report["projected_issues_output"] = projected_issues_file
             report["projected_issue_count"] = len(projected_issues)
+        else:
+            preflight = run_apply_preflight(args)
+            report["apply_preflight"] = {
+                "command": preflight["command"],
+                "rc": preflight["rc"],
+                "stdout": preflight["stdout"],
+                "stderr": preflight["stderr"],
+                "closed_match_violation_count": len(preflight["closed_match_violations"]),
+                "closed_match_violations": preflight["closed_match_violations"],
+            }
+            if preflight["rc"] != 0:
+                raise RuntimeError("apply preflight failed before backlog materialization")
+            if preflight["closed_match_violations"]:
+                raise RuntimeError(
+                    "closed match detected for exhausted execution contract; rerun with --allow-reopen-closed or choose a new contract"
+                )
         steps = build_steps(args, execution_contract, projected_issues_file=projected_issues_file)
         report["step_count"] = len(steps)
         report["steps"], report["verdict"] = execute_steps(steps)

--- a/planningops/scripts/test_backlog_materialization_contract.sh
+++ b/planningops/scripts/test_backlog_materialization_contract.sh
@@ -117,5 +117,53 @@ with tempfile.TemporaryDirectory() as td:
     assert results[1]["name"] == "backfill_issue_labels", results
     assert results[1]["stderr"] == "label-backfill-failed", results[1]
 
+    violations = mod.collect_closed_match_violations(
+        {
+            "results": [
+                {
+                    "plan_item_id": "A60",
+                    "execution_order": 60,
+                    "closed_match_detected": True,
+                    "closed_match_issue_number": 901,
+                    "reused_closed_issue": False,
+                }
+            ]
+        }
+    )
+    assert violations == [{"plan_item_id": "A60", "execution_order": 60, "closed_match_issue_number": 901}], violations
+
+    preflight_args = SimpleNamespace(
+        contract_file=str(contract_path),
+        compile_config="planningops/config/project-field-ids.json",
+        blueprint_defaults_config="planningops/config/ready-implementation-blueprint-defaults.json",
+        compile_output=str(td_path / "compile-preflight.json"),
+        allow_reopen_closed=False,
+    )
+
+    def fake_preflight_run(cmd):
+        Path(preflight_args.compile_output).write_text(
+            json.dumps(
+                {
+                    "results": [
+                        {
+                            "plan_item_id": "A60",
+                            "execution_order": 60,
+                            "closed_match_detected": True,
+                            "closed_match_issue_number": 901,
+                            "reused_closed_issue": False,
+                        }
+                    ]
+                },
+                ensure_ascii=True,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        return 0, "ok", ""
+
+    preflight = mod.run_apply_preflight(preflight_args, run_fn=fake_preflight_run)
+    assert preflight["rc"] == 0, preflight
+    assert preflight["closed_match_violations"] == violations, preflight
+
 print("backlog materialization contract ok")
 PY

--- a/planningops/scripts/test_compile_plan_to_backlog_contract.sh
+++ b/planningops/scripts/test_compile_plan_to_backlog_contract.sh
@@ -267,6 +267,23 @@ default_dry = mod.compile_item(
 assert default_dry["created_issue"] is True, default_dry
 assert default_dry["reused_closed_issue"] is False, default_dry
 
+detect_dry = mod.compile_item(
+    project={},
+    source_of_truth=fixture_doc["execution_contract"]["source_of_truth"],
+    plan_id=fixture_doc["execution_contract"]["plan_id"],
+    plan_revision=fixture_doc["execution_contract"]["plan_revision"],
+    item=item,
+    apply_mode=False,
+    open_issues=[],
+    closed_issues=[closed_issue],
+    allow_reopen_closed=False,
+    detect_closed_matches=True,
+    project_item_issue_index={},
+)
+assert detect_dry["created_issue"] is True, detect_dry
+assert detect_dry["closed_match_detected"] is True, detect_dry
+assert detect_dry["closed_match_issue_number"] == 901, detect_dry
+
 allow_dry = mod.compile_item(
     project={},
     source_of_truth=fixture_doc["execution_contract"]["source_of_truth"],


### PR DESCRIPTION
## Summary
- detect exact closed issue matches during materialization apply preflight
- block apply-mode backlog materialization from recreating already-consumed execution contracts
- keep reopen behavior explicit through `--allow-reopen-closed`

## Scope
- Initiative docs:
  - `docs/initiatives/unified-personal-agent-platform/40-quality/uap-automation-operations-summary.quality.md`
- Workbench docs:
  - none
- `planningops/` scripts/contracts:
  - `planningops/scripts/compile_plan_to_backlog.py`
  - `planningops/scripts/core/backlog/materialize.py`
  - `planningops/contracts/backlog-materialization-contract.md`
  - `planningops/scripts/test_compile_plan_to_backlog_contract.sh`
  - `planningops/scripts/test_backlog_materialization_contract.sh`
- `.github/` workflows:
  - none

## Linked Issues
- Closes #285
- Related #281
- Related #283

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_compile_plan_to_backlog_contract.sh`
  - `bash planningops/scripts/test_backlog_materialization_contract.sh`
  - `python3 -m py_compile planningops/scripts/compile_plan_to_backlog.py planningops/scripts/core/backlog/materialize.py`
  - `git diff --check`

## Risks
- Risk:
  - apply-mode materialization now fails faster on exact closed matches, so callers replaying historical contracts must opt into reopen explicitly
- Rollback:
  - revert this PR to restore previous apply behavior

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
