### PR TITLE
fix(planningops): align goal-driven pack workflow states

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-completion-notifier-wave1-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-completion-notifier-wave1-issue-pack.md
@@ -41,7 +41,7 @@ The rule for this wave is strict:
 | --- | --- | --- | --- | --- | --- |
 | `AH10` | 10 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `packages/messaging-adapter/src/goal_completion_notifier.ts` |
 | `AH20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/send_goal_completion_notification.py` |
-| `AH30` | 30 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `docs/runbook/goal-completion-notifier.md` |
+| `AH30` | 30 | `rather-not-work-on/monday` | `runtime` | `ready_contract` | `docs/runbook/goal-completion-notifier.md` |
 | `AH40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-completion-notifier-wave1-review.json` |
 
 ## Decomposition Rules

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-completion-notifier-wave1.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-completion-notifier-wave1.execution-contract.json
@@ -36,7 +36,7 @@
         "title": "Document monday goal completion notifier runbook",
         "target_repo": "rather-not-work-on/monday",
         "component": "runtime",
-        "workflow_state": "ready_implementation",
+        "workflow_state": "ready_contract",
         "loop_profile": "l1_contract_clarification",
         "plan_lane": "m3_guardrails",
         "depends_on": [

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-13-monday-channel-adapter-wave1-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-13-monday-channel-adapter-wave1-issue-pack.md
@@ -43,7 +43,7 @@ The rule for this wave is strict:
 | `AG10` | 10 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `packages/contract-bindings/src/operator_channels.ts` |
 | `AG20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `packages/messaging-adapter/src/operator_channel_adapter.ts` |
 | `AG30` | 30 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/send_operator_message.py` |
-| `AG40` | 40 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `docs/runbook/operator-channel-adapter.md` |
+| `AG40` | 40 | `rather-not-work-on/monday` | `runtime` | `ready_contract` | `docs/runbook/operator-channel-adapter.md` |
 | `AG50` | 50 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/monday-channel-adapter-wave1-review.json` |
 
 ## Decomposition Rules

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-13-monday-channel-adapter-wave1.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-13-monday-channel-adapter-wave1.execution-contract.json
@@ -50,7 +50,7 @@
         "title": "Document monday operator channel runbook and skill boundary",
         "target_repo": "rather-not-work-on/monday",
         "component": "runtime",
-        "workflow_state": "ready_implementation",
+        "workflow_state": "ready_contract",
         "loop_profile": "l1_contract_clarification",
         "plan_lane": "m3_guardrails",
         "depends_on": [


### PR DESCRIPTION
## Summary
- fix the monday channel adapter and goal completion notifier subpack contracts so `ready_contract` items use `l1_contract_clarification`
- keep the workbench tables and execution-contract JSONs in sync so PEC compilation and future issue projection both succeed

## Scope
- Initiative docs:
  - none
- Workbench docs:
  - docs/workbench/unified-personal-agent-platform/plans/2026-03-13-monday-channel-adapter-wave1-issue-pack.md
  - docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-completion-notifier-wave1-issue-pack.md
- `planningops/` scripts/contracts:
  - docs/workbench/unified-personal-agent-platform/plans/2026-03-13-monday-channel-adapter-wave1.execution-contract.json
  - docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-completion-notifier-wave1.execution-contract.json
- `.github/` workflows:
  - none

## Linked Issues
- Closes #289
- Related #287

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-13-monday-channel-adapter-wave1.execution-contract.json --output /tmp/monday-channel-adapter-wave1-report.json`
  - `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-completion-notifier-wave1.execution-contract.json --output /tmp/goal-completion-notifier-wave1-report.json`
  - `git diff --check`

## Risks
- Risk:
  - low; only workflow-state metadata changes, but incorrect metadata previously blocked backlog generation entirely
- Rollback:
  - revert commit `f62aa1f`

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
