### PR TITLE
feat(planningops): freeze local operator target resolution contract

### DIFF
--- a/planningops/contracts/local-operator-target-resolution-contract.md
+++ b/planningops/contracts/local-operator-target-resolution-contract.md
@@ -1,0 +1,120 @@
+# Local Operator Target Resolution Contract
+
+## Purpose
+Define the deterministic boundary for monday-owned local delivery target resolution when autonomous apply-mode flows need operator or terminal notifications without caller-supplied transport arguments.
+
+This contract exists so:
+- `planningops` can stay transport-agnostic while still completing local apply-mode delivery paths
+- `monday` can resolve local operator and terminal targets from repo-owned configuration instead of prompt-local guesses
+- local-first autonomy can deliver to a durable outbox sink before real Slack or email transports are introduced
+
+## Canonical Boundary
+- operator policy contract: `planningops/contracts/operator-channel-adapter-contract.md`
+- supervisor handoff contract: `planningops/contracts/supervisor-operator-handoff-contract.md`
+- reflection action handoff contract: `planningops/contracts/reflection-action-handoff-contract.md`
+- monday local outbox resolver: `monday/scripts/operator_channel_local_outbox.py`
+- monday status delivery CLI: `monday/scripts/send_operator_message.py`
+- monday goal-completion CLI: `monday/scripts/send_goal_completion_notification.py`
+- monday reflection delivery CLI: `monday/scripts/send_reflection_decision_update.py`
+- monday supervisor completion CLI: `monday/scripts/send_supervisor_goal_completion.py`
+- monday local target profiles: `monday/config/local-operator-channel-profiles.json`
+
+## Resolution Scope
+The local target resolution boundary applies only when monday delivery CLIs are invoked without an explicit concrete target on the primary local-first path.
+
+The boundary includes:
+- selecting one repo-owned local profile by `channel_kind`
+- resolving one deterministic local outbox sink target for that profile
+- emitting delivery evidence that records whether target resolution came from an explicit argument or a local profile
+
+The boundary does not include:
+- real Slack API calls
+- SMTP or third-party mail provider calls
+- planningops-owned recipient registries
+- prompt-authored target selection
+
+## Required Local Profile Document
+`monday/config/local-operator-channel-profiles.json` must exist once this contract is active.
+
+The profile document must include:
+- `config_version`
+- `profiles`
+
+Each profile entry must include:
+- `channel_kind`
+- `transport_kind`
+- `outbox_root`
+- `default_target_name`
+- `supports_threads`
+
+Profile rules:
+- `channel_kind` must match the channel kinds projected by `planningops` policy, including `slack_skill_cli` and `email_cli`
+- `transport_kind` must currently equal `local_outbox`
+- `outbox_root` must stay repo-root relative from the `monday` repo when possible
+- `default_target_name` must be a monday-owned logical name, not a real Slack channel ID or email address
+- `supports_threads` must be boolean
+
+## Required Delivery Evidence
+Every monday delivery CLI that resolves a local target must emit evidence containing:
+- `channel_kind`
+- `delivery_mode`
+- `delivery_verdict`
+- `delivery_idempotency_key`
+- `delivery_target`
+- `target_resolution_mode`
+- `target_profile_ref`
+
+Evidence rules:
+- `target_resolution_mode` must be one of `explicit_argument` or `local_profile`
+- `target_profile_ref` must be `-` only when `target_resolution_mode = explicit_argument`
+- `delivery_target` must be the resolved local sink target even when monday derived it from a profile
+
+## Deterministic Resolution Rules
+- monday must resolve local targets only from repo-owned config, explicit CLI arguments, or skill/MCP context that maps into the same monday-owned config model
+- planningops must never resolve a concrete `delivery_target` for the primary local autonomous path
+- when an explicit CLI target is provided, monday may use it as an override and must record `target_resolution_mode = explicit_argument`
+- when no explicit CLI target is provided, monday must resolve exactly one profile by `channel_kind`
+- identical apply-mode inputs plus the same monday local profile config must resolve the same local target apart from timestamps
+- monday must fail closed when `channel_kind` has no matching local profile
+- monday must fail closed when `transport_kind` is not supported by the invoked CLI
+
+## Local Outbox Rules
+- monday local apply-mode delivery must succeed by writing one deterministic outbox artifact and one delivery report when `transport_kind = local_outbox`
+- local outbox paths must remain inside the monday repo runtime-artifacts boundary
+- outbox artifact naming must be idempotent by the delivery idempotency key so repeated apply-mode attempts do not duplicate terminal notifications
+- thread-aware status updates may include a thread reference in outbox metadata, but local target resolution must not require one
+
+## Ownership Boundary
+### PlanningOps owns
+- channel intent and channel kind policy
+- handoff artifacts and completion policy
+- validation that monday delivery evidence remains wired to the control-plane artifacts
+
+### Monday owns
+- local target profile configuration
+- target resolution
+- local outbox persistence
+- transport-facing delivery evidence
+
+### PlanningOps must not own
+- local outbox sink paths
+- concrete Slack channel identifiers
+- concrete email recipients
+- transport credentials
+
+## Failure Rules
+- missing `monday/config/local-operator-channel-profiles.json` must fail local target resolution once this contract is active
+- missing or duplicate profile matches for a required `channel_kind` must fail delivery
+- `planningops` must fail if its primary local autonomous apply path still requires a caller-supplied concrete `delivery-target`
+- monday must fail if local outbox delivery cannot write deterministic evidence for `apply` mode
+- monday must not silently downgrade a local apply-mode delivery failure into `dry_run` or `skipped`
+
+## Validation
+- `planningops/scripts/test_local_operator_target_resolution_contract.sh`
+- `planningops/contracts/reflection-delivery-cycle-contract.md`
+- `planningops/contracts/supervisor-operator-handoff-contract.md`
+- `monday/scripts/operator_channel_local_outbox.py`
+- `monday/scripts/send_operator_message.py`
+- `monday/scripts/send_goal_completion_notification.py`
+- `monday/scripts/send_reflection_decision_update.py`
+- `monday/scripts/send_supervisor_goal_completion.py`

--- a/planningops/contracts/reflection-delivery-cycle-contract.md
+++ b/planningops/contracts/reflection-delivery-cycle-contract.md
@@ -16,6 +16,7 @@ This contract exists so:
 - monday delivery entrypoint: `monday/scripts/send_reflection_decision_update.py`
 - action handoff contract: `planningops/contracts/reflection-action-handoff-contract.md`
 - operator channel adapter contract: `planningops/contracts/operator-channel-adapter-contract.md`
+- local target resolution contract: `planningops/contracts/local-operator-target-resolution-contract.md`
 - supervisor handoff contract: `planningops/contracts/supervisor-operator-handoff-contract.md`
 
 ## Cycle Scope
@@ -50,6 +51,7 @@ Optional execution inputs may include:
 Input rules:
 - `--action-file` must point to a `verdict=pass` artifact governed by `planningops/contracts/reflection-action-handoff-contract.md`
 - `planningops` may forward a concrete `delivery-target` only when it is supplied externally; it must not resolve the target from control-plane policy
+- when no explicit `delivery-target` is supplied, monday may resolve a local target under `planningops/contracts/local-operator-target-resolution-contract.md`
 - `planningops` may forward `channel-kind` and `thread-ref` hints, but must not derive concrete Slack channel IDs or email recipients on its own
 
 ## Delivery Invocation
@@ -151,7 +153,7 @@ Each stage report must include:
 
 ## Failure Rules
 - missing monday entrypoint or missing action artifact must fail the cycle
-- `delivery_required = true` with missing `delivery-target` must fail when monday rejects the invocation
+- `delivery_required = true` with missing `delivery-target` must fail only when monday cannot resolve a valid local target under `planningops/contracts/local-operator-target-resolution-contract.md`
 - the runner must fail if monday returns non-zero or emits a non-pass delivery report in `dry-run`
 - the runner must fail if the monday delivery report cannot be loaded
 - the runner must fail if aggregate evidence would drop `goal_transition_report_path` for a goal-completion action

--- a/planningops/contracts/supervisor-operator-handoff-contract.md
+++ b/planningops/contracts/supervisor-operator-handoff-contract.md
@@ -163,7 +163,7 @@ PlanningOps must not set:
 - concrete email recipients
 - transport credentials
 
-Monday resolves delivery targets from local configuration, skill context, or operator-specified arguments.
+Monday resolves delivery targets from local configuration, skill context, or operator-specified arguments under `planningops/contracts/local-operator-target-resolution-contract.md`.
 
 ## Validation
 - implementation: `planningops/scripts/autonomous_supervisor_loop.py`

--- a/planningops/scripts/test_local_operator_target_resolution_contract.sh
+++ b/planningops/scripts/test_local_operator_target_resolution_contract.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+contract = Path("planningops/contracts/local-operator-target-resolution-contract.md")
+text = contract.read_text(encoding="utf-8")
+
+required_sections = [
+    "# Local Operator Target Resolution Contract",
+    "## Purpose",
+    "## Canonical Boundary",
+    "## Resolution Scope",
+    "## Required Local Profile Document",
+    "## Required Delivery Evidence",
+    "## Deterministic Resolution Rules",
+    "## Local Outbox Rules",
+    "## Ownership Boundary",
+    "## Failure Rules",
+    "## Validation",
+]
+for section in required_sections:
+    assert section in text, section
+
+required_fragments = [
+    "monday/scripts/operator_channel_local_outbox.py",
+    "monday/scripts/send_operator_message.py",
+    "monday/scripts/send_goal_completion_notification.py",
+    "monday/scripts/send_reflection_decision_update.py",
+    "monday/scripts/send_supervisor_goal_completion.py",
+    "monday/config/local-operator-channel-profiles.json",
+    "`target_resolution_mode`",
+    "`target_profile_ref`",
+    "`local_outbox`",
+    "planningops must never resolve a concrete `delivery_target`",
+    "must fail closed when `channel_kind` has no matching local profile",
+    "must remain inside the monday repo runtime-artifacts boundary",
+]
+for fragment in required_fragments:
+    assert fragment in text, fragment
+
+print("local operator target resolution contract ok")
+PY


### PR DESCRIPTION
## Summary
- freeze the monday-owned local operator target resolution boundary for local-first autonomous delivery
- add a dedicated contract and regression test for local profile/outbox resolution semantics
- align reflection-delivery and supervisor handoff contracts with the new local target resolution reference

## Scope
- Initiative docs:
- Workbench docs:
- `planningops/` scripts/contracts: `planningops/contracts/local-operator-target-resolution-contract.md`, `planningops/scripts/test_local_operator_target_resolution_contract.sh`, `planningops/contracts/reflection-delivery-cycle-contract.md`, `planningops/contracts/supervisor-operator-handoff-contract.md`
- `.github/` workflows:

## Linked Issues
- Closes rather-not-work-on/platform-planningops#440
- Related rather-not-work-on/platform-planningops#441

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_local_operator_target_resolution_contract.sh`
  - `bash planningops/scripts/test_reflection_delivery_cycle_contract.sh`
  - `bash planningops/scripts/test_supervisor_operator_handoff_contract.sh`
  - `git diff --check`

## Risks
- Risk: the contract now makes local profile resolution a first-class requirement, so monday implementation work must honor it rather than continuing to rely on explicit CLI targets
- Rollback: revert this PR to remove the new contract and return boundary docs to their previous wording

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
