### PR TITLE
docs(planningops): define wave6 worker outcome successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6-goal-brief.md
@@ -1,0 +1,63 @@
+---
+title: plan: Goal-Driven Autonomy Wave 6 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the worker completion lifecycle wave so monday advances from a durable queue store into a queue runtime that can finalize leased work as completed, retry_wait, or dead_letter with deterministic evidence.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - queue
+  - worker
+  - retry
+  - dead-letter
+---
+
+# Goal-Driven Autonomy Wave 6 Goal Brief
+
+## Objective
+
+Turn the durable queue runtime from wave5 into the first repo-owned worker completion lifecycle:
+- `platform-contracts` freezes only the worker outcome schema that genuinely crosses monday and planningops
+- `monday` records leased work as `completed`, `retry_wait`, or `dead_letter` in the SQLite queue store
+- `planningops` continues to reflect over outcome evidence without becoming a runtime mutation host
+
+## Success Outcomes
+
+- monday has a deterministic worker outcome entrypoint for leased queue items
+- queue items can transition from `leased` to `completed`, `retry_wait`, or `dead_letter` with explicit retry budget and evidence fields
+- shared worker outcome vocabulary is frozen in `platform-contracts` only where planningops must reason over the resulting evidence
+- planningops can review the worker completion lifecycle without taking ownership of queue mutation logic
+
+## Non-Goals
+
+- no provider execution dispatch in this wave
+- no distributed queue coordinator in this wave
+- no Slack-triggered queue mutation in this wave
+- no observability or provider topology redesign unrelated to queue completion outcomes
+
+## Operator Channels
+
+- primary operator channel: `slack_skill_cli`
+- terminal notification channel: `email_cli`
+
+## Completion References
+
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/active-goal-registry-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6-issue-pack.md
@@ -1,0 +1,59 @@
+---
+title: plan: Goal-Driven Autonomy Wave 6 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the sixth goal-driven autonomy wave so monday grows from a durable queue store into a queue runtime that can finalize leased work into completed, retry_wait, or dead_letter states with deterministic evidence.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - queue
+  - worker
+  - retry
+  - dead-letter
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 6 Issue Pack
+
+## Goal
+
+Move from a durable queue store to a deterministic worker completion lifecycle:
+- `planningops policy -> monday queue outcome transitions`
+
+This wave keeps the control-plane boundary from wave5 intact while adding the first durable completion, retry, and dead-letter semantics for leased work.
+
+## Wave 6 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `F10` | 10 | `rather-not-work-on/platform-contracts` | `contracts` | `ready_contract` | `schemas/runtime-queue-worker-outcome.schema.json` |
+| `F20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/record_queue_worker_outcome.py` |
+| `F30` | 30 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/test_record_queue_worker_outcome.sh` |
+| `F40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave6-review.json` |
+
+## Decomposition Rules
+
+- `F10` introduces only the worker outcome schema that planningops must read when reflecting over monday queue completion results.
+- `F20` adds a monday-owned CLI baseline that records `completed`, `retry_wait`, and `dead_letter` transitions for leased queue items.
+- `F30` proves the worker outcome lifecycle through deterministic local regression coverage and monday local CI wiring.
+- `F40` verifies the worker outcome lifecycle keeps planningops as control tower only and monday as runtime owner.
+
+## Dependencies
+
+- `F20` depends on `F10`
+- `F30` depends on `F10`, `F20`
+- `F40` depends on `F10`, `F20`, `F30`
+
+## Non-Goals
+
+- no provider execution adapter in this wave
+- no distributed scheduler daemon in this wave
+- no direct Slack-triggered queue mutation in this wave
+- no planningops-owned queue state transition helper

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6.execution-contract.json
@@ -1,0 +1,66 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave6",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "F10",
+        "execution_order": 10,
+        "title": "Freeze shared queue worker outcome schema",
+        "target_repo": "rather-not-work-on/platform-contracts",
+        "component": "contracts",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "schemas/runtime-queue-worker-outcome.schema.json"
+      },
+      {
+        "plan_item_id": "F20",
+        "execution_order": 20,
+        "title": "Implement monday worker outcome transition baseline",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "scripts/record_queue_worker_outcome.py"
+      },
+      {
+        "plan_item_id": "F30",
+        "execution_order": 30,
+        "title": "Verify monday worker outcome retry and dead-letter lifecycle",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "scripts/test_record_queue_worker_outcome.sh"
+      },
+      {
+        "plan_item_id": "F40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 6 worker outcome lifecycle alignment",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave6-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -116,6 +116,32 @@
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/active-goal-registry-contract.md"
       ],
+      "next_goal_key": "uap-goal-driven-autonomy-wave6",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave6",
+      "title": "Goal-driven autonomy through monday worker outcome lifecycle",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
       "operator_channels": {
         "primary_operator_channel": {
           "kind": "slack_skill_cli",


### PR DESCRIPTION
## Summary
- define the wave6 successor goal for monday worker outcome lifecycle work
- add the wave6 issue pack and execution contract
- link wave5 to wave6 in the active goal registry without promoting it yet

## Scope
- Initiative docs: none
- Workbench docs: `2026-03-14-goal-driven-autonomy-wave6-*`
- `planningops/` scripts/contracts: `planningops/config/active-goal-registry.json`
- `.github/` workflows: none

## Linked Issues
- Closes #340
- Related #337

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
  - `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6.execution-contract.json`

## Risks
- Risk: wave6 scope could still be refined when live materialization starts.
- Rollback: revert the successor docs and registry linkage, leaving wave5 as the terminal active goal.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
