### PR TITLE
feat(planningops): route reflection delivery through local target resolution

### DIFF
--- a/planningops/contracts/reflection-delivery-cycle-contract.md
+++ b/planningops/contracts/reflection-delivery-cycle-contract.md
@@ -47,12 +47,15 @@ Optional execution inputs may include:
 - `--workspace-root`
 - `--monday-repo-dir`
 - `--monday-python`
+- `--monday-profiles-config`
 
 Input rules:
 - `--action-file` must point to a `verdict=pass` artifact governed by `planningops/contracts/reflection-action-handoff-contract.md`
+- the primary local autonomous path must work without a caller-supplied concrete `delivery-target`
 - `planningops` may forward a concrete `delivery-target` only when it is supplied externally; it must not resolve the target from control-plane policy
 - when no explicit `delivery-target` is supplied, monday may resolve a local target under `planningops/contracts/local-operator-target-resolution-contract.md`
 - `planningops` may forward `channel-kind` and `thread-ref` hints, but must not derive concrete Slack channel IDs or email recipients on its own
+- `planningops` may forward a monday-owned local profile config hint only for deterministic testing or local environment selection; it must not author recipient policy inside that config
 
 ## Delivery Invocation
 The delivery-cycle runner must invoke only:
@@ -82,6 +85,10 @@ Every delivery-cycle run must emit one aggregate report that includes:
 - `monday_delivery_entrypoint`
 - `monday_delivery_report_ref`
 - `delivery_verdict`
+- `delivery_target_resolution_mode`
+- `delivery_target_profile_ref`
+- `delivery_transport_kind`
+- `delivery_outbox_message_ref`
 - `goal_transition_report_path`
 - `runner_contract_ref`
 - `stage_reports`
@@ -99,6 +106,10 @@ When `delivery_required = true`, the report must include:
 - `monday_delivery_entrypoint = monday/scripts/send_reflection_decision_update.py`
 - `monday_delivery_report_ref`
 - a projected `delivery_verdict` copied from monday delivery evidence
+- a projected `delivery_target_resolution_mode` copied from monday delivery evidence
+- a projected `delivery_target_profile_ref` copied from monday delivery evidence when monday resolved a local profile
+- a projected `delivery_transport_kind` copied from monday delivery evidence
+- a projected `delivery_outbox_message_ref` copied from monday delivery evidence when apply mode wrote a local outbox artifact
 
 ## Cycle Report
 The aggregate cycle report is the planningops-owned evidence layer for this stage.
@@ -106,7 +117,7 @@ The aggregate cycle report is the planningops-owned evidence layer for this stag
 The report must:
 - stay repo-root relative when pointing at artifacts
 - preserve the action artifact path and the monday delivery report path
-- summarize only the orchestration outcome, not raw transport internals
+- summarize local target-resolution and outbox routing without copying concrete recipients or raw transport payloads
 - remain deterministic for the same action artifact plus delivery arguments
 
 `stage_reports` must contain at least:
@@ -130,6 +141,7 @@ Each stage report must include:
 - `message_class_hint = goal_completed` must still flow through `monday/scripts/send_reflection_decision_update.py`
 - `goal_transition_report_path` must be preserved from the action artifact into the aggregate report
 - `planningops` may orchestrate the monday CLI, but transport behavior and delivery verdict semantics remain monday-owned
+- the aggregate report must preserve monday-owned local target resolution evidence without promoting concrete `deliveryTarget` values into planningops-owned fields
 - identical `dry-run` inputs must produce the same aggregate verdict and stage structure apart from timestamps
 
 ## Ownership Boundary

--- a/planningops/scripts/federation/run_reflection_delivery_cycle.py
+++ b/planningops/scripts/federation/run_reflection_delivery_cycle.py
@@ -139,6 +139,11 @@ def parse_args():
     parser.add_argument("--monday-repo-dir", default="monday", help="monday repo directory relative to workspace root")
     parser.add_argument("--monday-python", default=None, help="Optional Python interpreter override for monday leaf scripts")
     parser.add_argument(
+        "--monday-profiles-config",
+        default=None,
+        help="Optional monday local operator profile config override passed through to monday delivery CLIs",
+    )
+    parser.add_argument(
         "--monday-delivery-script",
         default="scripts/send_reflection_decision_update.py",
         help="monday delivery script path relative to the monday repo",
@@ -182,8 +187,30 @@ def base_report_fields(action_ref: str, action: dict | None) -> dict:
         "monday_delivery_entrypoint": "-",
         "monday_delivery_report_ref": "-",
         "delivery_verdict": "-",
+        "delivery_target_resolution_mode": "-",
+        "delivery_target_profile_ref": "-",
+        "delivery_transport_kind": "-",
+        "delivery_outbox_message_ref": "-",
         "goal_transition_report_path": str(action.get("goal_transition_report_path") or "-"),
         "runner_contract_ref": RUNNER_CONTRACT_REF,
+    }
+
+
+def extract_delivery_summary(delivery_report: dict) -> dict:
+    delegate_report = delivery_report.get("delegate_report") or {}
+    nested_report = (delegate_report.get("delivery_report") or delivery_report.get("delivery_report") or {})
+    outbox_message_ref = (
+        delegate_report.get("outbox_message_ref")
+        or delivery_report.get("outbox_message_ref")
+        or nested_report.get("outboxMessageRef")
+        or "-"
+    )
+    return {
+        "delivery_verdict": str(nested_report.get("deliveryVerdict") or "-"),
+        "delivery_target_resolution_mode": str(nested_report.get("targetResolutionMode") or "-"),
+        "delivery_target_profile_ref": str(nested_report.get("targetProfileRef") or "-"),
+        "delivery_transport_kind": str(nested_report.get("transportKind") or "-"),
+        "delivery_outbox_message_ref": str(outbox_message_ref or "-"),
     }
 
 
@@ -198,6 +225,10 @@ def failure_report(
     report_path: Path,
     monday_delivery_report_ref: str = "-",
     delivery_verdict: str = "-",
+    delivery_target_resolution_mode: str = "-",
+    delivery_target_profile_ref: str = "-",
+    delivery_transport_kind: str = "-",
+    delivery_outbox_message_ref: str = "-",
 ) -> int:
     payload = {
         "generated_at_utc": now_utc(),
@@ -206,6 +237,10 @@ def failure_report(
         "delivery_skipped": False,
         "monday_delivery_report_ref": monday_delivery_report_ref,
         "delivery_verdict": delivery_verdict,
+        "delivery_target_resolution_mode": delivery_target_resolution_mode,
+        "delivery_target_profile_ref": delivery_target_profile_ref,
+        "delivery_transport_kind": delivery_transport_kind,
+        "delivery_outbox_message_ref": delivery_outbox_message_ref,
         "stage_reports": stage_reports,
         "failure_stage": failure_stage,
         "error_count": len(errors),
@@ -329,6 +364,8 @@ def main() -> int:
         command.extend(["--channel-kind", args.channel_kind])
     if args.thread_ref:
         command.extend(["--thread-ref", args.thread_ref])
+    if args.monday_profiles_config:
+        command.extend(["--profiles-config", args.monday_profiles_config])
 
     rc, out, err = run_cmd(command, monday_repo, env)
     stage_reports.append(build_stage_report("delivery_execution", command, monday_repo, rc, out, err, delivery_output))
@@ -347,11 +384,7 @@ def main() -> int:
         )
 
     delivery_report = load_json(delivery_output)
-    delivery_verdict = str(
-        ((delivery_report.get("delegate_report") or {}).get("delivery_report") or {}).get("deliveryVerdict")
-        or ((delivery_report.get("delivery_report") or {}).get("deliveryVerdict"))
-        or "-"
-    )
+    delivery_summary = extract_delivery_summary(delivery_report)
     errors = list(delivery_report.get("errors") or [])
     if rc != 0:
         errors = errors or ["monday delivery entrypoint returned non-zero"]
@@ -364,7 +397,7 @@ def main() -> int:
             errors=errors,
             report_path=report_output,
             monday_delivery_report_ref=delivery_report_ref,
-            delivery_verdict=delivery_verdict,
+            **delivery_summary,
         )
     if delivery_report.get("verdict") != "pass":
         return failure_report(
@@ -376,7 +409,7 @@ def main() -> int:
             errors=errors or ["monday delivery report verdict must be pass"],
             report_path=report_output,
             monday_delivery_report_ref=delivery_report_ref,
-            delivery_verdict=delivery_verdict,
+            **delivery_summary,
         )
 
     payload = {
@@ -386,7 +419,7 @@ def main() -> int:
         "delivery_skipped": False,
         "monday_delivery_entrypoint": MONDAY_DELIVERY_ENTRYPOINT,
         "monday_delivery_report_ref": delivery_report_ref,
-        "delivery_verdict": delivery_verdict,
+        **delivery_summary,
         "stage_reports": stage_reports,
         "error_count": 0,
         "errors": [],
@@ -394,7 +427,7 @@ def main() -> int:
     }
     write_report(report_output, payload)
     print(f"report written: {report_output}")
-    print(f"verdict=pass delivery_verdict={delivery_verdict}")
+    print(f"verdict=pass delivery_verdict={delivery_summary['delivery_verdict']}")
     return 0
 
 

--- a/planningops/scripts/test_reflection_delivery_cycle.sh
+++ b/planningops/scripts/test_reflection_delivery_cycle.sh
@@ -14,6 +14,28 @@ if [[ ! -f "$MONDAY_REPO/scripts/send_reflection_decision_update.py" ]]; then
   exit 0
 fi
 
+cat >"$TMP_DIR/local-operator-channel-profiles.json" <<JSON
+{
+  "config_version": "1",
+  "profiles": {
+    "slack_skill_cli": {
+      "channel_kind": "slack_skill_cli",
+      "transport_kind": "local_outbox",
+      "outbox_root": "$TMP_DIR/local-outbox",
+      "default_target_name": "primary-operator-thread",
+      "supports_threads": true
+    },
+    "email_cli": {
+      "channel_kind": "email_cli",
+      "transport_kind": "local_outbox",
+      "outbox_root": "$TMP_DIR/local-outbox",
+      "default_target_name": "terminal-completion",
+      "supports_threads": false
+    }
+  }
+}
+JSON
+
 cat >"$TMP_DIR/continue-action.json" <<'JSON'
 {
   "handoff_contract_ref": "planningops/contracts/reflection-action-handoff-contract.md",
@@ -110,22 +132,40 @@ python3 planningops/scripts/run_reflection_delivery_cycle.py \
 python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/replan-action.json" \
-  --delivery-target "slack://monday/thread-wave10" \
   --thread-ref "thread-wave10" \
+  --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --run-id "test-reflection-delivery-replan" \
   --output "$TMP_DIR/replan-report.json" >/dev/null
 
 python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/goal-completed-action.json" \
-  --delivery-target "mailto:operator@example.com" \
+  --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --run-id "test-reflection-delivery-complete" \
   --output "$TMP_DIR/goal-completed-report.json" >/dev/null
+
+python3 planningops/scripts/run_reflection_delivery_cycle.py \
+  --workspace-root .. \
+  --action-file "$TMP_DIR/replan-action.json" \
+  --thread-ref "thread-wave10" \
+  --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
+  --mode apply \
+  --run-id "test-reflection-delivery-replan-apply-local" \
+  --output "$TMP_DIR/replan-apply-local-report.json" >/dev/null
+
+python3 planningops/scripts/run_reflection_delivery_cycle.py \
+  --workspace-root .. \
+  --action-file "$TMP_DIR/goal-completed-action.json" \
+  --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
+  --mode apply \
+  --run-id "test-reflection-delivery-complete-apply-local" \
+  --output "$TMP_DIR/goal-completed-apply-local-report.json" >/dev/null
 
 if python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/replan-action.json" \
   --delivery-target "slack://monday/thread-wave10" \
+  --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --mode apply \
   --run-id "test-reflection-delivery-replan-apply" \
   --output "$TMP_DIR/replan-apply-report.json" >/dev/null; then
@@ -133,7 +173,7 @@ if python3 planningops/scripts/run_reflection_delivery_cycle.py \
   exit 1
 fi
 
-python3 - "$TMP_DIR/continue-report.json" "$TMP_DIR/replan-report.json" "$TMP_DIR/goal-completed-report.json" "$TMP_DIR/replan-apply-report.json" <<'PY'
+python3 - "$TMP_DIR/continue-report.json" "$TMP_DIR/replan-report.json" "$TMP_DIR/goal-completed-report.json" "$TMP_DIR/replan-apply-local-report.json" "$TMP_DIR/goal-completed-apply-local-report.json" "$TMP_DIR/replan-apply-report.json" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -141,7 +181,9 @@ from pathlib import Path
 continue_report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 replan_report = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
 goal_completed_report = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
-replan_apply_report = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
+replan_apply_local_report = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
+goal_completed_apply_local_report = json.loads(Path(sys.argv[5]).read_text(encoding="utf-8"))
+replan_apply_report = json.loads(Path(sys.argv[6]).read_text(encoding="utf-8"))
 
 assert continue_report["verdict"] == "pass", continue_report
 assert continue_report["delivery_required"] is False, continue_report
@@ -154,17 +196,36 @@ assert replan_report["delivery_required"] is True, replan_report
 assert replan_report["delivery_skipped"] is False, replan_report
 assert replan_report["monday_delivery_entrypoint"] == "monday/scripts/send_reflection_decision_update.py", replan_report
 assert replan_report["delivery_verdict"] == "dry_run", replan_report
+assert replan_report["delivery_target_resolution_mode"] == "local_profile", replan_report
+assert replan_report["delivery_target_profile_ref"].endswith("local-operator-channel-profiles.json#/profiles/slack_skill_cli"), replan_report
+assert replan_report["delivery_transport_kind"] == "local_outbox", replan_report
+assert replan_report["delivery_outbox_message_ref"] == "-", replan_report
 assert replan_report["stage_reports"][0]["stage"] == "delivery_execution", replan_report
 assert replan_report["stage_reports"][0]["verdict"] == "pass", replan_report
 
 assert goal_completed_report["verdict"] == "pass", goal_completed_report
 assert goal_completed_report["message_class_hint"] == "goal_completed", goal_completed_report
 assert goal_completed_report["delivery_verdict"] == "dry_run", goal_completed_report
+assert goal_completed_report["delivery_target_resolution_mode"] == "local_profile", goal_completed_report
+assert goal_completed_report["delivery_target_profile_ref"].endswith("local-operator-channel-profiles.json#/profiles/email_cli"), goal_completed_report
+assert goal_completed_report["delivery_transport_kind"] == "local_outbox", goal_completed_report
 assert goal_completed_report["goal_transition_report_path"].endswith("goal-transition-report.json"), goal_completed_report
+
+assert replan_apply_local_report["verdict"] == "pass", replan_apply_local_report
+assert replan_apply_local_report["delivery_verdict"] == "delivered_local_outbox", replan_apply_local_report
+assert replan_apply_local_report["delivery_target_resolution_mode"] == "local_profile", replan_apply_local_report
+assert replan_apply_local_report["delivery_outbox_message_ref"].endswith(".json"), replan_apply_local_report
+
+assert goal_completed_apply_local_report["verdict"] == "pass", goal_completed_apply_local_report
+assert goal_completed_apply_local_report["delivery_verdict"] == "delivered_local_outbox", goal_completed_apply_local_report
+assert goal_completed_apply_local_report["delivery_target_resolution_mode"] == "local_profile", goal_completed_apply_local_report
+assert goal_completed_apply_local_report["delivery_outbox_message_ref"].endswith(".json"), goal_completed_apply_local_report
 
 assert replan_apply_report["verdict"] == "fail", replan_apply_report
 assert replan_apply_report["delivery_skipped"] is False, replan_apply_report
 assert replan_apply_report["delivery_verdict"] == "blocked", replan_apply_report
+assert replan_apply_report["delivery_target_resolution_mode"] == "explicit_argument", replan_apply_report
+assert replan_apply_report["delivery_target_profile_ref"] == "-", replan_apply_report
 assert replan_apply_report["failure_stage"] == "delivery_execution", replan_apply_report
 assert replan_apply_report["error_count"] >= 1, replan_apply_report
 

--- a/planningops/scripts/test_reflection_delivery_cycle_contract.sh
+++ b/planningops/scripts/test_reflection_delivery_cycle_contract.sh
@@ -30,14 +30,20 @@ required_fragments = [
     "monday/scripts/send_reflection_decision_update.py",
     "planningops/contracts/reflection-action-handoff-contract.md",
     "planningops/contracts/operator-channel-adapter-contract.md",
+    "planningops/contracts/local-operator-target-resolution-contract.md",
     "`reflection_action_ref`",
     "`monday_delivery_report_ref`",
     "`delivery_verdict`",
+    "`delivery_target_resolution_mode`",
+    "`delivery_target_profile_ref`",
+    "`delivery_transport_kind`",
+    "`delivery_outbox_message_ref`",
     "`goal_transition_report_path`",
     "`delivery_skipped = true`",
     "`dry-run` or `apply`",
     "must not call:",
     "concrete Slack or email transport execution",
+    "must work without a caller-supplied concrete `delivery-target`",
 ]
 for fragment in required_fragments:
     assert fragment in text, fragment


### PR DESCRIPTION
## Summary
- let the reflection-delivery runner pass through monday-owned local operator profile config and preserve monday local target-resolution evidence in the planningops aggregate report
- make the primary local path succeed without caller-supplied concrete delivery targets while keeping explicit external targets blocked in apply mode
- cover the local-profile dry-run/apply path in the reflection delivery cycle regression suite

## Scope
- runtime orchestration: `planningops/scripts/federation/run_reflection_delivery_cycle.py`
- contracts/tests: `planningops/contracts/reflection-delivery-cycle-contract.md`, `planningops/scripts/test_reflection_delivery_cycle_contract.sh`, `planningops/scripts/test_reflection_delivery_cycle.sh`

## Linked Issues
- Closes rather-not-work-on/platform-planningops#442
- Related rather-not-work-on/platform-planningops#443

## Validation
- [x] `bash planningops/scripts/test_reflection_delivery_cycle_contract.sh`
- [x] `bash planningops/scripts/test_reflection_delivery_cycle.sh`
- [x] `python3 -m py_compile planningops/scripts/federation/run_reflection_delivery_cycle.py`
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `git diff --check`

## Risks
- Risk: planningops aggregate reports now preserve monday local target-resolution metadata, so downstream consumers should keep treating those fields as summary evidence and not as transport authority
- Rollback: revert this PR to restore explicit-target-only aggregate semantics

## Review Checklist
- [x] Repo-qualified planningops issue link included.
- [x] planningops stays transport-agnostic and does not own concrete recipients.
- [x] Explicit external apply-mode targets still fail closed.
