### PR TITLE
plan: add autonomous scheduler and queue roadmap

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md
@@ -1,0 +1,261 @@
+---
+title: plan: Autonomous Scheduler and Queue Control Plane Roadmap
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines how UAP autonomy graduates from Codex-hosted recurring automation to a monday-owned scheduler and queue runtime with local-first durability, deterministic reflection, and operator-channel completion handling.
+tags:
+  - uap
+  - autonomy
+  - scheduler
+  - queue
+  - planningops
+  - monday
+  - slack
+  - email
+---
+
+# Autonomous Scheduler and Queue Control Plane Roadmap
+
+## Purpose
+
+Move from "Codex automation triggers PlanningOps scripts" to a durable runtime where:
+- `planningops` remains the control tower and single source of truth for goals, contracts, queue policy, and completion rules
+- `monday` owns the actual scheduler, queue persistence, worker leasing, dispatch, retries, and operator-channel delivery
+- Slack/email remain thin wrappers over monday-owned CLI or MCP surfaces
+
+This roadmap is the migration plan for that change. It is not a permission to move scheduler runtime into `platform-planningops`.
+
+## Current Baseline
+
+Today the platform already has:
+- an autonomous supervisor loop in `platform-planningops`
+- active-goal registry and successor-goal promotion
+- backlog materialization from execution contracts
+- monday-owned operator-channel CLI baselines for status and completion delivery
+- a historical scheduler queue baseline in `monday` proving dequeue, duplicate detection, and dependency blocking
+
+What is still missing:
+- a durable monday-owned schedule registry and execution queue
+- lease, heartbeat, retry-budget, and dead-letter semantics
+- a canonical policy boundary between "goal selection" and "queue dispatch"
+- a path that no longer depends on Codex recurring automation as the long-term scheduler host
+
+## Target End State
+
+The desired steady state is:
+1. operator or upstream trigger creates or updates an active goal
+2. `planningops` compiles goal intent into executable policy and queue-ready work definitions
+3. `monday` scheduler materializes, leases, runs, retries, and completes queued work
+4. post-run reflection feeds back into `planningops` through deterministic evidence
+5. monday sends operator status and terminal completion notifications through repo-owned channel adapters
+6. when a goal is achieved, terminal email is sent once and the system waits for the next goal or schedule tick
+
+## Ownership Boundary
+
+### `platform-planningops`
+
+Owns:
+- goal briefs
+- active-goal registry
+- execution contracts
+- queue admission rules
+- scheduling policy and recurrence intent
+- retry/escalation policy
+- reflection and replan policy
+- completion policy
+
+Must not own:
+- production scheduler daemon
+- queue storage backend
+- worker leasing implementation
+- Slack or mail transport implementation
+
+### `monday`
+
+Owns:
+- scheduler runtime
+- queue persistence
+- lease and heartbeat management
+- worker dispatch
+- retry and dead-letter execution
+- operator-channel adapters
+- terminal notification delivery
+
+Must not own:
+- global planning policy
+- canonical backlog semantics
+- control-plane truth for goal completion
+
+### `platform-contracts`
+
+Owns only shared schemas that genuinely cross repos:
+- queue item schema
+- scheduler event schema
+- lease lifecycle schema
+- dead-letter record schema
+- run completion envelope schema when shared across planningops and monday
+
+### `platform-provider-gateway` and `platform-observability-gateway`
+
+Remain execution dependencies only:
+- provider invocation and routing
+- observability ingest, replay, and delivery
+
+They should not become the queue orchestrator.
+
+## Queue Model
+
+The long-term queue model must support these states:
+- `scheduled`
+- `ready`
+- `leased`
+- `running`
+- `blocked`
+- `retry_wait`
+- `dead_letter`
+- `completed`
+
+Each queue item must eventually carry:
+- `queue_item_id`
+- `goal_key`
+- `schedule_key`
+- `idempotency_key`
+- `priority_class`
+- `lease_owner`
+- `lease_expires_at_utc`
+- `retry_budget_remaining`
+- `attempt_count`
+- `dependency_keys`
+- `blocked_reason`
+- `dead_letter_reason`
+- `completion_evidence_ref`
+
+## Scheduling Model
+
+The scheduler must support these trigger families:
+- recurring schedule tick
+- one-shot goal activation
+- dependency-unblock wake
+- retry-after wake
+- reflection-triggered replan insertion
+- manual operator injection
+
+The first implementation should be local-first and durable:
+- queue backend: SQLite inside `monday`
+- scheduler loop: repo-owned CLI entrypoint first
+- no distributed coordinator in the first phase
+
+This is the right default because it maximizes debuggability, keeps state explicit, and avoids premature infra decisions.
+
+## Reflection and Self-Supervision Loop
+
+Reflection is not a side feature. It is part of the queue contract.
+
+Every scheduler cycle must be able to answer:
+1. did a leased item finish, block, retry, or dead-letter?
+2. did verification pass?
+3. does the result require replan or backlog replenishment?
+4. should the active goal be promoted, paused, or escalated?
+5. should monday notify Slack now, email once, or stay silent?
+
+Reflection triggers must include at least:
+- verification failure
+- repeated retry exhaustion
+- dead-letter transition
+- unresolved dependency drift
+- backlog exhaustion without eligible follow-up work
+- achieved goal with no promoted successor
+
+## Operator Interaction Model
+
+Operator interaction should converge to:
+- human <-> Slack
+- Slack skill -> monday-owned CLI or MCP adapter
+- monday -> planningops control-plane artifacts
+- planningops never sends channel messages directly
+
+Terminal completion policy remains:
+- completion is decided by `planningops`
+- delivery is performed by `monday`
+- email is sent once when goal transitions to `achieved`
+
+## Migration Phases
+
+### Phase 0: Baseline Already Present
+
+- Codex-hosted automation triggers the current supervisor loop
+- active-goal promotion exists
+- monday operator-channel CLI baselines exist
+- historical monday scheduler queue smoke exists
+
+### Phase 1: Contract Freeze
+
+Freeze:
+- scheduler and queue control-plane boundary
+- shared queue schemas
+- monday queue runtime topology
+- retry, lease, heartbeat, dead-letter vocabulary
+
+### Phase 2: Monday Local Queue Runtime
+
+Implement in `monday`:
+- local SQLite-backed queue store
+- lease and heartbeat baseline
+- scheduler cycle CLI
+- worker dequeue and completion recording
+
+### Phase 3: PlanningOps Policy Integration
+
+Connect:
+- goal registry
+- execution contract compiler
+- queue admission and recurrence policy
+- materialized queue insertion
+
+### Phase 4: Self-Supervised Reflection Integration
+
+Add:
+- retry-budget aware reflection
+- dead-letter to replan mapping
+- automatic backlog replenishment triggers
+- successor-goal promotion from queue completion signals
+
+### Phase 5: Operator Surface Integration
+
+Upgrade monday so Slack and email are not just standalone CLIs but queue-aware delivery surfaces:
+- status updates keyed by goal/run
+- blocked reports keyed by queue item
+- terminal completion idempotency by goal achievement
+
+### Phase 6: Externalized Runtime Backends
+
+Only after the local-first model is stable:
+- move queue storage to Postgres or managed durable backend if needed
+- add object storage or external event sink where it clearly reduces risk
+- preserve the same contracts and state model
+
+## Decisions Fixed Now
+
+- `planningops` remains policy and memory, not scheduler runtime
+- `monday` owns scheduler and queue execution
+- local-first SQLite is the default first backend
+- Slack and email remain thin wrappers over monday-owned CLI or MCP surfaces
+- migration must preserve deterministic evidence and replayability
+
+## Explicitly Deferred
+
+- distributed queue infrastructure
+- Redis-first or cloud-first scheduler design
+- direct Slack intake changing active goals before queue/runtime semantics are stable
+- replacing CLI boundaries with MCP before CLI proves insufficient
+
+## Next Planning Step
+
+The next successor goal after wave 3 should freeze the scheduler/queue foundation as wave 4:
+- goal brief: `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-goal-brief.md`
+- issue pack: `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-issue-pack.md`
+- execution contract: `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-goal-brief.md
@@ -1,0 +1,60 @@
+---
+title: plan: Goal-Driven Autonomy Wave 4 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the scheduler and queue foundation wave so autonomy can graduate from Codex-hosted recurring execution to a monday-owned runtime with durable queue semantics and planningops-owned policy.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - queue
+---
+
+# Goal-Driven Autonomy Wave 4 Goal Brief
+
+## Objective
+
+Make autonomy schedulable without depending on Codex recurring automation as the long-term runtime host:
+- `planningops` stays the source of truth for goal, schedule, queue, and reflection policy
+- `monday` becomes the owner of the scheduler and queue runtime
+- shared queue and lifecycle semantics move into explicit contracts before durable implementation expands
+
+## Success Outcomes
+
+- the scheduler/queue control-plane boundary is frozen before runtime growth
+- monday has a defined local-first queue runtime shape with lease, retry, and dead-letter semantics
+- planningops can hand schedule and queue policy to monday without becoming a runtime daemon
+- future operator interaction flows remain queue-aware and goal-aware instead of prompt-local
+
+## Non-Goals
+
+- no distributed scheduler backend in this wave
+- no direct Slack goal intake yet
+- no cloud-first storage decision in this wave
+- no provider or observability runtime redesign unrelated to queue dispatch
+
+## Operator Channels
+
+- primary operator channel: `slack_skill_cli`
+- terminal notification channel: `email_cli`
+
+## Completion References
+
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/active-goal-registry-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-issue-pack.md
@@ -1,0 +1,59 @@
+---
+title: plan: Goal-Driven Autonomy Wave 4 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the fourth goal-driven autonomy wave so PlanningOps freezes the scheduler and queue control-plane boundary and monday becomes the planned owner of durable local-first scheduling runtime.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - queue
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 4 Issue Pack
+
+## Goal
+
+Move from operator handoff alone to a queue-aware runtime foundation:
+- `planningops policy -> monday-owned scheduler/queue runtime`
+
+This wave freezes the contract and runtime shape required to replace Codex recurring automation with monday-owned scheduling later.
+
+## Wave 4 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `D10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md` |
+| `D20` | 20 | `rather-not-work-on/platform-contracts` | `contracts` | `ready_contract` | `schemas/runtime-scheduler-queue-item.schema.json` |
+| `D30` | 30 | `rather-not-work-on/monday` | `runtime` | `ready_contract` | `docs/adr/adr-0002-local-first-scheduler-queue-runtime.md` |
+| `D40` | 40 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/run_scheduled_queue_cycle.py` |
+| `D50` | 50 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave4-review.json` |
+
+## Decomposition Rules
+
+- `D10` freezes the scheduler/queue policy boundary so planningops continues to own goals, queue admission, retries, escalation, and completion policy without becoming a daemon host.
+- `D20` introduces only the shared queue schemas that genuinely cross repo boundaries; repo-local runtime details stay in monday.
+- `D30` documents the monday local-first runtime shape, storage decision, package responsibility, and migration constraints before runtime implementation expands.
+- `D40` adds the first monday-owned scheduled queue cycle CLI baseline that can later replace Codex recurring automation as the execution entrypoint.
+- `D50` verifies the wave keeps monday as execution-plane owner while planningops remains the control tower.
+
+## Dependencies
+
+- `D20` depends on `D10`
+- `D30` depends on `D10`, `D20`
+- `D40` depends on `D20`, `D30`
+- `D50` depends on `D10`, `D20`, `D30`, `D40`
+
+## Non-Goals
+
+- no distributed queue backend in this wave
+- no Slack transport wiring changes outside monday-owned adapters
+- no scheduler runtime implementation inside `platform-planningops`
+- no provider or observability orchestration ownership change

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4.execution-contract.json
@@ -1,0 +1,82 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave4",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "D10",
+        "execution_order": 10,
+        "title": "Freeze autonomous scheduler and queue control-plane contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md"
+      },
+      {
+        "plan_item_id": "D20",
+        "execution_order": 20,
+        "title": "Freeze shared runtime scheduler queue schemas",
+        "target_repo": "rather-not-work-on/platform-contracts",
+        "component": "contracts",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "schemas/runtime-scheduler-queue-item.schema.json"
+      },
+      {
+        "plan_item_id": "D30",
+        "execution_order": 30,
+        "title": "Define monday local-first scheduler queue runtime topology",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "docs/adr/adr-0002-local-first-scheduler-queue-runtime.md"
+      },
+      {
+        "plan_item_id": "D40",
+        "execution_order": 40,
+        "title": "Implement monday scheduled queue cycle CLI baseline",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          20,
+          30
+        ],
+        "primary_output": "scripts/run_scheduled_queue_cycle.py"
+      },
+      {
+        "plan_item_id": "D50",
+        "execution_order": 50,
+        "title": "Review goal-driven autonomy wave 4 scheduler queue alignment",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30,
+          40
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave4-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -64,6 +64,32 @@
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/active-goal-registry-contract.md"
       ],
+      "next_goal_key": "uap-goal-driven-autonomy-wave4",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave4",
+      "title": "Goal-driven autonomy through monday-owned scheduler and queue runtime",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
       "operator_channels": {
         "primary_operator_channel": {
           "kind": "slack_skill_cli",


### PR DESCRIPTION
## Summary
- add a dedicated roadmap for graduating autonomy from Codex-hosted recurring runs to a monday-owned scheduler and queue runtime
- register wave 4 as the draft successor after wave 3 so future automation has a deterministic next control-plane target
- keep the ownership boundary explicit: planningops owns policy and memory, monday owns scheduler/queue execution

## Scope
- Initiative docs: none
- Workbench docs: add scheduler/queue roadmap plus wave4 goal brief, issue pack, and execution contract
- `planningops/` scripts/contracts: update `planningops/config/active-goal-registry.json` with wave3 -> wave4 successor linkage
- `.github/` workflows: none

## Linked Issues
- Closes #312
- Related #303

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
- [x] `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4.execution-contract.json --output /tmp/wave4-compile-report.json`
- [ ] Additional checks (if any): none

## Risks
- Risk: automation could promote into wave4 earlier than intended if wave3 is force-completed without review
- Rollback: revert active-goal registry successor linkage and remove the wave4 planning documents

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
