### PR TITLE
docs(planningops): freeze reflection cycle orchestration contract

### DIFF
--- a/.github/workflows/planningops-contracts-dryrun.yml
+++ b/.github/workflows/planningops-contracts-dryrun.yml
@@ -36,6 +36,7 @@ jobs:
           bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
           bash planningops/scripts/test_worker_outcome_reflection_contract.sh
           bash planningops/scripts/test_reflection_action_handoff_contract.sh
+          bash planningops/scripts/test_reflection_cycle_orchestration_contract.sh
           bash planningops/scripts/test_evaluate_worker_outcome_reflection.sh
           bash planningops/scripts/test_apply_worker_outcome_reflection.sh
           bash planningops/scripts/test_supervisor_experiment_auto_executor_contract.sh
@@ -71,6 +72,7 @@ jobs:
                   "test_supervisor_experiment_auto_executor_contract",
                   "test_worker_outcome_reflection_contract",
                   "test_reflection_action_handoff_contract",
+                  "test_reflection_cycle_orchestration_contract",
                   "test_evaluate_worker_outcome_reflection",
                   "test_apply_worker_outcome_reflection",
                   "validate_worker_task_pack_ci_report",

--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -24,6 +24,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `operator-channel-adapter-contract.md`: monday-owned Slack/email channel adapter boundary and evidence rules
 - `supervisor-operator-handoff-contract.md`: canonical supervisor artifact to monday CLI handoff boundary
 - `autonomous-scheduler-queue-control-plane-contract.md`: policy boundary between planningops control plane and monday scheduler/queue runtime
+- `reflection-cycle-orchestration-contract.md`: end-to-end worker-outcome packet -> evaluation -> action orchestration boundary
 - `supervisor-experiment-auto-executor-contract.md`: trigger-to-worktree comparative execution and decision contract
 - `worker-task-pack-contract.md`: worker execution bundle and render safety contract
 - `checkpoint-resume-contract.md`: checkpoint and resume behavior

--- a/planningops/contracts/reflection-cycle-orchestration-contract.md
+++ b/planningops/contracts/reflection-cycle-orchestration-contract.md
@@ -1,0 +1,117 @@
+# Reflection Cycle Orchestration Contract
+
+## Purpose
+Freeze the thin control-plane orchestration path that turns one monday worker outcome into one planningops reflection decision and one planningops action artifact.
+
+This contract exists so:
+- `planningops` can run the reflection chain end to end without prompt-local glue
+- `monday` remains the owner of runtime outcome export and downstream operator delivery
+- later scheduler and queue work can reuse one deterministic cycle runner instead of re-stitching the same steps in ad hoc scripts
+
+## Canonical Boundary
+- runtime exporter: `monday/scripts/export_worker_outcome_reflection_packet.py`
+- control-plane evaluator: `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
+- control-plane applier: `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
+- orchestration runner: `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
+- downstream monday consumer: `monday/scripts/send_reflection_decision_update.py`
+
+## Cycle Scope
+The reflection cycle covered by this contract is:
+1. read one monday worker outcome artifact
+2. export one reflection packet through the monday-owned exporter
+3. evaluate the packet into one planningops reflection decision
+4. apply the decision into one planningops action artifact
+5. emit one planningops-owned cycle report
+
+The cycle ends at the action artifact.
+
+The cycle must not:
+- mutate monday queue state directly
+- invoke monday delivery transports directly
+- derive new reflection vocabularies outside the existing contracts
+
+## Required Inputs
+The orchestration runner must accept enough input to resolve the full cycle deterministically:
+- a worker outcome artifact path
+- an active-goal registry path
+- a goal key or a deterministic active-goal resolution path
+- an execution mode: `dry-run` or `apply`
+- explicit output paths or deterministic default output locations for:
+  - the reflection packet
+  - the reflection evaluation
+  - the reflection action artifact
+  - the cycle report
+
+## Required Outputs
+Every successful cycle must emit:
+- one reflection packet artifact
+- one reflection evaluation artifact
+- one reflection action artifact
+- one cycle report
+
+## Cycle Report
+Every cycle report must include:
+- `generated_at_utc`
+- `mode`
+- `goal_key`
+- `source_outcome_ref`
+- `reflection_packet_ref`
+- `reflection_evaluation_ref`
+- `reflection_action_ref`
+- `reflection_decision`
+- `action_kind`
+- `delivery_required`
+- `goal_transition_required`
+- `goal_transition_report_path`
+- `runner_contract_ref`
+- `verdict`
+
+Optional cycle report fields may include:
+- `queue_item_id`
+- `worker_run_id`
+- `decision_reason`
+- `control_plane_action`
+- `operator_channel_role`
+- `operator_channel_kind`
+- `operator_channel_execution_repo`
+
+## Deterministic Orchestration Rules
+- the runner must call the monday exporter instead of recreating packet logic inside planningops
+- the runner must call the planningops evaluator instead of deriving decisions inline
+- the runner must call the planningops applier instead of deriving action mappings inline
+- the runner must pass the same goal context to the evaluator and applier within one cycle
+- the runner must preserve repo-root-relative evidence refs in its emitted cycle report whenever the produced artifact lives inside the repo
+- `dry-run` mode must preserve control-plane intent without invoking goal transition side effects beyond those already allowed by the applier in `dry-run`
+- `apply` mode may allow the applier to perform goal transition side effects, but only through `planningops/scripts/core/goals/transition_goal_state.py`
+
+## Failure Rules
+- exporter failure must fail the cycle before evaluation starts
+- evaluator failure must fail the cycle before action application starts
+- applier failure must fail the cycle before the runner reports success
+- the runner must fail closed and emit deterministic failure evidence instead of silently skipping a stage
+- the runner must never report `verdict=pass` when any stage returns `verdict=fail`
+
+## Ownership Boundary
+### PlanningOps owns
+- cycle orchestration
+- cycle report evidence
+- control-plane evaluation and action application
+- goal transition policy side effects initiated by the applier
+
+### Monday owns
+- worker outcome production
+- reflection packet export implementation
+- operator-channel delivery implementation
+- queue persistence and lease mutation
+
+### PlanningOps must not own
+- runtime queue dequeue, retry, or dead-letter mutation
+- concrete Slack or email transport execution
+- transport credentials or delivery target resolution
+
+## Validation
+- `planningops/scripts/test_reflection_cycle_orchestration_contract.sh`
+- `monday/scripts/export_worker_outcome_reflection_packet.py`
+- `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
+- `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
+- `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`

--- a/planningops/scripts/test_reflection_cycle_orchestration_contract.sh
+++ b/planningops/scripts/test_reflection_cycle_orchestration_contract.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+contract = Path("planningops/contracts/reflection-cycle-orchestration-contract.md")
+text = contract.read_text(encoding="utf-8")
+
+required_sections = [
+    "# Reflection Cycle Orchestration Contract",
+    "## Purpose",
+    "## Canonical Boundary",
+    "## Cycle Scope",
+    "## Required Inputs",
+    "## Required Outputs",
+    "## Cycle Report",
+    "## Deterministic Orchestration Rules",
+    "## Failure Rules",
+    "## Ownership Boundary",
+    "## Validation",
+]
+for section in required_sections:
+    assert section in text, section
+
+required_fragments = [
+    "monday/scripts/export_worker_outcome_reflection_packet.py",
+    "planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py",
+    "planningops/scripts/core/goals/apply_worker_outcome_reflection.py",
+    "planningops/scripts/federation/run_worker_outcome_reflection_cycle.py",
+    "monday/scripts/send_reflection_decision_update.py",
+    "`generated_at_utc`",
+    "`reflection_packet_ref`",
+    "`reflection_evaluation_ref`",
+    "`reflection_action_ref`",
+    "`goal_transition_report_path`",
+    "`dry-run` or `apply`",
+    "must call the monday exporter instead of recreating packet logic inside planningops",
+    "must not own",
+    "concrete Slack or email transport execution",
+]
+for fragment in required_fragments:
+    assert fragment in text, fragment
+
+print("reflection cycle orchestration contract ok")
+PY


### PR DESCRIPTION
## Summary
- add the wave9 reflection cycle orchestration contract
- add a contract regression test and wire it into planningops dry-run CI
- update the contracts index for the new control-plane boundary

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: `planningops/contracts/reflection-cycle-orchestration-contract.md`, `planningops/scripts/test_reflection_cycle_orchestration_contract.sh`, `planningops/contracts/README.md`
- `.github/` workflows: `.github/workflows/planningops-contracts-dryrun.yml`

## Linked Issues
- Closes rather-not-work-on/platform-planningops#372
- Related #373

## Validation
- [ ] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `bash planningops/scripts/test_reflection_cycle_orchestration_contract.sh`; `bash planningops/scripts/test_worker_outcome_reflection_contract.sh`; `bash planningops/scripts/test_reflection_action_handoff_contract.sh`; `bash planningops/scripts/test_evaluate_worker_outcome_reflection.sh`; `bash planningops/scripts/test_apply_worker_outcome_reflection.sh`; `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/planningops-contracts-dryrun.yml"); puts "yaml ok"'`

## Risks
- Risk: the contract can over-constrain the upcoming runner if the orchestration boundary is wrong
- Rollback: revert this PR and re-open `#372`

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
