### PR TITLE
feat: align wave3 active goal review

### DIFF
--- a/planningops/artifacts/validation/goal-driven-autonomy-wave2-to-wave3-transition.json
+++ b/planningops/artifacts/validation/goal-driven-autonomy-wave2-to-wave3-transition.json
@@ -1,0 +1,124 @@
+{
+  "generated_at_utc": "2026-03-14T04:47:54.315863+00:00",
+  "registry": "planningops/config/active-goal-registry.json",
+  "mode": "apply",
+  "goal_key": "uap-goal-driven-autonomy-wave2",
+  "from_status": "active",
+  "to_status": "achieved",
+  "activate_next_goal_key": "uap-goal-driven-autonomy-wave3",
+  "transition_reason": "wave3_delivery_surfaces_implemented_and_reviewed",
+  "evidence_refs": [],
+  "active_goal_key_before": "uap-goal-driven-autonomy-wave2",
+  "active_goal_key_after": "uap-goal-driven-autonomy-wave3",
+  "goal_transition_kind": "promotion",
+  "verdict": "pass",
+  "error_count": 0,
+  "errors": [],
+  "proposed_registry": {
+    "registry_version": 1,
+    "active_goal_key": "uap-goal-driven-autonomy-wave3",
+    "goals": [
+      {
+        "goal_key": "uap-goal-driven-autonomy-wave1",
+        "title": "Goal-driven autonomy through Monday operator channels",
+        "status": "achieved",
+        "owner_repo": "rather-not-work-on/platform-planningops",
+        "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave1-goal-brief.md",
+        "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave1.execution-contract.json",
+        "completion_contract_refs": [
+          "planningops/contracts/goal-completion-contract.md",
+          "planningops/contracts/operator-channel-adapter-contract.md"
+        ],
+        "operator_channels": {
+          "primary_operator_channel": {
+            "kind": "slack_skill_cli",
+            "execution_repo": "rather-not-work-on/monday",
+            "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+          },
+          "terminal_notification_channel": {
+            "kind": "email_cli",
+            "execution_repo": "rather-not-work-on/monday",
+            "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+          }
+        }
+      },
+      {
+        "goal_key": "uap-goal-driven-autonomy-wave2",
+        "title": "Goal-driven autonomy through automatic goal promotion",
+        "status": "achieved",
+        "owner_repo": "rather-not-work-on/platform-planningops",
+        "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2-goal-brief.md",
+        "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2.execution-contract.json",
+        "completion_contract_refs": [
+          "planningops/contracts/goal-completion-contract.md",
+          "planningops/contracts/operator-channel-adapter-contract.md",
+          "planningops/contracts/active-goal-registry-contract.md"
+        ],
+        "next_goal_key": "uap-goal-driven-autonomy-wave3",
+        "operator_channels": {
+          "primary_operator_channel": {
+            "kind": "slack_skill_cli",
+            "execution_repo": "rather-not-work-on/monday",
+            "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+          },
+          "terminal_notification_channel": {
+            "kind": "email_cli",
+            "execution_repo": "rather-not-work-on/monday",
+            "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+          }
+        }
+      },
+      {
+        "goal_key": "uap-goal-driven-autonomy-wave3",
+        "title": "Goal-driven autonomy through supervisor to monday operator handoff",
+        "status": "active",
+        "owner_repo": "rather-not-work-on/platform-planningops",
+        "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3-goal-brief.md",
+        "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3.execution-contract.json",
+        "completion_contract_refs": [
+          "planningops/contracts/goal-completion-contract.md",
+          "planningops/contracts/operator-channel-adapter-contract.md",
+          "planningops/contracts/active-goal-registry-contract.md"
+        ],
+        "next_goal_key": "uap-goal-driven-autonomy-wave4",
+        "operator_channels": {
+          "primary_operator_channel": {
+            "kind": "slack_skill_cli",
+            "execution_repo": "rather-not-work-on/monday",
+            "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+          },
+          "terminal_notification_channel": {
+            "kind": "email_cli",
+            "execution_repo": "rather-not-work-on/monday",
+            "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+          }
+        }
+      },
+      {
+        "goal_key": "uap-goal-driven-autonomy-wave4",
+        "title": "Goal-driven autonomy through monday-owned scheduler and queue runtime",
+        "status": "draft",
+        "owner_repo": "rather-not-work-on/platform-planningops",
+        "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-goal-brief.md",
+        "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4.execution-contract.json",
+        "completion_contract_refs": [
+          "planningops/contracts/goal-completion-contract.md",
+          "planningops/contracts/operator-channel-adapter-contract.md",
+          "planningops/contracts/active-goal-registry-contract.md"
+        ],
+        "operator_channels": {
+          "primary_operator_channel": {
+            "kind": "slack_skill_cli",
+            "execution_repo": "rather-not-work-on/monday",
+            "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+          },
+          "terminal_notification_channel": {
+            "kind": "email_cli",
+            "execution_repo": "rather-not-work-on/monday",
+            "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/planningops/artifacts/validation/goal-driven-autonomy-wave3-review.json
+++ b/planningops/artifacts/validation/goal-driven-autonomy-wave3-review.json
@@ -1,0 +1,155 @@
+{
+  "generated_at_utc": "2026-03-14T04:49:24.724691+00:00",
+  "wave_id": "uap-goal-driven-autonomy-wave3",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3-issue-pack.md",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 315,
+      "state": "CLOSED",
+      "title": "plan: [10] Freeze supervisor to monday operator handoff contract",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/315",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 316,
+      "state": "CLOSED",
+      "title": "plan: [20] Implement monday supervisor status update CLI",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/316",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 317,
+      "state": "CLOSED",
+      "title": "plan: [30] Implement monday supervisor goal completion CLI",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/317",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 318,
+      "state": "CLOSED",
+      "title": "plan: [40] Document planningops to monday supervisor handoff runbook",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/318",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/contracts/supervisor-operator-handoff-contract.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/send_supervisor_status_update.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/send_supervisor_goal_completion.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/docs/runbook/planningops-supervisor-handoff.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    }
+  ],
+  "boundary_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/send_operator_message.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must remain control tower only; delivery entrypoints belong in monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/send_goal_completion_notification.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must remain control tower only; delivery entrypoints belong in monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/send_supervisor_status_update.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must remain control tower only; delivery entrypoints belong in monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/send_supervisor_goal_completion.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must remain control tower only; delivery entrypoints belong in monday"
+    }
+  ],
+  "registry_checks": [
+    {
+      "name": "active_goal_key",
+      "expected": "uap-goal-driven-autonomy-wave3",
+      "actual": "uap-goal-driven-autonomy-wave3",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave2_status",
+      "expected": "achieved",
+      "actual": "achieved",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave3_status",
+      "expected": "active",
+      "actual": "active",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave4_status",
+      "expected": "draft",
+      "actual": "draft",
+      "verdict": "pass"
+    }
+  ],
+  "validation_checks": [
+    {
+      "name": "planningops/test_active_goal_registry_contract",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/test_autonomous_supervisor_loop_contract",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/test_supervisor_operator_handoff_contract",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/uap_docs_workbench",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_supervisor_status_update_cli",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_supervisor_goal_completion_cli",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_runtime_guardrails",
+      "verdict": "pass"
+    }
+  ],
+  "check_count": 23,
+  "failure_count": 0,
+  "verdict": "pass"
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -1,6 +1,6 @@
 {
   "registry_version": 1,
-  "active_goal_key": "uap-goal-driven-autonomy-wave2",
+  "active_goal_key": "uap-goal-driven-autonomy-wave3",
   "goals": [
     {
       "goal_key": "uap-goal-driven-autonomy-wave1",
@@ -29,7 +29,7 @@
     {
       "goal_key": "uap-goal-driven-autonomy-wave2",
       "title": "Goal-driven autonomy through automatic goal promotion",
-      "status": "active",
+      "status": "achieved",
       "owner_repo": "rather-not-work-on/platform-planningops",
       "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2-goal-brief.md",
       "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2.execution-contract.json",
@@ -55,7 +55,7 @@
     {
       "goal_key": "uap-goal-driven-autonomy-wave3",
       "title": "Goal-driven autonomy through supervisor to monday operator handoff",
-      "status": "draft",
+      "status": "active",
       "owner_repo": "rather-not-work-on/platform-planningops",
       "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3-goal-brief.md",
       "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave3.execution-contract.json",

--- a/planningops/scripts/test_active_goal_registry_contract.sh
+++ b/planningops/scripts/test_active_goal_registry_contract.sh
@@ -16,7 +16,18 @@ python3 planningops/scripts/validate_active_goal_registry.py \
   --strict >/dev/null
 
 resolved_contract="$(python3 planningops/scripts/core/goals/resolve_active_goal.py --registry "$valid_registry" --field execution_contract_file)"
-[ "$resolved_contract" = "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2.execution-contract.json" ]
+expected_contract="$(python3 - <<'PY' "$valid_registry"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+active_goal_key = str(doc.get("active_goal_key") or "").strip()
+active_goal = next(goal for goal in doc["goals"] if str(goal.get("goal_key") or "").strip() == active_goal_key)
+print(active_goal["execution_contract_file"])
+PY
+)"
+[ "$resolved_contract" = "$expected_contract" ]
 
 cat >"$invalid_registry" <<'JSON'
 {

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -415,6 +415,14 @@ with tempfile.TemporaryDirectory() as td:
     )
 
     materialize_expect_contract = td_path / "materialize-expect-contract.py"
+    default_active_contract = json.loads(Path("planningops/config/active-goal-registry.json").read_text(encoding="utf-8"))
+    active_goal_key = str(default_active_contract.get("active_goal_key") or "").strip()
+    active_goal_contract = next(
+        goal["execution_contract_file"]
+        for goal in default_active_contract["goals"]
+        if str(goal.get("goal_key") or "").strip() == active_goal_key
+    )
+
     materialize_expect_contract.write_text(
         "\n".join(
             [
@@ -428,7 +436,7 @@ with tempfile.TemporaryDirectory() as td:
                 "parser.add_argument('--projected-issues-output', default=None)",
                 "parser.add_argument('--apply', action='store_true')",
                 "args = parser.parse_args()",
-                "expected = 'docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave2.execution-contract.json'",
+                f"expected = {active_goal_contract!r}",
                 "report = {'verdict': 'pass' if args.contract_file == expected else 'fail', 'contract_file': args.contract_file}",
                 "Path(args.output).write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding='utf-8')",
                 "if report['verdict'] != 'pass':",
@@ -627,10 +635,8 @@ with tempfile.TemporaryDirectory() as td:
     )
     assert rc_registry_resolved == 1, rc_registry_resolved
     registry_resolved_doc = json.loads(out_registry_resolved.read_text(encoding="utf-8"))
-    assert registry_resolved_doc["resolved_active_goal"]["goal_key"] == "uap-goal-driven-autonomy-wave2", registry_resolved_doc
-    assert registry_resolved_doc["resolved_active_goal"]["execution_contract_file"].endswith(
-        "2026-03-13-goal-driven-autonomy-wave2.execution-contract.json"
-    ), registry_resolved_doc
+    assert registry_resolved_doc["resolved_active_goal"]["goal_key"] == active_goal_key, registry_resolved_doc
+    assert registry_resolved_doc["resolved_active_goal"]["execution_contract_file"] == active_goal_contract, registry_resolved_doc
 
     goal_registry = td_path / "goal-registry.json"
     goal_registry.write_text(


### PR DESCRIPTION
## Summary
- promote the active goal registry from wave2 to wave3 now that the wave3 handoff deliverables are in place
- generalize active-goal regression tests so they follow the current registry instead of hardcoding wave2
- record a deterministic wave3 alignment review artifact that verifies closure, repo ownership, boundary discipline, and validation status

## Scope
- Runtime/packages: none
- Scripts/contracts/docs: `planningops/config/active-goal-registry.json`, `planningops/scripts/test_active_goal_registry_contract.sh`, `planningops/scripts/test_autonomous_supervisor_loop_contract.sh`, `planningops/artifacts/validation/goal-driven-autonomy-wave2-to-wave3-transition.json`, `planningops/artifacts/validation/goal-driven-autonomy-wave3-review.json`
- `.github/` workflows: none

## Linked Issues
- Closes rather-not-work-on/platform-planningops#319
- Related rather-not-work-on/platform-planningops#315
- Related rather-not-work-on/platform-planningops#316
- Related rather-not-work-on/platform-planningops#317
- Related rather-not-work-on/platform-planningops#318

## Validation
- [ ] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- [ ] `bash planningops/scripts/test_active_goal_registry_contract.sh`
- [ ] Additional checks (if any): `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`, `bash planningops/scripts/test_supervisor_operator_handoff_contract.sh`, `bash /Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/test_supervisor_status_update_cli.sh`, `bash /Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/test_supervisor_goal_completion_cli.sh`, `bash /Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/test_runtime_guardrails.sh`, `git diff --check`

## Risks
- Risk: active goal promotion changes what the automation resolves by default.
- Rollback: revert this PR to return the registry and review artifact to the previous state.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] PR includes a repo-qualified planningops issue ref.
- [x] README or topology guidance updated if workflow expectations changed.
- [x] Validation commands were run locally.
