### PR TITLE
docs(planningops): define wave11 successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11-goal-brief.md
@@ -1,0 +1,58 @@
+---
+title: plan: Goal-Driven Autonomy Wave 11 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the eleventh goal-driven autonomy wave so monday's scheduled queue cycle can flow through planningops reflection and delivery orchestration as one deterministic control-plane loop.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - reflection
+  - delivery
+  - orchestration
+---
+
+# Goal-Driven Autonomy Wave 11 Goal Brief
+
+## Objective
+
+Extend wave10 from a delivery-stage loop into one queue-aware orchestration path:
+- `monday scheduled queue cycle -> worker outcome -> reflection cycle -> delivery cycle`
+- planningops emits one aggregate scheduled reflection-delivery report without taking over monday queue mutation or transport ownership
+- review evidence proves the control plane can drive the next autonomous loop step from a scheduled queue run instead of manual fixture handoff
+
+## Success Outcomes
+
+- planningops has a repo-owned scheduled reflection-delivery cycle contract
+- planningops has a federated entrypoint that runs monday scheduled queue work and chains the resulting outcome through reflection and delivery orchestration
+- planningops has a regression test for the scheduled reflection-delivery cycle using monday-owned scheduler and delivery entrypoints
+- wave11 keeps queue mutation and concrete transport execution inside monday
+
+## Non-Goals
+
+- no daemonized scheduler service
+- no new queue persistence redesign
+- no new Slack or email transport implementation
+- no planningops-owned queue lease or retry mutation
+
+## Completion References
+
+- `planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md`
+- `planningops/contracts/reflection-cycle-orchestration-contract.md`
+- `planningops/contracts/reflection-delivery-cycle-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11-issue-pack.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 11 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the eleventh goal-driven autonomy wave so monday scheduled queue execution can feed planningops reflection and delivery orchestration as one deterministic control-plane loop.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - reflection
+  - delivery
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 11 Issue Pack
+
+## Goal
+
+Move from delivery-stage orchestration to one scheduled autonomous loop:
+- `monday scheduled queue cycle -> worker outcome -> reflection cycle -> delivery cycle`
+- planningops emits one aggregate scheduled reflection-delivery report
+- monday remains the owner of queue mutation and transport execution
+
+## Wave 11 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `K10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/scheduled-reflection-delivery-cycle-contract.md` |
+| `K20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py` |
+| `K30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/test_scheduled_reflection_delivery_cycle.sh` |
+| `K40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave11-review.json` |
+
+## Decomposition Rules
+
+- `K10` freezes the orchestration inputs, outputs, and ownership only; it does not redesign monday queue persistence or delivery payloads.
+- `K20` adds a control-plane runner that reuses monday-owned scheduler and delivery entrypoints rather than embedding queue or transport logic in planningops.
+- `K30` verifies end-to-end determinism using monday-owned runtime entrypoints plus planningops-owned reflection and delivery-cycle orchestration.
+- `K40` verifies the scheduled layer stayed thin and respected the control-plane versus runtime/transport boundary.
+
+## Dependencies
+
+- `K20` depends on `K10`
+- `K30` depends on `K10`, `K20`
+- `K40` depends on `K10`, `K20`, `K30`
+
+## Non-Goals
+
+- no background daemon or long-running queue worker
+- no planningops-owned queue state mutation
+- no new provider or observability transport work
+- no new shared schema unless existing queue and reflection contracts prove insufficient

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11.execution-contract.json
@@ -1,0 +1,66 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave11",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "K10",
+        "execution_order": 10,
+        "title": "Freeze scheduled reflection delivery cycle contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/scheduled-reflection-delivery-cycle-contract.md"
+      },
+      {
+        "plan_item_id": "K20",
+        "execution_order": 20,
+        "title": "Run scheduled reflection delivery cycle through planningops orchestration",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py"
+      },
+      {
+        "plan_item_id": "K30",
+        "execution_order": 30,
+        "title": "Verify the end-to-end scheduled reflection delivery cycle",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "planningops/scripts/test_scheduled_reflection_delivery_cycle.sh"
+      },
+      {
+        "plan_item_id": "K40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 11 scheduled reflection delivery cycle",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave11-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -246,6 +246,32 @@
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/active-goal-registry-contract.md"
       ],
+      "next_goal_key": "uap-goal-driven-autonomy-wave11",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave11",
+      "title": "Goal-driven autonomy through scheduled reflection delivery cycle orchestration",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
       "operator_channels": {
         "primary_operator_channel": {
           "kind": "slack_skill_cli",


### PR DESCRIPTION
## Summary
- define the wave11 successor after wave10 so the active goal chain does not stop at the reflection delivery cycle
- scope wave11 around one scheduled queue -> reflection -> delivery orchestration loop

## Scope
- Initiative docs:
- Workbench docs:
  - `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11-goal-brief.md`
  - `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11-issue-pack.md`
  - `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11.execution-contract.json`
- `planningops/` scripts/contracts:
  - `planningops/config/active-goal-registry.json`
- `.github/` workflows:

## Linked Issues
- Closes rather-not-work-on/platform-planningops#392
- Related rather-not-work-on/platform-planningops#386

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
  - `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave11.execution-contract.json --output /tmp/wave11-compile-report.json`
  - `git diff --check`

## Risks
- Risk: wave11 scope could still be too broad if scheduler orchestration boundaries are not kept thin.
- Rollback: revert this PR; active wave10 behavior remains intact.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
