### PR TITLE
feat(planningops): remove scheduled worker outcome bridge input

### DIFF
--- a/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
+++ b/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
@@ -47,6 +47,7 @@ Optional execution inputs may include:
 - `--workspace-root`
 - `--monday-repo-dir`
 - `--monday-python`
+- `--worker-outcome-root`
 - `--queue-db`
 - `--queue-seed-file`
 - `--transition-log`
@@ -55,12 +56,12 @@ Optional execution inputs may include:
 - `--delivery-target`
 - `--channel-kind`
 - `--thread-ref`
-- `--worker-outcome-json` only as an explicit legacy compatibility path while scheduler-native selection is being wired
 
 Input rules:
 - the runner must invoke `monday/scripts/run_scheduled_queue_cycle.py` instead of recreating queue dequeue logic in `planningops`
 - when `--goal-key` is supplied, it must be forwarded consistently through the scheduled run, reflection cycle, and delivery cycle
 - `planningops` may forward operator-channel hints such as `delivery-target`, `channel-kind`, and `thread-ref`, but must not derive concrete transport recipients on its own
+- `planningops` may pass only a monday-owned worker outcome root hint and must not supply a canonical worker outcome file path for the primary path
 - the primary path must resolve the worker outcome through monday scheduler-native selection and monday-emitted handoff evidence rather than a control-plane-owned worker-outcome file path
 
 ## Required Outputs

--- a/planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py
+++ b/planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py
@@ -154,9 +154,9 @@ def parse_args():
     )
     parser.add_argument("--queue", required=True, help="Queue seed file for the monday scheduled queue cycle")
     parser.add_argument(
-        "--worker-outcome-json",
-        default=None,
-        help="Optional bridge input forwarded to monday so the scheduled report can emit a worker-outcome handoff",
+        "--worker-outcome-root",
+        default="runtime-artifacts/worker-outcome",
+        help="monday-owned worker outcome root used for scheduler-native selection",
     )
     parser.add_argument("--active-goal-registry", default="planningops/config/active-goal-registry.json")
     parser.add_argument("--queue-db", default=None)
@@ -318,15 +318,14 @@ def main() -> int:
         "--transition-log",
         str(transition_log_path),
     ]
-    if args.worker_outcome_json:
-        scheduled_command.extend(
-            [
-                "--worker-outcome-json",
-                args.worker_outcome_json,
-                "--worker-outcome-handoff-output",
-                str(scheduled_handoff_output),
-            ]
-        )
+    scheduled_command.extend(
+        [
+            "--worker-outcome-root",
+            args.worker_outcome_root,
+            "--worker-outcome-handoff-output",
+            str(scheduled_handoff_output),
+        ]
+    )
     if args.queue_db:
         scheduled_command.extend(["--queue-db", str(resolve_output_path(planningops_repo, args.queue_db, Path(args.queue_db)))])
 

--- a/planningops/scripts/test_scheduled_reflection_delivery_cycle.sh
+++ b/planningops/scripts/test_scheduled_reflection_delivery_cycle.sh
@@ -14,6 +14,9 @@ if [[ ! -f "$MONDAY_REPO/scripts/run_scheduled_queue_cycle.py" ]]; then
   exit 0
 fi
 
+WORKER_OUTCOME_ROOT="$TMP_DIR/monday-runtime-artifacts/worker-outcome"
+mkdir -p "$WORKER_OUTCOME_ROOT"
+
 python3 - "$TMP_DIR/registry.json" <<'PY'
 import json
 import sys
@@ -58,7 +61,7 @@ cat >"$TMP_DIR/queue.json" <<'JSON'
 }
 JSON
 
-cat >"$TMP_DIR/outcome-retry.json" <<'JSON'
+cat >"$WORKER_OUTCOME_ROOT/outcome-retry.json" <<'JSON'
 {
   "transition_id": "wave11-outcome-continue",
   "queue_item_id": "queue-wave11-001",
@@ -76,7 +79,7 @@ cat >"$TMP_DIR/outcome-retry.json" <<'JSON'
 }
 JSON
 
-cat >"$TMP_DIR/outcome-dead-letter.json" <<'JSON'
+cat >"$WORKER_OUTCOME_ROOT/outcome-dead-letter.json" <<'JSON'
 {
   "transition_id": "wave11-outcome-replan",
   "queue_item_id": "queue-wave11-001",
@@ -94,7 +97,7 @@ cat >"$TMP_DIR/outcome-dead-letter.json" <<'JSON'
 }
 JSON
 
-cat >"$TMP_DIR/outcome-dead-letter-apply.json" <<'JSON'
+cat >"$WORKER_OUTCOME_ROOT/outcome-dead-letter-apply.json" <<'JSON'
 {
   "transition_id": "wave11-outcome-replan-apply",
   "queue_item_id": "queue-wave11-001",
@@ -115,7 +118,7 @@ JSON
 python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
   --workspace-root .. \
   --queue "$TMP_DIR/queue.json" \
-  --worker-outcome-json "$TMP_DIR/outcome-retry.json" \
+  --worker-outcome-root "$WORKER_OUTCOME_ROOT" \
   --idempotency "$TMP_DIR/continue-idempotency.json" \
   --transition-log "$TMP_DIR/continue-transition-log.ndjson" \
   --scheduled-output "$TMP_DIR/continue-scheduled-cycle-report.json" \
@@ -128,7 +131,7 @@ python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
 python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
   --workspace-root .. \
   --queue "$TMP_DIR/queue.json" \
-  --worker-outcome-json "$TMP_DIR/outcome-dead-letter.json" \
+  --worker-outcome-root "$WORKER_OUTCOME_ROOT" \
   --idempotency "$TMP_DIR/replan-idempotency.json" \
   --transition-log "$TMP_DIR/replan-transition-log.ndjson" \
   --scheduled-output "$TMP_DIR/replan-scheduled-cycle-report.json" \
@@ -143,7 +146,7 @@ python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
 if python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
   --workspace-root .. \
   --queue "$TMP_DIR/queue.json" \
-  --worker-outcome-json "$TMP_DIR/outcome-dead-letter-apply.json" \
+  --worker-outcome-root "$WORKER_OUTCOME_ROOT" \
   --idempotency "$TMP_DIR/replan-apply-idempotency.json" \
   --transition-log "$TMP_DIR/replan-apply-transition-log.ndjson" \
   --scheduled-output "$TMP_DIR/replan-apply-scheduled-cycle-report.json" \

--- a/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
+++ b/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
@@ -34,6 +34,7 @@ required_fragments = [
     "planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md",
     "planningops/contracts/reflection-cycle-orchestration-contract.md",
     "planningops/contracts/reflection-delivery-cycle-contract.md",
+    "`--worker-outcome-root`",
     "`scheduled_cycle_report_ref`",
     "`worker_outcome_ref`",
     "`worker_outcome_handoff_ref`",
@@ -44,6 +45,7 @@ required_fragments = [
     "`reflection_cycle`",
     "`delivery_cycle`",
     "queue row mutation or lease heartbeat logic",
+    "must not supply a canonical worker outcome file path",
     "must not require `--worker-outcome-json` for the primary path",
 ]
 for fragment in required_fragments:


### PR DESCRIPTION
## Summary
- remove the planningops-side `--worker-outcome-json` bridge input from the scheduled orchestration runner
- forward only a monday-owned worker-outcome root so monday performs canonical selection before emitting handoff evidence
- update the scheduled reflection-delivery contract and regression test to reflect the new boundary

## Scope
- planningops scheduled reflection-delivery runner
- scheduled reflection-delivery contract
- scheduled reflection-delivery regression

## Linked Issues
- Closes rather-not-work-on/platform-planningops#420

## Validation
- `bash planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
- `bash planningops/scripts/test_scheduled_reflection_delivery_cycle.sh`
- `python3 -m py_compile planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `git diff --check`

## Risks
- planningops now assumes monday selector support is present on the monday side; merge order must keep monday `#419` ahead of this PR
- primary-path tests depend on sibling monday checkout for local e2e, while repo-only CI still validates contracts and docs

## Review Checklist
- [x] planningops no longer chooses a canonical worker outcome file directly
- [x] monday remains the owner of scheduler-native selection
- [x] regression test uses the scheduler-native path instead of the bridge input
