### PR TITLE
feat(planningops): evaluate worker outcome reflection

### DIFF
--- a/.github/workflows/planningops-contracts-dryrun.yml
+++ b/.github/workflows/planningops-contracts-dryrun.yml
@@ -35,6 +35,7 @@ jobs:
           bash planningops/scripts/test_supervisor_operator_handoff_contract.sh
           bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
           bash planningops/scripts/test_worker_outcome_reflection_contract.sh
+          bash planningops/scripts/test_evaluate_worker_outcome_reflection.sh
           bash planningops/scripts/test_supervisor_experiment_auto_executor_contract.sh
           python3 planningops/scripts/validate_worker_task_pack.py \
             --runtime-profile-file planningops/config/runtime-profiles.json \
@@ -66,6 +67,7 @@ jobs:
                   "test_supervisor_operator_handoff_contract",
                   "test_supervisor_experiment_auto_executor_contract",
                   "test_worker_outcome_reflection_contract",
+                  "test_evaluate_worker_outcome_reflection",
                   "validate_worker_task_pack_ci_report",
               ],
               "artifacts": {

--- a/planningops/fixtures/worker-outcome-reflection-packet.completed.sample.json
+++ b/planningops/fixtures/worker-outcome-reflection-packet.completed.sample.json
@@ -1,0 +1,34 @@
+{
+  "packet_version": 1,
+  "exported_at_utc": "2026-03-14T08:00:05Z",
+  "source_repo": "rather-not-work-on/monday",
+  "source_contract_ref": "platform-contracts/schemas/runtime-queue-worker-outcome.schema.json",
+  "reflection_contract_ref": "planningops/contracts/worker-outcome-reflection-contract.md",
+  "source_outcome_ref": "runtime-artifacts/worker-outcome/wave7-run-001.json",
+  "worker_outcome": {
+    "transition_id": "wave7-outcome-001",
+    "queue_item_id": "queue-wave7-001",
+    "goal_key": "uap-goal-driven-autonomy-wave7",
+    "schedule_key": "local-tick-5m",
+    "lease_owner": "monday-local-worker",
+    "worker_run_id": "wave7-run-001",
+    "state_from": "leased",
+    "state_to": "completed",
+    "transition_reason": "worker.completed",
+    "occurred_at_utc": "2026-03-14T08:00:00Z",
+    "attempt_count": 1,
+    "retry_budget_remaining": 2,
+    "completion_evidence_ref": "runtime-artifacts/worker-outcome/wave7-run-001.json"
+  },
+  "reflection_hints": {
+    "outcome_class": "completion",
+    "completion_candidate": true,
+    "retry_exhausted": false,
+    "dead_letter": false,
+    "operator_attention_recommended": false,
+    "allowed_decisions": [
+      "continue",
+      "goal_achieved"
+    ]
+  }
+}

--- a/planningops/fixtures/worker-outcome-reflection-packet.dead-letter.sample.json
+++ b/planningops/fixtures/worker-outcome-reflection-packet.dead-letter.sample.json
@@ -1,0 +1,34 @@
+{
+  "packet_version": 1,
+  "exported_at_utc": "2026-03-14T08:30:05Z",
+  "source_repo": "rather-not-work-on/monday",
+  "source_contract_ref": "platform-contracts/schemas/runtime-queue-worker-outcome.schema.json",
+  "reflection_contract_ref": "planningops/contracts/worker-outcome-reflection-contract.md",
+  "source_outcome_ref": "runtime-artifacts/worker-outcome/wave7-run-003.json",
+  "worker_outcome": {
+    "transition_id": "wave7-outcome-003",
+    "queue_item_id": "queue-wave7-001",
+    "goal_key": "uap-goal-driven-autonomy-wave7",
+    "schedule_key": "local-tick-5m",
+    "lease_owner": "monday-local-worker",
+    "worker_run_id": "wave7-run-003",
+    "state_from": "leased",
+    "state_to": "dead_letter",
+    "transition_reason": "worker.retry_exhausted",
+    "occurred_at_utc": "2026-03-14T08:30:00Z",
+    "attempt_count": 2,
+    "retry_budget_remaining": 0,
+    "dead_letter_reason": "retry_budget_exhausted"
+  },
+  "reflection_hints": {
+    "outcome_class": "dead_letter",
+    "completion_candidate": false,
+    "retry_exhausted": true,
+    "dead_letter": true,
+    "operator_attention_recommended": true,
+    "allowed_decisions": [
+      "replan_required",
+      "operator_notify"
+    ]
+  }
+}

--- a/planningops/fixtures/worker-outcome-reflection-packet.goal-mismatch.sample.json
+++ b/planningops/fixtures/worker-outcome-reflection-packet.goal-mismatch.sample.json
@@ -1,0 +1,34 @@
+{
+  "packet_version": 1,
+  "exported_at_utc": "2026-03-14T08:31:05Z",
+  "source_repo": "rather-not-work-on/monday",
+  "source_contract_ref": "platform-contracts/schemas/runtime-queue-worker-outcome.schema.json",
+  "reflection_contract_ref": "planningops/contracts/worker-outcome-reflection-contract.md",
+  "source_outcome_ref": "runtime-artifacts/worker-outcome/wave6-run-003.json",
+  "worker_outcome": {
+    "transition_id": "wave6-outcome-003",
+    "queue_item_id": "queue-wave6-001",
+    "goal_key": "uap-goal-driven-autonomy-wave6",
+    "schedule_key": "local-tick-5m",
+    "lease_owner": "monday-local-worker",
+    "worker_run_id": "wave6-run-003",
+    "state_from": "leased",
+    "state_to": "dead_letter",
+    "transition_reason": "worker.retry_exhausted",
+    "occurred_at_utc": "2026-03-14T08:30:00Z",
+    "attempt_count": 2,
+    "retry_budget_remaining": 0,
+    "dead_letter_reason": "retry_budget_exhausted"
+  },
+  "reflection_hints": {
+    "outcome_class": "dead_letter",
+    "completion_candidate": false,
+    "retry_exhausted": true,
+    "dead_letter": true,
+    "operator_attention_recommended": true,
+    "allowed_decisions": [
+      "replan_required",
+      "operator_notify"
+    ]
+  }
+}

--- a/planningops/fixtures/worker-outcome-reflection-packet.retry.sample.json
+++ b/planningops/fixtures/worker-outcome-reflection-packet.retry.sample.json
@@ -1,0 +1,33 @@
+{
+  "packet_version": 1,
+  "exported_at_utc": "2026-03-14T08:10:05Z",
+  "source_repo": "rather-not-work-on/monday",
+  "source_contract_ref": "platform-contracts/schemas/runtime-queue-worker-outcome.schema.json",
+  "reflection_contract_ref": "planningops/contracts/worker-outcome-reflection-contract.md",
+  "source_outcome_ref": "runtime-artifacts/worker-outcome/wave7-run-002.json",
+  "worker_outcome": {
+    "transition_id": "wave7-outcome-002",
+    "queue_item_id": "queue-wave7-001",
+    "goal_key": "uap-goal-driven-autonomy-wave7",
+    "schedule_key": "local-tick-5m",
+    "lease_owner": "monday-local-worker",
+    "worker_run_id": "wave7-run-002",
+    "state_from": "leased",
+    "state_to": "retry_wait",
+    "transition_reason": "worker.retryable_failure",
+    "occurred_at_utc": "2026-03-14T08:10:00Z",
+    "attempt_count": 1,
+    "retry_budget_remaining": 1,
+    "retry_after_utc": "2099-03-14T08:20:00Z"
+  },
+  "reflection_hints": {
+    "outcome_class": "retry_wait",
+    "completion_candidate": false,
+    "retry_exhausted": false,
+    "dead_letter": false,
+    "operator_attention_recommended": false,
+    "allowed_decisions": [
+      "continue"
+    ]
+  }
+}

--- a/planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py
+++ b/planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from resolve_active_goal import build_resolved_payload, load_json, resolve_active_goal, validate_registry
+
+
+REQUIRED_PACKET_FIELDS = [
+    "packet_version",
+    "exported_at_utc",
+    "source_repo",
+    "source_contract_ref",
+    "source_outcome_ref",
+    "worker_outcome",
+    "reflection_hints",
+]
+REQUIRED_OUTCOME_FIELDS = [
+    "transition_id",
+    "queue_item_id",
+    "goal_key",
+    "schedule_key",
+    "lease_owner",
+    "worker_run_id",
+    "state_from",
+    "state_to",
+    "transition_reason",
+    "occurred_at_utc",
+    "attempt_count",
+    "retry_budget_remaining",
+]
+REQUIRED_HINT_FIELDS = [
+    "outcome_class",
+    "completion_candidate",
+    "retry_exhausted",
+    "dead_letter",
+    "operator_attention_recommended",
+    "allowed_decisions",
+]
+ALLOWED_DECISIONS = {"continue", "replan_required", "goal_achieved", "operator_notify"}
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Evaluate monday worker outcome reflection packets into planningops decisions")
+    parser.add_argument("--packet-json", required=True)
+    parser.add_argument("--active-goal-registry", default="planningops/config/active-goal-registry.json")
+    parser.add_argument("--goal-key", default=None)
+    parser.add_argument("--output", default="planningops/artifacts/validation/worker-outcome-reflection-evaluation.json")
+    return parser.parse_args()
+
+
+def require_fields(doc: dict, required_fields: list[str], prefix: str, errors: list[str]) -> None:
+    for field in required_fields:
+        if field not in doc:
+            errors.append(f"{prefix}.{field} is required")
+
+
+def validate_packet(packet: dict, errors: list[str]) -> None:
+    if not isinstance(packet, dict):
+        errors.append("packet must be an object")
+        return
+    require_fields(packet, REQUIRED_PACKET_FIELDS, "packet", errors)
+    outcome = packet.get("worker_outcome")
+    hints = packet.get("reflection_hints")
+    if not isinstance(outcome, dict):
+        errors.append("packet.worker_outcome must be an object")
+    else:
+        require_fields(outcome, REQUIRED_OUTCOME_FIELDS, "packet.worker_outcome", errors)
+    if not isinstance(hints, dict):
+        errors.append("packet.reflection_hints must be an object")
+    else:
+        require_fields(hints, REQUIRED_HINT_FIELDS, "packet.reflection_hints", errors)
+        allowed = hints.get("allowed_decisions")
+        if not isinstance(allowed, list) or not allowed:
+            errors.append("packet.reflection_hints.allowed_decisions must be non-empty list")
+        else:
+            invalid = sorted(set(str(item) for item in allowed) - ALLOWED_DECISIONS)
+            if invalid:
+                errors.append(f"packet.reflection_hints.allowed_decisions invalid: {invalid}")
+
+
+def resolve_goal_context(registry_path: Path, goal_key: str | None) -> tuple[dict | None, list[str]]:
+    if not registry_path.exists():
+        return None, [f"active goal registry not found: {registry_path}"]
+    registry = load_json(registry_path)
+    repo_root = Path(__file__).resolve().parents[4]
+    errors = validate_registry(registry, repo_root=repo_root)
+    if errors:
+        return None, [f"active goal registry invalid: {error}" for error in errors]
+    try:
+        goal = build_resolved_payload(resolve_active_goal(registry, goal_key=goal_key))
+    except RuntimeError as exc:
+        return None, [str(exc)]
+    return goal, []
+
+
+def derive_decision(packet: dict, active_goal: dict | None, errors: list[str]) -> tuple[str | None, str | None]:
+    outcome = packet["worker_outcome"]
+    hints = packet["reflection_hints"]
+    packet_goal_key = str(outcome["goal_key"])
+    active_goal_key = str((active_goal or {}).get("goal_key") or "")
+    allowed = list(hints["allowed_decisions"])
+
+    if active_goal_key and packet_goal_key != active_goal_key:
+        decision = "operator_notify"
+        reason = "packet_goal_mismatch_active_goal"
+    else:
+        outcome_class = str(hints["outcome_class"])
+        if outcome_class == "dead_letter":
+            decision = "replan_required"
+            reason = "dead_letter_runtime_outcome"
+        elif outcome_class == "retry_wait":
+            decision = "continue"
+            reason = "retry_wait_runtime_outcome"
+        elif outcome_class == "completion" and bool(hints["completion_candidate"]):
+            decision = "goal_achieved"
+            reason = "completed_runtime_outcome"
+        else:
+            errors.append(f"unsupported outcome_class decision mapping: {outcome_class}")
+            return None, None
+
+    if decision not in allowed:
+        errors.append(f"decision_not_allowed_by_packet: {decision}")
+        return None, None
+    return decision, reason
+
+
+def control_plane_action_for(decision: str) -> str:
+    mapping = {
+        "continue": "none",
+        "replan_required": "replan_backlog",
+        "goal_achieved": "evaluate_goal_completion",
+        "operator_notify": "notify_operator",
+    }
+    return mapping[decision]
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[4]
+    packet_path = repo_root / args.packet_json
+    packet = load_json(packet_path)
+    errors: list[str] = []
+    validate_packet(packet, errors)
+
+    active_goal = None
+    if not errors:
+        active_goal, goal_errors = resolve_goal_context(repo_root / args.active_goal_registry, args.goal_key)
+        errors.extend(goal_errors)
+
+    decision = None
+    decision_reason = None
+    if not errors:
+        decision, decision_reason = derive_decision(packet, active_goal, errors)
+
+    outcome = packet.get("worker_outcome") or {}
+    payload = {
+        "generated_at_utc": now_utc(),
+        "packet_json": args.packet_json,
+        "source_packet_ref": args.packet_json,
+        "source_outcome_ref": packet.get("source_outcome_ref"),
+        "active_goal_key": None if active_goal is None else active_goal.get("goal_key"),
+        "packet_goal_key": outcome.get("goal_key"),
+        "queue_item_id": outcome.get("queue_item_id"),
+        "worker_run_id": outcome.get("worker_run_id"),
+        "allowed_decisions": ((packet.get("reflection_hints") or {}).get("allowed_decisions") or []),
+        "reflection_decision": decision,
+        "decision_reason": decision_reason,
+        "decision_timestamp_utc": now_utc(),
+        "control_plane_action": None if decision is None else control_plane_action_for(decision),
+        "reflection_contract_ref": "planningops/contracts/worker-outcome-reflection-contract.md",
+        "verdict": "pass" if not errors else "fail",
+        "error_count": len(errors),
+        "errors": errors,
+    }
+
+    output_path = repo_root / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(payload, ensure_ascii=True, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/test_evaluate_worker_outcome_reflection.sh
+++ b/planningops/scripts/test_evaluate_worker_outcome_reflection.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+python3 planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py \
+  --packet-json planningops/fixtures/worker-outcome-reflection-packet.completed.sample.json \
+  --output "$TMP_DIR/completed-eval.json" >/dev/null
+
+python3 planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py \
+  --packet-json planningops/fixtures/worker-outcome-reflection-packet.retry.sample.json \
+  --output "$TMP_DIR/retry-eval.json" >/dev/null
+
+python3 planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py \
+  --packet-json planningops/fixtures/worker-outcome-reflection-packet.dead-letter.sample.json \
+  --output "$TMP_DIR/dead-letter-eval.json" >/dev/null
+
+python3 planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py \
+  --packet-json planningops/fixtures/worker-outcome-reflection-packet.goal-mismatch.sample.json \
+  --output "$TMP_DIR/goal-mismatch-eval.json" >/dev/null
+
+python3 - "$TMP_DIR/completed-eval.json" "$TMP_DIR/retry-eval.json" "$TMP_DIR/dead-letter-eval.json" "$TMP_DIR/goal-mismatch-eval.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+completed = json.loads(Path(sys.argv[1]).read_text())
+retry = json.loads(Path(sys.argv[2]).read_text())
+dead_letter = json.loads(Path(sys.argv[3]).read_text())
+goal_mismatch = json.loads(Path(sys.argv[4]).read_text())
+
+assert completed["verdict"] == "pass", completed
+assert completed["reflection_decision"] == "goal_achieved", completed
+assert completed["control_plane_action"] == "evaluate_goal_completion", completed
+
+assert retry["verdict"] == "pass", retry
+assert retry["reflection_decision"] == "continue", retry
+assert retry["control_plane_action"] == "none", retry
+
+assert dead_letter["verdict"] == "pass", dead_letter
+assert dead_letter["reflection_decision"] == "replan_required", dead_letter
+assert dead_letter["control_plane_action"] == "replan_backlog", dead_letter
+
+assert goal_mismatch["verdict"] == "pass", goal_mismatch
+assert goal_mismatch["reflection_decision"] == "operator_notify", goal_mismatch
+assert goal_mismatch["control_plane_action"] == "notify_operator", goal_mismatch
+
+print("evaluate worker outcome reflection test passed")
+PY


### PR DESCRIPTION
## Summary
- add a deterministic evaluator that turns monday reflection packets into planningops decisions
- cover completed, retry-wait, dead-letter, and active-goal mismatch paths with fixtures and contract tests
- run the reflection evaluator regression in planningops dry-run CI

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: add `evaluate_worker_outcome_reflection.py`, fixtures, and regression test
- `.github/` workflows: run the evaluator regression in `validate-and-dry-run`

## Linked Issues
- Closes #354
- Related #355

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_evaluate_worker_outcome_reflection.sh`
  - `bash planningops/scripts/test_worker_outcome_reflection_contract.sh`
  - `python3 -m py_compile planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
  - `git diff --check`

## Risks
- Risk: `completed -> goal_achieved` is a baseline mapping and may need refinement once queue breadth per goal increases.
- Rollback: revert this PR and keep wave7 at packet-export only.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
