### PR TITLE
feat(planningops): wire supervisor completion through monday local delivery

### DIFF
--- a/planningops/contracts/autonomous-supervisor-loop-contract.md
+++ b/planningops/contracts/autonomous-supervisor-loop-contract.md
@@ -19,6 +19,8 @@ Operator summary artifact:
 - `planningops/artifacts/supervisor/<run-id>/operator-summary.md`
 Inbox payload artifact:
 - `planningops/artifacts/supervisor/<run-id>/inbox-payload.json`
+Optional goal-completion delivery artifact:
+- `planningops/artifacts/supervisor/<run-id>/goal-completion-delivery-report.json`
 
 ## Required Decisions Per Cycle
 1. `last_verdict` and `reason_code`
@@ -84,6 +86,8 @@ Output:
 - `planningops/artifacts/supervisor/last-run-operator-report.json`
 - `planningops/artifacts/supervisor/last-run-operator-summary.md`
 - `planningops/artifacts/supervisor/last-run-inbox-payload.json`
+- when `stop_reason=goal_completed` and monday delivery is available:
+  - `planningops/artifacts/supervisor/last-run-goal-completion-delivery-report.json`
 
 ## Testability Mapping
 - implementation:

--- a/planningops/contracts/supervisor-operator-handoff-contract.md
+++ b/planningops/contracts/supervisor-operator-handoff-contract.md
@@ -67,6 +67,7 @@ Optional fields:
 - `primary_operator_channel`
 - `terminal_notification_channel`
 - `goal_transition_report_path`
+- `goal_completion_delivery_report_path`
 
 ### `operator-summary.md`
 Human-readable attachment for the operator surface.
@@ -137,6 +138,7 @@ When `message_class_hint=goal_completed`:
   - `operator-summary.md`
   - the referenced `goal-transition-report.json`
 - monday must use `terminal_notification_channel`, not `primary_operator_channel`, for terminal delivery
+- when planningops invokes monday-owned terminal delivery, `operator-report.json` may also include `goal_completion_delivery_report_path`
 
 ## Status/Decision Handoff Rule
 

--- a/planningops/scripts/autonomous_supervisor_loop.py
+++ b/planningops/scripts/autonomous_supervisor_loop.py
@@ -32,9 +32,104 @@ def now_utc():
     return datetime.now(timezone.utc).isoformat()
 
 
-def run(args):
-    cp = subprocess.run(args, capture_output=True, text=True)
+def run(args, cwd: Path | None = None):
+    cp = subprocess.run(args, capture_output=True, text=True, cwd=str(cwd) if cwd else None)
     return cp.returncode, cp.stdout.strip(), cp.stderr.strip()
+
+
+def resolve_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_workspace_root(planningops_repo: Path, raw_workspace_root: str) -> Path:
+    candidate = (planningops_repo / raw_workspace_root).resolve()
+    if (candidate / "monday").exists():
+        return candidate
+    if (planningops_repo.parent / "monday").exists():
+        return planningops_repo.parent
+    return candidate
+
+
+def resolve_component_repo(workspace_root: Path, repo_dir: str) -> Path:
+    path = Path(repo_dir)
+    if path.is_absolute():
+        return path
+    return (workspace_root / path).resolve()
+
+
+def extract_delivery_summary(delivery_report: dict) -> dict:
+    delegate_report = delivery_report.get("delegate_report") or {}
+    nested_report = (delegate_report.get("delivery_report") or delivery_report.get("delivery_report") or {})
+    outbox_message_ref = (
+        delegate_report.get("outbox_message_ref")
+        or delivery_report.get("outbox_message_ref")
+        or nested_report.get("outboxMessageRef")
+        or "-"
+    )
+    return {
+        "delivery_verdict": str(nested_report.get("deliveryVerdict") or "-"),
+        "delivery_target_resolution_mode": str(nested_report.get("targetResolutionMode") or "-"),
+        "delivery_target_profile_ref": str(nested_report.get("targetProfileRef") or "-"),
+        "delivery_transport_kind": str(nested_report.get("transportKind") or "-"),
+        "delivery_outbox_message_ref": str(outbox_message_ref or "-"),
+    }
+
+
+def run_goal_completion_delivery(args, run_dir: Path, operator_report_path: Path, operator_summary_path: Path):
+    operator_report = load_json(operator_report_path, {})
+    if str(operator_report.get("message_class_hint") or "") != "goal_completed":
+        return {"enabled": False}
+
+    planningops_repo = resolve_repo_root()
+    workspace_root = resolve_workspace_root(planningops_repo, args.workspace_root)
+    monday_repo = resolve_component_repo(workspace_root, args.monday_repo_dir)
+    monday_script = monday_repo / args.monday_supervisor_goal_completion_script
+    delivery_output = run_dir / "goal-completion-delivery-report.json"
+
+    if not monday_script.exists():
+        return {
+            "enabled": False,
+            "skip_reason": "monday_repo_unavailable",
+            "output_path": str(delivery_output),
+            "verdict": "skipped",
+        }
+
+    command = [
+        args.monday_python or sys.executable,
+        args.monday_supervisor_goal_completion_script,
+        "--operator-report-file",
+        str(operator_report_path),
+        "--operator-summary-file",
+        str(operator_summary_path),
+        "--mode",
+        args.mode,
+        "--output",
+        str(delivery_output),
+    ]
+    if args.monday_profiles_config:
+        command.extend(["--profiles-config", args.monday_profiles_config])
+
+    rc, out, err = run(command, cwd=monday_repo)
+    report = load_json(delivery_output, {})
+    summary = extract_delivery_summary(report if isinstance(report, dict) else {})
+    errors = list(report.get("errors") or []) if isinstance(report, dict) else []
+    verdict = "pass" if rc == 0 and isinstance(report, dict) and report.get("verdict") == "pass" else "fail"
+    if verdict == "fail" and not errors:
+        errors = ["monday supervisor goal completion delivery failed"]
+
+    return {
+        "enabled": True,
+        "rc": rc,
+        "command": command,
+        "cwd": str(monday_repo),
+        "stdout": out[-2000:],
+        "stderr": err[-2000:],
+        "output_path": str(delivery_output),
+        "report": report if isinstance(report, dict) else {},
+        "errors": errors,
+        "verdict": verdict,
+        **summary,
+    }
 
 
 def load_json(path: Path, default):
@@ -230,6 +325,7 @@ def build_operator_report(summary: dict, summary_path: Path, run_dir: Path):
     last_cycle = cycles[-1] if cycles else {}
     stop_reason = str(summary.get("stop_reason") or "")
     stop_details = summary.get("stop_details") or {}
+    goal_completion_delivery = summary.get("goal_completion_delivery") or {}
     guidance = stop_details.get("rate_limit_guidance") or last_cycle.get("rate_limit_guidance") or {}
     cycle_number = stop_details.get("cycle") or last_cycle.get("cycle")
     cycle_report_path = None
@@ -372,9 +468,41 @@ def build_operator_report(summary: dict, summary_path: Path, run_dir: Path):
                     **(report.get("guidance") or {}),
                     "goal_transition_report_path": transition.get("output_path"),
                     "completed_goal_key": transition.get("goal_key"),
+                    "goal_completion_delivery_report_path": goal_completion_delivery.get("output_path"),
+                    "goal_completion_delivery_verdict": goal_completion_delivery.get("delivery_verdict"),
+                    "goal_completion_delivery_target_resolution_mode": goal_completion_delivery.get("delivery_target_resolution_mode"),
+                    "goal_completion_delivery_target_profile_ref": goal_completion_delivery.get("delivery_target_profile_ref"),
+                    "goal_completion_delivery_outbox_message_ref": goal_completion_delivery.get("delivery_outbox_message_ref"),
                 },
             }
         )
+        if goal_completion_delivery.get("output_path"):
+            report["goal_completion_delivery_report_path"] = goal_completion_delivery.get("output_path")
+        return decorate_operator_handoff(report, summary, stop_reason)
+
+    if stop_reason == "goal_completion_delivery_failed":
+        transition = stop_details.get("goal_transition") or {}
+        report.update(
+            {
+                "status": "blocked",
+                "headline": "Supervisor completed the active goal but terminal delivery failed.",
+                "operator_action": "inspect_goal_completion_delivery",
+                "needs_human_attention": True,
+                "reason": (goal_completion_delivery.get("errors") or ["Goal completion delivery failed."])[0],
+                "guidance": {
+                    **(report.get("guidance") or {}),
+                    "goal_transition_report_path": transition.get("output_path"),
+                    "completed_goal_key": transition.get("goal_key"),
+                    "goal_completion_delivery_report_path": goal_completion_delivery.get("output_path"),
+                    "goal_completion_delivery_verdict": goal_completion_delivery.get("delivery_verdict"),
+                    "goal_completion_delivery_target_resolution_mode": goal_completion_delivery.get("delivery_target_resolution_mode"),
+                    "goal_completion_delivery_target_profile_ref": goal_completion_delivery.get("delivery_target_profile_ref"),
+                    "goal_completion_delivery_outbox_message_ref": goal_completion_delivery.get("delivery_outbox_message_ref"),
+                },
+            }
+        )
+        if goal_completion_delivery.get("output_path"):
+            report["goal_completion_delivery_report_path"] = goal_completion_delivery.get("output_path")
         return decorate_operator_handoff(report, summary, stop_reason)
 
     if stop_reason == "goal_transition_failed":
@@ -453,6 +581,9 @@ def build_inbox_payload(operator_report: dict, operator_summary_path: Path):
     cycle_report_path = operator_report.get("cycle_report_path")
     if cycle_report_path:
         attachments.append(str(cycle_report_path))
+    goal_completion_delivery_report_path = operator_report.get("goal_completion_delivery_report_path")
+    if goal_completion_delivery_report_path:
+        attachments.append(str(goal_completion_delivery_report_path))
 
     lines = [
         f"Status: {operator_report.get('status')}",
@@ -715,6 +846,14 @@ def parse_args():
     parser.add_argument("--backlog-materialization-contract-file", default=None)
     parser.add_argument("--active-goal-registry", default="planningops/config/active-goal-registry.json")
     parser.add_argument("--active-goal-key", default=None)
+    parser.add_argument("--workspace-root", default="..")
+    parser.add_argument("--monday-repo-dir", default="monday")
+    parser.add_argument("--monday-python", default=None)
+    parser.add_argument("--monday-profiles-config", default=None)
+    parser.add_argument(
+        "--monday-supervisor-goal-completion-script",
+        default="scripts/send_supervisor_goal_completion.py",
+    )
     return parser.parse_args()
 
 
@@ -951,7 +1090,6 @@ def main():
                 }
                 break
             if args.mode == "apply":
-                resolved_active_goal = None
                 args.active_goal_key = None
                 stop_reason = "goal_completed"
                 stop_details = {
@@ -1100,17 +1238,42 @@ def main():
     summary["operator_summary_last_path"] = str(last_operator_summary_path)
     summary["inbox_payload_path"] = str(inbox_payload_path)
     summary["inbox_payload_last_path"] = str(last_inbox_payload_path)
-    save_json(output_path, summary)
-    save_json(run_dir / "summary.json", summary)
     operator_report = build_operator_report(summary, output_path, run_dir)
     save_json(operator_report_path, operator_report)
     save_json(last_operator_report_path, operator_report)
     operator_summary = build_operator_summary_markdown(operator_report)
     operator_summary_path.write_text(operator_summary, encoding="utf-8")
     last_operator_summary_path.write_text(operator_summary, encoding="utf-8")
+    if stop_reason == "goal_completed":
+        last_goal_completion_delivery_path = output_path.with_name(f"{output_path.stem}-goal-completion-delivery-report.json")
+        goal_completion_delivery = run_goal_completion_delivery(args, run_dir, operator_report_path, operator_summary_path)
+        summary["goal_completion_delivery_path"] = str(run_dir / "goal-completion-delivery-report.json")
+        summary["goal_completion_delivery_last_path"] = str(last_goal_completion_delivery_path)
+        summary["goal_completion_delivery"] = goal_completion_delivery
+        if goal_completion_delivery.get("enabled") and isinstance(goal_completion_delivery.get("report"), dict) and goal_completion_delivery["report"]:
+            save_json(last_goal_completion_delivery_path, goal_completion_delivery["report"])
+        if goal_completion_delivery.get("enabled") and goal_completion_delivery.get("verdict") != "pass":
+            stop_reason = "goal_completion_delivery_failed"
+            supervisor_verdict = "fail"
+            stop_details = {
+                "previous_stop_reason": "goal_completed",
+                "goal_transition": stop_details.get("goal_transition") or {},
+                "goal_completion_delivery": goal_completion_delivery,
+            }
+            summary["supervisor_verdict"] = supervisor_verdict
+            summary["stop_reason"] = stop_reason
+            summary["stop_details"] = stop_details
+        operator_report = build_operator_report(summary, output_path, run_dir)
+        save_json(operator_report_path, operator_report)
+        save_json(last_operator_report_path, operator_report)
+        operator_summary = build_operator_summary_markdown(operator_report)
+        operator_summary_path.write_text(operator_summary, encoding="utf-8")
+        last_operator_summary_path.write_text(operator_summary, encoding="utf-8")
     inbox_payload = build_inbox_payload(operator_report, last_operator_summary_path)
     save_json(inbox_payload_path, inbox_payload)
     save_json(last_inbox_payload_path, inbox_payload)
+    save_json(output_path, summary)
+    save_json(run_dir / "summary.json", summary)
     print(json.dumps(summary, ensure_ascii=True, indent=2))
     return 0 if supervisor_verdict == "pass" else 1
 

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -16,6 +16,7 @@ def run_supervisor(args):
 with tempfile.TemporaryDirectory() as td:
     td_path = Path(td)
     artifacts_root = td_path / "supervisor-artifacts"
+    monday_goal_completion_script = Path.cwd().parent / "monday" / "scripts" / "send_supervisor_goal_completion.py"
 
     # 1) continue-on-experiment should allow multi-cycle run and converge.
     out_converged = td_path / "supervisor-converged.json"
@@ -843,34 +844,62 @@ with tempfile.TemporaryDirectory() as td:
         ),
         encoding="utf-8",
     )
+    terminal_profiles_config = td_path / "local-operator-channel-profiles.json"
+    terminal_profiles_config.write_text(
+        json.dumps(
+            {
+                "config_version": 1,
+                "profiles": {
+                    "email_cli": {
+                        "channel_kind": "email_cli",
+                        "transport_kind": "local_outbox",
+                        "outbox_root": str(td_path / "local-outbox"),
+                        "default_target_name": "terminal-completion",
+                        "supports_threads": False,
+                    }
+                },
+            },
+            ensure_ascii=True,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
 
     # 13) apply-mode completion without successor should stop cleanly and leave no active goal.
     out_goal_completed = td_path / "supervisor-goal-completed.json"
-    rc_goal_completed, _, _ = run_supervisor(
-        [
-            "python3",
-            "planningops/scripts/autonomous_supervisor_loop.py",
-            "--mode",
-            "apply",
-            "--max-cycles",
-            "1",
-            "--continue-on-experiment",
-            "--loop-result-sequence-file",
-            str(no_eligible_sequence),
-            "--items-file",
-            "planningops/fixtures/backlog-stock-items-sample.json",
-            "--offline",
-            "--artifacts-root",
-            str(artifacts_root),
-            "--output",
-            str(out_goal_completed),
-            "--auto-materialize-backlog",
-            "--backlog-materializer-script",
-            str(materialize_expect_contract),
-            "--active-goal-registry",
-            str(terminal_registry),
-        ]
-    )
+    goal_completed_cmd = [
+        "python3",
+        "planningops/scripts/autonomous_supervisor_loop.py",
+        "--mode",
+        "apply",
+        "--max-cycles",
+        "1",
+        "--continue-on-experiment",
+        "--loop-result-sequence-file",
+        str(no_eligible_sequence),
+        "--items-file",
+        "planningops/fixtures/backlog-stock-items-sample.json",
+        "--offline",
+        "--artifacts-root",
+        str(artifacts_root),
+        "--output",
+        str(out_goal_completed),
+        "--auto-materialize-backlog",
+        "--backlog-materializer-script",
+        str(materialize_expect_contract),
+        "--active-goal-registry",
+        str(terminal_registry),
+    ]
+    if monday_goal_completion_script.exists():
+        goal_completed_cmd.extend(
+            [
+                "--workspace-root",
+                str(Path.cwd().parent),
+                "--monday-profiles-config",
+                str(terminal_profiles_config),
+            ]
+        )
+    rc_goal_completed, _, _ = run_supervisor(goal_completed_cmd)
     assert rc_goal_completed == 0, rc_goal_completed
     goal_completed_doc = json.loads(out_goal_completed.read_text(encoding="utf-8"))
     assert goal_completed_doc["supervisor_verdict"] == "pass", goal_completed_doc
@@ -878,6 +907,22 @@ with tempfile.TemporaryDirectory() as td:
     goal_completed_operator = json.loads(Path(goal_completed_doc["operator_report_last_path"]).read_text(encoding="utf-8"))
     assert goal_completed_operator["status"] == "ok", goal_completed_operator
     assert goal_completed_operator["operator_action"] == "notify_goal_completion", goal_completed_operator
+    goal_completed_inbox = json.loads(Path(goal_completed_doc["inbox_payload_last_path"]).read_text(encoding="utf-8"))
+    if monday_goal_completion_script.exists():
+        delivery = goal_completed_doc["goal_completion_delivery"]
+        assert delivery["enabled"] is True, delivery
+        assert delivery["verdict"] == "pass", delivery
+        assert delivery["delivery_verdict"] == "delivered_local_outbox", delivery
+        assert delivery["delivery_target_resolution_mode"] == "local_profile", delivery
+        assert delivery["delivery_target_profile_ref"].endswith("local-operator-channel-profiles.json#/profiles/email_cli"), delivery
+        assert delivery["delivery_outbox_message_ref"].endswith(".json"), delivery
+        assert Path(delivery["delivery_outbox_message_ref"]).exists(), delivery
+        assert goal_completed_operator["goal_completion_delivery_report_path"].endswith("goal-completion-delivery-report.json"), goal_completed_operator
+        assert any(str(attachment).endswith("goal-completion-delivery-report.json") for attachment in goal_completed_inbox["attachments"]), goal_completed_inbox
+    else:
+        delivery = goal_completed_doc["goal_completion_delivery"]
+        assert delivery["enabled"] is False, delivery
+        assert delivery["skip_reason"] == "monday_repo_unavailable", delivery
     terminal_registry_doc = json.loads(terminal_registry.read_text(encoding="utf-8"))
     assert terminal_registry_doc["active_goal_key"] == "", terminal_registry_doc
     assert terminal_registry_doc["goals"][0]["status"] == "achieved", terminal_registry_doc


### PR DESCRIPTION
## Summary
- invoke monday's supervisor goal-completion CLI from the planningops supervisor when a goal completes and persist deterministic delivery evidence
- keep repo-only runs safe by skipping delivery when the sibling monday runtime is unavailable, while federated runs use monday local profile resolution and local outbox delivery
- attach goal-completion delivery evidence to supervisor summary/operator artifacts so terminal completion remains auditable

## Scope
- supervisor runtime: `planningops/scripts/autonomous_supervisor_loop.py`
- contracts: `planningops/contracts/autonomous-supervisor-loop-contract.md`, `planningops/contracts/supervisor-operator-handoff-contract.md`
- regression: `planningops/scripts/test_autonomous_supervisor_loop_contract.sh`

## Linked Issues
- Closes rather-not-work-on/platform-planningops#443
- Related rather-not-work-on/platform-planningops#444

## Validation
- [x] `python3 -m py_compile planningops/scripts/autonomous_supervisor_loop.py`
- [x] `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`
- [x] `bash planningops/scripts/test_supervisor_operator_handoff_contract.sh`
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `git diff --check`

## Risks
- Risk: apply-mode goal completion now depends on monday being present in the federated workspace to emit terminal delivery evidence; when monday is missing, delivery is explicitly skipped instead of silently faked
- Rollback: revert this PR to restore handoff-only supervisor completion behavior

## Review Checklist
- [x] Repo-qualified planningops issue link included.
- [x] planningops stays transport-agnostic and delegates terminal delivery to monday.
- [x] Supervisor completion artifacts remain deterministic in both federated and repo-only environments.
