### PR TITLE
docs(planningops): define wave19 delivery-cycle delegation successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19-goal-brief.md
@@ -1,0 +1,58 @@
+---
+title: plan: Goal-Driven Autonomy Wave 19 Goal Brief
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the nineteenth goal-driven autonomy wave so planningops delegates operator and goal-completion delivery through monday-owned local delivery-cycle entrypoints instead of stitching lower-level delivery and dispatch steps itself.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - operator
+  - scheduler
+  - slack
+  - email
+---
+
+# Goal-Driven Autonomy Wave 19 Goal Brief
+
+## Objective
+
+Move planningops orchestration up to the monday-owned entrypoint boundary:
+- `planningops reflection action -> monday run_operator_message_delivery_cycle.py`
+- `planningops goal completion decision -> monday run_goal_completion_delivery_cycle.py`
+- planningops keeps contract/review ownership while monday remains the only runtime owner for delivery, dispatch export, acknowledgement, and receipt mutation
+
+## Success Outcomes
+
+- planningops has a contract that freezes orchestration against monday local delivery-cycle entrypoints rather than lower-level delivery CLIs
+- the reflection delivery cycle calls the monday operator-message delivery cycle entrypoint on the primary local path
+- the autonomous supervisor goal-completion path calls the monday goal-completion delivery cycle entrypoint on the primary local path
+- aggregate reports still link monday runtime-owned delivery, dispatch, acknowledgement, and receipt artifacts without planningops mutating them
+- review evidence proves planningops no longer owns the stitched delivery-plus-dispatch path on the primary local autonomy flow
+
+## Non-Goals
+
+- no real Slack API delivery yet
+- no SMTP or third-party email provider integration yet
+- no planningops-owned delivery daemon or queue worker
+- no monday scheduler daemon changes in this wave
+
+## Completion References
+
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/local-delivery-cycle-entrypoint-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19-issue-pack.md
@@ -1,0 +1,56 @@
+---
+title: plan: Goal-Driven Autonomy Wave 19 Issue Pack
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the nineteenth goal-driven autonomy wave so planningops consumes monday local delivery-cycle entrypoints as the primary orchestration boundary for operator and terminal notifications.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - operator
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 19 Issue Pack
+
+## Goal
+
+Make monday local delivery-cycle entrypoints the primary planningops orchestration boundary:
+- `reflection action -> monday operator delivery cycle`
+- `goal completion decision -> monday goal completion delivery cycle`
+- monday remains the only owner of local delivery, dispatch export, acknowledgement, and receipt mutation
+- planningops keeps orchestration, contract, and review ownership only
+
+## Wave 19 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `S10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/local-delivery-cycle-orchestration-contract.md` |
+| `S20` | 20 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/federation/run_reflection_delivery_cycle.py` |
+| `S30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/autonomous_supervisor_loop.py` |
+| `S40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave19-review.json` |
+
+## Decomposition Rules
+
+- `S10` freezes only the control-plane boundary for delegating to monday local delivery-cycle entrypoints; it does not redesign monday transport payloads or queue schemas.
+- `S20` upgrades the reflection delivery cycle to call monday operator-message delivery-cycle entrypoints on the primary local path instead of lower-level delivery CLIs.
+- `S30` upgrades the autonomous supervisor goal-completion path to call monday goal-completion delivery-cycle entrypoints on the primary local path instead of lower-level delivery CLIs.
+- `S40` verifies planningops remains transport-agnostic and monday remains the sole runtime owner of delivery mutation.
+
+## Dependencies
+
+- `S20` depends on `S10`
+- `S30` depends on `S10`
+- `S40` depends on `S10`, `S20`, `S30`
+
+## Non-Goals
+
+- no real Slack API delivery
+- no SMTP or third-party email provider integration
+- no monday scheduler daemon changes
+- no planningops-owned delivery worker

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19.execution-contract.json
@@ -1,0 +1,57 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave19",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "S10",
+        "execution_order": 10,
+        "title": "Freeze monday local delivery-cycle orchestration contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/local-delivery-cycle-orchestration-contract.md"
+      },
+      {
+        "plan_item_id": "S20",
+        "execution_order": 20,
+        "title": "Delegate reflection delivery through monday operator delivery cycle entrypoint",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10],
+        "primary_output": "planningops/scripts/federation/run_reflection_delivery_cycle.py"
+      },
+      {
+        "plan_item_id": "S30",
+        "execution_order": 30,
+        "title": "Delegate supervisor goal completion through monday goal-completion delivery cycle entrypoint",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10],
+        "primary_output": "planningops/scripts/autonomous_supervisor_loop.py"
+      },
+      {
+        "plan_item_id": "S40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 19 delivery-cycle orchestration",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [10, 20, 30],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave19-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/artifacts/validation/active-goal-registry-report.json
+++ b/planningops/artifacts/validation/active-goal-registry-report.json
@@ -1,21 +1,21 @@
 {
-  "generated_at_utc": "2026-03-15T05:25:27.739424+00:00",
+  "generated_at_utc": "2026-03-15T06:00:47.157717+00:00",
   "registry": "planningops/config/active-goal-registry.json",
   "verdict": "pass",
   "error_count": 0,
   "errors": [],
-  "active_goal_key": "uap-goal-driven-autonomy-wave17",
+  "active_goal_key": "uap-goal-driven-autonomy-wave18",
   "resolved_goal": {
-    "goal_key": "uap-goal-driven-autonomy-wave17",
-    "title": "Wave 17 - Monday Local Dispatch Cycle",
+    "goal_key": "uap-goal-driven-autonomy-wave18",
+    "title": "Wave 18 - Monday Local Delivery Cycle Entrypoints",
     "status": "active",
     "owner_repo": "rather-not-work-on/platform-planningops",
-    "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave17-goal-brief.md",
-    "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave17.execution-contract.json",
+    "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18-goal-brief.md",
+    "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave18.execution-contract.json",
     "completion_contract_refs": [
       "planningops/contracts/operator-channel-adapter-contract.md",
       "planningops/contracts/goal-completion-contract.md",
-      "planningops/contracts/local-outbox-dispatch-handoff-contract.md"
+      "planningops/contracts/local-dispatch-cycle-handoff-contract.md"
     ],
     "operator_channels": {
       "primary_operator_channel": {
@@ -29,6 +29,7 @@
         "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
       }
     },
+    "next_goal_key": "uap-goal-driven-autonomy-wave19",
     "primary_operator_channel": {
       "kind": "slack_skill_cli",
       "execution_repo": "rather-not-work-on/monday",

--- a/planningops/artifacts/validation/plan-compile-report.json
+++ b/planningops/artifacts/validation/plan-compile-report.json
@@ -1,17 +1,22 @@
 {
   "mode": "dry-run",
-  "contract_file": "planningops/fixtures/plan-execution-contract-sample.json",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19.execution-contract.json",
   "validation_errors": [],
   "results": [
     {
-      "plan_item_id": "sample-001",
-      "execution_order": 1,
+      "plan_item_id": "S10",
+      "execution_order": 10,
       "issue_number": null,
-      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-1",
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-10",
       "created_issue": true,
       "dedup_match_state": null,
+      "dedup_strategy": null,
       "reused_closed_issue": false,
       "reopened_closed_issue": false,
+      "closed_match_detected": false,
+      "closed_match_issue_number": null,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
       "field_updates": [
         "initiative(text)",
         "target_repo(text)",
@@ -19,15 +24,91 @@
         "status(todo)",
         "component(planningops)",
         "workflow_state(ready_contract)",
-        "loop_profile(l1_contract_clarification)"
+        "loop_profile(l1_contract_clarification)",
+        "plan_lane(m1_contract_freeze)"
+      ]
+    },
+    {
+      "plan_item_id": "S20",
+      "execution_order": 20,
+      "issue_number": null,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-20",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "closed_match_detected": false,
+      "closed_match_issue_number": null,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(planningops)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l3_implementation_tdd)",
+        "plan_lane(m2_sync_core)"
+      ]
+    },
+    {
+      "plan_item_id": "S30",
+      "execution_order": 30,
+      "issue_number": null,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-30",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "closed_match_detected": false,
+      "closed_match_issue_number": null,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(planningops)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l3_implementation_tdd)",
+        "plan_lane(m2_sync_core)"
+      ]
+    },
+    {
+      "plan_item_id": "S40",
+      "execution_order": 40,
+      "issue_number": null,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-40",
+      "created_issue": true,
+      "dedup_match_state": null,
+      "dedup_strategy": null,
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "closed_match_detected": false,
+      "closed_match_issue_number": null,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(in_progress)",
+        "component(planningops)",
+        "workflow_state(review_gate)",
+        "loop_profile(l4_integration_reconcile)",
+        "plan_lane(m3_guardrails)"
       ]
     }
   ],
-  "plan_id": "sample-pec-plan",
+  "plan_id": "uap-goal-driven-autonomy-wave19",
   "plan_revision": 1,
-  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-03-plan-auto-executable-plans-contract-and-runner-plan.md",
-  "items_total": 1,
-  "open_issues_scanned": 8,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19-issue-pack.md",
+  "items_total": 4,
+  "open_issues_scanned": 1,
   "closed_issues_scanned": 0,
   "verdict": "pass"
 }

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -464,6 +464,42 @@
           "execution_repo": "rather-not-work-on/monday",
           "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
         }
+      },
+      "next_goal_key": "uap-goal-driven-autonomy-wave19"
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave19",
+      "title": "Wave 19 - PlanningOps Delivery Cycle Delegation",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/local-delivery-cycle-entrypoint-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      },
+      "primary_operator_channel": {
+        "kind": "slack_skill_cli",
+        "execution_repo": "rather-not-work-on/monday",
+        "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+      },
+      "terminal_notification_channel": {
+        "kind": "email_cli",
+        "execution_repo": "rather-not-work-on/monday",
+        "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- define wave19 as the successor to wave18
- link wave18 to wave19 in the active-goal registry
- record the current registry and plan-compile validation artifacts for the new successor

## Scope
- Runtime/packages: none
- Scripts/contracts/docs:
  - docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19-*
  - planningops/config/active-goal-registry.json
  - planningops/artifacts/validation/active-goal-registry-report.json
  - planningops/artifacts/validation/plan-compile-report.json
- `.github/` workflows: none

## Linked Issues
- Closes rather-not-work-on/platform-planningops#475
- Related rather-not-work-on/platform-planningops#468
- Related rather-not-work-on/platform-planningops#469
- Related rather-not-work-on/platform-planningops#470
- Related rather-not-work-on/platform-planningops#471

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
- [x] `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19.execution-contract.json`
- [x] Additional checks (if any): validation artifacts were refreshed from those commands.

## Risks
- Risk: wave19 is planningops-only, so the next promotion/materialization step must happen before any implementation begins.
- Rollback: revert this PR to drop the successor definition and restore wave18 as the last linked goal.

## Review Checklist
- [x] Changes are from a feature branch.
- [x] PR includes a repo-qualified planningops issue ref.
- [x] README or topology guidance updated if workflow expectations changed.
- [x] Validation commands were run locally.
