### PR TITLE
docs(planningops): define wave7 reflection successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7-goal-brief.md
@@ -1,0 +1,61 @@
+---
+title: plan: Goal-Driven Autonomy Wave 7 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the reflection integration wave so monday worker outcomes become deterministic planningops inputs for replan, continue, and goal-completion decisions.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - reflection
+  - queue
+  - worker
+---
+
+# Goal-Driven Autonomy Wave 7 Goal Brief
+
+## Objective
+
+Turn monday worker outcomes into planningops reflection decisions:
+- `monday` exports deterministic worker outcome reflection packets
+- `planningops` evaluates those packets into control-plane decisions such as `continue`, `replan_required`, `goal_achieved`, or `operator_notify`
+- queue mutation remains in monday while reflection and goal policy remain in planningops
+
+## Success Outcomes
+
+- monday has a repo-owned reflection packet export entrypoint for queue worker outcomes
+- planningops has a deterministic evaluator that consumes reflection packets and produces decision artifacts
+- dead-letter and retry exhaustion can trigger explicit replan signals without moving runtime mutation into planningops
+- goal advancement remains evidence-driven instead of prompt-local
+
+## Non-Goals
+
+- no direct Slack delivery changes in this wave
+- no provider execution redesign in this wave
+- no external queue backend or daemon migration in this wave
+- no planningops-owned runtime queue mutation
+
+## Operator Channels
+
+- primary operator channel: `slack_skill_cli`
+- terminal notification channel: `email_cli`
+
+## Completion References
+
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/active-goal-registry-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7-issue-pack.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 7 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the seventh goal-driven autonomy wave so monday worker outcomes are exported as deterministic reflection packets and planningops can evaluate them into control-plane decisions.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - reflection
+  - queue
+  - worker
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 7 Issue Pack
+
+## Goal
+
+Move from durable worker outcomes to deterministic reflection decisions:
+- `monday worker outcomes -> planningops reflection policy`
+
+This wave keeps monday as execution-plane owner while letting planningops turn worker outcome evidence into explicit replan or completion decisions.
+
+## Wave 7 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `G10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/worker-outcome-reflection-contract.md` |
+| `G20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `scripts/export_worker_outcome_reflection_packet.py` |
+| `G30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py` |
+| `G40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave7-review.json` |
+
+## Decomposition Rules
+
+- `G10` freezes only the planningops-side reflection decision contract and does not add queue mutation helpers.
+- `G20` exports monday-owned worker outcome packets in a deterministic format that planningops can read without coupling to queue tables directly.
+- `G30` evaluates reflection packets into explicit control-plane decisions while keeping runtime mutation out of planningops.
+- `G40` verifies the reflection layer preserves the control-plane/runtime boundary and leaves queue execution in monday.
+
+## Dependencies
+
+- `G20` depends on `G10`
+- `G30` depends on `G10`, `G20`
+- `G40` depends on `G10`, `G20`, `G30`
+
+## Non-Goals
+
+- no direct Slack/email transport change in this wave
+- no provider or observability runtime redesign in this wave
+- no planningops-owned queue lease or completion mutation
+- no external queue backend migration

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7.execution-contract.json
@@ -1,0 +1,66 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave7",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "G10",
+        "execution_order": 10,
+        "title": "Freeze planningops worker outcome reflection contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/worker-outcome-reflection-contract.md"
+      },
+      {
+        "plan_item_id": "G20",
+        "execution_order": 20,
+        "title": "Export monday worker outcome reflection packets",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "scripts/export_worker_outcome_reflection_packet.py"
+      },
+      {
+        "plan_item_id": "G30",
+        "execution_order": 30,
+        "title": "Evaluate worker outcome reflection into planningops decisions",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py"
+      },
+      {
+        "plan_item_id": "G40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 7 reflection integration alignment",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave7-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -142,6 +142,32 @@
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/active-goal-registry-contract.md"
       ],
+      "next_goal_key": "uap-goal-driven-autonomy-wave7",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave7",
+      "title": "Goal-driven autonomy through worker outcome reflection integration",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
       "operator_channels": {
         "primary_operator_channel": {
           "kind": "slack_skill_cli",


### PR DESCRIPTION
## Summary
- define the wave7 successor goal for worker outcome reflection integration
- add the wave7 issue pack and execution contract
- link wave6 to wave7 in the active goal registry without promoting it yet

## Scope
- Initiative docs: none
- Workbench docs: `2026-03-14-goal-driven-autonomy-wave7-*`
- `planningops/` scripts/contracts: `planningops/config/active-goal-registry.json`
- `.github/` workflows: none

## Linked Issues
- Closes #349
- Related #346

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
  - `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave7.execution-contract.json`

## Risks
- Risk: wave7 scope may still narrow once reflection packet/export details are implemented.
- Rollback: revert the successor docs and registry linkage, leaving wave6 as the terminal active goal.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
