### PR TITLE
docs(planningops): define wave18 local delivery cycle successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-goal-brief.md
@@ -1,0 +1,59 @@
+---
+title: plan: Goal-Driven Autonomy Wave 18 Goal Brief
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the eighteenth goal-driven autonomy wave so monday exposes one-shot local delivery cycle entrypoints that drive outbox delivery, dispatch packet export, and local dispatch consumption through a single runtime-owned command surface.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - operator
+  - dispatch
+  - slack
+  - email
+  - scheduler
+---
+
+# Goal-Driven Autonomy Wave 18 Goal Brief
+
+## Objective
+
+Collapse wave15 to wave17 local operator delivery steps behind monday-owned entrypoints:
+- `operator payload -> local outbox delivery -> dispatch packet -> local dispatch cycle`
+- `goal completion payload -> local outbox delivery -> dispatch packet -> local dispatch cycle`
+- planningops keeps contract/review ownership while monday owns the runtime mutation path end to end
+
+## Success Outcomes
+
+- planningops has a contract that freezes one-shot monday local delivery cycle entrypoints without taking ownership of monday runtime mutation
+- monday exposes one entrypoint for operator message delivery cycles and one entrypoint for goal completion delivery cycles
+- each monday entrypoint emits aggregate evidence that links the delivery wrapper, dispatch packet, execution packet, acknowledgement checkpoint, and dispatch receipt
+- future Slack skill or terminal notifier adapters can swap behind the monday entrypoints without changing planningops orchestration contracts
+- review evidence proves planningops still does not own monday delivery execution, dispatch packet export, acknowledgement, or receipt mutation
+
+## Non-Goals
+
+- no real Slack API delivery yet
+- no SMTP or third-party email provider integration yet
+- no planningops-owned delivery worker or daemon
+- no remote scheduler service outside monday yet
+
+## Completion References
+
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/local-dispatch-cycle-handoff-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-issue-pack.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 18 Issue Pack
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the eighteenth goal-driven autonomy wave so monday-owned entrypoints can drive one local operator delivery cycle or goal completion delivery cycle without planningops owning transport-facing runtime mutation.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - operator
+  - dispatch
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 18 Issue Pack
+
+## Goal
+
+Operationalize monday local delivery cycles behind stable monday entrypoints:
+- `operator payload -> monday local delivery cycle`
+- `goal completion payload -> monday local delivery cycle`
+- monday owns local outbox delivery, dispatch packet export, execution packet emission, acknowledgement, and receipt mutation
+- planningops keeps contract/review ownership and does not own runtime delivery loops or transport-facing mutation
+
+## Wave 18 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `R10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/local-delivery-cycle-entrypoint-contract.md` |
+| `R20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `monday/scripts/run_operator_message_delivery_cycle.py` |
+| `R30` | 30 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `monday/scripts/run_goal_completion_delivery_cycle.py` |
+| `R40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave18-review.json` |
+
+## Decomposition Rules
+
+- `R10` freezes only the monday-owned entrypoint contract and aggregate evidence model; it does not introduce real Slack or SMTP provider calls.
+- `R20` exposes one monday-owned entrypoint that drives operator-channel local outbox delivery through dispatch packet export and the local dispatch cycle.
+- `R30` exposes one monday-owned entrypoint that drives goal completion local outbox delivery through dispatch packet export and the local dispatch cycle.
+- `R40` verifies planningops still does not own monday delivery execution, dispatch packet export, acknowledgement, or receipt mutation and that monday owns the runtime delivery cycle.
+
+## Dependencies
+
+- `R20` depends on `R10`
+- `R30` depends on `R10`
+- `R40` depends on `R10`, `R20`, `R30`
+
+## Non-Goals
+
+- no real Slack API delivery
+- no SMTP or third-party email provider integration
+- no planningops-owned delivery daemon
+- no scheduler service outside monday yet

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18.execution-contract.json
@@ -1,0 +1,57 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave18",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "R10",
+        "execution_order": 10,
+        "title": "Freeze monday local delivery cycle entrypoint contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/local-delivery-cycle-entrypoint-contract.md"
+      },
+      {
+        "plan_item_id": "R20",
+        "execution_order": 20,
+        "title": "Run monday operator message local delivery cycle",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10],
+        "primary_output": "monday/scripts/run_operator_message_delivery_cycle.py"
+      },
+      {
+        "plan_item_id": "R30",
+        "execution_order": 30,
+        "title": "Run monday goal completion local delivery cycle",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10],
+        "primary_output": "monday/scripts/run_goal_completion_delivery_cycle.py"
+      },
+      {
+        "plan_item_id": "R40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 18 local delivery cycle entrypoints",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [10, 20, 30],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave18-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -438,6 +438,32 @@
           "execution_repo": "rather-not-work-on/monday",
           "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
         }
+      },
+      "next_goal_key": "uap-goal-driven-autonomy-wave18"
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave18",
+      "title": "Wave 18 - Monday Local Delivery Cycle Entrypoints",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/local-dispatch-cycle-handoff-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary
- define wave18 as the successor to wave17 so monday can expose one-shot local delivery cycle entrypoints
- link wave17 to wave18 in the active-goal registry and freeze the next issue pack/execution contract

## Scope
- Initiative docs:
- Workbench docs:
  - `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-goal-brief.md`
  - `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-issue-pack.md`
  - `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18.execution-contract.json`
- `planningops/` scripts/contracts:
  - `planningops/config/active-goal-registry.json`
- `.github/` workflows:

## Linked Issues
- Closes #466
- Related #460
- Related #463

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
  - `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18.execution-contract.json`
  - `git diff --check`

## Risks
- Risk: wave18 currently defines only the successor control-plane pack, so runtime progress still depends on a later promotion/materialization step.
- Rollback: revert this PR to remove the successor linkage and wave18 planning docs.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
