### PR TITLE
plan(planningops): define wave15 local operator outbox successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15-goal-brief.md
@@ -1,0 +1,58 @@
+---
+title: plan: Goal-Driven Autonomy Wave 15 Goal Brief
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the fifteenth goal-driven autonomy wave so monday resolves local operator and terminal notification targets from repo-owned config and apply-mode delivery no longer depends on caller-supplied transport arguments.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - scheduler
+  - operator
+  - outbox
+  - email
+---
+
+# Goal-Driven Autonomy Wave 15 Goal Brief
+
+## Objective
+
+Make apply-mode operator delivery self-contained for local-first autonomy:
+- `planningops reflection or supervisor handoff -> monday local target resolver -> monday local outbox delivery report`
+- planningops no longer needs to pass concrete `delivery-target` or `channel-kind` flags for the primary local path
+- monday remains the owner of local operator target resolution, idempotent outbox delivery, and terminal notification dispatch
+
+## Success Outcomes
+
+- planningops has a contract that freezes the local operator target resolution boundary without taking ownership of concrete recipients
+- monday can resolve deterministic local targets for `slack_skill_cli` and `email_cli` from repo-owned config
+- monday operator and goal-completion delivery CLIs can succeed in `apply` mode against a local outbox sink without caller-supplied transport arguments
+- planningops scheduled reflection delivery and supervisor goal-completion paths can execute their primary local apply path through monday-owned target resolution
+- review evidence proves planningops still does not own concrete delivery targets or transport credentials
+
+## Non-Goals
+
+- no real Slack API integration
+- no SMTP or third-party mail provider integration
+- no cloud queue backend
+- no planningops-owned transport config or recipient registry
+
+## Completion References
+
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15-issue-pack.md
@@ -1,0 +1,59 @@
+---
+title: plan: Goal-Driven Autonomy Wave 15 Issue Pack
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the fifteenth goal-driven autonomy wave so monday-owned local outbox delivery replaces blocked apply-mode transport placeholders and planningops can complete local apply paths without explicit transport arguments.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - operator
+  - outbox
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 15 Issue Pack
+
+## Goal
+
+Move from caller-supplied transport arguments to monday-owned local target resolution:
+- `planningops reflection or supervisor handoff -> monday local target resolver -> monday local outbox delivery`
+- planningops stops supplying concrete `delivery-target` values for the primary local apply path
+- monday owns local delivery target profiles, outbox persistence, and idempotent operator-notification dispatch
+
+## Wave 15 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `O10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/local-operator-target-resolution-contract.md` |
+| `O20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `monday/scripts/operator_channel_local_outbox.py` |
+| `O30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/federation/run_reflection_delivery_cycle.py` |
+| `O40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/autonomous_supervisor_loop.py` |
+| `O50` | 50 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave15-review.json` |
+
+## Decomposition Rules
+
+- `O10` freezes only the ownership and evidence boundary for monday-owned local target resolution and outbox delivery; it does not define real Slack or SMTP integration.
+- `O20` adds the monday-owned local outbox module, repo-local target profiles, and the minimum CLI changes needed so operator and goal-completion delivery succeed in `apply` mode for the local path.
+- `O30` updates planningops reflection-delivery orchestration to rely on monday local target resolution for the primary local apply path instead of requiring explicit transport parameters.
+- `O40` updates planningops supervisor completion handling to hand off goal-completion delivery through monday local target resolution and persist deterministic evidence.
+- `O50` verifies planningops still does not own concrete recipients or transport execution and that monday owns local outbox delivery semantics.
+
+## Dependencies
+
+- `O20` depends on `O10`
+- `O30` depends on `O10`, `O20`
+- `O40` depends on `O10`, `O20`
+- `O50` depends on `O10`, `O20`, `O30`, `O40`
+
+## Non-Goals
+
+- no real Slack token flow
+- no SMTP delivery implementation
+- no planningops-owned recipient config
+- no remote queue backend changes

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15.execution-contract.json
@@ -1,0 +1,69 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave15",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "O10",
+        "execution_order": 10,
+        "title": "Freeze monday local operator target resolution contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/local-operator-target-resolution-contract.md"
+      },
+      {
+        "plan_item_id": "O20",
+        "execution_order": 20,
+        "title": "Add monday local outbox resolver for operator and terminal delivery",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10],
+        "primary_output": "monday/scripts/operator_channel_local_outbox.py"
+      },
+      {
+        "plan_item_id": "O30",
+        "execution_order": 30,
+        "title": "Route planningops reflection delivery through monday local target resolution",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10, 20],
+        "primary_output": "planningops/scripts/federation/run_reflection_delivery_cycle.py"
+      },
+      {
+        "plan_item_id": "O40",
+        "execution_order": 40,
+        "title": "Route supervisor completion delivery through monday local target resolution",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10, 20],
+        "primary_output": "planningops/scripts/autonomous_supervisor_loop.py"
+      },
+      {
+        "plan_item_id": "O50",
+        "execution_order": 50,
+        "title": "Review goal-driven autonomy wave 15 local operator outbox delivery",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [10, 20, 30, 40],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave15-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/artifacts/validation/active-goal-registry-report.json
+++ b/planningops/artifacts/validation/active-goal-registry-report.json
@@ -1,17 +1,17 @@
 {
-  "generated_at_utc": "2026-03-14T10:06:50.579974+00:00",
+  "generated_at_utc": "2026-03-15T04:25:05.800566+00:00",
   "registry": "planningops/config/active-goal-registry.json",
   "verdict": "pass",
   "error_count": 0,
   "errors": [],
-  "active_goal_key": "uap-goal-driven-autonomy-wave13",
+  "active_goal_key": "uap-goal-driven-autonomy-wave14",
   "resolved_goal": {
-    "goal_key": "uap-goal-driven-autonomy-wave13",
-    "title": "Goal-driven autonomy through scheduler-native worker-outcome selection",
+    "goal_key": "uap-goal-driven-autonomy-wave14",
+    "title": "Goal-driven autonomy through monday-owned queue admission handoff",
     "status": "active",
     "owner_repo": "rather-not-work-on/platform-planningops",
-    "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave13-goal-brief.md",
-    "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave13.execution-contract.json",
+    "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14-goal-brief.md",
+    "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-14-goal-driven-autonomy-wave14.execution-contract.json",
     "completion_contract_refs": [
       "planningops/contracts/goal-completion-contract.md",
       "planningops/contracts/operator-channel-adapter-contract.md",
@@ -29,6 +29,7 @@
         "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
       }
     },
+    "next_goal_key": "uap-goal-driven-autonomy-wave15",
     "primary_operator_channel": {
       "kind": "slack_skill_cli",
       "execution_repo": "rather-not-work-on/monday",

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -361,6 +361,32 @@
           "execution_repo": "rather-not-work-on/monday",
           "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
         }
+      },
+      "next_goal_key": "uap-goal-driven-autonomy-wave15"
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave15",
+      "title": "Goal-driven autonomy through monday local operator outbox delivery",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/active-goal-registry-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary
- define wave15 as the next successor after wave14
- focus the next wave on monday-owned local target resolution and local outbox delivery for fully autonomous apply paths
- extend the active goal registry with the wave14 -> wave15 successor linkage

## Scope
- Initiative docs:
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15-goal-brief.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15-issue-pack.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15.execution-contract.json`
- `planningops/` scripts/contracts: `planningops/config/active-goal-registry.json`, `planningops/artifacts/validation/active-goal-registry-report.json`
- `.github/` workflows:

## Linked Issues
- Closes rather-not-work-on/platform-planningops#437
- Related rather-not-work-on/platform-planningops#432

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
  - `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave15.execution-contract.json`
  - `git diff --check`

## Risks
- Risk: the next wave scope may still need trimming if monday local outbox delivery proves to span too many apply paths at once
- Rollback: revert this PR and remove the wave14 successor linkage from the registry

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
