### PR TITLE
feat(planningops): add goal lifecycle transition contract

### DIFF
--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -19,6 +19,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `autonomous-supervisor-loop-contract.md`: multi-cycle plan-work-review-replan orchestration contract
 - `goal-brief-contract.md`: outcome-level objective brief required before a goal becomes active
 - `active-goal-registry-contract.md`: canonical active goal pointer and execution-contract resolution rules
+- `goal-lifecycle-transition-contract.md`: allowed active-goal state transitions and promotion rules
 - `goal-completion-contract.md`: machine-checkable achieved-state and terminal notification policy
 - `operator-channel-adapter-contract.md`: monday-owned Slack/email channel adapter boundary and evidence rules
 - `supervisor-experiment-auto-executor-contract.md`: trigger-to-worktree comparative execution and decision contract

--- a/planningops/contracts/active-goal-registry-contract.md
+++ b/planningops/contracts/active-goal-registry-contract.md
@@ -39,6 +39,7 @@ Provide one canonical machine-readable pointer to the current active goal so aut
 ## Usage Rules
 - Supervisor/materialization automation must prefer the active goal registry over hard-coded contract paths when both are available.
 - If the registry has no active goal, automation must stop with a review-required outcome instead of inventing a goal.
+- Registry state changes must follow `planningops/contracts/goal-lifecycle-transition-contract.md`.
 
 ## Validation
 - `planningops/scripts/validate_active_goal_registry.py`

--- a/planningops/contracts/goal-completion-contract.md
+++ b/planningops/contracts/goal-completion-contract.md
@@ -15,6 +15,7 @@ Define when an active goal is complete enough to stop autonomous execution and e
   - required verification artifacts report `verdict=pass`,
   - the operator channel has received a completion summary,
   - terminal notification has been recorded once.
+- The `active -> achieved` state change must be validated under `planningops/contracts/goal-lifecycle-transition-contract.md`.
 
 ## Notification Rules
 - Terminal notification is required only on transition to `achieved`.

--- a/planningops/contracts/goal-lifecycle-transition-contract.md
+++ b/planningops/contracts/goal-lifecycle-transition-contract.md
@@ -1,0 +1,69 @@
+# Goal Lifecycle Transition Contract
+
+## Purpose
+Define the only allowed state transitions for the active goal registry so automation can promote the next goal without reusing stale backlog or inventing ad hoc goal state.
+
+## Canonical Boundary
+- registry file: `planningops/config/active-goal-registry.json`
+- resolver: `planningops/scripts/core/goals/resolve_active_goal.py`
+- follow-up mutator: `planningops/scripts/core/goals/transition_goal_state.py`
+
+## Allowed Goal States
+- `draft`
+- `active`
+- `blocked`
+- `achieved`
+- `archived`
+
+## Allowed Transitions
+- `draft -> active`
+- `draft -> archived`
+- `active -> blocked`
+- `active -> achieved`
+- `blocked -> active`
+- `blocked -> archived`
+- `achieved -> archived`
+
+Transitions outside this list are invalid and must fail closed.
+
+## Transition Preconditions
+- Exactly one goal may be `active` after the transition completes.
+- `active_goal_key` must always match the unique active goal.
+- `active -> achieved` requires completion evidence that satisfies `planningops/contracts/goal-completion-contract.md`.
+- `active -> blocked` requires a concrete blocker reason and evidence reference.
+- `achieved -> archived` requires the goal to keep its completion references and execution contract path for audit lookup.
+- `draft -> active` or `blocked -> active` requires every referenced file in the goal entry to exist.
+
+## Promotion Rules
+- When an `active` goal transitions to `achieved`, automation may promote the next goal only if a single candidate is explicitly selected.
+- Promotion must never reopen or reuse issues belonging to an `achieved` goal.
+- If no next goal is available, automation must stop with a compact completion summary instead of falling back to stale contract materialization.
+
+## Evidence Rules
+- Every transition attempt must emit:
+  - `goal_key`
+  - `from_status`
+  - `to_status`
+  - `transition_reason`
+  - `transition_timestamp_utc`
+  - `evidence_refs`
+  - `verdict`
+- Transition evidence must be deterministic for the same input registry and requested transition.
+
+## Ownership Boundary
+- PlanningOps owns:
+  - lifecycle policy
+  - state transition validation
+  - registry mutation evidence
+- Monday owns:
+  - operator-facing notifications that may result from an `achieved` transition
+
+## Failure Rules
+- Invalid transitions must not mutate the registry.
+- Transition validation failure must return a blocked review outcome, not silent fallback.
+- Supervisor logic must treat an exhausted active goal without a promoted successor as `replan_required`, not `quality_gate_fail`.
+
+## Validation Targets
+- `planningops/scripts/validate_active_goal_registry.py`
+- `planningops/scripts/core/goals/resolve_active_goal.py`
+- `planningops/scripts/core/goals/transition_goal_state.py` (follow-up)

--- a/planningops/scripts/test_active_goal_registry_contract.sh
+++ b/planningops/scripts/test_active_goal_registry_contract.sh
@@ -16,7 +16,7 @@ python3 planningops/scripts/validate_active_goal_registry.py \
   --strict >/dev/null
 
 resolved_contract="$(python3 planningops/scripts/core/goals/resolve_active_goal.py --registry "$valid_registry" --field execution_contract_file)"
-[ "$resolved_contract" = "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave1.execution-contract.json" ]
+[ "$resolved_contract" = "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2.execution-contract.json" ]
 
 cat >"$invalid_registry" <<'JSON'
 {


### PR DESCRIPTION
## Summary
- add a canonical goal lifecycle transition contract so the active-goal registry has one explicit state machine
- link active-goal and goal-completion contracts to the new transition policy
- align the active goal registry contract test with the current wave2 registry truth

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts:
  - add `planningops/contracts/goal-lifecycle-transition-contract.md`
  - update contract index and cross-references
  - update `test_active_goal_registry_contract.sh`
- `.github/` workflows:
  - none

## Linked Issues
- Closes #301
- Related #302

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_active_goal_registry_contract.sh`
  - `python3 planningops/scripts/validate_active_goal_registry.py --strict`
  - `git diff --check`

## Risks
- Risk:
  - this PR freezes transition semantics before the mutator script exists, so follow-up implementation must honor the same state graph
- Rollback:
  - revert this PR to remove the transition contract and restore the previous implicit lifecycle rules

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [ ] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
