### PR TITLE
docs(planningops): define wave12 successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12-goal-brief.md
@@ -1,0 +1,58 @@
+---
+title: plan: Goal-Driven Autonomy Wave 12 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the twelfth goal-driven autonomy wave so monday scheduled queue evidence can publish a deterministic worker-outcome handoff that planningops consumes without an explicit operator-supplied worker-outcome artifact path.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - handoff
+  - worker-outcome
+  - orchestration
+---
+
+# Goal-Driven Autonomy Wave 12 Goal Brief
+
+## Objective
+
+Extend wave11 from an explicit worker-outcome input into a true monday-to-planningops handoff path:
+- `monday scheduled queue cycle -> worker-outcome handoff artifact -> planningops reflection cycle -> delivery cycle`
+- planningops no longer depends on an operator-supplied `--worker-outcome-json` for the primary scheduled loop
+- monday remains the owner of queue mutation and worker-outcome production, while planningops remains the owner of reflection and delivery orchestration
+
+## Success Outcomes
+
+- planningops has a repo-owned scheduled worker-outcome handoff contract
+- monday scheduled queue evidence emits a deterministic worker-outcome handoff reference for one scheduled run
+- planningops scheduled reflection-delivery runner consumes the monday handoff path instead of requiring a direct worker-outcome file argument for the primary path
+- review evidence proves the scheduled loop remains thin and keeps queue/runtime ownership inside monday
+
+## Non-Goals
+
+- no daemonized scheduler service
+- no new queue persistence redesign
+- no planningops-owned queue state mutation
+- no new Slack or email transport implementation
+
+## Completion References
+
+- `planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md`
+- `planningops/contracts/scheduled-reflection-delivery-cycle-contract.md`
+- `planningops/contracts/reflection-cycle-orchestration-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12-issue-pack.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 12 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the twelfth goal-driven autonomy wave so monday can publish deterministic scheduled worker-outcome handoff evidence that planningops consumes without an explicit worker-outcome file input.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - handoff
+  - worker-outcome
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 12 Issue Pack
+
+## Goal
+
+Move from explicit worker-outcome input to a monday-owned handoff path:
+- `monday scheduled queue cycle -> scheduled worker-outcome handoff -> planningops scheduled reflection-delivery cycle`
+- monday emits the handoff evidence
+- planningops consumes the handoff evidence and stays a thin control-plane orchestrator
+
+## Wave 12 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `L10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/scheduled-worker-outcome-handoff-contract.md` |
+| `L20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `monday/scripts/run_scheduled_queue_cycle.py` |
+| `L30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py` |
+| `L40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave12-review.json` |
+
+## Decomposition Rules
+
+- `L10` freezes only the monday scheduled worker-outcome handoff boundary; it does not redesign queue schemas or delivery payloads.
+- `L20` updates monday scheduled evidence to emit one deterministic handoff artifact reference for the current scheduled run.
+- `L30` updates planningops scheduled orchestration to resolve monday handoff evidence before entering reflection and delivery orchestration.
+- `L40` verifies planningops still does not own queue mutation and still does not host monday transport execution.
+
+## Dependencies
+
+- `L20` depends on `L10`
+- `L30` depends on `L10`, `L20`
+- `L40` depends on `L10`, `L20`, `L30`
+
+## Non-Goals
+
+- no scheduler daemon
+- no new distributed queue backend
+- no new provider or observability transport work
+- no planningops-owned worker-outcome emission

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12.execution-contract.json
@@ -1,0 +1,66 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave12",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "L10",
+        "execution_order": 10,
+        "title": "Freeze scheduled worker-outcome handoff contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/scheduled-worker-outcome-handoff-contract.md"
+      },
+      {
+        "plan_item_id": "L20",
+        "execution_order": 20,
+        "title": "Emit scheduled worker-outcome handoff from monday queue evidence",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "monday/scripts/run_scheduled_queue_cycle.py"
+      },
+      {
+        "plan_item_id": "L30",
+        "execution_order": 30,
+        "title": "Consume scheduled worker-outcome handoff in planningops orchestration",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py"
+      },
+      {
+        "plan_item_id": "L40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 12 scheduled worker-outcome handoff",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave12-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -272,6 +272,32 @@
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/active-goal-registry-contract.md"
       ],
+      "next_goal_key": "uap-goal-driven-autonomy-wave12",
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave12",
+      "title": "Goal-driven autonomy through scheduled worker-outcome handoff orchestration",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
       "operator_channels": {
         "primary_operator_channel": {
           "kind": "slack_skill_cli",


### PR DESCRIPTION
## Summary
- define the wave12 successor goal, issue pack, and execution contract
- link wave11 to wave12 in the active-goal registry through `next_goal_key`
- focus the next wave on removing the explicit worker-outcome input by introducing monday-owned scheduled handoff evidence

## Scope
- Initiative docs:
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12-goal-brief.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12-issue-pack.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12.execution-contract.json`
- `planningops/` scripts/contracts: `planningops/config/active-goal-registry.json`
- `.github/` workflows:

## Linked Issues
- Closes rather-not-work-on/platform-planningops#404
- Related rather-not-work-on/platform-planningops#397

## Validation
- [ ] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
  - `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave12.execution-contract.json --output /tmp/wave12-compile-report.json`
  - `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
  - `git diff --check`

## Risks
- Risk: wave11 remains active until a later apply cycle promotes wave12 and materializes its live backlog.
- Rollback: revert this PR to remove the wave12 successor definition and `next_goal_key` linkage.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
