### PR TITLE
feat(planningops): define worker outcome reflection contract

### DIFF
--- a/.github/workflows/planningops-contracts-dryrun.yml
+++ b/.github/workflows/planningops-contracts-dryrun.yml
@@ -34,6 +34,7 @@ jobs:
           bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh
           bash planningops/scripts/test_supervisor_operator_handoff_contract.sh
           bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
+          bash planningops/scripts/test_worker_outcome_reflection_contract.sh
           bash planningops/scripts/test_supervisor_experiment_auto_executor_contract.sh
           python3 planningops/scripts/validate_worker_task_pack.py \
             --runtime-profile-file planningops/config/runtime-profiles.json \
@@ -64,6 +65,7 @@ jobs:
                   "test_autonomous_supervisor_loop_contract",
                   "test_supervisor_operator_handoff_contract",
                   "test_supervisor_experiment_auto_executor_contract",
+                  "test_worker_outcome_reflection_contract",
                   "validate_worker_task_pack_ci_report",
               ],
               "artifacts": {

--- a/planningops/contracts/worker-outcome-reflection-contract.md
+++ b/planningops/contracts/worker-outcome-reflection-contract.md
@@ -1,0 +1,117 @@
+# Worker Outcome Reflection Contract
+
+## Purpose
+Define the deterministic handoff between monday-owned queue worker outcomes and planningops-owned reflection decisions.
+
+This contract exists so:
+- `monday` can export reflection-ready evidence without leaking queue table internals into planningops
+- `planningops` can evaluate runtime outcomes into control-plane decisions without mutating the runtime queue
+- both repos share one fixed packet and decision vocabulary for wave7 and later scheduler work
+
+## Canonical Boundary
+- runtime source schema: `platform-contracts/schemas/runtime-queue-worker-outcome.schema.json`
+- runtime exporter target: `monday/scripts/export_worker_outcome_reflection_packet.py`
+- control-plane evaluator target: `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
+
+## Reflection Packet Envelope
+Every reflection packet exported by `monday` must include:
+- `packet_version`
+- `exported_at_utc`
+- `source_repo`
+- `source_contract_ref`
+- `source_outcome_ref`
+- `worker_outcome`
+- `reflection_hints`
+
+### Required Source Outcome Fields
+`worker_outcome` must preserve the canonical runtime fields:
+- `transition_id`
+- `queue_item_id`
+- `goal_key`
+- `schedule_key`
+- `lease_owner`
+- `worker_run_id`
+- `state_from`
+- `state_to`
+- `transition_reason`
+- `occurred_at_utc`
+- `attempt_count`
+- `retry_budget_remaining`
+
+Optional outcome fields may pass through when present:
+- `completion_evidence_ref`
+- `retry_after_utc`
+- `dead_letter_reason`
+
+### Required Reflection Hints
+`reflection_hints` must be derived deterministically from the runtime outcome and include:
+- `outcome_class`
+- `completion_candidate`
+- `retry_exhausted`
+- `dead_letter`
+- `operator_attention_recommended`
+- `allowed_decisions`
+
+### Outcome Class Vocabulary
+The packet-level `outcome_class` vocabulary is:
+- `completion`
+- `retry_wait`
+- `dead_letter`
+
+## Decision Vocabulary
+PlanningOps may emit only these reflection decisions:
+- `continue`
+- `replan_required`
+- `goal_achieved`
+- `operator_notify`
+
+Every evaluator result must include:
+- `goal_key`
+- `queue_item_id`
+- `worker_run_id`
+- `source_packet_ref`
+- `reflection_decision`
+- `decision_reason`
+- `decision_timestamp_utc`
+- `control_plane_action`
+- `verdict`
+
+## Deterministic Mapping Rules
+- `state_to = completed` maps to `outcome_class = completion`
+- `state_to = retry_wait` maps to `outcome_class = retry_wait`
+- `state_to = dead_letter` maps to `outcome_class = dead_letter`
+- `outcome_class = completion` may allow only `continue` or `goal_achieved`
+- `outcome_class = retry_wait` must allow only `continue`
+- `outcome_class = dead_letter` may allow only `replan_required` or `operator_notify`
+- `retry_budget_remaining = 0` or a populated `dead_letter_reason` must set `operator_attention_recommended = true`
+- the evaluator must fail closed if the packet proposes a decision outside `allowed_decisions`
+
+## Ownership Boundary
+### Monday owns
+- queue runtime mutation
+- runtime outcome production
+- reflection packet export
+- repo-local runtime evidence paths
+
+### PlanningOps owns
+- reflection decision policy
+- goal promotion and replanning policy
+- operator escalation intent
+- completion policy references
+
+### PlanningOps must not own
+- queue lease updates
+- dequeue/retry/dead-letter mutation
+- monday queue persistence internals
+
+## Failure Rules
+- missing or malformed runtime source fields must fail packet export
+- malformed `reflection_hints` must fail evaluation
+- evaluators must return deterministic failure evidence instead of silently defaulting to `continue`
+- control-plane evaluation must not mutate monday queue state directly
+
+## Validation
+- `planningops/scripts/test_worker_outcome_reflection_contract.sh`
+- `platform-contracts/schemas/runtime-queue-worker-outcome.schema.json`
+- `monday/scripts/export_worker_outcome_reflection_packet.py`
+- `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`

--- a/planningops/scripts/test_worker_outcome_reflection_contract.sh
+++ b/planningops/scripts/test_worker_outcome_reflection_contract.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+contract = Path("planningops/contracts/worker-outcome-reflection-contract.md")
+text = contract.read_text(encoding="utf-8")
+
+required_sections = [
+    "# Worker Outcome Reflection Contract",
+    "## Purpose",
+    "## Canonical Boundary",
+    "## Reflection Packet Envelope",
+    "## Decision Vocabulary",
+    "## Deterministic Mapping Rules",
+    "## Ownership Boundary",
+    "## Failure Rules",
+    "## Validation",
+]
+for section in required_sections:
+    assert section in text, section
+
+required_fragments = [
+    "platform-contracts/schemas/runtime-queue-worker-outcome.schema.json",
+    "monday/scripts/export_worker_outcome_reflection_packet.py",
+    "planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py",
+    "`packet_version`",
+    "`reflection_hints`",
+    "`continue`",
+    "`replan_required`",
+    "`goal_achieved`",
+    "`operator_notify`",
+    "PlanningOps must not own",
+    "queue lease updates",
+]
+for fragment in required_fragments:
+    assert fragment in text, fragment
+
+print("worker outcome reflection contract ok")
+PY


### PR DESCRIPTION
## Summary
- freeze the monday-to-planningops reflection packet and decision vocabulary for wave7
- add a contract regression test for the new reflection boundary
- wire the new contract test into the planningops dry-run reliability pack

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: new reflection contract and contract test
- `.github/` workflows: add the reflection contract test to `validate-and-dry-run`

## Linked Issues
- Closes #352
- Related #353
- Related #354
- Related #355

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_worker_outcome_reflection_contract.sh`
  - `git diff --check`

## Risks
- Risk: G20/G30 may still need minor vocabulary expansion if worker outcome export reveals missing hints.
- Rollback: revert this PR and keep wave7 blocked at the contract stage.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
