### PR TITLE
docs(planningops): add wave4 scheduler queue review evidence

### DIFF
--- a/planningops/artifacts/validation/goal-driven-autonomy-wave4-review.json
+++ b/planningops/artifacts/validation/goal-driven-autonomy-wave4-review.json
@@ -1,0 +1,149 @@
+{
+  "generated_at_utc": "2026-03-14T06:51:29.123862+00:00",
+  "wave_id": "uap-goal-driven-autonomy-wave4",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave4-issue-pack.md",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 322,
+      "state": "CLOSED",
+      "title": "plan: [10] Freeze autonomous scheduler and queue control-plane contract",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/322",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 323,
+      "state": "CLOSED",
+      "title": "plan: [20] Freeze shared runtime scheduler queue schemas",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/323",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 324,
+      "state": "CLOSED",
+      "title": "plan: [30] Define monday local-first scheduler queue runtime topology",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/324",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 325,
+      "state": "CLOSED",
+      "title": "plan: [40] Implement monday scheduled queue cycle CLI baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/325",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-contracts/schemas/runtime-scheduler-queue-item.schema.json",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-contracts"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/docs/adr/adr-0002-local-first-scheduler-queue-runtime.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/run_scheduled_queue_cycle.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    }
+  ],
+  "boundary_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_scheduled_queue_cycle.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "monday must remain scheduler runtime owner; planningops must not host the queue cycle entrypoint"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/scheduler_queue.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "monday must remain scheduler runtime owner; planningops must not host queue persistence helpers"
+    }
+  ],
+  "registry_checks": [
+    {
+      "name": "active_goal_key",
+      "expected": "uap-goal-driven-autonomy-wave4",
+      "actual": "uap-goal-driven-autonomy-wave4",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave3_status",
+      "expected": "achieved",
+      "actual": "achieved",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave4_status",
+      "expected": "active",
+      "actual": "active",
+      "verdict": "pass"
+    }
+  ],
+  "validation_checks": [
+    {
+      "name": "planningops/uap_docs_workbench",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/test_active_goal_registry_contract",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/test_autonomous_scheduler_queue_control_plane_contract",
+      "verdict": "pass"
+    },
+    {
+      "name": "platform-contracts/validate_contracts",
+      "verdict": "pass"
+    },
+    {
+      "name": "platform-contracts/test_validate_contracts_strict",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_scheduler_queue_runtime_adr",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_run_scheduled_queue_cycle",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_runtime_guardrails",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_module_readmes",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/typecheck",
+      "verdict": "pass"
+    }
+  ],
+  "check_count": 23,
+  "failure_count": 0,
+  "verdict": "pass"
+}


### PR DESCRIPTION
## Summary
- add the wave4 review artifact that reconciles scheduler queue control-plane and runtime ownership across planningops, contracts, and monday
- verify D10 through D40 are closed and their canonical outputs exist at the expected paths
- record that wave4 remains active with monday owning the queue cycle runtime and planningops remaining policy-only

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts: `planningops/artifacts/validation/goal-driven-autonomy-wave4-review.json`
- `.github/` workflows:

## Linked Issues
- Closes #326
- Related #322
- Related #323
- Related #324
- Related #325

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `bash planningops/scripts/test_active_goal_registry_contract.sh`, `bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh`, `python3 ../platform-contracts/scripts/validate_contracts.py --root ../platform-contracts`, `python3 ../platform-contracts/scripts/test_validate_contracts_strict.py`, `bash ../monday/scripts/test_scheduler_queue_runtime_adr.sh`, `bash ../monday/scripts/test_run_scheduled_queue_cycle.sh`, `bash ../monday/scripts/test_runtime_guardrails.sh`, `bash ../monday/scripts/test_module_readmes.sh`, `cd ../monday && npx --yes pnpm@10 typecheck`

## Risks
- Risk: review evidence could drift from actual repo state if future wave4 changes land without refreshing the artifact.
- Rollback: Revert this PR to remove the review artifact and reopen the review gate.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
