### PR TITLE
feat(planningops): freeze scheduled reflection delivery contract

### DIFF
--- a/.github/workflows/planningops-contracts-dryrun.yml
+++ b/.github/workflows/planningops-contracts-dryrun.yml
@@ -38,6 +38,7 @@ jobs:
           bash planningops/scripts/test_reflection_action_handoff_contract.sh
           bash planningops/scripts/test_reflection_cycle_orchestration_contract.sh
           bash planningops/scripts/test_reflection_delivery_cycle_contract.sh
+          bash planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
           bash planningops/scripts/test_evaluate_worker_outcome_reflection.sh
           bash planningops/scripts/test_apply_worker_outcome_reflection.sh
           bash planningops/scripts/test_worker_outcome_reflection_cycle.sh
@@ -77,6 +78,7 @@ jobs:
                   "test_reflection_action_handoff_contract",
                   "test_reflection_cycle_orchestration_contract",
                   "test_reflection_delivery_cycle_contract",
+                  "test_scheduled_reflection_delivery_cycle_contract",
                   "test_evaluate_worker_outcome_reflection",
                   "test_apply_worker_outcome_reflection",
                   "test_worker_outcome_reflection_cycle",

--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -26,6 +26,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `autonomous-scheduler-queue-control-plane-contract.md`: policy boundary between planningops control plane and monday scheduler/queue runtime
 - `reflection-cycle-orchestration-contract.md`: end-to-end worker-outcome packet -> evaluation -> action orchestration boundary
 - `reflection-delivery-cycle-contract.md`: action artifact -> monday delivery -> aggregate delivery evidence orchestration boundary
+- `scheduled-reflection-delivery-cycle-contract.md`: scheduled monday queue cycle -> reflection cycle -> delivery cycle orchestration boundary
 - `supervisor-experiment-auto-executor-contract.md`: trigger-to-worktree comparative execution and decision contract
 - `worker-task-pack-contract.md`: worker execution bundle and render safety contract
 - `checkpoint-resume-contract.md`: checkpoint and resume behavior

--- a/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
+++ b/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
@@ -1,0 +1,149 @@
+# Scheduled Reflection Delivery Cycle Contract
+
+## Purpose
+Define the deterministic boundary for the first queue-aware autonomous control-plane loop:
+
+- `monday scheduled queue cycle -> worker outcome -> reflection cycle -> delivery cycle`
+
+This contract exists so:
+- `planningops` can orchestrate one scheduled autonomous loop without embedding queue mutation or transport logic
+- `monday` remains the owner of scheduled dequeue, lease/retry state changes, and operator-channel execution
+- later queue and scheduler evolution can reuse one auditable stage boundary instead of re-stitching runtime, reflection, and delivery steps ad hoc
+
+## Canonical Boundary
+- monday scheduled runtime entrypoint: `monday/scripts/run_scheduled_queue_cycle.py`
+- monday reflection exporter: `monday/scripts/export_worker_outcome_reflection_packet.py`
+- planningops reflection-cycle runner: `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
+- planningops delivery-cycle runner: `planningops/scripts/federation/run_reflection_delivery_cycle.py`
+- planningops scheduled-cycle runner: `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`
+- scheduler boundary contract: `planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md`
+- reflection boundary contract: `planningops/contracts/reflection-cycle-orchestration-contract.md`
+- delivery boundary contract: `planningops/contracts/reflection-delivery-cycle-contract.md`
+
+## Cycle Scope
+The scheduled reflection-delivery cycle starts when `planningops` invokes the monday-owned scheduled queue entrypoint.
+
+The cycle includes:
+1. invoking one monday scheduled queue cycle
+2. loading one monday worker outcome artifact from that scheduled run
+3. running the planningops-owned reflection cycle over that worker outcome
+4. running the planningops-owned delivery cycle over the emitted reflection action artifact
+5. writing one planningops-owned aggregate scheduled cycle report
+
+The cycle does not include:
+- planningops-owned queue lease mutation
+- planningops-owned retry or dead-letter mutation
+- direct Slack or email transport execution inside `planningops`
+- redesigning monday payload formats or queue persistence
+
+## Required Inputs
+Every scheduled reflection-delivery run must accept:
+- `--mode` with `dry-run` or `apply`
+- `--output`
+
+Optional execution inputs may include:
+- `--workspace-root`
+- `--monday-repo-dir`
+- `--monday-python`
+- `--queue-db`
+- `--queue-seed-file`
+- `--transition-log`
+- `--schedule-key`
+- `--goal-key`
+- `--delivery-target`
+- `--channel-kind`
+- `--thread-ref`
+
+Input rules:
+- the runner must invoke `monday/scripts/run_scheduled_queue_cycle.py` instead of recreating queue dequeue logic in `planningops`
+- when `--goal-key` is supplied, it must be forwarded consistently through the scheduled run, reflection cycle, and delivery cycle
+- `planningops` may forward operator-channel hints such as `delivery-target`, `channel-kind`, and `thread-ref`, but must not derive concrete transport recipients on its own
+
+## Required Outputs
+Every successful run must emit:
+- one monday scheduled queue evidence report
+- one planningops reflection-cycle report
+- one planningops delivery-cycle report
+- one planningops-owned aggregate scheduled cycle report
+
+The aggregate scheduled cycle report must include:
+- `generated_at_utc`
+- `mode`
+- `goal_key`
+- `scheduled_cycle_report_ref`
+- `worker_outcome_ref`
+- `reflection_cycle_report_ref`
+- `reflection_action_ref`
+- `delivery_cycle_report_ref`
+- `reflection_decision`
+- `action_kind`
+- `delivery_required`
+- `delivery_skipped`
+- `goal_transition_required`
+- `goal_transition_report_path`
+- `runner_contract_ref`
+- `stage_reports`
+- `error_count`
+- `errors`
+- `verdict`
+
+## Stage Reports
+`stage_reports` must contain at least:
+- `scheduled_queue_cycle`
+- `reflection_cycle`
+- `delivery_cycle`
+
+Each stage report must include:
+- `stage`
+- `command`
+- `cwd`
+- `exit_code`
+- `stdout_tail`
+- `stderr_tail`
+- `artifact_path`
+- `artifact_exists`
+- `verdict`
+
+## Deterministic Orchestration Rules
+- the runner must call the monday scheduled queue entrypoint instead of dequeuing work directly in `planningops`
+- the runner must derive `worker_outcome_ref` from monday scheduled queue evidence instead of reconstructing worker outcome paths inline
+- the runner must call the planningops reflection-cycle runner instead of re-implementing reflection export, evaluation, or action mapping inline
+- the runner must call the planningops delivery-cycle runner instead of re-implementing monday delivery invocation inline
+- the runner must preserve `goal_transition_report_path` from the reflection action artifact through the delivery cycle and aggregate report
+- `delivery_required = false` must still produce a successful aggregate report with `delivery_skipped = true`
+- identical `dry-run` inputs must produce the same stage structure and verdicts apart from timestamps
+
+## Ownership Boundary
+### PlanningOps owns
+- scheduled-cycle orchestration
+- aggregate scheduled cycle evidence
+- path normalization across scheduled, reflection, and delivery stages
+- verification that monday scheduler evidence, reflection evidence, and delivery evidence are wired together correctly
+
+### Monday owns
+- queue persistence
+- dequeue, lease, retry, and dead-letter mutation
+- scheduled queue execution evidence
+- worker outcome production
+- operator-channel delivery execution
+
+### PlanningOps must not own
+- queue row mutation or lease heartbeat logic
+- concrete Slack or email transport execution
+- delivery target resolution from operator policy
+- monday runtime payload schema redesign
+
+## Failure Rules
+- missing monday scheduled entrypoint or missing scheduled evidence must fail the cycle
+- the runner must fail if monday scheduled queue evidence does not resolve exactly one worker outcome artifact for the current cycle
+- reflection-cycle failure must fail the aggregate cycle before delivery starts
+- delivery-cycle failure must fail the aggregate cycle even if scheduled and reflection stages passed
+- the runner must fail if aggregate evidence would drop `goal_transition_report_path` for a goal-completion path
+- the runner must not silently downgrade scheduled, reflection, or delivery failures into `delivery_skipped`
+
+## Validation
+- `planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
+- `monday/scripts/run_scheduled_queue_cycle.py`
+- `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
+- `planningops/scripts/federation/run_reflection_delivery_cycle.py`
+- `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`

--- a/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
+++ b/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+contract = Path("planningops/contracts/scheduled-reflection-delivery-cycle-contract.md")
+text = contract.read_text(encoding="utf-8")
+
+required_sections = [
+    "# Scheduled Reflection Delivery Cycle Contract",
+    "## Purpose",
+    "## Canonical Boundary",
+    "## Cycle Scope",
+    "## Required Inputs",
+    "## Required Outputs",
+    "## Stage Reports",
+    "## Deterministic Orchestration Rules",
+    "## Ownership Boundary",
+    "## Failure Rules",
+    "## Validation",
+]
+for section in required_sections:
+    assert section in text, section
+
+required_fragments = [
+    "monday/scripts/run_scheduled_queue_cycle.py",
+    "monday/scripts/export_worker_outcome_reflection_packet.py",
+    "planningops/scripts/federation/run_worker_outcome_reflection_cycle.py",
+    "planningops/scripts/federation/run_reflection_delivery_cycle.py",
+    "planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py",
+    "planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md",
+    "planningops/contracts/reflection-cycle-orchestration-contract.md",
+    "planningops/contracts/reflection-delivery-cycle-contract.md",
+    "`scheduled_cycle_report_ref`",
+    "`worker_outcome_ref`",
+    "`reflection_cycle_report_ref`",
+    "`delivery_cycle_report_ref`",
+    "`goal_transition_report_path`",
+    "`scheduled_queue_cycle`",
+    "`reflection_cycle`",
+    "`delivery_cycle`",
+    "queue row mutation or lease heartbeat logic",
+]
+for fragment in required_fragments:
+    assert fragment in text, fragment
+
+print("scheduled reflection delivery cycle contract ok")
+PY


### PR DESCRIPTION
## Summary
- add the canonical scheduled reflection-delivery cycle contract for wave11 K10
- add a contract regression script and wire it into the dry-run reliability pack
- register the contract in the contracts index so later K20/K30 work builds on a fixed boundary

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts: `planningops/contracts/scheduled-reflection-delivery-cycle-contract.md`, `planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`, `planningops/contracts/README.md`
- `.github/` workflows: `.github/workflows/planningops-contracts-dryrun.yml`

## Linked Issues
- Closes rather-not-work-on/platform-planningops#394
- Related rather-not-work-on/platform-planningops#395

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
  - `bash planningops/scripts/test_validate_script_roles_contract.sh`
  - `bash planningops/scripts/test_validate_repo_boundaries_contract.sh`
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/planningops-contracts-dryrun.yml"); puts "yaml ok"'`
  - `git diff --check`

## Risks
- Risk: K20 may reveal minor contract gaps once the scheduled runner is implemented.
- Rollback: revert this PR to remove the new contract/test and dry-run hook.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
