### PR TITLE
test(planningops): add scheduled reflection delivery regression

### DIFF
--- a/.github/workflows/planningops-contracts-dryrun.yml
+++ b/.github/workflows/planningops-contracts-dryrun.yml
@@ -43,6 +43,7 @@ jobs:
           bash planningops/scripts/test_apply_worker_outcome_reflection.sh
           bash planningops/scripts/test_worker_outcome_reflection_cycle.sh
           bash planningops/scripts/test_reflection_delivery_cycle.sh
+          bash planningops/scripts/test_scheduled_reflection_delivery_cycle.sh
           bash planningops/scripts/test_supervisor_experiment_auto_executor_contract.sh
           python3 planningops/scripts/validate_worker_task_pack.py \
             --runtime-profile-file planningops/config/runtime-profiles.json \
@@ -83,6 +84,7 @@ jobs:
                   "test_apply_worker_outcome_reflection",
                   "test_worker_outcome_reflection_cycle",
                   "test_reflection_delivery_cycle",
+                  "test_scheduled_reflection_delivery_cycle",
                   "validate_worker_task_pack_ci_report",
               ],
               "artifacts": {

--- a/planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py
+++ b/planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py
@@ -146,6 +146,7 @@ def parse_args():
     )
     parser.add_argument("--queue", required=True, help="Queue seed file for the monday scheduled queue cycle")
     parser.add_argument("--worker-outcome-json", required=True, help="Worker outcome artifact to feed into reflection")
+    parser.add_argument("--active-goal-registry", default="planningops/config/active-goal-registry.json")
     parser.add_argument("--queue-db", default=None)
     parser.add_argument("--idempotency", default=None)
     parser.add_argument("--transition-log", default=None)
@@ -406,6 +407,8 @@ def main() -> int:
         str(worker_outcome_path),
         "--source-outcome-ref",
         worker_outcome_ref,
+        "--active-goal-registry",
+        args.active_goal_registry,
         "--mode",
         args.mode,
         "--run-id",

--- a/planningops/scripts/test_scheduled_reflection_delivery_cycle.sh
+++ b/planningops/scripts/test_scheduled_reflection_delivery_cycle.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKSPACE_ROOT="$(cd "$ROOT_DIR/.." && pwd)"
+MONDAY_REPO="$WORKSPACE_ROOT/monday"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+if [[ ! -f "$MONDAY_REPO/scripts/run_scheduled_queue_cycle.py" ]]; then
+  echo "scheduled reflection delivery cycle test skipped: sibling monday repo unavailable"
+  exit 0
+fi
+
+python3 - "$TMP_DIR/registry.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path("planningops/config/active-goal-registry.json")
+doc = json.loads(source.read_text(encoding="utf-8"))
+doc["active_goal_key"] = "uap-goal-driven-autonomy-wave11"
+for goal in doc["goals"]:
+    key = goal["goal_key"]
+    if key == "uap-goal-driven-autonomy-wave11":
+        goal["status"] = "active"
+    elif key == "uap-goal-driven-autonomy-wave12":
+        goal["status"] = "draft"
+    elif goal.get("status") == "active":
+        goal["status"] = "draft"
+Path(sys.argv[1]).write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$TMP_DIR/queue.json" <<'JSON'
+{
+  "queue_items": [
+    {
+      "queue_item_id": "queue-wave11-001",
+      "goal_key": "uap-goal-driven-autonomy-wave11",
+      "schedule_key": "local-tick-5m",
+      "state": "ready",
+      "idempotency_key": "wave11:queue-wave11-001",
+      "priority_class": "standard",
+      "retry_budget": {
+        "max_attempts": 3,
+        "backoff_profile": "exponential"
+      },
+      "retry_budget_remaining": 2,
+      "attempt_count": 1,
+      "dependency_keys": [],
+      "escalation_policy_ref": "planningops/contracts/escalation-gate-contract.md",
+      "completion_policy_ref": "planningops/contracts/goal-completion-contract.md"
+    }
+  ],
+  "completed_queue_item_ids": []
+}
+JSON
+
+cat >"$TMP_DIR/outcome-retry.json" <<'JSON'
+{
+  "transition_id": "wave11-outcome-continue",
+  "queue_item_id": "queue-wave11-001",
+  "goal_key": "uap-goal-driven-autonomy-wave11",
+  "schedule_key": "local-tick-5m",
+  "lease_owner": "monday-local-worker",
+  "worker_run_id": "wave11-run-continue",
+  "state_from": "leased",
+  "state_to": "retry_wait",
+  "transition_reason": "worker.retryable_failure",
+  "occurred_at_utc": "2026-03-14T09:00:00Z",
+  "attempt_count": 1,
+  "retry_budget_remaining": 1,
+  "retry_after_utc": "2099-03-14T09:10:00Z"
+}
+JSON
+
+cat >"$TMP_DIR/outcome-dead-letter.json" <<'JSON'
+{
+  "transition_id": "wave11-outcome-replan",
+  "queue_item_id": "queue-wave11-001",
+  "goal_key": "uap-goal-driven-autonomy-wave11",
+  "schedule_key": "local-tick-5m",
+  "lease_owner": "monday-local-worker",
+  "worker_run_id": "wave11-run-replan",
+  "state_from": "leased",
+  "state_to": "dead_letter",
+  "transition_reason": "worker.retry_exhausted",
+  "occurred_at_utc": "2026-03-14T09:05:00Z",
+  "attempt_count": 2,
+  "retry_budget_remaining": 0,
+  "dead_letter_reason": "retry_budget_exhausted"
+}
+JSON
+
+python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
+  --workspace-root .. \
+  --queue "$TMP_DIR/queue.json" \
+  --worker-outcome-json "$TMP_DIR/outcome-retry.json" \
+  --active-goal-registry "$TMP_DIR/registry.json" \
+  --goal-key uap-goal-driven-autonomy-wave11 \
+  --run-id "test-scheduled-reflection-delivery-continue" \
+  --output "$TMP_DIR/continue-report.json" >/dev/null
+
+python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
+  --workspace-root .. \
+  --queue "$TMP_DIR/queue.json" \
+  --worker-outcome-json "$TMP_DIR/outcome-dead-letter.json" \
+  --active-goal-registry "$TMP_DIR/registry.json" \
+  --goal-key uap-goal-driven-autonomy-wave11 \
+  --delivery-target "slack://monday/wave11" \
+  --thread-ref "wave11-thread" \
+  --run-id "test-scheduled-reflection-delivery-replan" \
+  --output "$TMP_DIR/replan-report.json" >/dev/null
+
+if python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
+  --workspace-root .. \
+  --queue "$TMP_DIR/queue.json" \
+  --worker-outcome-json "$TMP_DIR/outcome-dead-letter.json" \
+  --active-goal-registry "$TMP_DIR/registry.json" \
+  --goal-key uap-goal-driven-autonomy-wave11 \
+  --delivery-target "slack://monday/wave11" \
+  --thread-ref "wave11-thread" \
+  --mode apply \
+  --run-id "test-scheduled-reflection-delivery-replan-apply" \
+  --output "$TMP_DIR/replan-apply-report.json" >/dev/null; then
+  echo "expected scheduled reflection delivery cycle apply to fail without monday transport"
+  exit 1
+fi
+
+python3 - "$TMP_DIR/continue-report.json" "$TMP_DIR/replan-report.json" "$TMP_DIR/replan-apply-report.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+continue_report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+replan_report = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+replan_apply_report = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+
+for report in [continue_report, replan_report]:
+    assert report["verdict"] == "pass", report
+    assert report["goal_key"] == "uap-goal-driven-autonomy-wave11", report
+    assert report["scheduled_cycle_report_ref"].endswith("scheduled-cycle-report.json"), report
+    assert report["reflection_cycle_report_ref"].endswith("reflection-cycle-report.json"), report
+    assert report["delivery_cycle_report_ref"].endswith("delivery-cycle-report.json"), report
+    assert report["worker_outcome_ref"].endswith(".json"), report
+    assert [row["stage"] for row in report["stage_reports"]] == [
+        "scheduled_queue_cycle",
+        "reflection_cycle",
+        "delivery_cycle",
+    ], report
+    assert all(row["verdict"] == "pass" for row in report["stage_reports"]), report
+
+assert continue_report["reflection_decision"] == "continue", continue_report
+assert continue_report["action_kind"] == "record_continue", continue_report
+assert continue_report["delivery_required"] is False, continue_report
+assert continue_report["delivery_skipped"] is True, continue_report
+assert continue_report["goal_transition_required"] is False, continue_report
+assert continue_report["goal_transition_report_path"] == "-", continue_report
+
+assert replan_report["reflection_decision"] == "replan_required", replan_report
+assert replan_report["action_kind"] == "trigger_replan_review", replan_report
+assert replan_report["delivery_required"] is True, replan_report
+assert replan_report["delivery_skipped"] is False, replan_report
+assert replan_report["goal_transition_required"] is False, replan_report
+
+assert replan_apply_report["verdict"] == "fail", replan_apply_report
+assert replan_apply_report["failure_stage"] == "delivery_cycle", replan_apply_report
+assert replan_apply_report["error_count"] >= 1, replan_apply_report
+assert replan_apply_report["stage_reports"][0]["stage"] == "scheduled_queue_cycle", replan_apply_report
+assert replan_apply_report["stage_reports"][1]["stage"] == "reflection_cycle", replan_apply_report
+assert replan_apply_report["stage_reports"][2]["stage"] == "delivery_cycle", replan_apply_report
+
+print("scheduled reflection delivery cycle test passed")
+PY


### PR DESCRIPTION
## Summary
- add the wave11 K30 end-to-end regression for the scheduled reflection-delivery cycle
- make the scheduled runner accept an active-goal registry override so the regression stays deterministic after future goal promotions
- wire the new regression into the dry-run reliability pack

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts: `planningops/scripts/test_scheduled_reflection_delivery_cycle.sh`, `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`
- `.github/` workflows: `.github/workflows/planningops-contracts-dryrun.yml`

## Linked Issues
- Closes rather-not-work-on/platform-planningops#396
- Related rather-not-work-on/platform-planningops#397

## Validation
- [ ] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_scheduled_reflection_delivery_cycle.sh`
  - `python3 -m py_compile planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py planningops/scripts/run_scheduled_reflection_delivery_cycle.py`
  - `bash planningops/scripts/test_validate_repo_boundaries_contract.sh`
  - `bash planningops/scripts/test_validate_script_roles_contract.sh`
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/planningops-contracts-dryrun.yml"); puts "yaml ok"'`
  - `git diff --check`

## Risks
- Risk: the scheduled runner still requires an explicit worker-outcome artifact because monday scheduled evidence does not yet publish one path directly.
- Rollback: revert this PR to remove the regression and the active-goal-registry override input.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
