### PR TITLE
docs(planningops): record wave16 review artifact

### DIFF
--- a/planningops/artifacts/validation/goal-driven-autonomy-wave16-review.json
+++ b/planningops/artifacts/validation/goal-driven-autonomy-wave16-review.json
@@ -1,0 +1,162 @@
+{
+  "generated_at_utc": "2026-03-15T05:15:59.449316+00:00",
+  "wave_id": "uap-goal-driven-autonomy-wave16",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-issue-pack.md",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 452,
+      "state": "CLOSED",
+      "title": "plan: [10] Freeze monday local outbox dispatch handoff contract",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/452",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 453,
+      "state": "CLOSED",
+      "title": "plan: [20] Export monday local outbox dispatch packet",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/453",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 454,
+      "state": "CLOSED",
+      "title": "plan: [30] Acknowledge monday local outbox dispatch completion",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/454",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/contracts/local-outbox-dispatch-handoff-contract.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/export_local_outbox_dispatch_packet.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/ack_local_outbox_dispatch.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/local_outbox_dispatch_common.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    }
+  ],
+  "boundary_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/export_local_outbox_dispatch_packet.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must not own monday local outbox dispatch packet export logic"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/ack_local_outbox_dispatch.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must not own monday local outbox acknowledgement checkpoints"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/runtime-artifacts/messaging",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must not own monday runtime outbox, dispatch, or acknowledgement artifact storage"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/run_reflection_delivery_cycle.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "monday must not host planningops reflection delivery orchestration"
+    }
+  ],
+  "registry_checks": [
+    {
+      "name": "active_goal_key",
+      "expected": "uap-goal-driven-autonomy-wave16",
+      "actual": "uap-goal-driven-autonomy-wave16",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave15_status",
+      "expected": "achieved",
+      "actual": "achieved",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave16_status",
+      "expected": "active",
+      "actual": "active",
+      "verdict": "pass"
+    }
+  ],
+  "validation_checks": [
+    {
+      "name": "planningops/uap_docs_all",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/test_local_outbox_dispatch_handoff_contract",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/validate_active_goal_registry",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/validate_issue_quality_wave16",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_export_local_outbox_dispatch_packet",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_ack_local_outbox_dispatch",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_operator_channel_delivery_cli",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_module_readmes",
+      "verdict": "pass"
+    }
+  ],
+  "behavior_checks": [
+    {
+      "name": "dispatch_packet_export_from_local_outbox_delivery",
+      "verdict": "pass",
+      "message": "monday converts delivered_local_outbox reports into deterministic dispatch packets without planningops mutating runtime artifacts"
+    },
+    {
+      "name": "dispatch_ack_checkpoint_dedupes_repeated_calls",
+      "verdict": "pass",
+      "message": "monday writes one acknowledgement checkpoint per delivery idempotency key and repeated calls report already_recorded without duplicating runtime state"
+    },
+    {
+      "name": "planningops_remains_transport_agnostic",
+      "verdict": "pass",
+      "message": "planningops owns contract and review evidence only while monday owns outbox, dispatch, and acknowledgement runtime mutation"
+    }
+  ],
+  "check_count": 18,
+  "failure_count": 0,
+  "verdict": "pass"
+}


### PR DESCRIPTION
## Summary
- record the wave16 review artifact after contract, dispatch export, and acknowledgement delivery changes landed
- verify planningops remains control-plane only while monday owns outbox, dispatch, and acknowledgement runtime mutation
- close the final wave16 review gate

## Scope
- Initiative docs: docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave16-issue-pack.md
- Workbench docs: none
- planningops scripts/contracts: planningops/artifacts/validation/goal-driven-autonomy-wave16-review.json
- GitHub workflows: none

## Linked Issues
- Closes #455
- Related #452
- Related #453
- Related #454

## Validation
- [x] bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all
- [x] Additional checks (if any): review artifact confirms monday tests for export, ack, operator channel delivery, and module readmes all passed
- [x] Additional checks (if any): git diff --check

## Risks
- Risk: the review artifact is only as good as the referenced validations, so future notifier work must keep these checks current.
- Rollback: revert this PR and rerun wave16 review after revalidating the dependent monday and planningops changes.

## Review Checklist
- [x] No direct main edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, README and navigation docs were updated together when required.
- [x] Evidence artifacts/logs are attached or linked.
