### PR TITLE
docs: define wave9 reflection cycle successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9-goal-brief.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 9 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the ninth goal-driven autonomy wave so planningops can orchestrate a full reflection cycle from monday worker outcome packets into action artifacts without prompt-local glue.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - reflection
+  - orchestration
+  - scheduler
+---
+
+# Goal-Driven Autonomy Wave 9 Goal Brief
+
+## Objective
+
+Turn the wave7 and wave8 components into one deterministic orchestration path:
+- `monday worker outcome packet -> planningops evaluation -> planningops action artifact`
+- a single planningops-owned federated runner can exercise that chain end to end
+- review evidence can prove the chain stays policy-owned by planningops and transport-owned by monday
+
+## Success Outcomes
+
+- planningops has a repo-owned reflection cycle orchestration contract
+- planningops has a federated entrypoint that runs packet evaluation and action application in one flow
+- planningops has a regression test for the full reflection cycle using monday-owned leaf scripts
+- wave9 keeps queue mutation and transport execution outside planningops
+
+## Non-Goals
+
+- no scheduler backend migration
+- no new Slack or email transport implementation
+- no monday-owned planning policy
+- no planningops-owned queue mutation
+
+## Completion References
+
+- `planningops/contracts/worker-outcome-reflection-contract.md`
+- `planningops/contracts/reflection-action-handoff-contract.md`
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9-issue-pack.md
@@ -1,0 +1,55 @@
+---
+title: plan: Goal-Driven Autonomy Wave 9 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the ninth goal-driven autonomy wave so the reflection packet, evaluation, and action-handoff steps can run as one deterministic control-plane orchestration loop.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - reflection
+  - orchestration
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 9 Issue Pack
+
+## Goal
+
+Move from disconnected reflection components to one deterministic orchestration flow:
+- `worker outcome packet -> reflection evaluation -> reflection action artifact`
+
+This wave makes the reflection chain executable as a control-plane loop instead of a set of isolated commands.
+
+## Wave 9 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `I10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/reflection-cycle-orchestration-contract.md` |
+| `I20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py` |
+| `I30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/test_worker_outcome_reflection_cycle.sh` |
+| `I40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave9-review.json` |
+
+## Decomposition Rules
+
+- `I10` freezes orchestration inputs and outputs only; it does not redesign packet or action vocabularies.
+- `I20` adds a control-plane runner that reuses existing monday and planningops entrypoints rather than re-implementing them.
+- `I30` verifies end-to-end determinism using monday-owned leaf scripts and planningops-owned evaluation/action steps.
+- `I40` verifies the orchestration layer stayed thin and respected the control-plane versus runtime boundary.
+
+## Dependencies
+
+- `I20` depends on `I10`
+- `I30` depends on `I10`, `I20`
+- `I40` depends on `I10`, `I20`, `I30`
+
+## Non-Goals
+
+- no monday transport redesign
+- no queue store mutation from planningops
+- no new shared schema unless the existing contracts prove insufficient

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9.execution-contract.json
@@ -1,0 +1,66 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave9",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "I10",
+        "execution_order": 10,
+        "title": "Freeze reflection cycle orchestration contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/reflection-cycle-orchestration-contract.md"
+      },
+      {
+        "plan_item_id": "I20",
+        "execution_order": 20,
+        "title": "Run worker outcome reflection cycle through planningops orchestration",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "planningops/scripts/federation/run_worker_outcome_reflection_cycle.py"
+      },
+      {
+        "plan_item_id": "I30",
+        "execution_order": 30,
+        "title": "Verify the end-to-end worker outcome reflection cycle",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "planningops/scripts/test_worker_outcome_reflection_cycle.sh"
+      },
+      {
+        "plan_item_id": "I40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 9 reflection cycle orchestration",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave9-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -194,6 +194,32 @@
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/active-goal-registry-contract.md"
       ],
+      "next_goal_key": "uap-goal-driven-autonomy-wave9",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave9",
+      "title": "Goal-driven autonomy through reflection cycle orchestration",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
       "operator_channels": {
         "primary_operator_channel": {
           "kind": "slack_skill_cli",


### PR DESCRIPTION
## Summary
- define the wave9 successor goal for reflection cycle orchestration
- register wave9 as the explicit successor of wave8 in the active-goal registry
- add the wave9 issue pack and execution contract so the next backlog can materialize from main

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9-goal-brief.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9-issue-pack.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9.execution-contract.json`
- `planningops/` scripts/contracts: `planningops/config/active-goal-registry.json`
- `.github/` workflows: none

## Linked Issues
- Related #366
- Related #365

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`, `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave9.execution-contract.json`, `git diff --check`

## Risks
- Risk: wave9 scope may need decomposition changes if the first orchestration runner proves too broad.
- Rollback: revert this PR to remove the wave9 successor registration and return wave8 to having no explicit successor.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
