### PR TITLE
docs(planningops): define wave14 successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14-goal-brief.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 14 Goal Brief
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the fourteenth goal-driven autonomy wave so planningops stops feeding monday scheduled execution with a direct queue seed file and instead hands off queue admission through a monday-owned runtime boundary.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - queue
+  - admission
+  - handoff
+---
+
+# Goal-Driven Autonomy Wave 14 Goal Brief
+
+## Objective
+
+Remove the remaining queue seed bridge from the scheduled control-plane path by splitting admission from execution:
+- `planningops queue admission packet -> monday queue admission CLI -> monday scheduled queue cycle -> monday worker-outcome selector -> planningops reflection + delivery`
+- monday owns queue admission and scheduled execution from runtime-owned state
+- planningops no longer drives the primary path by passing a direct queue seed file into the scheduled runtime entrypoint
+
+## Success Outcomes
+
+- planningops has a repo-owned contract for queue admission handoff into monday
+- monday can admit one deterministic queue packet into the runtime queue store before running the scheduled cycle
+- monday scheduled execution can run from queue-store state on the primary path without a direct queue seed file input from planningops
+- planningops scheduled orchestration consumes monday admission and scheduled evidence without taking ownership of queue mutation
+
+## Non-Goals
+
+- no distributed queue backend
+- no daemonized scheduler service
+- no planningops-owned queue persistence
+- no new provider or observability transport work
+
+## Completion References
+
+- `planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md`
+- `planningops/contracts/scheduler-native-worker-outcome-selection-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14-issue-pack.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 14 Issue Pack
+type: plan
+date: 2026-03-14
+updated: 2026-03-14
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the fourteenth goal-driven autonomy wave so queue admission becomes a monday-owned runtime step and scheduled execution no longer depends on a direct planningops queue seed input.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - queue
+  - admission
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 14 Issue Pack
+
+## Goal
+
+Move from direct queue seed forwarding to queue admission handoff:
+- `planningops queue admission packet -> monday queue admission CLI -> monday scheduled queue cycle -> monday worker-outcome selector -> planningops reflection-delivery cycle`
+- planningops stops driving the primary runtime path with a direct `--queue` seed input to monday scheduled execution
+- monday owns queue admission, queue-store mutation, and scheduled execution state
+
+## Wave 14 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `N10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/scheduled-queue-admission-handoff-contract.md` |
+| `N20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `monday/scripts/admit_scheduled_queue_packet.py` |
+| `N30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py` |
+| `N40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave14-review.json` |
+
+## Decomposition Rules
+
+- `N10` freezes only the queue admission handoff boundary and store-only scheduled execution expectation; it does not redesign queue schemas or worker outcome schemas.
+- `N20` adds a monday-owned queue admission CLI and the minimum runtime changes needed so the scheduled cycle can run from queue-store state on the primary path.
+- `N30` updates planningops orchestration to call monday admission before monday scheduled execution and removes the direct queue seed file from the primary runtime path.
+- `N40` verifies planningops still does not own queue mutation or queue storage and that monday owns both admission and scheduled execution.
+
+## Dependencies
+
+- `N20` depends on `N10`
+- `N30` depends on `N10`, `N20`
+- `N40` depends on `N10`, `N20`, `N30`
+
+## Non-Goals
+
+- no distributed queue backend
+- no scheduler daemon
+- no planningops-owned queue mutation cache
+- no provider or observability transport changes

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14.execution-contract.json
@@ -1,0 +1,66 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave14",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "N10",
+        "execution_order": 10,
+        "title": "Freeze scheduled queue admission handoff contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/scheduled-queue-admission-handoff-contract.md"
+      },
+      {
+        "plan_item_id": "N20",
+        "execution_order": 20,
+        "title": "Add monday queue admission CLI and store-only scheduled cycle path",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10
+        ],
+        "primary_output": "monday/scripts/admit_scheduled_queue_packet.py"
+      },
+      {
+        "plan_item_id": "N30",
+        "execution_order": 30,
+        "title": "Route planningops scheduled orchestration through monday queue admission",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [
+          10,
+          20
+        ],
+        "primary_output": "planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py"
+      },
+      {
+        "plan_item_id": "N40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 14 queue admission handoff",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [
+          10,
+          20,
+          30
+        ],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave14-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -335,6 +335,32 @@
           "execution_repo": "rather-not-work-on/monday",
           "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
         }
+      },
+      "next_goal_key": "uap-goal-driven-autonomy-wave14"
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave14",
+      "title": "Goal-driven autonomy through monday-owned queue admission handoff",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary
- define wave14 as the successor to wave13
- focus the next autonomy wave on monday-owned queue admission and store-only scheduled execution
- link the active-goal registry from wave13 to the new draft successor

## Scope
- wave14 goal brief
- wave14 issue pack
- wave14 execution contract
- active-goal successor linkage

## Linked Issues
- Closes rather-not-work-on/platform-planningops#426

## Validation
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict --output /tmp/active-goal-registry-wave14-report.json`
- `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14.execution-contract.json --output /tmp/goal-driven-autonomy-wave14-compile-report.json`
- `git diff --check`

## Risks
- successor only; no live promotion or backlog materialization in this PR
- wave14 assumes monday will own queue admission and store-only scheduled execution, so follow-on implementation must preserve that runtime boundary

## Review Checklist
- [x] wave13 now points to a concrete successor
- [x] wave14 decomposes into contract, monday runtime, planningops orchestration, and review
- [x] planningops remains the control plane, not the queue runtime
