### PR TITLE
refactor: delegate delivery through monday cycles

### DIFF
--- a/planningops/contracts/autonomous-supervisor-loop-contract.md
+++ b/planningops/contracts/autonomous-supervisor-loop-contract.md
@@ -20,7 +20,7 @@ Operator summary artifact:
 Inbox payload artifact:
 - `planningops/artifacts/supervisor/<run-id>/inbox-payload.json`
 Optional goal-completion delivery artifact:
-- `planningops/artifacts/supervisor/<run-id>/goal-completion-delivery-report.json`
+- `monday/runtime-artifacts/messaging/delivery-cycles/supervisor-goal-completion-<run-id>.json`
 
 ## Required Decisions Per Cycle
 1. `last_verdict` and `reason_code`
@@ -87,7 +87,7 @@ Output:
 - `planningops/artifacts/supervisor/last-run-operator-summary.md`
 - `planningops/artifacts/supervisor/last-run-inbox-payload.json`
 - when `stop_reason=goal_completed` and monday delivery is available:
-  - `planningops/artifacts/supervisor/last-run-goal-completion-delivery-report.json`
+  - planningops may cache a copy of the monday delivery-cycle report as local evidence
 
 ## Testability Mapping
 - implementation:

--- a/planningops/contracts/local-delivery-cycle-entrypoint-contract.md
+++ b/planningops/contracts/local-delivery-cycle-entrypoint-contract.md
@@ -54,7 +54,7 @@ Every monday local delivery cycle entrypoint report must include:
 - `verdict`
 
 Aggregate report rules:
-- `cycle_status` must be one of `recorded`, `already_recorded`, `blocked`, or `no_ready_dispatch_packet`
+- `cycle_status` must be one of `recorded`, `already_recorded`, `dry_run`, `blocked`, or `no_ready_dispatch_packet`
 - `verdict` must be `pass` or `fail`
 - `source_payload_ref` may point outside `runtime-artifacts/` only when the caller supplied an explicit payload file
 - every other `*_ref` field must point to monday-owned runtime artifacts
@@ -62,7 +62,9 @@ Aggregate report rules:
 
 ## Deterministic Entrypoint Rules
 - monday must derive the aggregate report only from the payload, monday-owned config, and monday-owned runtime artifacts
+- monday may accept high-level reflection-action or supervisor-handoff inputs and translate them into canonical payloads before the delivery CLI stage
 - monday must run delivery CLI -> dispatch packet export -> dispatch cycle in-order for apply-mode local delivery
+- monday must stop after delivery evidence and emit `cycle_status = dry_run` when dry-run mode is requested
 - monday must not require `planningops` to provide explicit dispatch packet paths on the primary local autonomous path
 - monday must return the already-recorded state deterministically when receipt or acknowledgement checkpoints already exist
 - monday must fail closed if local delivery did not produce `delivered_local_outbox`

--- a/planningops/contracts/reflection-action-handoff-contract.md
+++ b/planningops/contracts/reflection-action-handoff-contract.md
@@ -11,7 +11,7 @@ This contract exists so:
 ## Canonical Boundary
 - reflection evaluator: `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
 - action applier: `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
-- monday delivery entrypoint: `monday/scripts/send_reflection_decision_update.py`
+- monday operator delivery entrypoint: `monday/scripts/run_operator_message_delivery_cycle.py`
 - operator channel policy: `planningops/contracts/operator-channel-adapter-contract.md`
 - goal completion policy: `planningops/contracts/goal-completion-contract.md`
 
@@ -119,7 +119,8 @@ PlanningOps may emit only these `operator_channel_role` values:
 - control-plane evidence and handoff summaries
 
 ### Monday owns
-- translating action artifacts into concrete delivery payloads
+- translating action artifacts into concrete operator delivery payloads
+- local delivery-cycle execution for operator-message classes
 - resolving concrete delivery targets from local config or skill context
 - invoking Slack/email transport through CLI or MCP adapters
 - returning delivery evidence
@@ -143,4 +144,4 @@ PlanningOps may emit only these `operator_channel_role` values:
 - `planningops/scripts/test_reflection_action_handoff_contract.sh`
 - `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
 - `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
-- `monday/scripts/send_reflection_decision_update.py`
+- `monday/scripts/run_operator_message_delivery_cycle.py`

--- a/planningops/contracts/reflection-cycle-orchestration-contract.md
+++ b/planningops/contracts/reflection-cycle-orchestration-contract.md
@@ -13,7 +13,7 @@ This contract exists so:
 - control-plane evaluator: `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
 - control-plane applier: `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
 - orchestration runner: `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
-- downstream monday consumer: `monday/scripts/send_reflection_decision_update.py`
+- downstream monday consumer: `monday/scripts/run_operator_message_delivery_cycle.py`
 
 ## Cycle Scope
 The reflection cycle covered by this contract is:
@@ -115,3 +115,4 @@ Optional cycle report fields may include:
 - `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
 - `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
 - `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
+- `planningops/scripts/federation/run_reflection_delivery_cycle.py`

--- a/planningops/contracts/reflection-delivery-cycle-contract.md
+++ b/planningops/contracts/reflection-delivery-cycle-contract.md
@@ -13,8 +13,9 @@ This contract exists so:
 ## Canonical Boundary
 - reflection action producer: `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
 - delivery-cycle runner: `planningops/scripts/federation/run_reflection_delivery_cycle.py`
-- monday delivery entrypoint: `monday/scripts/send_reflection_decision_update.py`
+- monday delivery entrypoint: `monday/scripts/run_operator_message_delivery_cycle.py`
 - action handoff contract: `planningops/contracts/reflection-action-handoff-contract.md`
+- local delivery-cycle orchestration contract: `planningops/contracts/local-delivery-cycle-orchestration-contract.md`
 - operator channel adapter contract: `planningops/contracts/operator-channel-adapter-contract.md`
 - local target resolution contract: `planningops/contracts/local-operator-target-resolution-contract.md`
 - supervisor handoff contract: `planningops/contracts/supervisor-operator-handoff-contract.md`
@@ -59,17 +60,18 @@ Input rules:
 
 ## Delivery Invocation
 The delivery-cycle runner must invoke only:
-- `monday/scripts/send_reflection_decision_update.py`
+- `monday/scripts/run_operator_message_delivery_cycle.py`
 
 The runner must not call:
 - `monday/scripts/send_operator_message.py`
 - `monday/scripts/send_goal_completion_notification.py`
-directly from `planningops`
+- `monday/scripts/send_reflection_decision_update.py`
+directly from `planningops` on the primary local path
 
 The monday entrypoint remains responsible for:
-- choosing the correct delivery delegate
-- translating the action artifact into the final payload
+- translating the reflection action into the final operator payload
 - emitting delivery evidence
+- emitting delivery-cycle evidence under the monday runtime-artifacts boundary
 
 ## Required Outputs
 Every delivery-cycle run must emit one aggregate report that includes:
@@ -103,7 +105,7 @@ When `delivery_required = false`, the report must still include:
 - `monday_delivery_report_ref = -`
 
 When `delivery_required = true`, the report must include:
-- `monday_delivery_entrypoint = monday/scripts/send_reflection_decision_update.py`
+- `monday_delivery_entrypoint = monday/scripts/run_operator_message_delivery_cycle.py`
 - `monday_delivery_report_ref`
 - a projected `delivery_verdict` copied from monday delivery evidence
 - a projected `delivery_target_resolution_mode` copied from monday delivery evidence
@@ -136,9 +138,9 @@ Each stage report must include:
 
 ## Deterministic Orchestration Rules
 - the runner must fail closed if the action artifact does not reference `planningops/contracts/reflection-action-handoff-contract.md`
-- the runner must call the monday delivery entrypoint instead of recreating payload logic inside `planningops`
+- the runner must call the monday delivery entrypoint instead of invoking lower-level monday delivery CLIs from `planningops`
 - `reflection_decision = continue` must not force delivery execution; the cycle may end with `delivery_skipped = true`
-- `message_class_hint = goal_completed` must still flow through `monday/scripts/send_reflection_decision_update.py`
+- `message_class_hint = goal_completed` must fail closed in this runner because goal-completion delivery belongs to `monday/scripts/run_goal_completion_delivery_cycle.py`
 - `goal_transition_report_path` must be preserved from the action artifact into the aggregate report
 - `planningops` may orchestrate the monday CLI, but transport behavior and delivery verdict semantics remain monday-owned
 - the aggregate report must preserve monday-owned local target resolution evidence without promoting concrete `deliveryTarget` values into planningops-owned fields
@@ -152,8 +154,8 @@ Each stage report must include:
 - validation that the action artifact and monday delivery evidence are wired together correctly
 
 ### Monday owns
-- delivery payload construction
-- status versus completion delegate selection
+- reflection-action-to-payload translation for operator-message classes
+- local delivery-cycle execution
 - Slack/email adapter execution
 - transport-facing delivery evidence
 
@@ -176,4 +178,4 @@ Each stage report must include:
 - `planningops/scripts/federation/run_reflection_delivery_cycle.py`
 - `planningops/scripts/test_reflection_delivery_cycle.sh`
 - `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
-- `monday/scripts/send_reflection_decision_update.py`
+- `monday/scripts/run_operator_message_delivery_cycle.py`

--- a/planningops/scripts/autonomous_supervisor_loop.py
+++ b/planningops/scripts/autonomous_supervisor_loop.py
@@ -57,17 +57,25 @@ def resolve_component_repo(workspace_root: Path, repo_dir: str) -> Path:
     return (workspace_root / path).resolve()
 
 
-def extract_delivery_summary(delivery_report: dict) -> dict:
-    delegate_report = delivery_report.get("delegate_report") or {}
-    nested_report = (delegate_report.get("delivery_report") or delivery_report.get("delivery_report") or {})
-    outbox_message_ref = (
-        delegate_report.get("outbox_message_ref")
-        or delivery_report.get("outbox_message_ref")
-        or nested_report.get("outboxMessageRef")
-        or "-"
-    )
+def normalize_workspace_path(workspace_root: Path, path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(workspace_root.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
+def extract_delivery_summary(delivery_cycle_report: dict, monday_repo: Path) -> dict:
+    delivery_report_ref = str(delivery_cycle_report.get("delivery_report_ref") or "-")
+    nested_report = {}
+    if delivery_report_ref != "-":
+        delivery_report_path = (monday_repo / delivery_report_ref).resolve()
+        if delivery_report_path.exists():
+            loaded = load_json(delivery_report_path, {})
+            if isinstance(loaded, dict):
+                nested_report = loaded.get("delivery_report") or loaded
+    outbox_message_ref = nested_report.get("outboxMessageRef") or nested_report.get("outbox_message_ref") or "-"
     return {
-        "delivery_verdict": str(nested_report.get("deliveryVerdict") or "-"),
+        "delivery_verdict": str(delivery_cycle_report.get("delivery_verdict") or nested_report.get("deliveryVerdict") or "-"),
         "delivery_target_resolution_mode": str(nested_report.get("targetResolutionMode") or "-"),
         "delivery_target_profile_ref": str(nested_report.get("targetProfileRef") or "-"),
         "delivery_transport_kind": str(nested_report.get("transportKind") or "-"),
@@ -84,7 +92,8 @@ def run_goal_completion_delivery(args, run_dir: Path, operator_report_path: Path
     workspace_root = resolve_workspace_root(planningops_repo, args.workspace_root)
     monday_repo = resolve_component_repo(workspace_root, args.monday_repo_dir)
     monday_script = monday_repo / args.monday_supervisor_goal_completion_script
-    delivery_output = run_dir / "goal-completion-delivery-report.json"
+    monday_output_rel = Path("runtime-artifacts") / "messaging" / "delivery-cycles" / f"supervisor-goal-completion-{run_dir.name}.json"
+    delivery_output = (monday_repo / monday_output_rel).resolve()
 
     if not monday_script.exists():
         return {
@@ -104,14 +113,19 @@ def run_goal_completion_delivery(args, run_dir: Path, operator_report_path: Path
         "--mode",
         args.mode,
         "--output",
-        str(delivery_output),
+        str(monday_output_rel),
     ]
     if args.monday_profiles_config:
         command.extend(["--profiles-config", args.monday_profiles_config])
 
     rc, out, err = run(command, cwd=monday_repo)
+    parsed_stdout_report = parse_json_doc(out)
+    if not delivery_output.exists() and isinstance(parsed_stdout_report, dict):
+        reported_ref = str(parsed_stdout_report.get("report_ref") or "").strip()
+        if reported_ref:
+            delivery_output = (monday_repo / reported_ref).resolve()
     report = load_json(delivery_output, {})
-    summary = extract_delivery_summary(report if isinstance(report, dict) else {})
+    summary = extract_delivery_summary(report if isinstance(report, dict) else {}, monday_repo)
     errors = list(report.get("errors") or []) if isinstance(report, dict) else []
     verdict = "pass" if rc == 0 and isinstance(report, dict) and report.get("verdict") == "pass" else "fail"
     if verdict == "fail" and not errors:
@@ -124,7 +138,7 @@ def run_goal_completion_delivery(args, run_dir: Path, operator_report_path: Path
         "cwd": str(monday_repo),
         "stdout": out[-2000:],
         "stderr": err[-2000:],
-        "output_path": str(delivery_output),
+        "output_path": normalize_workspace_path(workspace_root, delivery_output),
         "report": report if isinstance(report, dict) else {},
         "errors": errors,
         "verdict": verdict,
@@ -852,7 +866,7 @@ def parse_args():
     parser.add_argument("--monday-profiles-config", default=None)
     parser.add_argument(
         "--monday-supervisor-goal-completion-script",
-        default="scripts/send_supervisor_goal_completion.py",
+        default="scripts/run_goal_completion_delivery_cycle.py",
     )
     return parser.parse_args()
 
@@ -1247,7 +1261,7 @@ def main():
     if stop_reason == "goal_completed":
         last_goal_completion_delivery_path = output_path.with_name(f"{output_path.stem}-goal-completion-delivery-report.json")
         goal_completion_delivery = run_goal_completion_delivery(args, run_dir, operator_report_path, operator_summary_path)
-        summary["goal_completion_delivery_path"] = str(run_dir / "goal-completion-delivery-report.json")
+        summary["goal_completion_delivery_path"] = str(goal_completion_delivery.get("output_path") or "-")
         summary["goal_completion_delivery_last_path"] = str(last_goal_completion_delivery_path)
         summary["goal_completion_delivery"] = goal_completion_delivery
         if goal_completion_delivery.get("enabled") and isinstance(goal_completion_delivery.get("report"), dict) and goal_completion_delivery["report"]:

--- a/planningops/scripts/federation/run_reflection_delivery_cycle.py
+++ b/planningops/scripts/federation/run_reflection_delivery_cycle.py
@@ -23,7 +23,7 @@ from federated_python_env import (
 
 RUNNER_CONTRACT_REF = "planningops/contracts/reflection-delivery-cycle-contract.md"
 ACTION_CONTRACT_REF = "planningops/contracts/reflection-action-handoff-contract.md"
-MONDAY_DELIVERY_ENTRYPOINT = "monday/scripts/send_reflection_decision_update.py"
+MONDAY_DELIVERY_ENTRYPOINT = "monday/scripts/run_operator_message_delivery_cycle.py"
 
 REQUIRED_ACTION_FIELDS = [
     "active_goal_key",
@@ -105,6 +105,13 @@ def normalize_repo_path(repo_root: Path, path: Path) -> str:
         return str(path.resolve())
 
 
+def normalize_workspace_path(workspace_root: Path, path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(workspace_root.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
 def load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -112,6 +119,17 @@ def load_json(path: Path) -> dict:
 def write_report(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_json_doc(raw: str) -> dict | None:
+    text = (raw or "").strip()
+    if not text:
+        return None
+    try:
+        doc = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return doc if isinstance(doc, dict) else None
 
 
 def run_cmd(command: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
@@ -145,7 +163,7 @@ def parse_args():
     )
     parser.add_argument(
         "--monday-delivery-script",
-        default="scripts/send_reflection_decision_update.py",
+        default="scripts/run_operator_message_delivery_cycle.py",
         help="monday delivery script path relative to the monday repo",
     )
     parser.add_argument("--action-file", required=True, help="Reflection action artifact path")
@@ -196,22 +214,33 @@ def base_report_fields(action_ref: str, action: dict | None) -> dict:
     }
 
 
-def extract_delivery_summary(delivery_report: dict) -> dict:
-    delegate_report = delivery_report.get("delegate_report") or {}
-    nested_report = (delegate_report.get("delivery_report") or delivery_report.get("delivery_report") or {})
-    outbox_message_ref = (
-        delegate_report.get("outbox_message_ref")
-        or delivery_report.get("outbox_message_ref")
-        or nested_report.get("outboxMessageRef")
-        or "-"
-    )
+def extract_delivery_summary(delivery_cycle_report: dict, monday_repo: Path) -> dict:
+    delivery_report_ref = str(delivery_cycle_report.get("delivery_report_ref") or "-")
+    nested_report: dict = {}
+    if delivery_report_ref != "-":
+        delivery_report_path = (monday_repo / delivery_report_ref).resolve()
+        if delivery_report_path.exists():
+            loaded = load_json(delivery_report_path)
+            if isinstance(loaded, dict):
+                nested_report = loaded.get("delivery_report") or loaded
+    outbox_message_ref = nested_report.get("outboxMessageRef") or nested_report.get("outbox_message_ref") or "-"
     return {
-        "delivery_verdict": str(nested_report.get("deliveryVerdict") or "-"),
+        "delivery_verdict": str(delivery_cycle_report.get("delivery_verdict") or nested_report.get("deliveryVerdict") or "-"),
         "delivery_target_resolution_mode": str(nested_report.get("targetResolutionMode") or "-"),
         "delivery_target_profile_ref": str(nested_report.get("targetProfileRef") or "-"),
         "delivery_transport_kind": str(nested_report.get("transportKind") or "-"),
         "delivery_outbox_message_ref": str(outbox_message_ref or "-"),
     }
+
+
+def resolve_monday_output(raw_path: str | None, run_id: str, monday_repo: Path) -> tuple[str, Path]:
+    default_rel = Path("runtime-artifacts") / "messaging" / "delivery-cycles" / f"reflection-delivery-cycle-{run_id}.json"
+    if raw_path is None:
+        return str(default_rel), (monday_repo / default_rel).resolve()
+    output_path = Path(raw_path)
+    if output_path.is_absolute():
+        return str(output_path), output_path.resolve()
+    return str(output_path), (monday_repo / output_path).resolve()
 
 
 def failure_report(
@@ -287,7 +316,6 @@ def main() -> int:
     python_bin = args.monday_python or bootstrap_info["preferred_python"]
 
     report_dir = planningops_repo / "planningops" / "artifacts" / "validation" / "reflection-delivery-cycle" / args.run_id
-    delivery_output = resolve_output_path(planningops_repo, args.delivery_output, report_dir / "delivery-report.json")
     report_output = resolve_output_path(planningops_repo, args.output, report_dir / "cycle-report.json")
 
     stage_reports: list[dict] = []
@@ -348,15 +376,17 @@ def main() -> int:
             report_path=report_output,
         )
 
+    monday_output_arg, monday_output_path = resolve_monday_output(args.delivery_output, args.run_id, monday_repo)
+
     command = [
         python_bin,
         args.monday_delivery_script,
-        "--action-file",
+        "--reflection-action-file",
         str(action_path),
         "--mode",
         args.mode,
         "--output",
-        str(delivery_output),
+        monday_output_arg,
     ]
     if args.delivery_target:
         command.extend(["--delivery-target", args.delivery_target])
@@ -368,9 +398,15 @@ def main() -> int:
         command.extend(["--profiles-config", args.monday_profiles_config])
 
     rc, out, err = run_cmd(command, monday_repo, env)
+    parsed_stdout_report = parse_json_doc(out)
+    delivery_output = monday_output_path
+    if not delivery_output.exists() and parsed_stdout_report:
+        reported_ref = str(parsed_stdout_report.get("report_ref") or "").strip()
+        if reported_ref:
+            delivery_output = (monday_repo / reported_ref).resolve()
     stage_reports.append(build_stage_report("delivery_execution", command, monday_repo, rc, out, err, delivery_output))
 
-    delivery_report_ref = normalize_repo_path(planningops_repo, delivery_output)
+    delivery_report_ref = normalize_workspace_path(workspace_root, delivery_output)
     if not delivery_output.exists():
         return failure_report(
             args=args,
@@ -384,7 +420,7 @@ def main() -> int:
         )
 
     delivery_report = load_json(delivery_output)
-    delivery_summary = extract_delivery_summary(delivery_report)
+    delivery_summary = extract_delivery_summary(delivery_report, monday_repo)
     errors = list(delivery_report.get("errors") or [])
     if rc != 0:
         errors = errors or ["monday delivery entrypoint returned non-zero"]

--- a/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
+++ b/planningops/scripts/test_autonomous_supervisor_loop_contract.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 python3 - <<'PY'
 import json
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -16,7 +17,8 @@ def run_supervisor(args):
 with tempfile.TemporaryDirectory() as td:
     td_path = Path(td)
     artifacts_root = td_path / "supervisor-artifacts"
-    monday_goal_completion_script = Path.cwd().parent / "monday" / "scripts" / "send_supervisor_goal_completion.py"
+    monday_goal_completion_script = Path.cwd().parent / "monday" / "scripts" / "run_goal_completion_delivery_cycle.py"
+    monday_runtime_test_root = Path.cwd().parent / "monday" / "runtime-artifacts" / f"test-supervisor-{td_path.name}"
 
     # 1) continue-on-experiment should allow multi-cycle run and converge.
     out_converged = td_path / "supervisor-converged.json"
@@ -853,7 +855,7 @@ with tempfile.TemporaryDirectory() as td:
                     "email_cli": {
                         "channel_kind": "email_cli",
                         "transport_kind": "local_outbox",
-                        "outbox_root": str(td_path / "local-outbox"),
+                        "outbox_root": str(monday_runtime_test_root / "local-outbox"),
                         "default_target_name": "terminal-completion",
                         "supports_threads": False,
                     }
@@ -916,9 +918,10 @@ with tempfile.TemporaryDirectory() as td:
         assert delivery["delivery_target_resolution_mode"] == "local_profile", delivery
         assert delivery["delivery_target_profile_ref"].endswith("local-operator-channel-profiles.json#/profiles/email_cli"), delivery
         assert delivery["delivery_outbox_message_ref"].endswith(".json"), delivery
-        assert Path(delivery["delivery_outbox_message_ref"]).exists(), delivery
-        assert goal_completed_operator["goal_completion_delivery_report_path"].endswith("goal-completion-delivery-report.json"), goal_completed_operator
-        assert any(str(attachment).endswith("goal-completion-delivery-report.json") for attachment in goal_completed_inbox["attachments"]), goal_completed_inbox
+        delivery_outbox_path = monday_goal_completion_script.parent.parent / delivery["delivery_outbox_message_ref"]
+        assert delivery_outbox_path.exists(), delivery
+        assert goal_completed_operator["goal_completion_delivery_report_path"].startswith("monday/runtime-artifacts/messaging/delivery-cycles/"), goal_completed_operator
+        assert any(str(attachment).startswith("monday/runtime-artifacts/messaging/delivery-cycles/") for attachment in goal_completed_inbox["attachments"]), goal_completed_inbox
     else:
         delivery = goal_completed_doc["goal_completion_delivery"]
         assert delivery["enabled"] is False, delivery
@@ -926,6 +929,7 @@ with tempfile.TemporaryDirectory() as td:
     terminal_registry_doc = json.loads(terminal_registry.read_text(encoding="utf-8"))
     assert terminal_registry_doc["active_goal_key"] == "", terminal_registry_doc
     assert terminal_registry_doc["goals"][0]["status"] == "achieved", terminal_registry_doc
+    shutil.rmtree(monday_runtime_test_root, ignore_errors=True)
 
 print("autonomous supervisor loop contract tests ok")
 PY

--- a/planningops/scripts/test_local_delivery_cycle_entrypoint_contract.sh
+++ b/planningops/scripts/test_local_delivery_cycle_entrypoint_contract.sh
@@ -31,7 +31,7 @@ required_fragments = [
     "`execution_packet_ref`",
     "`ack_checkpoint_ref`",
     "`dispatch_receipt_ref`",
-    "`cycle_status` must be one of `recorded`, `already_recorded`, `blocked`, or `no_ready_dispatch_packet`",
+    "`cycle_status` must be one of `recorded`, `already_recorded`, `dry_run`, `blocked`, or `no_ready_dispatch_packet`",
     "must run delivery CLI -> dispatch packet export -> dispatch cycle in-order",
     "must remain under the monday repo `runtime-artifacts/` boundary",
     "aggregate delivery cycle report emission",

--- a/planningops/scripts/test_reflection_action_handoff_contract.sh
+++ b/planningops/scripts/test_reflection_action_handoff_contract.sh
@@ -25,7 +25,7 @@ for section in required_sections:
 required_fragments = [
     "planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py",
     "planningops/scripts/core/goals/apply_worker_outcome_reflection.py",
-    "monday/scripts/send_reflection_decision_update.py",
+    "monday/scripts/run_operator_message_delivery_cycle.py",
     "`record_continue`",
     "`trigger_replan_review`",
     "`prepare_goal_completion`",

--- a/planningops/scripts/test_reflection_cycle_orchestration_contract.sh
+++ b/planningops/scripts/test_reflection_cycle_orchestration_contract.sh
@@ -28,7 +28,7 @@ required_fragments = [
     "planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py",
     "planningops/scripts/core/goals/apply_worker_outcome_reflection.py",
     "planningops/scripts/federation/run_worker_outcome_reflection_cycle.py",
-    "monday/scripts/send_reflection_decision_update.py",
+    "monday/scripts/run_operator_message_delivery_cycle.py",
     "`generated_at_utc`",
     "`reflection_packet_ref`",
     "`reflection_evaluation_ref`",

--- a/planningops/scripts/test_reflection_delivery_cycle.sh
+++ b/planningops/scripts/test_reflection_delivery_cycle.sh
@@ -4,12 +4,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKSPACE_ROOT="$(cd "$ROOT_DIR/.." && pwd)"
 MONDAY_REPO="$WORKSPACE_ROOT/monday"
+MONDAY_TEST_OUTBOX_ROOT="$MONDAY_REPO/runtime-artifacts/test-reflection-delivery-cycle/local-outbox"
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+trap 'rm -rf "$TMP_DIR" "$MONDAY_REPO/runtime-artifacts/test-reflection-delivery-cycle" "$MONDAY_REPO/runtime-artifacts/messaging/delivery-reports" "$MONDAY_REPO/runtime-artifacts/messaging/delivery-cycles" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-packets" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-acks" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-execution-packets" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-receipts"' EXIT
 
 cd "$ROOT_DIR"
 
-if [[ ! -f "$MONDAY_REPO/scripts/send_reflection_decision_update.py" ]]; then
+if [[ ! -f "$MONDAY_REPO/scripts/run_operator_message_delivery_cycle.py" ]]; then
   echo "reflection delivery cycle test skipped: sibling monday repo unavailable"
   exit 0
 fi
@@ -21,14 +22,14 @@ cat >"$TMP_DIR/local-operator-channel-profiles.json" <<JSON
     "slack_skill_cli": {
       "channel_kind": "slack_skill_cli",
       "transport_kind": "local_outbox",
-      "outbox_root": "$TMP_DIR/local-outbox",
+      "outbox_root": "$MONDAY_TEST_OUTBOX_ROOT/slack",
       "default_target_name": "primary-operator-thread",
       "supports_threads": true
     },
     "email_cli": {
       "channel_kind": "email_cli",
       "transport_kind": "local_outbox",
-      "outbox_root": "$TMP_DIR/local-outbox",
+      "outbox_root": "$MONDAY_TEST_OUTBOX_ROOT/email",
       "default_target_name": "terminal-completion",
       "supports_threads": false
     }
@@ -137,12 +138,15 @@ python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --run-id "test-reflection-delivery-replan" \
   --output "$TMP_DIR/replan-report.json" >/dev/null
 
-python3 planningops/scripts/run_reflection_delivery_cycle.py \
+if python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/goal-completed-action.json" \
   --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --run-id "test-reflection-delivery-complete" \
-  --output "$TMP_DIR/goal-completed-report.json" >/dev/null
+  --output "$TMP_DIR/goal-completed-report.json" >/dev/null; then
+  echo "expected goal-completed reflection delivery dry-run to fail closed"
+  exit 1
+fi
 
 python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
@@ -153,13 +157,16 @@ python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --run-id "test-reflection-delivery-replan-apply-local" \
   --output "$TMP_DIR/replan-apply-local-report.json" >/dev/null
 
-python3 planningops/scripts/run_reflection_delivery_cycle.py \
+if python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/goal-completed-action.json" \
   --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --mode apply \
   --run-id "test-reflection-delivery-complete-apply-local" \
-  --output "$TMP_DIR/goal-completed-apply-local-report.json" >/dev/null
+  --output "$TMP_DIR/goal-completed-apply-local-report.json" >/dev/null; then
+  echo "expected goal-completed reflection delivery apply to fail closed"
+  exit 1
+fi
 
 if python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
@@ -194,7 +201,7 @@ assert continue_report["monday_delivery_report_ref"] == "-", continue_report
 assert replan_report["verdict"] == "pass", replan_report
 assert replan_report["delivery_required"] is True, replan_report
 assert replan_report["delivery_skipped"] is False, replan_report
-assert replan_report["monday_delivery_entrypoint"] == "monday/scripts/send_reflection_decision_update.py", replan_report
+assert replan_report["monday_delivery_entrypoint"] == "monday/scripts/run_operator_message_delivery_cycle.py", replan_report
 assert replan_report["delivery_verdict"] == "dry_run", replan_report
 assert replan_report["delivery_target_resolution_mode"] == "local_profile", replan_report
 assert replan_report["delivery_target_profile_ref"].endswith("local-operator-channel-profiles.json#/profiles/slack_skill_cli"), replan_report
@@ -203,23 +210,19 @@ assert replan_report["delivery_outbox_message_ref"] == "-", replan_report
 assert replan_report["stage_reports"][0]["stage"] == "delivery_execution", replan_report
 assert replan_report["stage_reports"][0]["verdict"] == "pass", replan_report
 
-assert goal_completed_report["verdict"] == "pass", goal_completed_report
+assert goal_completed_report["verdict"] == "fail", goal_completed_report
 assert goal_completed_report["message_class_hint"] == "goal_completed", goal_completed_report
-assert goal_completed_report["delivery_verdict"] == "dry_run", goal_completed_report
-assert goal_completed_report["delivery_target_resolution_mode"] == "local_profile", goal_completed_report
-assert goal_completed_report["delivery_target_profile_ref"].endswith("local-operator-channel-profiles.json#/profiles/email_cli"), goal_completed_report
-assert goal_completed_report["delivery_transport_kind"] == "local_outbox", goal_completed_report
-assert goal_completed_report["goal_transition_report_path"].endswith("goal-transition-report.json"), goal_completed_report
+assert goal_completed_report["failure_stage"] == "delivery_execution", goal_completed_report
+assert goal_completed_report["error_count"] >= 1, goal_completed_report
 
 assert replan_apply_local_report["verdict"] == "pass", replan_apply_local_report
 assert replan_apply_local_report["delivery_verdict"] == "delivered_local_outbox", replan_apply_local_report
 assert replan_apply_local_report["delivery_target_resolution_mode"] == "local_profile", replan_apply_local_report
 assert replan_apply_local_report["delivery_outbox_message_ref"].endswith(".json"), replan_apply_local_report
 
-assert goal_completed_apply_local_report["verdict"] == "pass", goal_completed_apply_local_report
-assert goal_completed_apply_local_report["delivery_verdict"] == "delivered_local_outbox", goal_completed_apply_local_report
-assert goal_completed_apply_local_report["delivery_target_resolution_mode"] == "local_profile", goal_completed_apply_local_report
-assert goal_completed_apply_local_report["delivery_outbox_message_ref"].endswith(".json"), goal_completed_apply_local_report
+assert goal_completed_apply_local_report["verdict"] == "fail", goal_completed_apply_local_report
+assert goal_completed_apply_local_report["failure_stage"] == "delivery_execution", goal_completed_apply_local_report
+assert goal_completed_apply_local_report["error_count"] >= 1, goal_completed_apply_local_report
 
 assert replan_apply_report["verdict"] == "fail", replan_apply_report
 assert replan_apply_report["delivery_skipped"] is False, replan_apply_report

--- a/planningops/scripts/test_reflection_delivery_cycle_contract.sh
+++ b/planningops/scripts/test_reflection_delivery_cycle_contract.sh
@@ -27,7 +27,7 @@ for section in required_sections:
 required_fragments = [
     "planningops/scripts/core/goals/apply_worker_outcome_reflection.py",
     "planningops/scripts/federation/run_reflection_delivery_cycle.py",
-    "monday/scripts/send_reflection_decision_update.py",
+    "monday/scripts/run_operator_message_delivery_cycle.py",
     "planningops/contracts/reflection-action-handoff-contract.md",
     "planningops/contracts/operator-channel-adapter-contract.md",
     "planningops/contracts/local-operator-target-resolution-contract.md",


### PR DESCRIPTION
## Summary
- rewire reflection delivery to monday operator delivery-cycle entrypoints instead of the legacy reflection wrapper
- rewire supervisor goal completion to monday goal-completion delivery-cycle entrypoints instead of the legacy supervisor wrapper
- align contracts and regressions so planningops points at monday-owned runtime artifacts on the primary local path

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: reflection delivery cycle, autonomous supervisor loop, related contracts and regressions
- `.github/` workflows: none

## Linked Issues
- Closes rather-not-work-on/platform-planningops#478
- Closes rather-not-work-on/platform-planningops#479

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_reflection_delivery_cycle_contract.sh`
  - `bash planningops/scripts/test_reflection_action_handoff_contract.sh`
  - `bash planningops/scripts/test_reflection_cycle_orchestration_contract.sh`
  - `bash planningops/scripts/test_local_delivery_cycle_entrypoint_contract.sh`
  - `bash planningops/scripts/test_reflection_delivery_cycle.sh`
  - `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`
  - `bash planningops/scripts/test_supervisor_operator_handoff_contract.sh`
  - `python3 -m py_compile planningops/scripts/federation/run_reflection_delivery_cycle.py planningops/scripts/autonomous_supervisor_loop.py`

## Risks
- Risk: planningops and monday entrypoint contracts can drift if sibling monday main does not include the matching high-level input support.
- Rollback: revert this PR and keep planningops on the legacy monday wrappers until the sibling entrypoint contract is restored.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
