### PR TITLE
docs(planningops): add wave6 worker outcome review

### DIFF
--- a/planningops/artifacts/validation/goal-driven-autonomy-wave6-review.json
+++ b/planningops/artifacts/validation/goal-driven-autonomy-wave6-review.json
@@ -1,0 +1,158 @@
+{
+  "generated_at_utc": "2026-03-14T07:31:14.362696+00:00",
+  "wave_id": "uap-goal-driven-autonomy-wave6",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6-issue-pack.md",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 343,
+      "state": "CLOSED",
+      "title": "plan: [10] Freeze shared queue worker outcome schema",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/343",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 344,
+      "state": "CLOSED",
+      "title": "plan: [20] Implement monday worker outcome transition baseline",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/344",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 345,
+      "state": "CLOSED",
+      "title": "plan: [30] Verify monday worker outcome retry and dead-letter lifecycle",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/345",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave6.execution-contract.json",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-contracts/schemas/runtime-queue-worker-outcome.schema.json",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-contracts"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/record_queue_worker_outcome.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/test_record_queue_worker_outcome.sh",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/run_scheduled_queue_cycle.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    }
+  ],
+  "boundary_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/record_queue_worker_outcome.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "monday must remain worker outcome runtime owner; planningops must not host worker outcome mutation entrypoints"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/runtime_queue_store.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "monday must remain queue persistence owner; planningops must not host SQLite queue helpers"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_scheduled_queue_cycle.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "monday must remain scheduler runtime owner; planningops must not host queue cycle entrypoints"
+    }
+  ],
+  "registry_checks": [
+    {
+      "name": "active_goal_key",
+      "expected": "uap-goal-driven-autonomy-wave6",
+      "actual": "uap-goal-driven-autonomy-wave6",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave5_status",
+      "expected": "achieved",
+      "actual": "achieved",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave6_status",
+      "expected": "active",
+      "actual": "active",
+      "verdict": "pass"
+    }
+  ],
+  "validation_checks": [
+    {
+      "name": "planningops/uap_docs_all",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/test_active_goal_registry_contract",
+      "verdict": "pass"
+    },
+    {
+      "name": "platform-contracts/validate_contracts",
+      "verdict": "pass"
+    },
+    {
+      "name": "platform-contracts/test_validate_contracts_strict",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_runtime_queue_store",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_run_scheduled_queue_cycle_store",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_record_queue_worker_outcome_cli",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_record_queue_worker_outcome",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_runtime_guardrails",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_module_readmes",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/typecheck",
+      "verdict": "pass"
+    }
+  ],
+  "check_count": 25,
+  "failure_count": 0,
+  "verdict": "pass"
+}


### PR DESCRIPTION
## Summary
- add the wave6 review artifact for the worker outcome lifecycle wave
- record issue, file, boundary, registry, and validation checks against the merged wave state

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: `planningops/artifacts/validation/goal-driven-autonomy-wave6-review.json`
- `.github/` workflows: none

## Linked Issues
- Closes #346
- Related #345

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 -m json.tool planningops/artifacts/validation/goal-driven-autonomy-wave6-review.json`
  - `git diff --check`

## Risks
- Risk: review artifact can drift if follow-up runtime changes land without regenerating the wave review.
- Rollback: revert this commit and regenerate the review artifact from the latest merged wave state.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
