### PR TITLE
docs(planningops): add wave5 durable queue runtime review

### DIFF
--- a/planningops/artifacts/validation/goal-driven-autonomy-wave5-review.json
+++ b/planningops/artifacts/validation/goal-driven-autonomy-wave5-review.json
@@ -1,0 +1,148 @@
+{
+  "generated_at_utc": "2026-03-14T07:12:50.030596+00:00",
+  "wave_id": "uap-goal-driven-autonomy-wave5",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5-issue-pack.md",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 334,
+      "state": "CLOSED",
+      "title": "plan: [10] Freeze durable queue lease lifecycle contract in platform-contracts",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/334",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 335,
+      "state": "CLOSED",
+      "title": "plan: [20] Implement monday SQLite queue store baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/335",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 336,
+      "state": "CLOSED",
+      "title": "plan: [30] Persist lease-aware scheduled queue cycle in monday",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/336",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave5.execution-contract.json",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-contracts/schemas/runtime-scheduler-lease-lifecycle.schema.json",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-contracts"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/runtime_queue_store.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/run_scheduled_queue_cycle.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/test_run_scheduled_queue_cycle_store.sh",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    }
+  ],
+  "boundary_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/runtime_queue_store.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "monday must remain durable queue runtime owner; planningops must not host SQLite queue helpers"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_scheduled_queue_cycle.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "monday must remain durable queue runtime owner; planningops must not host the scheduled queue cycle entrypoint"
+    }
+  ],
+  "registry_checks": [
+    {
+      "name": "active_goal_key",
+      "expected": "uap-goal-driven-autonomy-wave5",
+      "actual": "uap-goal-driven-autonomy-wave5",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave4_status",
+      "expected": "achieved",
+      "actual": "achieved",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave5_status",
+      "expected": "active",
+      "actual": "active",
+      "verdict": "pass"
+    }
+  ],
+  "validation_checks": [
+    {
+      "name": "planningops/uap_docs_all",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/test_active_goal_registry_contract",
+      "verdict": "pass"
+    },
+    {
+      "name": "platform-contracts/validate_contracts",
+      "verdict": "pass"
+    },
+    {
+      "name": "platform-contracts/test_validate_contracts_strict",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_runtime_queue_store",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_run_scheduled_queue_cycle",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_run_scheduled_queue_cycle_store",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_runtime_guardrails",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_module_readmes",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/typecheck",
+      "verdict": "pass"
+    }
+  ],
+  "check_count": 23,
+  "failure_count": 0,
+  "verdict": "pass"
+}


### PR DESCRIPTION
## Summary
- add the wave5 review artifact for the durable monday queue runtime
- record issue, file, boundary, registry, and validation checks for the completed wave

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: `planningops/artifacts/validation/goal-driven-autonomy-wave5-review.json`
- `.github/` workflows: none

## Linked Issues
- Closes #337
- Related #334

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 -m json.tool planningops/artifacts/validation/goal-driven-autonomy-wave5-review.json`
  - `git diff --check`

## Risks
- Risk: review artifact contents can drift if later manual changes land without a new review pass.
- Rollback: revert this commit and regenerate the review artifact from the latest merged wave state.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
