### PR TITLE
docs(planningops): record wave18 local delivery review

### DIFF
--- a/planningops/artifacts/validation/goal-driven-autonomy-wave18-review.json
+++ b/planningops/artifacts/validation/goal-driven-autonomy-wave18-review.json
@@ -1,0 +1,179 @@
+{
+  "generated_at_utc": "2026-03-15T05:57:01Z",
+  "wave_id": "uap-goal-driven-autonomy-wave18",
+  "spec": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-issue-pack.md",
+  "workspace_root": "/Volumes/T7 Touch/mini/rather-not-work-on",
+  "issue_checks": [
+    {
+      "number": 468,
+      "state": "CLOSED",
+      "title": "plan: [10] Freeze monday local delivery cycle entrypoint contract",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/468",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 469,
+      "state": "CLOSED",
+      "title": "plan: [20] Run monday operator message local delivery cycle",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/469",
+      "verdict": "pass",
+      "message": ""
+    },
+    {
+      "number": 470,
+      "state": "CLOSED",
+      "title": "plan: [30] Run monday goal completion local delivery cycle",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/470",
+      "verdict": "pass",
+      "message": ""
+    }
+  ],
+  "file_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/contracts/local-delivery-cycle-entrypoint-contract.md",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/platform-planningops"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/run_operator_message_delivery_cycle.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/run_goal_completion_delivery_cycle.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/scripts/local_delivery_cycle_common.py",
+      "exists": true,
+      "missing_markers": [],
+      "verdict": "pass",
+      "repo": "rather-not-work-on/monday"
+    }
+  ],
+  "boundary_checks": [
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_operator_message_delivery_cycle.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must not own monday operator-message local delivery entrypoints"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_goal_completion_delivery_cycle.py",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must not own monday goal-completion local delivery entrypoints"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/runtime-artifacts/messaging/delivery-cycles",
+      "exists": false,
+      "verdict": "pass",
+      "message": "planningops must not become the storage owner for monday local delivery-cycle runtime artifacts"
+    },
+    {
+      "path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/planningops/scripts/test_local_delivery_cycle_entrypoint_contract.sh",
+      "exists": false,
+      "verdict": "pass",
+      "message": "monday must not host planningops contract validation ownership"
+    }
+  ],
+  "registry_checks": [
+    {
+      "name": "active_goal_key",
+      "expected": "uap-goal-driven-autonomy-wave18",
+      "actual": "uap-goal-driven-autonomy-wave18",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave17_status",
+      "expected": "achieved",
+      "actual": "achieved",
+      "verdict": "pass"
+    },
+    {
+      "name": "wave18_status",
+      "expected": "active",
+      "actual": "active",
+      "verdict": "pass"
+    }
+  ],
+  "validation_checks": [
+    {
+      "name": "planningops/uap_docs_all",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/test_local_delivery_cycle_entrypoint_contract",
+      "verdict": "pass"
+    },
+    {
+      "name": "planningops/validate_active_goal_registry",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_run_operator_message_delivery_cycle",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_run_goal_completion_delivery_cycle",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_operator_channel_delivery_cli",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_export_local_outbox_dispatch_packet",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_ack_local_outbox_dispatch",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_export_local_dispatch_execution_packet",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_run_local_dispatch_cycle",
+      "verdict": "pass"
+    },
+    {
+      "name": "monday/test_module_readmes",
+      "verdict": "pass"
+    }
+  ],
+  "behavior_checks": [
+    {
+      "name": "operator_message_delivery_cycle_records_delivery_and_dispatch_state",
+      "verdict": "pass",
+      "message": "monday can take an operator-message payload through local outbox delivery, dispatch packet export, execution packet emission, acknowledgement, and receipt recording under monday-owned runtime artifacts"
+    },
+    {
+      "name": "goal_completion_delivery_cycle_records_delivery_and_dispatch_state",
+      "verdict": "pass",
+      "message": "monday can take a goal-completion payload through local outbox delivery and one deterministic local dispatch cycle without planningops mutating delivery state"
+    },
+    {
+      "name": "delivery_cycle_replay_is_idempotent",
+      "verdict": "pass",
+      "message": "re-running either local delivery entrypoint converges to already_recorded and already_acknowledged state rather than duplicating outbox or receipt artifacts"
+    },
+    {
+      "name": "planningops_remains_contract_and_review_owner",
+      "verdict": "pass",
+      "message": "planningops owns the entrypoint contract and review evidence while monday owns the delivery entrypoints, dispatch export, acknowledgement, and receipt mutation"
+    }
+  ],
+  "check_count": 18,
+  "failure_count": 0,
+  "verdict": "pass"
+}


### PR DESCRIPTION
## Summary
- record wave18 review evidence after monday local delivery-cycle entrypoints merged
- confirm wave18 issue closure, file ownership, registry state, and validation coverage

## Scope
- Runtime/packages: none
- Scripts/contracts/docs:
  - planningops/artifacts/validation/goal-driven-autonomy-wave18-review.json
- `.github/` workflows: none

## Linked Issues
- Closes rather-not-work-on/platform-planningops#471
- Related rather-not-work-on/platform-planningops#468
- Related rather-not-work-on/platform-planningops#469
- Related rather-not-work-on/platform-planningops#470

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `bash planningops/scripts/test_local_delivery_cycle_entrypoint_contract.sh`
- [x] `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
- [x] Additional checks (if any): monday wave18 delivery-cycle regressions passed before review artifact was recorded.

## Risks
- Risk: review evidence can drift if future wave18 changes land outside the recorded validations.
- Rollback: revert this PR and regenerate the review artifact from current main state.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] PR includes a repo-qualified planningops issue ref.
- [x] README or topology guidance updated if workflow expectations changed.
- [x] Validation commands were run locally.
