### PR TITLE
feat(planningops): route scheduled orchestration through queue admission

### DIFF
--- a/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
+++ b/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
@@ -11,6 +11,8 @@ This contract exists so:
 - later queue and scheduler evolution can reuse one auditable stage boundary instead of re-stitching runtime, reflection, and delivery steps ad hoc
 
 ## Canonical Boundary
+- monday queue admission entrypoint: `monday/scripts/admit_scheduled_queue_packet.py`
+- queue admission handoff contract: `planningops/contracts/scheduled-queue-admission-handoff-contract.md`
 - monday scheduled runtime entrypoint: `monday/scripts/run_scheduled_queue_cycle.py`
 - scheduler-native selection contract: `planningops/contracts/scheduler-native-worker-outcome-selection-contract.md`
 - scheduled worker-outcome handoff contract: `planningops/contracts/scheduled-worker-outcome-handoff-contract.md`
@@ -26,11 +28,12 @@ This contract exists so:
 The scheduled reflection-delivery cycle starts when `planningops` invokes the monday-owned scheduled queue entrypoint.
 
 The cycle includes:
-1. invoking one monday scheduled queue cycle
-2. loading one monday worker outcome artifact from that scheduled run
-3. running the planningops-owned reflection cycle over that worker outcome
-4. running the planningops-owned delivery cycle over the emitted reflection action artifact
-5. writing one planningops-owned aggregate scheduled cycle report
+1. invoking one monday queue admission step
+2. invoking one monday scheduled queue cycle against monday-owned queue-store state
+3. loading one monday worker outcome artifact from that scheduled run
+4. running the planningops-owned reflection cycle over that worker outcome
+5. running the planningops-owned delivery cycle over the emitted reflection action artifact
+6. writing one planningops-owned aggregate scheduled cycle report
 
 The cycle does not include:
 - planningops-owned queue lease mutation
@@ -41,12 +44,14 @@ The cycle does not include:
 ## Required Inputs
 Every scheduled reflection-delivery run must accept:
 - `--mode` with `dry-run` or `apply`
+- `--queue`
 - `--output`
 
 Optional execution inputs may include:
 - `--workspace-root`
 - `--monday-repo-dir`
 - `--monday-python`
+- `--monday-admission-script`
 - `--worker-outcome-root`
 - `--queue-db`
 - `--queue-seed-file`
@@ -58,14 +63,18 @@ Optional execution inputs may include:
 - `--thread-ref`
 
 Input rules:
+- the runner must accept a planningops-owned queue seed input but translate it into a queue admission packet before monday scheduled execution starts
+- the runner must invoke `monday/scripts/admit_scheduled_queue_packet.py` before `monday/scripts/run_scheduled_queue_cycle.py`
 - the runner must invoke `monday/scripts/run_scheduled_queue_cycle.py` instead of recreating queue dequeue logic in `planningops`
 - when `--goal-key` is supplied, it must be forwarded consistently through the scheduled run, reflection cycle, and delivery cycle
 - `planningops` may forward operator-channel hints such as `delivery-target`, `channel-kind`, and `thread-ref`, but must not derive concrete transport recipients on its own
 - `planningops` may pass only a monday-owned worker outcome root hint and must not supply a canonical worker outcome file path for the primary path
 - the primary path must resolve the worker outcome through monday scheduler-native selection and monday-emitted handoff evidence rather than a control-plane-owned worker-outcome file path
+- the primary path must not forward a direct `--queue` seed input into monday scheduled execution once queue admission is in scope
 
 ## Required Outputs
 Every successful run must emit:
+- one monday queue admission report
 - one monday scheduled queue evidence report
 - one planningops reflection-cycle report
 - one planningops delivery-cycle report
@@ -75,6 +84,7 @@ The aggregate scheduled cycle report must include:
 - `generated_at_utc`
 - `mode`
 - `goal_key`
+- `queue_admission_report_ref`
 - `scheduled_cycle_report_ref`
 - `worker_outcome_ref`
 - `reflection_cycle_report_ref`
@@ -94,6 +104,7 @@ The aggregate scheduled cycle report must include:
 
 ## Stage Reports
 `stage_reports` must contain at least:
+- `queue_admission`
 - `scheduled_queue_cycle`
 - `reflection_cycle`
 - `delivery_cycle`
@@ -111,6 +122,8 @@ Each stage report must include:
 
 ## Deterministic Orchestration Rules
 - the runner must call the monday scheduled queue entrypoint instead of dequeuing work directly in `planningops`
+- the runner must call monday queue admission before monday scheduled execution on the primary path
+- the runner must persist one queue admission packet and one queue admission report per control-plane run
 - the runner must treat `planningops/contracts/scheduler-native-worker-outcome-selection-contract.md` as the canonical source of worker-outcome selection ownership
 - the runner must resolve `worker_outcome_handoff_ref` from monday scheduled queue evidence under `planningops/contracts/scheduled-worker-outcome-handoff-contract.md`
 - the runner must derive `worker_outcome_ref` from the resolved handoff artifact instead of reconstructing worker outcome paths inline
@@ -124,11 +137,13 @@ Each stage report must include:
 ## Ownership Boundary
 ### PlanningOps owns
 - scheduled-cycle orchestration
+- queue admission packet emission
 - aggregate scheduled cycle evidence
 - path normalization across scheduled, reflection, and delivery stages
 - verification that monday scheduler evidence, reflection evidence, and delivery evidence are wired together correctly
 
 ### Monday owns
+- queue admission execution
 - queue persistence
 - dequeue, lease, retry, and dead-letter mutation
 - scheduled queue execution evidence
@@ -143,6 +158,7 @@ Each stage report must include:
 
 ## Failure Rules
 - missing monday scheduled entrypoint or missing scheduled evidence must fail the cycle
+- missing monday admission entrypoint or missing queue admission evidence must fail the cycle
 - the runner must fail if monday scheduled queue evidence does not resolve exactly one worker outcome artifact for the current cycle
 - reflection-cycle failure must fail the aggregate cycle before delivery starts
 - delivery-cycle failure must fail the aggregate cycle even if scheduled and reflection stages passed
@@ -151,8 +167,10 @@ Each stage report must include:
 
 ## Validation
 - `planningops/scripts/test_scheduler_native_worker_outcome_selection_contract.sh`
+- `planningops/scripts/test_scheduled_queue_admission_handoff_contract.sh`
 - `planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
 - `planningops/scripts/test_scheduled_worker_outcome_handoff_contract.sh`
+- `monday/scripts/admit_scheduled_queue_packet.py`
 - `monday/scripts/run_scheduled_queue_cycle.py`
 - `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
 - `planningops/scripts/federation/run_reflection_delivery_cycle.py`

--- a/planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py
+++ b/planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py
@@ -22,7 +22,9 @@ from federated_python_env import (  # noqa: E402
 
 
 RUNNER_CONTRACT_REF = "planningops/contracts/scheduled-reflection-delivery-cycle-contract.md"
+ADMISSION_CONTRACT_REF = "planningops/contracts/scheduled-queue-admission-handoff-contract.md"
 HANDOFF_CONTRACT_REF = "planningops/contracts/scheduled-worker-outcome-handoff-contract.md"
+MONDAY_ADMISSION_ENTRYPOINT = "monday/scripts/admit_scheduled_queue_packet.py"
 MONDAY_SCHEDULED_ENTRYPOINT = "monday/scripts/run_scheduled_queue_cycle.py"
 REFLECTION_RUNNER = "planningops/scripts/federation/run_worker_outcome_reflection_cycle.py"
 DELIVERY_RUNNER = "planningops/scripts/federation/run_reflection_delivery_cycle.py"
@@ -121,6 +123,13 @@ def write_report(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 
 
+def derive_single_queue_value(queue_doc: dict, key: str) -> str:
+    values = {str(item.get(key) or "").strip() for item in queue_doc.get("queue_items", []) if str(item.get(key) or "").strip()}
+    if len(values) != 1:
+        raise ValueError(f"queue seed must provide exactly one {key}; got {sorted(values)}")
+    return next(iter(values))
+
+
 def run_cmd(command: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
     completed = subprocess.run(command, cwd=str(cwd), capture_output=True, text=True, env=env)
     return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
@@ -148,6 +157,11 @@ def parse_args():
     parser.add_argument("--monday-repo-dir", default="monday", help="monday repo directory relative to workspace root")
     parser.add_argument("--monday-python", default=None, help="Optional Python interpreter override for monday leaf scripts")
     parser.add_argument(
+        "--monday-admission-script",
+        default="scripts/admit_scheduled_queue_packet.py",
+        help="monday queue admission script path relative to the monday repo",
+    )
+    parser.add_argument(
         "--monday-scheduled-script",
         default="scripts/run_scheduled_queue_cycle.py",
         help="monday scheduled queue script path relative to the monday repo",
@@ -173,6 +187,8 @@ def parse_args():
     )
     parser.add_argument("--scheduled-output", default=None)
     parser.add_argument("--scheduled-handoff-output", default=None)
+    parser.add_argument("--admission-packet-output", default=None)
+    parser.add_argument("--admission-output", default=None)
     parser.add_argument("--packet-output", default=None)
     parser.add_argument("--evaluation-output", default=None)
     parser.add_argument("--action-output", default=None)
@@ -198,6 +214,7 @@ def failure_report(
     *,
     args,
     goal_key: str,
+    queue_admission_report_ref: str,
     scheduled_cycle_report_ref: str,
     worker_outcome_ref: str,
     reflection_cycle_report_ref: str,
@@ -212,6 +229,7 @@ def failure_report(
         "generated_at_utc": now_utc(),
         "mode": args.mode,
         "goal_key": goal_key,
+        "queue_admission_report_ref": queue_admission_report_ref,
         "scheduled_cycle_report_ref": scheduled_cycle_report_ref,
         "worker_outcome_ref": worker_outcome_ref,
         "reflection_cycle_report_ref": reflection_cycle_report_ref,
@@ -254,13 +272,24 @@ def main() -> int:
     python_bin = args.monday_python or bootstrap_info["preferred_python"]
 
     queue_path = resolve_input_path(planningops_repo, workspace_root, monday_repo, args.queue)
+    queue_doc = load_json(queue_path)
+    queue_items = queue_doc.get("queue_items", [])
+    if not isinstance(queue_items, list) or not queue_items:
+        raise SystemExit("queue seed must provide a non-empty queue_items list")
 
     report_dir = (
         planningops_repo / "planningops" / "artifacts" / "validation" / "scheduled-reflection-delivery-cycle" / args.run_id
     )
+    queue_db_path = resolve_output_path(planningops_repo, args.queue_db, report_dir / "runtime-queue.sqlite3")
     scheduled_output = resolve_output_path(planningops_repo, args.scheduled_output, report_dir / "scheduled-cycle-report.json")
     scheduled_handoff_output = resolve_output_path(
         planningops_repo, args.scheduled_handoff_output, report_dir / "worker-outcome-handoff.json"
+    )
+    admission_packet_output = resolve_output_path(
+        planningops_repo, args.admission_packet_output, report_dir / "queue-admission-packet.json"
+    )
+    admission_output = resolve_output_path(
+        planningops_repo, args.admission_output, report_dir / "queue-admission-report.json"
     )
     packet_output = resolve_output_path(planningops_repo, args.packet_output, report_dir / "reflection-packet.json")
     evaluation_output = resolve_output_path(
@@ -282,17 +311,35 @@ def main() -> int:
 
     stage_reports: list[dict] = []
     worker_outcome_ref = "-"
+    queue_admission_report_ref = normalize_repo_path(planningops_repo, admission_output)
     scheduled_report_ref = normalize_repo_path(planningops_repo, scheduled_output)
     reflection_report_ref = normalize_repo_path(planningops_repo, reflection_output)
     delivery_report_ref = normalize_repo_path(planningops_repo, delivery_output)
     action_ref = normalize_repo_path(planningops_repo, action_output)
     goal_key = args.goal_key or "-"
 
+    monday_admission_script = monday_repo / args.monday_admission_script
+    if not monday_admission_script.exists():
+        return failure_report(
+            args=args,
+            goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
+            scheduled_cycle_report_ref=scheduled_report_ref,
+            worker_outcome_ref=worker_outcome_ref,
+            reflection_cycle_report_ref=reflection_report_ref,
+            reflection_action_ref=action_ref,
+            delivery_cycle_report_ref=delivery_report_ref,
+            stage_reports=stage_reports,
+            failure_stage="resolve_monday_queue_admission_entrypoint",
+            errors=[f"monday admission script not found: {args.monday_admission_script}"],
+            report_path=report_output,
+        )
     monday_script = monday_repo / args.monday_scheduled_script
     if not monday_script.exists():
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -304,11 +351,76 @@ def main() -> int:
             report_path=report_output,
         )
 
+    derived_goal_key = derive_single_queue_value(queue_doc, "goal_key")
+    derived_schedule_key = derive_single_queue_value(queue_doc, "schedule_key")
+    if args.goal_key and args.goal_key != derived_goal_key:
+        return failure_report(
+            args=args,
+            goal_key=args.goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
+            scheduled_cycle_report_ref=scheduled_report_ref,
+            worker_outcome_ref=worker_outcome_ref,
+            reflection_cycle_report_ref=reflection_report_ref,
+            reflection_action_ref=action_ref,
+            delivery_cycle_report_ref=delivery_report_ref,
+            stage_reports=stage_reports,
+            failure_stage="build_queue_admission_packet",
+            errors=[f"queue seed goal_key mismatch: expected {args.goal_key}, got {derived_goal_key}"],
+            report_path=report_output,
+        )
+    goal_key = args.goal_key or derived_goal_key
+
+    admission_packet = {
+        "admission_version": 1,
+        "generated_at_utc": now_utc(),
+        "admission_contract_ref": ADMISSION_CONTRACT_REF,
+        "source_repo": "rather-not-work-on/platform-planningops",
+        "goal_key": goal_key,
+        "schedule_key": derived_schedule_key,
+        "queue_seed_ref": normalize_repo_path(planningops_repo, queue_path),
+        "seed_format": "runtime_scheduler_queue_items_json",
+        "seed_item_count": len(queue_items),
+        "verdict": "pass",
+    }
+    write_report(admission_packet_output, admission_packet)
+
+    admission_command = [
+        python_bin,
+        args.monday_admission_script,
+        "--packet",
+        str(admission_packet_output),
+        "--planningops-repo-dir",
+        str(planningops_repo),
+        "--queue-db",
+        str(queue_db_path),
+        "--replace-existing",
+        "--output",
+        str(admission_output),
+    ]
+    rc, out, err = run_cmd(admission_command, monday_repo, env)
+    stage_reports.append(build_stage_report("queue_admission", admission_command, monday_repo, rc, out, err, admission_output))
+    if rc != 0:
+        errors = ["queue_admission_failed"]
+        if admission_output.exists():
+            errors.extend(load_json(admission_output).get("errors") or [])
+        return failure_report(
+            args=args,
+            goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
+            scheduled_cycle_report_ref=scheduled_report_ref,
+            worker_outcome_ref=worker_outcome_ref,
+            reflection_cycle_report_ref=reflection_report_ref,
+            reflection_action_ref=action_ref,
+            delivery_cycle_report_ref=delivery_report_ref,
+            stage_reports=stage_reports,
+            failure_stage="queue_admission",
+            errors=errors,
+            report_path=report_output,
+        )
+
     scheduled_command = [
         python_bin,
         args.monday_scheduled_script,
-        "--queue",
-        str(queue_path),
         "--run-id",
         f"{args.run_id}-scheduled",
         "--idempotency",
@@ -326,8 +438,7 @@ def main() -> int:
             str(scheduled_handoff_output),
         ]
     )
-    if args.queue_db:
-        scheduled_command.extend(["--queue-db", str(resolve_output_path(planningops_repo, args.queue_db, Path(args.queue_db)))])
+    scheduled_command.extend(["--queue-db", str(queue_db_path)])
 
     rc, out, err = run_cmd(scheduled_command, monday_repo, env)
     stage_reports.append(build_stage_report("scheduled_queue_cycle", scheduled_command, monday_repo, rc, out, err, scheduled_output))
@@ -338,6 +449,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -353,6 +465,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -369,6 +482,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -385,6 +499,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -403,6 +518,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -422,6 +538,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -442,6 +559,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -464,6 +582,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -479,6 +598,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -498,6 +618,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -517,6 +638,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -577,6 +699,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -592,6 +715,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -638,6 +762,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -653,6 +778,7 @@ def main() -> int:
         return failure_report(
             args=args,
             goal_key=goal_key,
+            queue_admission_report_ref=queue_admission_report_ref,
             scheduled_cycle_report_ref=scheduled_report_ref,
             worker_outcome_ref=worker_outcome_ref,
             reflection_cycle_report_ref=reflection_report_ref,
@@ -669,6 +795,7 @@ def main() -> int:
         "generated_at_utc": now_utc(),
         "mode": args.mode,
         "goal_key": reflection_report.get("goal_key") or goal_key,
+        "queue_admission_report_ref": queue_admission_report_ref,
         "scheduled_cycle_report_ref": scheduled_report_ref,
         "worker_outcome_ref": worker_outcome_ref,
         "reflection_cycle_report_ref": reflection_report_ref,

--- a/planningops/scripts/test_scheduled_reflection_delivery_cycle.sh
+++ b/planningops/scripts/test_scheduled_reflection_delivery_cycle.sh
@@ -118,6 +118,7 @@ JSON
 python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
   --workspace-root .. \
   --queue "$TMP_DIR/queue.json" \
+  --queue-db "$TMP_DIR/continue-runtime-queue.sqlite3" \
   --worker-outcome-root "$WORKER_OUTCOME_ROOT" \
   --idempotency "$TMP_DIR/continue-idempotency.json" \
   --transition-log "$TMP_DIR/continue-transition-log.ndjson" \
@@ -131,6 +132,7 @@ python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
 python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
   --workspace-root .. \
   --queue "$TMP_DIR/queue.json" \
+  --queue-db "$TMP_DIR/replan-runtime-queue.sqlite3" \
   --worker-outcome-root "$WORKER_OUTCOME_ROOT" \
   --idempotency "$TMP_DIR/replan-idempotency.json" \
   --transition-log "$TMP_DIR/replan-transition-log.ndjson" \
@@ -146,6 +148,7 @@ python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
 if python3 planningops/scripts/run_scheduled_reflection_delivery_cycle.py \
   --workspace-root .. \
   --queue "$TMP_DIR/queue.json" \
+  --queue-db "$TMP_DIR/replan-apply-runtime-queue.sqlite3" \
   --worker-outcome-root "$WORKER_OUTCOME_ROOT" \
   --idempotency "$TMP_DIR/replan-apply-idempotency.json" \
   --transition-log "$TMP_DIR/replan-apply-transition-log.ndjson" \
@@ -174,11 +177,13 @@ replan_apply_report = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
 for report in [continue_report, replan_report]:
     assert report["verdict"] == "pass", report
     assert report["goal_key"] == "uap-goal-driven-autonomy-wave11", report
+    assert report["queue_admission_report_ref"].endswith("queue-admission-report.json"), report
     assert report["scheduled_cycle_report_ref"].endswith("scheduled-cycle-report.json"), report
     assert report["reflection_cycle_report_ref"].endswith("reflection-cycle-report.json"), report
     assert report["delivery_cycle_report_ref"].endswith("delivery-cycle-report.json"), report
     assert report["worker_outcome_ref"].endswith(".json"), report
     assert [row["stage"] for row in report["stage_reports"]] == [
+        "queue_admission",
         "scheduled_queue_cycle",
         "reflection_cycle",
         "delivery_cycle",
@@ -208,9 +213,17 @@ assert replan_report["goal_transition_required"] is False, replan_report
 assert replan_apply_report["verdict"] == "fail", replan_apply_report
 assert replan_apply_report["failure_stage"] == "delivery_cycle", replan_apply_report
 assert replan_apply_report["error_count"] >= 1, replan_apply_report
-assert replan_apply_report["stage_reports"][0]["stage"] == "scheduled_queue_cycle", replan_apply_report
-assert replan_apply_report["stage_reports"][1]["stage"] == "reflection_cycle", replan_apply_report
-assert replan_apply_report["stage_reports"][2]["stage"] == "delivery_cycle", replan_apply_report
+assert replan_apply_report["queue_admission_report_ref"].endswith("queue-admission-report.json"), replan_apply_report
+assert [row["stage"] for row in replan_apply_report["stage_reports"]] == [
+    "queue_admission",
+    "scheduled_queue_cycle",
+    "reflection_cycle",
+    "delivery_cycle",
+], replan_apply_report
+assert replan_apply_report["stage_reports"][0]["verdict"] == "pass", replan_apply_report
+assert replan_apply_report["stage_reports"][1]["verdict"] == "pass", replan_apply_report
+assert replan_apply_report["stage_reports"][2]["verdict"] == "pass", replan_apply_report
+assert replan_apply_report["stage_reports"][3]["verdict"] == "fail", replan_apply_report
 
 print("scheduled reflection delivery cycle test passed")
 PY

--- a/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
+++ b/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
@@ -24,6 +24,8 @@ for section in required_sections:
     assert section in text, section
 
 required_fragments = [
+    "monday/scripts/admit_scheduled_queue_packet.py",
+    "planningops/contracts/scheduled-queue-admission-handoff-contract.md",
     "monday/scripts/run_scheduled_queue_cycle.py",
     "planningops/contracts/scheduler-native-worker-outcome-selection-contract.md",
     "planningops/contracts/scheduled-worker-outcome-handoff-contract.md",
@@ -34,18 +36,23 @@ required_fragments = [
     "planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md",
     "planningops/contracts/reflection-cycle-orchestration-contract.md",
     "planningops/contracts/reflection-delivery-cycle-contract.md",
+    "`--queue`",
     "`--worker-outcome-root`",
+    "`queue_admission_report_ref`",
     "`scheduled_cycle_report_ref`",
     "`worker_outcome_ref`",
     "`worker_outcome_handoff_ref`",
     "`reflection_cycle_report_ref`",
     "`delivery_cycle_report_ref`",
     "`goal_transition_report_path`",
+    "`queue_admission`",
     "`scheduled_queue_cycle`",
     "`reflection_cycle`",
     "`delivery_cycle`",
+    "must invoke `monday/scripts/admit_scheduled_queue_packet.py` before `monday/scripts/run_scheduled_queue_cycle.py`",
     "queue row mutation or lease heartbeat logic",
     "must not supply a canonical worker outcome file path",
+    "must not forward a direct `--queue` seed input into monday scheduled execution",
     "must not require `--worker-outcome-json` for the primary path",
 ]
 for fragment in required_fragments:


### PR DESCRIPTION
## Summary
- route the scheduled reflection-delivery runner through monday queue admission before scheduled execution
- persist queue admission packet/report evidence in the aggregate cycle output
- update scheduled cycle contract and regression tests to reflect the new stage order

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts: `planningops/contracts/scheduled-reflection-delivery-cycle-contract.md`, `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`, `planningops/scripts/test_scheduled_reflection_delivery_cycle.sh`, `planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
- `.github/` workflows:

## Linked Issues
- Closes rather-not-work-on/platform-planningops#431
- Related rather-not-work-on/platform-planningops#432

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_scheduled_reflection_delivery_cycle.sh`
  - `bash planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
  - `python3 -m py_compile planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`
  - `git diff --check`

## Risks
- Risk: scheduled orchestration now depends on monday queue admission evidence shape in addition to monday scheduled cycle evidence
- Rollback: revert this PR to restore the prior direct queue-seed handoff path

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
