### PR TITLE
docs(planningops): define wave5 durable queue runtime successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5-goal-brief.md
@@ -1,0 +1,61 @@
+---
+title: plan: Goal-Driven Autonomy Wave 5 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the durable local queue runtime wave so monday graduates from historical queue smoke into a SQLite-backed queue store with lease-aware scheduler execution.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - queue
+  - sqlite
+---
+
+# Goal-Driven Autonomy Wave 5 Goal Brief
+
+## Objective
+
+Turn the wave4 scheduler baseline into a durable monday-owned local runtime:
+- `platform-contracts` freezes shared lease lifecycle vocabulary that truly crosses repos
+- `monday` persists queue state locally with SQLite and records lease/heartbeat transitions
+- `planningops` continues to decide policy, completion, and reflection without becoming a queue host
+
+## Success Outcomes
+
+- monday has a repo-owned SQLite queue store baseline with deterministic local inspection
+- scheduled queue cycles persist queue item state instead of relying only on fixture-local memory
+- lease and heartbeat transitions are expressed with explicit shared schema rather than prompt-local fields
+- planningops can continue to evaluate queue results through evidence without owning runtime storage
+
+## Non-Goals
+
+- no distributed queue backend in this wave
+- no cloud migration of queue storage in this wave
+- no direct Slack intake changing queue state in this wave
+- no provider or observability orchestration redesign unrelated to queue persistence
+
+## Operator Channels
+
+- primary operator channel: `slack_skill_cli`
+- terminal notification channel: `email_cli`
+
+## Completion References
+
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/active-goal-registry-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5-issue-pack.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 5 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the fifth goal-driven autonomy wave so monday grows from a scheduler smoke baseline into a durable local queue runtime with SQLite-backed state and lease-aware execution.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - queue
+  - backlog
+  - sqlite
+---
+
+# Goal-Driven Autonomy Wave 5 Issue Pack
+
+## Goal
+
+Move from a historical queue-cycle smoke to a durable local runtime:
+- `planningops policy -> monday SQLite-backed queue runtime`
+
+This wave keeps the control-plane boundary from wave4 intact while adding the first durable queue state and lease lifecycle semantics in monday.
+
+## Wave 5 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `E10` | 10 | `rather-not-work-on/platform-contracts` | `contracts` | `ready_contract` | `schemas/runtime-scheduler-lease-lifecycle.schema.json` |
+| `E20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/runtime_queue_store.py` |
+| `E30` | 30 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/run_scheduled_queue_cycle.py` |
+| `E40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave5-review.json` |
+
+## Decomposition Rules
+
+- `E10` introduces only the shared lease lifecycle and dead-letter vocabulary that must remain stable across planningops and monday.
+- `E20` adds a monday-owned SQLite queue store baseline for local-first durability and explicit runtime inspection.
+- `E30` upgrades the scheduled queue cycle so it uses the queue store, records lease/heartbeat transitions, and preserves deterministic evidence output.
+- `E40` verifies the durable queue runtime still leaves planningops as control tower only and keeps monday as execution-plane owner.
+
+## Dependencies
+
+- `E20` depends on `E10`
+- `E30` depends on `E10`, `E20`
+- `E40` depends on `E10`, `E20`, `E30`
+
+## Non-Goals
+
+- no distributed lease coordinator in this wave
+- no cloud queue backend in this wave
+- no direct Slack-triggered queue mutation in this wave
+- no scheduler daemon hosted inside `platform-planningops`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5.execution-contract.json
@@ -1,0 +1,66 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave5",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "E10",
+        "execution_order": 10,
+        "title": "Freeze shared scheduler lease lifecycle schema",
+        "target_repo": "rather-not-work-on/platform-contracts",
+        "component": "contracts",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "schemas/runtime-scheduler-lease-lifecycle.schema.json"
+      },
+      {
+        "plan_item_id": "E20",
+        "execution_order": 20,
+        "title": "Implement monday SQLite queue store baseline",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "scripts/runtime_queue_store.py"
+      },
+      {
+        "plan_item_id": "E30",
+        "execution_order": 30,
+        "title": "Persist lease-aware scheduled queue cycle in monday",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "scripts/run_scheduled_queue_cycle.py"
+      },
+      {
+        "plan_item_id": "E40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 5 durable queue runtime alignment",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave5-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -90,6 +90,32 @@
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/active-goal-registry-contract.md"
       ],
+      "next_goal_key": "uap-goal-driven-autonomy-wave5",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave5",
+      "title": "Goal-driven autonomy through monday durable local queue runtime",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
       "operator_channels": {
         "primary_operator_channel": {
           "kind": "slack_skill_cli",


### PR DESCRIPTION
## Summary
- define wave5 as the durable local queue runtime successor to the completed wave4 scheduler baseline
- add the wave5 goal brief, issue pack, and execution contract for SQLite-backed queue persistence and lease-aware scheduler work
- link wave4 to wave5 in the active-goal registry without promoting the successor yet

## Scope
- Initiative docs:
- Workbench docs: `2026-03-14-goal-driven-autonomy-wave5-goal-brief.md`, `2026-03-14-goal-driven-autonomy-wave5-issue-pack.md`, `2026-03-14-goal-driven-autonomy-wave5.execution-contract.json`
- `planningops/` scripts/contracts: `planningops/config/active-goal-registry.json`
- `.github/` workflows:

## Linked Issues
- Closes #331
- Related #332

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`, `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5.execution-contract.json --detect-closed-match --output /tmp/wave5-compile-report.json`

## Risks
- Risk: successor scope could be too large if queue persistence and lease semantics are not kept local-first.
- Rollback: Revert this PR to remove the wave5 successor docs and registry linkage.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
