### PR TITLE
feat: add scheduler queue control-plane contract

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -219,6 +219,7 @@ jobs:
           bash planningops/scripts/test_memory_archive_contract.sh
           bash planningops/scripts/test_memory_rehydrate_contract.sh
           bash planningops/scripts/test_inventory_issue_lifecycle_contract.sh
+          bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
           python3 planningops/scripts/memory_compactor.py \
             --mode check \
             --root . \

--- a/.github/workflows/planningops-contracts-dryrun.yml
+++ b/.github/workflows/planningops-contracts-dryrun.yml
@@ -33,6 +33,7 @@ jobs:
           bash planningops/scripts/test_backlog_stock_replenishment_contract.sh
           bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh
           bash planningops/scripts/test_supervisor_operator_handoff_contract.sh
+          bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
           bash planningops/scripts/test_supervisor_experiment_auto_executor_contract.sh
           python3 planningops/scripts/validate_worker_task_pack.py \
             --runtime-profile-file planningops/config/runtime-profiles.json \

--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -23,6 +23,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `goal-completion-contract.md`: machine-checkable achieved-state and terminal notification policy
 - `operator-channel-adapter-contract.md`: monday-owned Slack/email channel adapter boundary and evidence rules
 - `supervisor-operator-handoff-contract.md`: canonical supervisor artifact to monday CLI handoff boundary
+- `autonomous-scheduler-queue-control-plane-contract.md`: policy boundary between planningops control plane and monday scheduler/queue runtime
 - `supervisor-experiment-auto-executor-contract.md`: trigger-to-worktree comparative execution and decision contract
 - `worker-task-pack-contract.md`: worker execution bundle and render safety contract
 - `checkpoint-resume-contract.md`: checkpoint and resume behavior

--- a/planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md
+++ b/planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md
@@ -1,0 +1,127 @@
+# Autonomous Scheduler Queue Control-Plane Contract
+
+## Purpose
+Freeze the canonical boundary between `platform-planningops` policy orchestration and the future `monday` scheduler/queue runtime.
+
+This contract exists so:
+- `planningops` remains the control tower and single source of truth
+- `monday` becomes the long-term scheduler host instead of Codex recurring automation
+- queue runtime growth does not pull daemon, lease, or transport behavior back into `planningops`
+
+## Ownership Boundary
+
+### PlanningOps owns
+- goal briefs
+- active-goal registry
+- execution contracts
+- schedule intent and recurrence policy
+- queue admission policy
+- retry and escalation policy
+- reflection and replan policy
+- completion policy
+
+### PlanningOps must not own
+- scheduler daemon host
+- queue persistence backend
+- lease or heartbeat implementation
+- worker dispatch loop
+- Slack or email transport implementation
+
+### Monday owns
+- scheduler runtime
+- queue persistence
+- lease and heartbeat management
+- dequeue, dispatch, and completion recording
+- retry wait and dead-letter execution
+- operator-channel delivery adapters
+
+### Platform-Contracts owns
+Only shared schemas that genuinely cross repo boundaries:
+- queue item schema
+- scheduler event schema
+- lease lifecycle schema
+- dead-letter record schema
+
+## Queue State Model
+The canonical queue state vocabulary is:
+- `scheduled`
+- `ready`
+- `leased`
+- `running`
+- `blocked`
+- `retry_wait`
+- `dead_letter`
+- `completed`
+
+PlanningOps may reference these states in policy, but monday owns the runtime transitions.
+
+## Scheduling Trigger Model
+The canonical trigger families are:
+- recurring schedule tick
+- one-shot goal activation
+- dependency-unblock wake
+- retry-after wake
+- reflection-triggered replan insertion
+- manual operator injection
+
+PlanningOps defines which triggers are allowed and when they should enqueue work.
+Monday decides how those triggers are materialized and executed at runtime.
+
+## Required Queue Policy Fields
+PlanningOps-generated queue-ready policy must eventually be able to describe:
+- `goal_key`
+- `schedule_key`
+- `priority_class`
+- `idempotency_key`
+- `dependency_keys`
+- `retry_budget`
+- `escalation_policy_ref`
+- `completion_policy_ref`
+
+These fields are policy inputs.
+Monday may extend repo-local runtime metadata, but must not redefine the meaning of the policy fields above.
+
+## Reflection and Escalation Rules
+Every monday-owned scheduler cycle must be able to feed deterministic evidence back into planningops for:
+- verification failure
+- retry exhaustion
+- dead-letter transition
+- unresolved dependency drift
+- backlog exhaustion without eligible follow-up work
+- achieved goal with no promoted successor
+
+PlanningOps uses that evidence to:
+- replenish backlog
+- promote or pause goals
+- escalate to the operator
+- emit terminal completion policy
+
+## Operator Channel Boundary
+- planningops decides whether operator status or terminal completion should happen
+- monday performs the actual operator delivery through repo-owned CLI or MCP adapters
+- scheduler/queue work must remain compatible with:
+  - `planningops/contracts/operator-channel-adapter-contract.md`
+  - `planningops/contracts/goal-completion-contract.md`
+  - `planningops/contracts/supervisor-operator-handoff-contract.md`
+
+## Local-First Runtime Rule
+The first durable scheduler/queue runtime must be local-first:
+- default backend: SQLite in `monday`
+- entrypoint shape: repo-owned CLI first
+- no distributed coordinator requirement in this phase
+
+PlanningOps must model policy so that migrating the backend later does not require redefining queue semantics.
+
+## Migration Rule
+Codex recurring automation is a temporary host only.
+
+The intended migration path is:
+1. planningops emits policy and active-goal truth
+2. monday runs the durable scheduler and queue cycle
+3. monday returns deterministic evidence to planningops
+4. planningops decides promotion, replenishment, escalation, and completion
+
+## Validation
+- roadmap reference: `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+- wave goal brief: `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-goal-brief.md`
+- contract regression: `planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh`

--- a/planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
+++ b/planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+contract = Path("planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md")
+text = contract.read_text(encoding="utf-8")
+
+required_sections = [
+    "# Autonomous Scheduler Queue Control-Plane Contract",
+    "## Purpose",
+    "## Ownership Boundary",
+    "## Queue State Model",
+    "## Scheduling Trigger Model",
+    "## Required Queue Policy Fields",
+    "## Reflection and Escalation Rules",
+    "## Operator Channel Boundary",
+    "## Local-First Runtime Rule",
+    "## Migration Rule",
+    "## Validation",
+]
+for section in required_sections:
+    assert section in text, section
+
+required_fragments = [
+    "PlanningOps must not own",
+    "Monday owns",
+    "Platform-Contracts owns",
+    "`scheduled`",
+    "`dead_letter`",
+    "recurring schedule tick",
+    "retry-after wake",
+    "SQLite in `monday`",
+    "Codex recurring automation is a temporary host only.",
+    "planningops/contracts/operator-channel-adapter-contract.md",
+]
+for fragment in required_fragments:
+    assert fragment in text, fragment
+
+print("autonomous scheduler queue control-plane contract ok")
+PY


### PR DESCRIPTION
## Summary
- freeze the control-plane boundary for the future monday-owned scheduler and queue runtime
- codify queue state, trigger, reflection, and ownership vocabulary before shared schemas or runtime growth continue
- enforce the new contract in planningops CI

## Scope
- Runtime/packages: none
- Scripts/contracts/docs: `planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md`, `planningops/contracts/README.md`, `planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh`
- `.github/` workflows: `.github/workflows/planningops-contracts-dryrun.yml`, `.github/workflows/federated-ci-matrix.yml`

## Linked Issues
- Closes rather-not-work-on/platform-planningops#322
- Related rather-not-work-on/platform-planningops#323
- Related rather-not-work-on/platform-planningops#324

## Validation
- [x] `bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh`
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- [x] Additional checks (if any): `git diff --check`

## Risks
- Risk: the contract may still omit a later-required runtime field and need a follow-up amendment.
- Rollback: revert this PR to remove the contract and CI gate.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] PR includes a repo-qualified planningops issue ref.
- [x] README or topology guidance updated if workflow expectations changed.
- [x] Validation commands were run locally.
