### PR TITLE
feat(planningops): freeze scheduled delivery handoff contract

### DIFF
--- a/planningops/contracts/README.md
+++ b/planningops/contracts/README.md
@@ -26,6 +26,7 @@ Define runtime behavior contracts used by the issue-resolution loop and quality 
 - `autonomous-scheduler-queue-control-plane-contract.md`: policy boundary between planningops control plane and monday scheduler/queue runtime
 - `reflection-cycle-orchestration-contract.md`: end-to-end worker-outcome packet -> evaluation -> action orchestration boundary
 - `reflection-delivery-cycle-contract.md`: action artifact -> monday delivery -> aggregate delivery evidence orchestration boundary
+- `scheduled-delivery-cycle-handoff-contract.md`: monday scheduled queue item -> monday local delivery-cycle entrypoint handoff boundary
 - `scheduled-reflection-delivery-cycle-contract.md`: scheduled monday queue cycle -> reflection cycle -> delivery cycle orchestration boundary
 - `supervisor-experiment-auto-executor-contract.md`: trigger-to-worktree comparative execution and decision contract
 - `worker-task-pack-contract.md`: worker execution bundle and render safety contract

--- a/planningops/contracts/scheduled-delivery-cycle-handoff-contract.md
+++ b/planningops/contracts/scheduled-delivery-cycle-handoff-contract.md
@@ -1,0 +1,105 @@
+# Scheduled Delivery Cycle Handoff Contract
+
+## Purpose
+Define the deterministic queue-native boundary where monday scheduled queue execution hands one delivery work item to the correct monday local delivery-cycle entrypoint.
+
+This contract exists so:
+- `planningops` can review and reason about recurring delivery execution without owning monday queue mutation
+- `monday` remains the only owner of queue dequeue, delivery-cycle execution, acknowledgement mutation, and receipt mutation
+- future Slack skill and terminal notifier adapters can stay behind monday-owned delivery-cycle entrypoints even when recurring execution becomes queue-native
+
+## Canonical Boundary
+- monday scheduled queue runtime: `monday/scripts/run_scheduled_queue_cycle.py`
+- monday scheduler delivery work-item mapper: `monday/scripts/scheduler_delivery_cycle_work_items.py`
+- monday operator delivery cycle entrypoint: `monday/scripts/run_operator_message_delivery_cycle.py`
+- monday goal completion delivery cycle entrypoint: `monday/scripts/run_goal_completion_delivery_cycle.py`
+- planningops local delivery-cycle orchestration contract: `planningops/contracts/local-delivery-cycle-orchestration-contract.md`
+- planningops local delivery-cycle entrypoint contract: `planningops/contracts/local-delivery-cycle-entrypoint-contract.md`
+- planningops goal completion contract: `planningops/contracts/goal-completion-contract.md`
+- planningops operator channel adapter contract: `planningops/contracts/operator-channel-adapter-contract.md`
+
+## Primary Recurring Path
+The primary recurring local autonomy path for delivery is:
+- `monday scheduled queue item -> monday/scripts/run_scheduled_queue_cycle.py -> monday local delivery-cycle entrypoint -> monday runtime artifacts`
+
+Queue-native delivery must select exactly one monday entrypoint per work item:
+- operator-message delivery work items must flow through `monday/scripts/run_operator_message_delivery_cycle.py`
+- goal-completion delivery work items must flow through `monday/scripts/run_goal_completion_delivery_cycle.py`
+
+`planningops` must not invoke monday one-shot delivery-cycle entrypoints directly for the recurring scheduler-owned path once scheduled delivery work items are in scope.
+
+## Delivery Work Item Shape
+Each monday scheduled delivery work item must carry enough information to select one local delivery-cycle entrypoint deterministically.
+
+Required fields:
+- `queue_item_id`
+- `goal_key`
+- `delivery_work_item_kind`
+- `message_class`
+- `source_artifact_ref`
+- `delivery_idempotency_key`
+
+Optional fields:
+- `delivery_target`
+- `channel_kind`
+- `thread_ref`
+- `goal_transition_report_ref`
+
+Field rules:
+- `delivery_work_item_kind` must be one of `operator_message_delivery` or `goal_completion_delivery`
+- `message_class` must align with the chosen work-item kind
+- `source_artifact_ref` must point at a monday-owned runtime artifact or a planningops-owned control-plane artifact explicitly allowed by the referenced monday entrypoint contract
+- `goal_transition_report_ref` is allowed only for goal-completion delivery work items
+
+## Required Outputs
+Every successful queue-native delivery execution must emit evidence that includes:
+- `queue_item_id`
+- `delivery_work_item_kind`
+- `selected_delivery_entrypoint`
+- `delivery_cycle_report_ref`
+- `delivery_cycle_verdict`
+
+Output rules:
+- `selected_delivery_entrypoint` must be one of the two monday local delivery-cycle entrypoints
+- `delivery_cycle_report_ref` must point at a monday-owned runtime artifact
+- monday queue execution may summarize delivery results, but planningops must treat monday runtime artifacts as the source of truth for delivery mutation
+
+## Deterministic Rules
+- identical `dry-run` inputs must preserve the same `selected_delivery_entrypoint` and the same verdict shape apart from timestamps
+- `operator_message_delivery` items must not invoke `monday/scripts/run_goal_completion_delivery_cycle.py`
+- `goal_completion_delivery` items must not invoke `monday/scripts/run_operator_message_delivery_cycle.py`
+- monday scheduled queue execution must not bypass local delivery-cycle entrypoints by calling lower-level delivery or dispatch scripts directly for queue-native delivery work
+- planningops review must fail if recurring delivery evidence shows direct one-shot invocation from planningops instead of monday scheduled queue ownership
+
+## Ownership Boundary
+### PlanningOps owns
+- contract expectations for queue-native delivery handoff
+- review evidence that confirms monday owns recurring delivery execution
+- goal completion policy and operator-channel policy
+
+### Monday owns
+- queue-item construction and persistence
+- queue dequeue, lease, retry, and dead-letter mutation
+- local delivery-cycle entrypoint selection
+- delivery execution and runtime artifact mutation
+
+### PlanningOps must not own
+- monday delivery work-item mutation
+- monday queue-item dequeue or completion mutation
+- concrete Slack or email transport execution
+- reconstruction of monday delivery-cycle evidence from control-plane-only state
+
+## Failure Rules
+- monday must fail if a delivery work item cannot resolve one valid local delivery-cycle entrypoint
+- monday must fail if a goal-completion delivery work item omits goal-completion evidence required by the monday goal completion entrypoint
+- monday must fail if queue-native delivery execution points outside the monday repo `runtime-artifacts/` boundary
+- planningops must fail review if recurring delivery paths still depend on direct one-shot invocation from `planningops`
+
+## Validation
+- `planningops/scripts/test_scheduled_delivery_cycle_handoff_contract.sh`
+- `planningops/contracts/local-delivery-cycle-orchestration-contract.md`
+- `planningops/contracts/local-delivery-cycle-entrypoint-contract.md`
+- `monday/scripts/run_scheduled_queue_cycle.py`
+- `monday/scripts/scheduler_delivery_cycle_work_items.py`
+- `monday/scripts/run_operator_message_delivery_cycle.py`
+- `monday/scripts/run_goal_completion_delivery_cycle.py`

--- a/planningops/scripts/test_scheduled_delivery_cycle_handoff_contract.sh
+++ b/planningops/scripts/test_scheduled_delivery_cycle_handoff_contract.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+contract = Path("planningops/contracts/scheduled-delivery-cycle-handoff-contract.md")
+text = contract.read_text(encoding="utf-8")
+
+required_sections = [
+    "# Scheduled Delivery Cycle Handoff Contract",
+    "## Purpose",
+    "## Canonical Boundary",
+    "## Primary Recurring Path",
+    "## Delivery Work Item Shape",
+    "## Required Outputs",
+    "## Deterministic Rules",
+    "## Ownership Boundary",
+    "## Failure Rules",
+    "## Validation",
+]
+for section in required_sections:
+    assert section in text, section
+
+required_fragments = [
+    "monday/scripts/run_scheduled_queue_cycle.py",
+    "monday/scripts/scheduler_delivery_cycle_work_items.py",
+    "monday/scripts/run_operator_message_delivery_cycle.py",
+    "monday/scripts/run_goal_completion_delivery_cycle.py",
+    "planningops/contracts/local-delivery-cycle-orchestration-contract.md",
+    "planningops/contracts/local-delivery-cycle-entrypoint-contract.md",
+    "`delivery_work_item_kind` must be one of `operator_message_delivery` or `goal_completion_delivery`",
+    "`operator_message_delivery` items must not invoke `monday/scripts/run_goal_completion_delivery_cycle.py`",
+    "`goal_completion_delivery` items must not invoke `monday/scripts/run_operator_message_delivery_cycle.py`",
+    "planningops review must fail if recurring delivery evidence shows direct one-shot invocation from planningops",
+    "`queue_item_id`",
+    "`selected_delivery_entrypoint`",
+    "`delivery_cycle_report_ref`",
+    "`delivery_cycle_verdict`",
+]
+for fragment in required_fragments:
+    assert fragment in text, fragment
+
+print("scheduled delivery cycle handoff contract ok")
+PY


### PR DESCRIPTION
## Summary
- add the wave20 scheduled delivery-cycle handoff contract
- codify queue-native delivery work-item vocabulary and required output evidence
- cover the new contract with a focused regression and index it in the contracts README

## Scope
- Initiative docs: none
- Workbench docs: none
- `planningops/` scripts/contracts: `planningops/contracts/scheduled-delivery-cycle-handoff-contract.md`, `planningops/scripts/test_scheduled_delivery_cycle_handoff_contract.sh`, `planningops/contracts/README.md`
- `.github/` workflows: none

## Linked Issues
- Closes #488
- Related #489

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `bash planningops/scripts/test_scheduled_delivery_cycle_handoff_contract.sh`
  - `git diff --check`

## Risks
- Risk: monday runtime may still need small vocabulary refinement when T20 implements concrete work-item mapping.
- Rollback: revert this PR to remove the new contract and keep wave20 unconstrained until runtime work lands.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
