### PR TITLE
feat(planningops): wire supervisor goal promotion path

### DIFF
--- a/planningops/contracts/active-goal-registry-contract.md
+++ b/planningops/contracts/active-goal-registry-contract.md
@@ -19,12 +19,15 @@ Provide one canonical machine-readable pointer to the current active goal so aut
 - `goal_brief_ref`
 - `execution_contract_file`
 - `completion_contract_refs`
+- `next_goal_key` (optional)
 - `operator_channels`
 
 ## Status Rules
 - Allowed statuses: `draft`, `active`, `blocked`, `achieved`, `archived`
-- Exactly one goal may be `active`
-- `active_goal_key` must match the unique `active` goal
+- At most one goal may be `active`
+- If one goal is active, `active_goal_key` must match that goal
+- If no goal is active, `active_goal_key` must be the empty string
+- `next_goal_key`, when present, must reference a different non-terminal goal entry
 
 ## Reference Rules
 - `goal_brief_ref` must resolve to an existing repo-relative file
@@ -40,6 +43,7 @@ Provide one canonical machine-readable pointer to the current active goal so aut
 - Supervisor/materialization automation must prefer the active goal registry over hard-coded contract paths when both are available.
 - If the registry has no active goal, automation must stop with a review-required outcome instead of inventing a goal.
 - Registry state changes must follow `planningops/contracts/goal-lifecycle-transition-contract.md`.
+- An achieved goal may keep `next_goal_key` as historical evidence of which successor was promoted next.
 
 ## Validation
 - `planningops/scripts/validate_active_goal_registry.py`

--- a/planningops/contracts/goal-lifecycle-transition-contract.md
+++ b/planningops/contracts/goal-lifecycle-transition-contract.md
@@ -27,8 +27,9 @@ Define the only allowed state transitions for the active goal registry so automa
 Transitions outside this list are invalid and must fail closed.
 
 ## Transition Preconditions
-- Exactly one goal may be `active` after the transition completes.
-- `active_goal_key` must always match the unique active goal.
+- At most one goal may be `active` after the transition completes.
+- `active_goal_key` must match the unique active goal when one exists.
+- `active_goal_key` must be empty when a transition intentionally leaves the registry without an active goal.
 - `active -> achieved` requires completion evidence that satisfies `planningops/contracts/goal-completion-contract.md`.
 - `active -> blocked` requires a concrete blocker reason and evidence reference.
 - `achieved -> archived` requires the goal to keep its completion references and execution contract path for audit lookup.
@@ -38,6 +39,7 @@ Transitions outside this list are invalid and must fail closed.
 - When an `active` goal transitions to `achieved`, automation may promote the next goal only if a single candidate is explicitly selected.
 - Promotion must never reopen or reuse issues belonging to an `achieved` goal.
 - If no next goal is available, automation must stop with a compact completion summary instead of falling back to stale contract materialization.
+- `active -> achieved` without a successor is allowed only when automation intentionally hands control back to operator channels for the next goal brief.
 
 ## Evidence Rules
 - Every transition attempt must emit:
@@ -61,7 +63,8 @@ Transitions outside this list are invalid and must fail closed.
 ## Failure Rules
 - Invalid transitions must not mutate the registry.
 - Transition validation failure must return a blocked review outcome, not silent fallback.
-- Supervisor logic must treat an exhausted active goal without a promoted successor as `replan_required`, not `quality_gate_fail`.
+- Supervisor logic must attempt goal transition before closed-issue replanning when the active goal is exhausted.
+- Supervisor logic must treat an exhausted active goal without a promoted successor as goal completion or `replan_required`, never `quality_gate_fail`.
 
 ## Validation Targets
 - `planningops/scripts/validate_active_goal_registry.py`

--- a/planningops/schemas/active-goal-registry.schema.json
+++ b/planningops/schemas/active-goal-registry.schema.json
@@ -15,8 +15,7 @@
       "const": 1
     },
     "active_goal_key": {
-      "type": "string",
-      "minLength": 1
+      "type": "string"
     },
     "goals": {
       "type": "array",
@@ -72,6 +71,10 @@
               "type": "string",
               "minLength": 1
             }
+          },
+          "next_goal_key": {
+            "type": "string",
+            "minLength": 1
           },
           "operator_channels": {
             "type": "object",

--- a/planningops/scripts/autonomous_supervisor_loop.py
+++ b/planningops/scripts/autonomous_supervisor_loop.py
@@ -20,6 +20,12 @@ from resolve_active_goal import build_resolved_payload, load_json as load_goal_j
 
 
 ARTIFACT_SINK = ArtifactSink(local_cache_external=True)
+GOAL_EXHAUSTION_REASON_CODES = {
+    "no_eligible_todo_issue",
+    "no_candidate_project_items",
+    "closed_issue_project_drift",
+    "inventory_only_candidates_only",
+}
 
 
 def now_utc():
@@ -43,9 +49,9 @@ def save_json(path: Path, data):
 
 
 def resolve_materialization_contract_from_goal(args):
-    if args.backlog_materialization_contract_file:
-        return args.backlog_materialization_contract_file, None
     if not args.active_goal_registry:
+        if args.backlog_materialization_contract_file:
+            return args.backlog_materialization_contract_file, None
         return None, None
 
     repo_root = Path(__file__).resolve().parents[2]
@@ -54,8 +60,54 @@ def resolve_materialization_contract_from_goal(args):
     errors = validate_registry(doc, repo_root=repo_root)
     if errors:
         raise RuntimeError(f"active goal registry invalid: {errors}")
-    goal = build_resolved_payload(resolve_active_goal(doc, goal_key=args.active_goal_key))
+    try:
+        goal = build_resolved_payload(resolve_active_goal(doc, goal_key=args.active_goal_key))
+    except RuntimeError as exc:
+        if "no active goal configured" in str(exc):
+            if args.backlog_materialization_contract_file:
+                return args.backlog_materialization_contract_file, None
+            return None, None
+        raise
     return str(goal["execution_contract_file"]), goal
+
+
+def run_goal_transition(args, cycle_dir: Path, active_goal: dict, evidence_refs: list[str]):
+    report_path = cycle_dir / "goal-transition-report.json"
+    next_goal_key = str(active_goal.get("next_goal_key") or "").strip() or None
+    cmd = [
+        sys.executable,
+        "planningops/scripts/core/goals/transition_goal_state.py",
+        "--registry",
+        args.active_goal_registry,
+        "--goal-key",
+        str(active_goal.get("goal_key")),
+        "--to-status",
+        "achieved",
+        "--reason",
+        "supervisor_detected_goal_exhaustion",
+        "--mode",
+        args.mode,
+        "--output",
+        str(report_path),
+    ]
+    if next_goal_key:
+        cmd.extend(["--activate-next-goal-key", next_goal_key])
+    for evidence_ref in evidence_refs:
+        if evidence_ref:
+            cmd.extend(["--evidence-ref", evidence_ref])
+
+    rc, out, err = run(cmd)
+    report = load_json(report_path, {})
+    return {
+        "enabled": True,
+        "rc": rc,
+        "command": cmd,
+        "stdout": out[-2000:],
+        "stderr": err[-2000:],
+        "output_path": str(report_path),
+        "report": report if isinstance(report, dict) else {},
+        "next_goal_key": next_goal_key,
+    }
 
 
 def parse_json_doc(raw: str):
@@ -232,6 +284,74 @@ def build_operator_report(summary: dict, summary_path: Path, run_dir: Path):
                 "status": "review_required",
                 "headline": "Supervisor stopped because backlog selection requires replanning.",
                 "operator_action": "regenerate_backlog_or_reconcile_project",
+            }
+        )
+        return report
+
+    if stop_reason == "goal_promotion_ready":
+        transition = stop_details.get("goal_transition") or {}
+        report.update(
+            {
+                "status": "review_required",
+                "headline": "Supervisor found a promotable successor goal.",
+                "operator_action": "review_goal_promotion",
+                "reason": "Active goal is exhausted and the next goal can be promoted deterministically.",
+                "guidance": {
+                    **(report.get("guidance") or {}),
+                    "goal_transition_report_path": transition.get("output_path"),
+                    "next_goal_key": transition.get("next_goal_key"),
+                },
+            }
+        )
+        return report
+
+    if stop_reason == "goal_completion_ready":
+        transition = stop_details.get("goal_transition") or {}
+        report.update(
+            {
+                "status": "review_required",
+                "headline": "Supervisor found an active goal ready for terminal completion.",
+                "operator_action": "review_goal_completion",
+                "reason": "Active goal is exhausted and no successor goal is currently registered.",
+                "guidance": {
+                    **(report.get("guidance") or {}),
+                    "goal_transition_report_path": transition.get("output_path"),
+                    "completed_goal_key": transition.get("goal_key"),
+                },
+            }
+        )
+        return report
+
+    if stop_reason == "goal_completed":
+        transition = stop_details.get("goal_transition") or {}
+        report.update(
+            {
+                "status": "ok",
+                "headline": "Supervisor completed the active goal and stopped cleanly.",
+                "operator_action": "notify_goal_completion",
+                "needs_human_attention": False,
+                "reason": "No successor goal is registered; emit terminal notification and wait for the next goal brief.",
+                "guidance": {
+                    **(report.get("guidance") or {}),
+                    "goal_transition_report_path": transition.get("output_path"),
+                    "completed_goal_key": transition.get("goal_key"),
+                },
+            }
+        )
+        return report
+
+    if stop_reason == "goal_transition_failed":
+        transition = stop_details.get("goal_transition") or {}
+        report.update(
+            {
+                "status": "blocked",
+                "headline": "Supervisor failed while transitioning the active goal.",
+                "operator_action": "inspect_goal_transition_failure",
+                "reason": transition.get("stderr") or "Goal transition failed.",
+                "guidance": {
+                    **(report.get("guidance") or {}),
+                    "goal_transition_report_path": transition.get("output_path"),
+                },
             }
         )
         return report
@@ -556,7 +676,7 @@ def main():
         except Exception as exc:  # noqa: BLE001
             print(str(exc))
             return 1
-        if not resolved_contract_file:
+        if not resolved_contract_file and resolved_active_goal is not None:
             print("backlog-materialization-contract-file or active-goal-registry is required when auto-materialize-backlog is enabled")
             return 1
         args.backlog_materialization_contract_file = resolved_contract_file
@@ -601,6 +721,7 @@ def main():
         experiment_trigger_artifact = None
         experiment_executor = {"enabled": False}
         backlog_materialization = {"enabled": False}
+        goal_transition = {"enabled": False}
         if experiment["triggered"]:
             experiment_trigger_artifact = cycle_dir / "experiment-trigger.json"
             save_json(
@@ -660,6 +781,14 @@ def main():
                 "projected_issues_output": None,
                 "verdict": None,
             },
+            "goal_transition": {
+                "enabled": False,
+                "rc": None,
+                "output_path": None,
+                "verdict": None,
+                "goal_key": None,
+                "next_goal_key": None,
+            },
             "project_items_source": project_items_source,
             "project_items_rate_limit_fallback_used": project_items_rate_limit_fallback_used,
             "project_items_rate_limit_error": project_items_rate_limit_error,
@@ -694,6 +823,88 @@ def main():
         if auto_paused:
             stop_reason = "escalation_auto_pause"
             stop_details = {"cycle": cycle_index, "reason_code": reason_code}
+            break
+        if (
+            verdict == "inconclusive"
+            and reason_code in GOAL_EXHAUSTION_REASON_CODES
+            and resolved_active_goal
+            and int(cycle_record["replenishment_candidates_count"]) == 0
+        ):
+            goal_transition = run_goal_transition(
+                args,
+                cycle_dir,
+                resolved_active_goal,
+                [
+                    "planningops/artifacts/loop-runner/last-run.json",
+                    cycle_record["backlog_gate"]["report_path"],
+                ],
+            )
+            cycle_record["goal_transition"] = {
+                "enabled": True,
+                "rc": goal_transition.get("rc"),
+                "output_path": goal_transition.get("output_path"),
+                "verdict": (goal_transition.get("report") or {}).get("verdict"),
+                "goal_key": (goal_transition.get("report") or {}).get("goal_key"),
+                "next_goal_key": goal_transition.get("next_goal_key"),
+            }
+            save_json(cycle_dir / "cycle-report.json", cycle_record)
+            if int(goal_transition.get("rc", 1)) != 0:
+                stop_reason = "goal_transition_failed"
+                stop_details = {
+                    "cycle": cycle_index,
+                    "reason_code": reason_code,
+                    "goal_transition": cycle_record["goal_transition"],
+                }
+                break
+            if goal_transition.get("next_goal_key"):
+                if args.mode == "apply":
+                    args.active_goal_key = goal_transition.get("next_goal_key")
+                    if args.auto_materialize_backlog:
+                        resolved_contract_file, resolved_active_goal = resolve_materialization_contract_from_goal(args)
+                        args.backlog_materialization_contract_file = resolved_contract_file
+                        backlog_materialization = run_backlog_materializer(args, cycle_dir)
+                        cycle_record["backlog_materialization"] = {
+                            "enabled": bool(backlog_materialization.get("enabled")),
+                            "rc": backlog_materialization.get("rc"),
+                            "output_path": backlog_materialization.get("output_path"),
+                            "projected_issues_output": backlog_materialization.get("projected_issues_output"),
+                            "verdict": (backlog_materialization.get("report") or {}).get("verdict"),
+                        }
+                        save_json(cycle_dir / "cycle-report.json", cycle_record)
+                        if backlog_materialization.get("enabled") and int(backlog_materialization.get("rc", 1)) != 0:
+                            stop_reason = "replan_materialization_failed"
+                            stop_details = {
+                                "cycle": cycle_index,
+                                "reason_code": reason_code,
+                                "backlog_materialization": cycle_record["backlog_materialization"],
+                                "goal_transition": cycle_record["goal_transition"],
+                            }
+                            break
+                    pass_streak = 0
+                    continue
+                stop_reason = "goal_promotion_ready"
+                stop_details = {
+                    "cycle": cycle_index,
+                    "reason_code": reason_code,
+                    "goal_transition": cycle_record["goal_transition"],
+                }
+                break
+            if args.mode == "apply":
+                resolved_active_goal = None
+                args.active_goal_key = None
+                stop_reason = "goal_completed"
+                stop_details = {
+                    "cycle": cycle_index,
+                    "reason_code": reason_code,
+                    "goal_transition": cycle_record["goal_transition"],
+                }
+                break
+            stop_reason = "goal_completion_ready"
+            stop_details = {
+                "cycle": cycle_index,
+                "reason_code": reason_code,
+                "goal_transition": cycle_record["goal_transition"],
+            }
             break
         if verdict == "inconclusive" and reason_code in {
             "no_eligible_todo_issue",
@@ -769,9 +980,17 @@ def main():
         "experiment_auto_executor_failed",
         "github_rate_limited",
         "replan_materialization_failed",
+        "goal_transition_failed",
     }:
         supervisor_verdict = "fail"
-    elif stop_reason in {"experiment_triggered", "sequence_exhausted", "replan_required", "max_cycles_reached"}:
+    elif stop_reason in {
+        "experiment_triggered",
+        "sequence_exhausted",
+        "replan_required",
+        "max_cycles_reached",
+        "goal_promotion_ready",
+        "goal_completion_ready",
+    }:
         supervisor_verdict = "inconclusive"
 
     summary = {
@@ -793,6 +1012,7 @@ def main():
             "backlog_replenishment": "planningops/contracts/backlog-stock-replenishment-contract.md",
             "backlog_materialization": "planningops/contracts/backlog-materialization-contract.md",
             "active_goal_registry": "planningops/contracts/active-goal-registry-contract.md",
+            "goal_lifecycle_transition": "planningops/contracts/goal-lifecycle-transition-contract.md",
             "goal_completion": "planningops/contracts/goal-completion-contract.md",
             "operator_channel_adapter": "planningops/contracts/operator-channel-adapter-contract.md",
         },

--- a/planningops/scripts/core/goals/resolve_active_goal.py
+++ b/planningops/scripts/core/goals/resolve_active_goal.py
@@ -31,6 +31,8 @@ def validate_registry(doc, repo_root: Path):
     active_goal_key = str(doc.get("active_goal_key") or "").strip()
     goal_keys = set()
     active_goals = []
+    goal_statuses = {}
+    deferred_successors = []
     for index, goal in enumerate(goals):
         path = f"goals[{index}]"
         if not isinstance(goal, dict):
@@ -60,6 +62,11 @@ def validate_registry(doc, repo_root: Path):
             errors.append(f"{path}.status invalid: {status}")
         if status == "active":
             active_goals.append(goal_key)
+        if goal_key:
+            goal_statuses[goal_key] = status
+        next_goal_key = str(goal.get("next_goal_key") or "").strip()
+        if next_goal_key:
+            deferred_successors.append((path, goal_key, next_goal_key))
         for ref_key in ["goal_brief_ref", "execution_contract_file"]:
             ref = str(goal.get(ref_key) or "").strip()
             if ref and not (repo_root / ref).exists():
@@ -97,18 +104,32 @@ def validate_registry(doc, repo_root: Path):
                     f"{path}.operator_channels.{channel_key}.adapter_contract_ref invalid: {adapter_contract_ref}"
                 )
 
-    if len(active_goals) != 1:
-        errors.append("exactly one active goal is required")
+    if len(active_goals) > 1:
+        errors.append("at most one active goal is allowed")
     if active_goal_key and active_goal_key not in goal_keys:
         errors.append(f"active_goal_key not found: {active_goal_key}")
     if len(active_goals) == 1 and active_goal_key != active_goals[0]:
         errors.append("active_goal_key must match the unique active goal")
+    if len(active_goals) == 0 and active_goal_key:
+        errors.append("active_goal_key must be empty when no goal is active")
+    for path, goal_key, next_goal_key in deferred_successors:
+        if next_goal_key not in goal_keys:
+            errors.append(f"{path}.next_goal_key not found: {next_goal_key}")
+            continue
+        if goal_key == next_goal_key:
+            errors.append(f"{path}.next_goal_key must differ from goal_key")
+            continue
+        next_status = goal_statuses.get(next_goal_key)
+        if next_status in {"achieved", "archived"}:
+            errors.append(f"{path}.next_goal_key not promotable: {next_goal_key}:{next_status}")
     return errors
 
 
 def resolve_active_goal(doc, goal_key: str | None = None):
     goals = doc["goals"]
     desired_key = str(goal_key or doc["active_goal_key"]).strip()
+    if not desired_key:
+        raise RuntimeError("no active goal configured")
     for goal in goals:
         if str(goal.get("goal_key") or "").strip() == desired_key:
             return goal

--- a/planningops/scripts/core/goals/transition_goal_state.py
+++ b/planningops/scripts/core/goals/transition_goal_state.py
@@ -54,6 +54,7 @@ def build_report(
         "evidence_refs": args.evidence_ref,
         "active_goal_key_before": before_doc.get("active_goal_key"),
         "active_goal_key_after": None if proposed_doc is None else proposed_doc.get("active_goal_key"),
+        "goal_transition_kind": "promotion" if args.activate_next_goal_key else "terminal_completion",
         "verdict": "pass" if not errors else "fail",
         "error_count": len(errors),
         "errors": errors,
@@ -113,7 +114,7 @@ def main() -> int:
                 errors.append(f"next_goal_not_promotable: {args.activate_next_goal_key}:{next_status}")
             if args.activate_next_goal_key == args.goal_key:
                 errors.append("activate_next_goal_key must differ from goal_key")
-        elif from_status == "active" and to_status != "active":
+        elif from_status == "active" and to_status != "active" and to_status != "achieved":
             errors.append("activate_next_goal_key required when transitioning the current active goal away from active")
 
         if from_status != "active" and to_status in {"blocked", "achieved"}:

--- a/planningops/scripts/test_active_goal_registry_contract.sh
+++ b/planningops/scripts/test_active_goal_registry_contract.sh
@@ -78,4 +78,76 @@ if python3 planningops/scripts/validate_active_goal_registry.py --registry "$inv
   exit 1
 fi
 
+cat >"$valid_registry" <<'JSON'
+{
+  "registry_version": 1,
+  "active_goal_key": "",
+  "goals": [
+    {
+      "goal_key": "goal-a",
+      "title": "Goal A",
+      "status": "achieved",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave1-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave1.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md"
+      ],
+      "next_goal_key": "goal-b",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "goal-b",
+      "title": "Goal B",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    }
+  ]
+}
+JSON
+
+python3 planningops/scripts/validate_active_goal_registry.py \
+  --registry "$valid_registry" \
+  --output "$report_path" \
+  --strict >/dev/null
+
+python3 - <<'PY' "$report_path"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "pass", report
+assert report["resolved_goal"] is None, report
+PY
+
 echo "active goal registry contract ok"

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -457,6 +457,8 @@ with tempfile.TemporaryDirectory() as td:
             "--auto-materialize-backlog",
             "--backlog-materializer-script",
             str(materialize_success),
+            "--active-goal-registry",
+            "",
             "--backlog-materialization-contract-file",
             "planningops/fixtures/plan-execution-contract-sample.json",
         ]
@@ -539,6 +541,8 @@ with tempfile.TemporaryDirectory() as td:
             "--auto-materialize-backlog",
             "--backlog-materializer-script",
             str(materialize_success),
+            "--active-goal-registry",
+            "",
             "--backlog-materialization-contract-file",
             "planningops/fixtures/plan-execution-contract-sample.json",
         ]
@@ -574,6 +578,8 @@ with tempfile.TemporaryDirectory() as td:
             "--auto-materialize-backlog",
             "--backlog-materializer-script",
             str(materialize_fail),
+            "--active-goal-registry",
+            "",
             "--backlog-materialization-contract-file",
             "planningops/fixtures/plan-execution-contract-sample.json",
         ]
@@ -619,6 +625,250 @@ with tempfile.TemporaryDirectory() as td:
     assert registry_resolved_doc["resolved_active_goal"]["execution_contract_file"].endswith(
         "2026-03-13-goal-driven-autonomy-wave2.execution-contract.json"
     ), registry_resolved_doc
+
+    goal_registry = td_path / "goal-registry.json"
+    goal_registry.write_text(
+        json.dumps(
+            {
+                "registry_version": 1,
+                "active_goal_key": "goal-a",
+                "goals": [
+                    {
+                        "goal_key": "goal-a",
+                        "title": "Goal A",
+                        "status": "active",
+                        "owner_repo": "rather-not-work-on/platform-planningops",
+                        "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave1-goal-brief.md",
+                        "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave1.execution-contract.json",
+                        "completion_contract_refs": ["planningops/contracts/goal-completion-contract.md"],
+                        "next_goal_key": "goal-b",
+                        "operator_channels": {
+                            "primary_operator_channel": {
+                                "kind": "slack_skill_cli",
+                                "execution_repo": "rather-not-work-on/monday",
+                                "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md",
+                            },
+                            "terminal_notification_channel": {
+                                "kind": "email_cli",
+                                "execution_repo": "rather-not-work-on/monday",
+                                "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md",
+                            },
+                        },
+                    },
+                    {
+                        "goal_key": "goal-b",
+                        "title": "Goal B",
+                        "status": "draft",
+                        "owner_repo": "rather-not-work-on/platform-planningops",
+                        "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2-goal-brief.md",
+                        "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2.execution-contract.json",
+                        "completion_contract_refs": ["planningops/contracts/goal-completion-contract.md"],
+                        "operator_channels": {
+                            "primary_operator_channel": {
+                                "kind": "slack_skill_cli",
+                                "execution_repo": "rather-not-work-on/monday",
+                                "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md",
+                            },
+                            "terminal_notification_channel": {
+                                "kind": "email_cli",
+                                "execution_repo": "rather-not-work-on/monday",
+                                "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md",
+                            },
+                        },
+                    },
+                ],
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    # 11) exhausted active goal should surface promotion readiness before replanning in dry-run mode.
+    out_goal_promotion_ready = td_path / "supervisor-goal-promotion-ready.json"
+    rc_goal_promotion_ready, _, _ = run_supervisor(
+        [
+            "python3",
+            "planningops/scripts/autonomous_supervisor_loop.py",
+            "--mode",
+            "dry-run",
+            "--max-cycles",
+            "1",
+            "--continue-on-experiment",
+            "--loop-result-sequence-file",
+            str(no_eligible_sequence),
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
+            "--output",
+            str(out_goal_promotion_ready),
+            "--auto-materialize-backlog",
+            "--backlog-materializer-script",
+            str(materialize_expect_contract),
+            "--active-goal-registry",
+            str(goal_registry),
+        ]
+    )
+    assert rc_goal_promotion_ready == 1, rc_goal_promotion_ready
+    goal_promotion_ready_doc = json.loads(out_goal_promotion_ready.read_text(encoding="utf-8"))
+    assert goal_promotion_ready_doc["supervisor_verdict"] == "inconclusive", goal_promotion_ready_doc
+    assert goal_promotion_ready_doc["stop_reason"] == "goal_promotion_ready", goal_promotion_ready_doc
+    assert goal_promotion_ready_doc["cycles"][0]["goal_transition"]["enabled"] is True, goal_promotion_ready_doc
+    assert goal_promotion_ready_doc["cycles"][0]["goal_transition"]["next_goal_key"] == "goal-b", goal_promotion_ready_doc
+    goal_promotion_operator = json.loads(Path(goal_promotion_ready_doc["operator_report_last_path"]).read_text(encoding="utf-8"))
+    assert goal_promotion_operator["operator_action"] == "review_goal_promotion", goal_promotion_operator
+
+    # 12) apply-mode promotion should activate the successor and continue with its contract.
+    apply_goal_promotion_sequence = td_path / "apply-goal-promotion-sequence.json"
+    apply_goal_promotion_sequence.write_text(
+        json.dumps(
+            {
+                "cycles": [
+                    {
+                        "rc": 2,
+                        "loop_result": {
+                            "result": "no_eligible_todo_issue",
+                            "reason_code": "no_eligible_todo_issue",
+                            "last_verdict": "inconclusive",
+                            "auto_paused": False,
+                            "replenishment_candidates_count": 0,
+                            "selection_trace": {"selected": None, "project_items_source": "live"},
+                        },
+                    },
+                    {
+                        "rc": 0,
+                        "loop_result": {
+                            "selected_issue": 777,
+                            "last_verdict": "pass",
+                            "reason_code": "ok",
+                            "auto_paused": False,
+                            "replenishment_candidates_count": 0,
+                            "selection_trace": {"selected": {"uncertainty_level": "low", "simulation_required": False}},
+                            "final_loop_profile": "L3 Implementation-TDD",
+                        },
+                    },
+                ]
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    out_apply_goal_promotion = td_path / "supervisor-apply-goal-promotion.json"
+    rc_apply_goal_promotion, _, _ = run_supervisor(
+        [
+            "python3",
+            "planningops/scripts/autonomous_supervisor_loop.py",
+            "--mode",
+            "apply",
+            "--max-cycles",
+            "2",
+            "--convergence-pass-streak",
+            "1",
+            "--continue-on-experiment",
+            "--loop-result-sequence-file",
+            str(apply_goal_promotion_sequence),
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
+            "--output",
+            str(out_apply_goal_promotion),
+            "--auto-materialize-backlog",
+            "--backlog-materializer-script",
+            str(materialize_success),
+            "--active-goal-registry",
+            str(goal_registry),
+        ]
+    )
+    assert rc_apply_goal_promotion == 0, rc_apply_goal_promotion
+    apply_goal_promotion_doc = json.loads(out_apply_goal_promotion.read_text(encoding="utf-8"))
+    assert apply_goal_promotion_doc["supervisor_verdict"] == "pass", apply_goal_promotion_doc
+    assert apply_goal_promotion_doc["stop_reason"] == "converged", apply_goal_promotion_doc
+    assert apply_goal_promotion_doc["resolved_active_goal"]["goal_key"] == "goal-b", apply_goal_promotion_doc
+    assert apply_goal_promotion_doc["cycles"][0]["backlog_materialization"]["verdict"] == "pass", apply_goal_promotion_doc
+    mutated_registry = json.loads(goal_registry.read_text(encoding="utf-8"))
+    goal_lookup = {item["goal_key"]: item for item in mutated_registry["goals"]}
+    assert mutated_registry["active_goal_key"] == "goal-b", mutated_registry
+    assert goal_lookup["goal-a"]["status"] == "achieved", mutated_registry
+    assert goal_lookup["goal-b"]["status"] == "active", mutated_registry
+
+    terminal_registry = td_path / "terminal-goal-registry.json"
+    terminal_registry.write_text(
+        json.dumps(
+            {
+                "registry_version": 1,
+                "active_goal_key": "goal-terminal",
+                "goals": [
+                    {
+                        "goal_key": "goal-terminal",
+                        "title": "Terminal Goal",
+                        "status": "active",
+                        "owner_repo": "rather-not-work-on/platform-planningops",
+                        "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2-goal-brief.md",
+                        "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2.execution-contract.json",
+                        "completion_contract_refs": ["planningops/contracts/goal-completion-contract.md"],
+                        "operator_channels": {
+                            "primary_operator_channel": {
+                                "kind": "slack_skill_cli",
+                                "execution_repo": "rather-not-work-on/monday",
+                                "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md",
+                            },
+                            "terminal_notification_channel": {
+                                "kind": "email_cli",
+                                "execution_repo": "rather-not-work-on/monday",
+                                "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md",
+                            },
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    # 13) apply-mode completion without successor should stop cleanly and leave no active goal.
+    out_goal_completed = td_path / "supervisor-goal-completed.json"
+    rc_goal_completed, _, _ = run_supervisor(
+        [
+            "python3",
+            "planningops/scripts/autonomous_supervisor_loop.py",
+            "--mode",
+            "apply",
+            "--max-cycles",
+            "1",
+            "--continue-on-experiment",
+            "--loop-result-sequence-file",
+            str(no_eligible_sequence),
+            "--items-file",
+            "planningops/fixtures/backlog-stock-items-sample.json",
+            "--offline",
+            "--artifacts-root",
+            str(artifacts_root),
+            "--output",
+            str(out_goal_completed),
+            "--auto-materialize-backlog",
+            "--backlog-materializer-script",
+            str(materialize_expect_contract),
+            "--active-goal-registry",
+            str(terminal_registry),
+        ]
+    )
+    assert rc_goal_completed == 0, rc_goal_completed
+    goal_completed_doc = json.loads(out_goal_completed.read_text(encoding="utf-8"))
+    assert goal_completed_doc["supervisor_verdict"] == "pass", goal_completed_doc
+    assert goal_completed_doc["stop_reason"] == "goal_completed", goal_completed_doc
+    goal_completed_operator = json.loads(Path(goal_completed_doc["operator_report_last_path"]).read_text(encoding="utf-8"))
+    assert goal_completed_operator["status"] == "ok", goal_completed_operator
+    assert goal_completed_operator["operator_action"] == "notify_goal_completion", goal_completed_operator
+    terminal_registry_doc = json.loads(terminal_registry.read_text(encoding="utf-8"))
+    assert terminal_registry_doc["active_goal_key"] == "", terminal_registry_doc
+    assert terminal_registry_doc["goals"][0]["status"] == "achieved", terminal_registry_doc
 
 print("autonomous supervisor loop contract tests ok")
 PY

--- a/planningops/scripts/test_transition_goal_state_contract.sh
+++ b/planningops/scripts/test_transition_goal_state_contract.sh
@@ -128,4 +128,27 @@ assert report["verdict"] == "fail", report
 assert "activate_next_goal_key required when transitioning the current active goal away from active" in report["errors"], report
 PY
 
+python3 planningops/scripts/core/goals/transition_goal_state.py \
+  --registry "$registry" \
+  --goal-key goal-b \
+  --to-status achieved \
+  --reason "goal_completed_without_successor" \
+  --evidence-ref "planningops/artifacts/validation/goal-driven-autonomy-wave2-review.json" \
+  --mode apply \
+  --output "$report" >/dev/null
+
+python3 - <<'PY' "$report" "$registry"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+registry = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+assert report["verdict"] == "pass", report
+assert report["goal_transition_kind"] == "terminal_completion", report
+assert registry["active_goal_key"] == "", registry
+goals = {item["goal_key"]: item for item in registry["goals"]}
+assert goals["goal-b"]["status"] == "achieved", goals
+PY
+
 echo "goal lifecycle transition contract ok"

--- a/planningops/scripts/validate_active_goal_registry.py
+++ b/planningops/scripts/validate_active_goal_registry.py
@@ -37,7 +37,8 @@ def main():
     doc = load_json(registry_path)
     errors = validate_registry(doc, repo_root=repo_root)
     resolved = None
-    if not errors:
+    active_goal_key = str(doc.get("active_goal_key") or "").strip()
+    if not errors and active_goal_key:
         resolved = build_resolved_payload(resolve_active_goal(doc))
 
     report = {


### PR DESCRIPTION
## Summary
- let the supervisor transition exhausted active goals before falling back to stale replanning
- allow the active goal registry to represent terminal completion with no active goal
- add contract coverage for goal promotion, terminal completion, and registry successor semantics

## Scope
- update the active goal registry contract/schema/validator for successor and terminal-completion semantics
- wire supervisor goal transition handling and operator-facing stop reasons
- extend contract coverage for promotion-ready, terminal-completion, and apply-mode successor activation

## Linked Issues
- Closes #303

## Validation
- bash planningops/scripts/test_active_goal_registry_contract.sh
- bash planningops/scripts/test_transition_goal_state_contract.sh
- bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all
- python3 -m py_compile planningops/scripts/autonomous_supervisor_loop.py planningops/scripts/validate_active_goal_registry.py planningops/scripts/core/goals/resolve_active_goal.py planningops/scripts/core/goals/transition_goal_state.py

## Risks
- wave2 currently has no registered successor goal, so apply-mode completion will stop cleanly and wait for the next goal instead of continuing automatically
- supervisor now prefers the active-goal registry over explicit materialization contract paths when both are provided

## Review Checklist
- [x] contracts updated with successor and terminal-completion semantics
- [x] supervisor dry-run/apply paths covered by contract tests
- [x] docs/profile checks pass locally
