### PR TITLE
docs(planningops): define wave16 local outbox dispatch successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-goal-brief.md
@@ -1,0 +1,59 @@
+---
+title: plan: Goal-Driven Autonomy Wave 16 Goal Brief
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the sixteenth goal-driven autonomy wave so monday-owned local outbox delivery artifacts become deterministic dispatch packets that future Slack skill and terminal notifier surfaces can consume without planningops reading runtime-owned transport state.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - operator
+  - outbox
+  - dispatch
+  - slack
+  - email
+---
+
+# Goal-Driven Autonomy Wave 16 Goal Brief
+
+## Objective
+
+Turn monday local outbox delivery into a reusable dispatch boundary:
+- `monday local outbox message -> monday dispatch packet -> skill or notifier surface`
+- monday owns outbox message selection, dispatch packet export, and post-dispatch acknowledgement
+- planningops remains the control tower and no longer needs to infer or poll runtime-owned transport state for the primary operator path
+
+## Success Outcomes
+
+- planningops has a contract that freezes the local outbox dispatch handoff boundary without taking ownership of runtime delivery state
+- monday can select one deterministic local outbox message and emit one dispatch packet for operator or terminal delivery surfaces
+- monday can acknowledge a dispatched local outbox message and persist deterministic checkpoint evidence
+- future Slack skill or email notifier integrations can consume monday dispatch packets instead of raw outbox files
+- review evidence proves planningops still does not own monday outbox mutation, dispatch execution, or concrete recipients
+
+## Non-Goals
+
+- no real Slack API delivery
+- no SMTP or third-party email provider integration
+- no planningops-owned outbox polling loop for the primary path
+- no daemonized dispatch worker yet
+
+## Completion References
+
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/local-operator-target-resolution-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-issue-pack.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 16 Issue Pack
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the sixteenth goal-driven autonomy wave so monday-owned local outbox artifacts turn into dispatch packets and acknowledgements that future Slack skill and terminal notifier surfaces can consume without planningops taking ownership of transport runtime state.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - operator
+  - outbox
+  - dispatch
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 16 Issue Pack
+
+## Goal
+
+Move from repo-local outbox files to monday-owned dispatch handoff artifacts:
+- `monday local outbox -> monday dispatch packet -> future Slack skill or terminal notifier`
+- monday owns outbox selection, dispatch packet emission, and acknowledgement checkpoints
+- planningops keeps contract/review ownership but does not poll or mutate runtime-owned transport artifacts on the primary path
+
+## Wave 16 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `P10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/local-outbox-dispatch-handoff-contract.md` |
+| `P20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `monday/scripts/export_local_outbox_dispatch_packet.py` |
+| `P30` | 30 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `monday/scripts/ack_local_outbox_dispatch.py` |
+| `P40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave16-review.json` |
+
+## Decomposition Rules
+
+- `P10` freezes only the outbox dispatch handoff boundary and evidence model; it does not define real Slack or SMTP execution.
+- `P20` exports one deterministic dispatch packet from one monday-owned local outbox message so downstream skill or notifier surfaces have a stable handoff format.
+- `P30` records dispatch acknowledgement and checkpoint evidence inside monday so transport-facing mutation stays runtime-owned.
+- `P40` verifies planningops still does not own monday outbox mutation or transport execution and that monday owns dispatch packet and acknowledgement semantics.
+
+## Dependencies
+
+- `P20` depends on `P10`
+- `P30` depends on `P10`, `P20`
+- `P40` depends on `P10`, `P20`, `P30`
+
+## Non-Goals
+
+- no real Slack API token flow
+- no SMTP provider integration
+- no planningops-owned dispatch queue
+- no remote scheduler service

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16.execution-contract.json
@@ -1,0 +1,57 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave16",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "P10",
+        "execution_order": 10,
+        "title": "Freeze monday local outbox dispatch handoff contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/local-outbox-dispatch-handoff-contract.md"
+      },
+      {
+        "plan_item_id": "P20",
+        "execution_order": 20,
+        "title": "Export monday local outbox dispatch packet",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10],
+        "primary_output": "monday/scripts/export_local_outbox_dispatch_packet.py"
+      },
+      {
+        "plan_item_id": "P30",
+        "execution_order": 30,
+        "title": "Acknowledge monday local outbox dispatch completion",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10, 20],
+        "primary_output": "monday/scripts/ack_local_outbox_dispatch.py"
+      },
+      {
+        "plan_item_id": "P40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 16 local outbox dispatch handoff",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [10, 20, 30],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave16-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -387,6 +387,31 @@
           "execution_repo": "rather-not-work-on/monday",
           "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
         }
+      },
+      "next_goal_key": "uap-goal-driven-autonomy-wave16"
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave16",
+      "title": "Wave 16 - Monday Local Outbox Dispatch Handoff",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/goal-completion-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary
- define wave16 as the successor to wave15 so local outbox delivery can evolve into monday-owned dispatch packets and acknowledgements
- link wave15 to wave16 in the active-goal registry
- validate the successor contract in dry-run before promotion/materialization

## Scope
- goal brief: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-goal-brief.md`
- issue pack: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-issue-pack.md`
- execution contract: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16.execution-contract.json`
- active goal registry: `planningops/config/active-goal-registry.json`

## Linked Issues
- Closes rather-not-work-on/platform-planningops#450

## Validation
- [x] `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
- [x] `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16.execution-contract.json`
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`

## Risks
- Risk: successor scope could still be too narrow or too broad relative to future Slack/email skill integration, so the first wave16 implementation card may need decomposition refinement
- Rollback: remove the wave16 successor linkage from the registry and revert these planning docs

## Review Checklist
- [x] Repo-qualified planningops issue link included.
- [x] planningops remains control-plane only.
- [x] wave16 stays local-first and does not pretend real Slack/email transport already exists.
