### PR TITLE
plan(planningops): register wave3 goal successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3-goal-brief.md
@@ -1,0 +1,56 @@
+---
+title: plan: Goal-Driven Autonomy Wave 3 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the next active goal for goal-driven autonomy so PlanningOps hands supervisor status and completion artifacts to monday-owned delivery CLIs instead of relying on direct Codex chat as the operator surface.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - slack
+  - email
+---
+
+# Goal-Driven Autonomy Wave 3 Goal Brief
+
+## Objective
+
+Make long-running autonomy hand operator communication to `monday` deterministically:
+- `planningops` produces canonical supervisor artifacts
+- `monday` consumes those artifacts through repo-owned CLI boundaries
+- Slack/email skills become thin wrappers over Monday-owned delivery entrypoints
+
+## Success Outcomes
+
+- `planningops` defines one canonical handoff contract from supervisor artifacts to monday messaging inputs
+- `monday` can consume a supervisor status/update payload file without prompt-authored transport logic
+- `monday` can consume a supervisor goal-completion payload file without manual envelope reconstruction
+- the next goal remains promotable from the active-goal registry without hand-editing backlog issues
+
+## Non-Goals
+
+- no real Slack or mail-provider credential wiring in this wave
+- no vendor HTTP transport implementation inside `platform-planningops`
+- no goal-intake-from-Slack workflow yet
+- no new MCP server surface unless the CLI handoff proves insufficient first
+
+## Operator Channels
+
+- primary operator channel: `slack_skill_cli`
+- terminal notification channel: `email_cli`
+
+## Completion References
+
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/active-goal-registry-contract.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3-issue-pack.md
@@ -1,0 +1,58 @@
+---
+title: plan: Goal-Driven Autonomy Wave 3 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the third goal-driven autonomy wave so PlanningOps can hand off supervisor status and terminal completion events to monday-owned CLI surfaces and keep operator communication outside direct Codex chat.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - operator-channel
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 3 Issue Pack
+
+## Goal
+
+Move from goal promotion alone to actual operator-loop handoff:
+- `planningops supervisor artifact -> monday CLI input -> channel delivery evidence`
+
+This wave keeps transport policy in contracts and real delivery ownership in `monday`.
+
+## Wave 3 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `C10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/contracts/supervisor-operator-handoff-contract.md` |
+| `C20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/send_supervisor_status_update.py` |
+| `C30` | 30 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/send_supervisor_goal_completion.py` |
+| `C40` | 40 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `docs/runbook/planningops-supervisor-handoff.md` |
+| `C50` | 50 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave3-review.json` |
+
+## Decomposition Rules
+
+- `C10` freezes the canonical shape of `operator-report.json`, `operator-summary.md`, and `inbox-payload.json` as inputs for monday-owned delivery surfaces.
+- `C20` adds a monday CLI entrypoint that accepts supervisor status/update payloads and emits delivery evidence.
+- `C30` adds a monday CLI entrypoint that accepts supervisor goal-completion payloads and emits delivery evidence without re-authoring the completion envelope in prompts.
+- `C40` documents how Slack/email skills call the monday CLI surface and which planningops artifacts they are allowed to consume.
+- `C50` verifies wave 3 keeps planningops as control tower only while monday owns the delivery bridge.
+
+## Dependencies
+
+- `C20` depends on `C10`
+- `C30` depends on `C10`
+- `C40` depends on `C20`, `C30`
+- `C50` depends on `C10`, `C20`, `C30`, `C40`
+
+## Non-Goals
+
+- no Slack bot token or mail provider setup in this wave
+- no direct channel send from `platform-planningops`
+- no user-facing skill prompt authority inside planningops
+- no automatic goal intake from Slack threads yet

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3.execution-contract.json
@@ -1,0 +1,81 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave3",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "C10",
+        "execution_order": 10,
+        "title": "Freeze supervisor to monday operator handoff contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/supervisor-operator-handoff-contract.md"
+      },
+      {
+        "plan_item_id": "C20",
+        "execution_order": 20,
+        "title": "Implement monday supervisor status update CLI",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "scripts/send_supervisor_status_update.py"
+      },
+      {
+        "plan_item_id": "C30",
+        "execution_order": 30,
+        "title": "Implement monday supervisor goal completion CLI",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "scripts/send_supervisor_goal_completion.py"
+      },
+      {
+        "plan_item_id": "C40",
+        "execution_order": 40,
+        "title": "Document planningops to monday supervisor handoff runbook",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          20,
+          30
+        ],
+        "primary_output": "docs/runbook/planningops-supervisor-handoff.md"
+      },
+      {
+        "plan_item_id": "C50",
+        "execution_order": 50,
+        "title": "Review goal-driven autonomy wave 3 operator handoff alignment",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30,
+          40
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave3-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -38,6 +38,32 @@
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/active-goal-registry-contract.md"
       ],
+      "next_goal_key": "uap-goal-driven-autonomy-wave3",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave3",
+      "title": "Goal-driven autonomy through supervisor to monday operator handoff",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
       "operator_channels": {
         "primary_operator_channel": {
           "kind": "slack_skill_cli",


### PR DESCRIPTION
## Summary
- add the wave3 goal brief, issue pack, and execution contract for monday supervisor handoff
- register wave3 as the deterministic successor to the current active wave2 goal
- validate that the wave3 execution contract compiles cleanly for future backlog materialization

## Scope
- add canonical workbench planning docs for goal-driven autonomy wave3
- update the active goal registry with a `next_goal_key` from wave2 to wave3
- keep wave3 as a draft successor only; do not materialize live issues yet

## Linked Issues
- Closes #310

## Validation
- python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --output /tmp/active-goal-registry-report.json --strict
- python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3.execution-contract.json --output /tmp/wave3-compile-report.json
- python3 planningops/scripts/core/backlog/materialize.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3.execution-contract.json --output /tmp/wave3-materialize-report.json
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- wave3 remains a draft successor until supervisor apply-mode promotes wave2 to achieved; no live backlog is created by this PR
- the next automation run still needs the supervisor to execute in apply-mode to materialize wave3 issues

## Review Checklist
- [x] successor goal refs resolve from the active goal registry
- [x] wave3 PEC dry-run compile/materialize passes locally
- [x] docs checks pass without introducing new canonical noise
