### PR TITLE
docs(planningops): freeze scheduler-native worker outcome selection contract

### DIFF
--- a/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
+++ b/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
@@ -12,6 +12,7 @@ This contract exists so:
 
 ## Canonical Boundary
 - monday scheduled runtime entrypoint: `monday/scripts/run_scheduled_queue_cycle.py`
+- scheduler-native selection contract: `planningops/contracts/scheduler-native-worker-outcome-selection-contract.md`
 - scheduled worker-outcome handoff contract: `planningops/contracts/scheduled-worker-outcome-handoff-contract.md`
 - monday reflection exporter: `monday/scripts/export_worker_outcome_reflection_packet.py`
 - planningops reflection-cycle runner: `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
@@ -54,11 +55,13 @@ Optional execution inputs may include:
 - `--delivery-target`
 - `--channel-kind`
 - `--thread-ref`
+- `--worker-outcome-json` only as an explicit legacy compatibility path while scheduler-native selection is being wired
 
 Input rules:
 - the runner must invoke `monday/scripts/run_scheduled_queue_cycle.py` instead of recreating queue dequeue logic in `planningops`
 - when `--goal-key` is supplied, it must be forwarded consistently through the scheduled run, reflection cycle, and delivery cycle
 - `planningops` may forward operator-channel hints such as `delivery-target`, `channel-kind`, and `thread-ref`, but must not derive concrete transport recipients on its own
+- the primary path must resolve the worker outcome through monday scheduler-native selection and monday-emitted handoff evidence rather than a control-plane-owned worker-outcome file path
 
 ## Required Outputs
 Every successful run must emit:
@@ -107,6 +110,7 @@ Each stage report must include:
 
 ## Deterministic Orchestration Rules
 - the runner must call the monday scheduled queue entrypoint instead of dequeuing work directly in `planningops`
+- the runner must treat `planningops/contracts/scheduler-native-worker-outcome-selection-contract.md` as the canonical source of worker-outcome selection ownership
 - the runner must resolve `worker_outcome_handoff_ref` from monday scheduled queue evidence under `planningops/contracts/scheduled-worker-outcome-handoff-contract.md`
 - the runner must derive `worker_outcome_ref` from the resolved handoff artifact instead of reconstructing worker outcome paths inline
 - the runner must call the planningops reflection-cycle runner instead of re-implementing reflection export, evaluation, or action mapping inline
@@ -114,6 +118,7 @@ Each stage report must include:
 - the runner must preserve `goal_transition_report_path` from the reflection action artifact through the delivery cycle and aggregate report
 - `delivery_required = false` must still produce a successful aggregate report with `delivery_skipped = true`
 - identical `dry-run` inputs must produce the same stage structure and verdicts apart from timestamps
+- once scheduler-native selection is available, the runner must not require `--worker-outcome-json` for the primary path
 
 ## Ownership Boundary
 ### PlanningOps owns
@@ -144,6 +149,7 @@ Each stage report must include:
 - the runner must not silently downgrade scheduled, reflection, or delivery failures into `delivery_skipped`
 
 ## Validation
+- `planningops/scripts/test_scheduler_native_worker_outcome_selection_contract.sh`
 - `planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
 - `planningops/scripts/test_scheduled_worker_outcome_handoff_contract.sh`
 - `monday/scripts/run_scheduled_queue_cycle.py`

--- a/planningops/contracts/scheduled-worker-outcome-handoff-contract.md
+++ b/planningops/contracts/scheduled-worker-outcome-handoff-contract.md
@@ -10,6 +10,8 @@ This contract exists so:
 
 ## Canonical Boundary
 - monday scheduled runtime entrypoint: `monday/scripts/run_scheduled_queue_cycle.py`
+- monday scheduler-native selector: `monday/scripts/select_scheduled_worker_outcome.py`
+- scheduler-native selection contract: `planningops/contracts/scheduler-native-worker-outcome-selection-contract.md`
 - monday queue worker outcome schema: `platform-contracts/schemas/runtime-queue-worker-outcome.schema.json`
 - monday reflection exporter: `monday/scripts/export_worker_outcome_reflection_packet.py`
 - planningops scheduled orchestrator: `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`
@@ -73,6 +75,7 @@ Integration rules:
 
 Consumer rules:
 - planningops must not require an explicit `--worker-outcome-json` input once the handoff path is available
+- monday must derive `source_worker_outcome_ref` from the scheduler-native selector for the primary path instead of a planningops bridge input
 - planningops may load `source_worker_outcome_ref` from the handoff artifact only after the handoff contract passes validation
 - planningops must fail closed if the handoff artifact points to a worker outcome from a different `scheduled_run_id`, `goal_key`, or `queue_item_id`
 - planningops may preserve `source_worker_outcome_ref` into reflection-cycle evidence, but it must not rewrite monday runtime paths into new control-plane-local paths
@@ -111,8 +114,10 @@ Consumer rules:
 - planningops must not silently fall back to a manually supplied worker outcome path when the handoff contract is in scope
 
 ## Validation
+- `planningops/scripts/test_scheduler_native_worker_outcome_selection_contract.sh`
 - `planningops/scripts/test_scheduled_worker_outcome_handoff_contract.sh`
 - `planningops/contracts/scheduled-reflection-delivery-cycle-contract.md`
 - `monday/scripts/run_scheduled_queue_cycle.py`
+- `monday/scripts/select_scheduled_worker_outcome.py`
 - `monday/scripts/export_worker_outcome_reflection_packet.py`
 - `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`

--- a/planningops/contracts/scheduler-native-worker-outcome-selection-contract.md
+++ b/planningops/contracts/scheduler-native-worker-outcome-selection-contract.md
@@ -1,0 +1,122 @@
+# Scheduler-Native Worker-Outcome Selection Contract
+
+## Purpose
+Define the monday-owned selector boundary that resolves exactly one worker outcome for the current scheduled queue run before the handoff reaches planningops.
+
+This contract exists so:
+- `monday` can resolve the current scheduled worker outcome from runtime-owned evidence instead of a control-plane-supplied bridge path
+- `planningops` can consume only monday-emitted handoff evidence for the primary scheduled reflection-delivery path
+- later scheduler and queue evolution can keep worker-outcome selection inside runtime ownership instead of leaking file-selection heuristics into planningops
+
+## Canonical Boundary
+- monday scheduled runtime entrypoint: `monday/scripts/run_scheduled_queue_cycle.py`
+- monday scheduler-native selector: `monday/scripts/select_scheduled_worker_outcome.py`
+- monday scheduler evidence schema: `monday/contracts/runtime-scheduler-evidence.schema.json`
+- monday worker outcome schema: `platform-contracts/schemas/runtime-queue-worker-outcome.schema.json`
+- monday scheduled worker-outcome handoff contract: `planningops/contracts/scheduled-worker-outcome-handoff-contract.md`
+- planningops scheduled orchestrator: `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`
+
+## Selection Scope
+The selector exists only to resolve one canonical worker outcome for one scheduled monday run.
+
+The selector includes:
+- reading monday-owned scheduler evidence for the current `scheduled_run_id`
+- verifying queue identity for the scheduled dequeue decision
+- resolving one worker outcome artifact for the selected queue item
+- returning deterministic references that the scheduled queue cycle can convert into handoff evidence
+
+The selector does not include:
+- queue dequeue, lease, retry, or dead-letter mutation
+- planningops-owned path normalization
+- reflection export, evaluation, or delivery orchestration
+- more than one worker outcome candidate for the same scheduled run
+
+## Required Selector Inputs
+Every scheduler-native selection run must accept enough monday-owned evidence to resolve the current worker outcome without a planningops-supplied worker-outcome path.
+
+Required selector inputs:
+- `scheduled_run_id`
+- one monday scheduler evidence document for that run
+- one monday-owned runtime-artifact root or equivalent runtime-owned search base
+
+Input rules:
+- the selector must treat monday scheduler evidence as the source of truth for `goal_key`, `schedule_key`, `queue_item_id`, and `worker_run_id`
+- the selector must not require `--worker-outcome-json` for the primary path
+- any compatibility bridge input must remain explicitly marked as legacy and must not redefine the canonical selector contract
+
+## Required Selector Output
+Every successful selector run must emit or return:
+- `selected = true`
+- `scheduled_run_id`
+- `goal_key`
+- `schedule_key`
+- `queue_item_id`
+- `worker_run_id`
+- `source_worker_outcome_ref`
+- `source_worker_outcome_contract_ref`
+- `selection_reason`
+- `selector_contract_ref`
+- `verdict`
+
+Field rules:
+- `selector_contract_ref` must equal `planningops/contracts/scheduler-native-worker-outcome-selection-contract.md`
+- `source_worker_outcome_contract_ref` must equal `platform-contracts/schemas/runtime-queue-worker-outcome.schema.json`
+- `source_worker_outcome_ref` must remain repo-root relative from the `monday` repo when possible
+- `selection_reason` may be only `scheduled_run_match` or `scheduler_no_dequeue`
+- `verdict` may be only `pass`, `skipped`, or `fail`
+
+## Handoff Integration Rules
+The monday scheduled queue cycle must use the selector output to populate the scheduled worker-outcome handoff artifact.
+
+Integration rules:
+- when the scheduler evidence shows one dequeued queue item for the current run, monday must resolve exactly one selector output before the handoff is written
+- when the scheduler evidence shows `scheduler_no_dequeue`, monday may emit `selected = false` semantics through the scheduled evidence and skip handoff creation
+- the handoff artifact must inherit `goal_key`, `schedule_key`, `queue_item_id`, `worker_run_id`, and `source_worker_outcome_ref` from the selector output instead of a planningops bridge argument
+- planningops must treat the selector-driven handoff as the canonical source for the primary path
+
+## PlanningOps Consumer Expectations
+`planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py` must consume monday scheduled evidence that was produced from the selector boundary.
+
+Consumer rules:
+- planningops must not decide which worker outcome file is canonical for a scheduled run
+- planningops may validate monday-emitted selector results only through the handoff contract
+- planningops must fail closed if the handoff points to a worker outcome whose `scheduled_run_id`, `goal_key`, `schedule_key`, or `queue_item_id` does not match the monday scheduler evidence
+- planningops may keep a legacy bridge flag only as an explicit compatibility path until the selector path is fully wired, but it must not remain the primary scheduled orchestration input
+
+## Deterministic Mapping Rules
+- one scheduled run may resolve zero or one selector result for the current control-plane cycle
+- if monday cannot identify exactly one worker outcome for the scheduled run, the selector must fail instead of guessing
+- identical monday scheduler evidence plus identical runtime-artifact state must resolve the same `source_worker_outcome_ref` apart from timestamps
+- selector resolution must not depend on planningops-owned temporary directories or artifact copies
+
+## Ownership Boundary
+### Monday owns
+- scheduler evidence
+- runtime-artifact lookup for the current worker outcome
+- selector execution and error handling
+- handoff emission derived from selector output
+
+### PlanningOps owns
+- contracts that validate the selector/handoff boundary
+- scheduled orchestration that consumes monday-emitted handoff evidence
+- review artifacts that prove the selector path remains monday-owned
+
+### PlanningOps must not own
+- worker outcome candidate search logic
+- scheduler evidence mutation
+- queue state mutation
+- runtime-artifact selection caches for monday runs
+
+## Failure Rules
+- missing scheduler evidence for the current run must fail selection
+- missing or ambiguous worker outcome candidates must fail selection
+- mismatched `goal_key`, `schedule_key`, `queue_item_id`, or `worker_run_id` between scheduler evidence and worker outcome evidence must fail selection
+- planningops must not silently fall back to a handwritten `source_worker_outcome_ref` when the selector contract is in scope
+
+## Validation
+- `planningops/scripts/test_scheduler_native_worker_outcome_selection_contract.sh`
+- `planningops/scripts/test_scheduled_worker_outcome_handoff_contract.sh`
+- `planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
+- `monday/scripts/select_scheduled_worker_outcome.py`
+- `monday/scripts/run_scheduled_queue_cycle.py`
+- `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -110,6 +110,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_supervisor_operator_handoff_contract.sh`
   - `test_supervisor_experiment_auto_executor_contract.sh`
   - `test_ralph_loop_local_worker_policy.sh`
+  - `test_scheduler_native_worker_outcome_selection_contract.sh`
   - `test_scheduled_worker_outcome_handoff_contract.sh`
   - `test_worker_executor_contract.sh`
   - `test_validate_blueprint_pack_contract.sh`

--- a/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
+++ b/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
@@ -25,6 +25,7 @@ for section in required_sections:
 
 required_fragments = [
     "monday/scripts/run_scheduled_queue_cycle.py",
+    "planningops/contracts/scheduler-native-worker-outcome-selection-contract.md",
     "planningops/contracts/scheduled-worker-outcome-handoff-contract.md",
     "monday/scripts/export_worker_outcome_reflection_packet.py",
     "planningops/scripts/federation/run_worker_outcome_reflection_cycle.py",
@@ -43,6 +44,7 @@ required_fragments = [
     "`reflection_cycle`",
     "`delivery_cycle`",
     "queue row mutation or lease heartbeat logic",
+    "must not require `--worker-outcome-json` for the primary path",
 ]
 for fragment in required_fragments:
     assert fragment in text, fragment

--- a/planningops/scripts/test_scheduled_worker_outcome_handoff_contract.sh
+++ b/planningops/scripts/test_scheduled_worker_outcome_handoff_contract.sh
@@ -25,6 +25,8 @@ for section in required_sections:
 
 required_fragments = [
     "monday/scripts/run_scheduled_queue_cycle.py",
+    "monday/scripts/select_scheduled_worker_outcome.py",
+    "planningops/contracts/scheduler-native-worker-outcome-selection-contract.md",
     "platform-contracts/schemas/runtime-queue-worker-outcome.schema.json",
     "monday/scripts/export_worker_outcome_reflection_packet.py",
     "planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py",
@@ -36,6 +38,7 @@ required_fragments = [
     "`source_worker_outcome_ref`",
     "`scheduled_run_id`",
     "must not require an explicit `--worker-outcome-json` input",
+    "derive `source_worker_outcome_ref` from the scheduler-native selector",
     "queue lease heartbeat logic",
 ]
 for fragment in required_fragments:

--- a/planningops/scripts/test_scheduler_native_worker_outcome_selection_contract.sh
+++ b/planningops/scripts/test_scheduler_native_worker_outcome_selection_contract.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+contract = Path("planningops/contracts/scheduler-native-worker-outcome-selection-contract.md")
+text = contract.read_text(encoding="utf-8")
+
+required_sections = [
+    "# Scheduler-Native Worker-Outcome Selection Contract",
+    "## Purpose",
+    "## Canonical Boundary",
+    "## Selection Scope",
+    "## Required Selector Inputs",
+    "## Required Selector Output",
+    "## Handoff Integration Rules",
+    "## PlanningOps Consumer Expectations",
+    "## Deterministic Mapping Rules",
+    "## Ownership Boundary",
+    "## Failure Rules",
+    "## Validation",
+]
+for section in required_sections:
+    assert section in text, section
+
+required_fragments = [
+    "monday/scripts/run_scheduled_queue_cycle.py",
+    "monday/scripts/select_scheduled_worker_outcome.py",
+    "monday/contracts/runtime-scheduler-evidence.schema.json",
+    "platform-contracts/schemas/runtime-queue-worker-outcome.schema.json",
+    "planningops/contracts/scheduled-worker-outcome-handoff-contract.md",
+    "planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py",
+    "`scheduled_run_id`",
+    "`source_worker_outcome_ref`",
+    "`selector_contract_ref`",
+    "must not require `--worker-outcome-json` for the primary path",
+    "worker outcome candidate search logic",
+]
+for fragment in required_fragments:
+    assert fragment in text, fragment
+
+print("scheduler-native worker outcome selection contract ok")
+PY


### PR DESCRIPTION
## Summary
- add a canonical contract for scheduler-native worker-outcome selection in monday
- update scheduled handoff and scheduled reflection-delivery contracts to reference the selector boundary
- add regression tests for the new contract and dependent contract references

## Scope
- planningops contracts
- planningops contract tests
- planningops scripts README index

## Linked Issues
- Closes rather-not-work-on/platform-planningops#418

## Validation
- `bash planningops/scripts/test_scheduler_native_worker_outcome_selection_contract.sh`
- `bash planningops/scripts/test_scheduled_worker_outcome_handoff_contract.sh`
- `bash planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `git diff --check`

## Risks
- contract freeze only; runtime behavior remains unchanged until `#419` and `#420`
- follow-on implementation must keep the legacy bridge path compatibility-scoped rather than re-expanding planningops ownership

## Review Checklist
- [x] contract references stay repo-root relative
- [x] planningops ownership boundary remains control-plane only
- [x] new test covers the canonical selector contract
