### PR TITLE
docs(planningops): define wave10 delivery-cycle successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10-goal-brief.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 10 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the tenth goal-driven autonomy wave so planningops can orchestrate reflection action artifacts through monday delivery entrypoints and collect delivery evidence without taking over transport ownership.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - reflection
+  - delivery
+  - orchestration
+---
+
+# Goal-Driven Autonomy Wave 10 Goal Brief
+
+## Objective
+
+Extend the wave9 reflection cycle into one deterministic delivery handoff path:
+- `planningops reflection action artifact -> monday delivery entrypoint -> delivery evidence`
+- planningops emits one aggregate delivery-cycle report without owning Slack or email transport details
+- review evidence proves the control plane still stops at policy and evidence while monday owns concrete delivery execution
+
+## Success Outcomes
+
+- planningops has a repo-owned reflection delivery cycle contract
+- planningops has a federated entrypoint that runs monday delivery from a reflection action artifact and records aggregate evidence
+- planningops has a regression test for the delivery cycle using monday-owned delivery entrypoints
+- wave10 keeps transport target resolution and credentials outside planningops
+
+## Non-Goals
+
+- no new Slack or email transport implementation
+- no planningops-owned delivery target resolution
+- no queue mutation from planningops
+- no monday-owned control-plane policy rewrite
+
+## Completion References
+
+- `planningops/contracts/reflection-action-handoff-contract.md`
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/supervisor-operator-handoff-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10-issue-pack.md
@@ -1,0 +1,56 @@
+---
+title: plan: Goal-Driven Autonomy Wave 10 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the tenth goal-driven autonomy wave so reflection action handoff, monday delivery execution, and aggregate delivery evidence can run as one deterministic control-plane orchestration loop.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - reflection
+  - delivery
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 10 Issue Pack
+
+## Goal
+
+Move from reflection action intent to deterministic delivery-cycle evidence:
+- `reflection action artifact -> monday delivery execution -> delivery evidence`
+
+This wave makes the delivery handoff executable as a planningops-owned orchestration loop without moving transport ownership out of monday.
+
+## Wave 10 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `J10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/reflection-delivery-cycle-contract.md` |
+| `J20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/federation/run_reflection_delivery_cycle.py` |
+| `J30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/test_reflection_delivery_cycle.sh` |
+| `J40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave10-review.json` |
+
+## Decomposition Rules
+
+- `J10` freezes orchestration inputs, outputs, and ownership only; it does not redesign monday delivery payloads.
+- `J20` adds a control-plane runner that reuses `monday/scripts/send_reflection_decision_update.py` rather than embedding transport logic in planningops.
+- `J30` verifies end-to-end determinism using planningops-owned reflection action artifacts and monday-owned delivery entrypoints.
+- `J40` verifies the delivery-cycle layer stayed thin and respected the control-plane versus transport boundary.
+
+## Dependencies
+
+- `J20` depends on `J10`
+- `J30` depends on `J10`, `J20`
+- `J40` depends on `J10`, `J20`, `J30`
+
+## Non-Goals
+
+- no delivery credential storage in planningops
+- no concrete Slack channel or email recipient resolution in planningops
+- no monday queue mutation from planningops
+- no new shared schema unless existing handoff contracts prove insufficient

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10.execution-contract.json
@@ -1,0 +1,66 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave10",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "J10",
+        "execution_order": 10,
+        "title": "Freeze reflection delivery cycle contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/reflection-delivery-cycle-contract.md"
+      },
+      {
+        "plan_item_id": "J20",
+        "execution_order": 20,
+        "title": "Run reflection delivery cycle through planningops orchestration",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "planningops/scripts/federation/run_reflection_delivery_cycle.py"
+      },
+      {
+        "plan_item_id": "J30",
+        "execution_order": 30,
+        "title": "Verify the end-to-end reflection delivery cycle",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "planningops/scripts/test_reflection_delivery_cycle.sh"
+      },
+      {
+        "plan_item_id": "J40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 10 reflection delivery cycle",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave10-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -220,6 +220,32 @@
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/active-goal-registry-contract.md"
       ],
+      "next_goal_key": "uap-goal-driven-autonomy-wave10",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave10",
+      "title": "Goal-driven autonomy through reflection delivery cycle orchestration",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
       "operator_channels": {
         "primary_operator_channel": {
           "kind": "slack_skill_cli",


### PR DESCRIPTION
## Summary
- define the wave10 goal brief, issue pack, and execution contract for reflection delivery orchestration
- link wave9 to wave10 in the active-goal registry so the goal chain stays continuous
- validate the new execution contract with a backlog compile dry-run

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10-goal-brief.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10-issue-pack.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10.execution-contract.json`
- `planningops/` scripts/contracts: `planningops/config/active-goal-registry.json`
- `.github/` workflows: none

## Linked Issues
- Closes rather-not-work-on/platform-planningops#381
- Related #375

## Validation
- [ ] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`; `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave10.execution-contract.json --output /tmp/wave10-compile-report.json`; `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`

## Risks
- Risk: the chosen wave10 scope may need re-splitting if delivery orchestration proves too broad
- Rollback: revert this PR and leave wave9 without a successor until the next brief is finalized

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
