### PR TITLE
docs(planningops): define wave21 successor

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-goal-brief.md
@@ -1,0 +1,59 @@
+---
+title: plan: Goal-Driven Autonomy Wave 21 Goal Brief
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the twenty-first goal-driven autonomy wave so planningops hands recurring operator and goal-completion delivery into monday-owned scheduled queue admission instead of calling monday delivery entrypoints directly.
+tags:
+  - uap
+  - goal
+  - autonomy
+  - planningops
+  - monday
+  - operator
+  - scheduler
+  - queue
+  - slack
+  - email
+---
+
+# Goal-Driven Autonomy Wave 21 Goal Brief
+
+## Objective
+
+Move the primary recurring delivery handoff up to monday queue admission:
+- `planningops reflection action -> monday scheduled delivery queue admission -> monday scheduled queue cycle`
+- `planningops goal completion decision -> monday scheduled delivery queue admission -> monday scheduled queue cycle`
+- planningops keeps contract, policy, and review ownership while monday owns queue insertion, dequeue, delivery execution, acknowledgement, and receipt mutation
+
+## Success Outcomes
+
+- planningops has a contract that freezes the handoff into monday-owned scheduled delivery queue admission
+- monday can take a reflection-action or goal-completion handoff and materialize one deterministic scheduled delivery work item plus queue item reference
+- planningops reflection delivery orchestration uses monday queue admission rather than directly invoking monday delivery-cycle entrypoints on the primary recurring path
+- autonomous supervisor goal-completion delivery uses the same monday queue-admission boundary on the primary recurring path
+- review evidence proves planningops no longer owns recurring delivery-cycle invocation and monday owns queue admission through delivery completion
+
+## Non-Goals
+
+- no real Slack API delivery yet
+- no SMTP or third-party email provider integration yet
+- no distributed or cloud scheduler backend
+- no planningops-owned queue worker or delivery daemon
+
+## Completion References
+
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/goal-completion-contract.md`
+- `planningops/contracts/scheduled-delivery-cycle-handoff-contract.md`
+
+## Roadmap Reference
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-14-autonomous-scheduler-queue-control-plane-plan.md`
+
+## Execution Contract
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md
@@ -1,0 +1,57 @@
+---
+title: plan: Goal-Driven Autonomy Wave 21 Issue Pack
+type: plan
+date: 2026-03-15
+updated: 2026-03-15
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the twenty-first goal-driven autonomy wave so planningops delegates recurring delivery into monday-owned scheduled queue admission instead of directly calling monday delivery entrypoints.
+tags:
+  - uap
+  - autonomy
+  - planningops
+  - monday
+  - operator
+  - scheduler
+  - queue
+  - backlog
+---
+
+# Goal-Driven Autonomy Wave 21 Issue Pack
+
+## Goal
+
+Move recurring delivery from direct monday delivery-cycle invocation into monday queue admission:
+- `handoff -> monday scheduled delivery queue admission -> monday scheduled queue cycle -> monday local delivery cycle entrypoint`
+- operator-message and goal-completion delivery remain monday-owned runtime work
+- planningops keeps contract/review ownership and stops acting like a delivery-cycle caller on the primary recurring path
+
+## Wave 21 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `U10` | 10 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_contract` | `planningops/contracts/scheduled-delivery-queue-admission-contract.md` |
+| `U20` | 20 | `rather-not-work-on/monday` | `runtime` | `ready_implementation` | `monday/scripts/enqueue_scheduled_delivery_work_item.py` |
+| `U30` | 30 | `rather-not-work-on/platform-planningops` | `planningops` | `ready_implementation` | `planningops/scripts/federation/run_reflection_delivery_cycle.py` |
+| `U40` | 40 | `rather-not-work-on/platform-planningops` | `planningops` | `review_gate` | `planningops/artifacts/validation/goal-driven-autonomy-wave21-review.json` |
+
+## Decomposition Rules
+
+- `U10` freezes only the control-plane handoff into monday queue admission; it does not redesign transport adapters.
+- `U20` introduces one monday-owned queue-admission entrypoint that accepts reflection-action and goal-completion handoffs and materializes deterministic scheduled delivery work items.
+- `U30` rewires planningops reflection delivery and supervisor goal-completion orchestration to call monday queue admission on the primary recurring path.
+- `U40` verifies planningops no longer owns recurring delivery-cycle invocation once queue-native admission is in scope.
+
+## Dependencies
+
+- `U20` depends on `U10`
+- `U30` depends on `U10`, `U20`
+- `U40` depends on `U10`, `U20`, `U30`
+
+## Non-Goals
+
+- no real Slack API delivery
+- no SMTP or third-party email provider integration
+- no distributed scheduler backend
+- no planningops-owned queue persistence

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json
@@ -1,0 +1,57 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-goal-driven-autonomy-wave21",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "U10",
+        "execution_order": 10,
+        "title": "Freeze monday scheduled delivery queue admission contract",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_contract",
+        "loop_profile": "l1_contract_clarification",
+        "plan_lane": "m1_contract_freeze",
+        "depends_on": [],
+        "primary_output": "planningops/contracts/scheduled-delivery-queue-admission-contract.md"
+      },
+      {
+        "plan_item_id": "U20",
+        "execution_order": 20,
+        "title": "Define monday scheduled delivery queue admission entrypoint",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10],
+        "primary_output": "monday/scripts/enqueue_scheduled_delivery_work_item.py"
+      },
+      {
+        "plan_item_id": "U30",
+        "execution_order": 30,
+        "title": "Delegate planningops recurring delivery through monday queue admission",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l3_implementation_tdd",
+        "plan_lane": "m2_sync_core",
+        "depends_on": [10, 20],
+        "primary_output": "planningops/scripts/federation/run_reflection_delivery_cycle.py"
+      },
+      {
+        "plan_item_id": "U40",
+        "execution_order": 40,
+        "title": "Review goal-driven autonomy wave 21 scheduled queue admission delegation",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "review_gate",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [10, 20, 30],
+        "primary_output": "planningops/artifacts/validation/goal-driven-autonomy-wave21-review.json"
+      }
+    ]
+  }
+}

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -526,6 +526,32 @@
           "execution_repo": "rather-not-work-on/monday",
           "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
         }
+      },
+      "next_goal_key": "uap-goal-driven-autonomy-wave21"
+    },
+    {
+      "goal_key": "uap-goal-driven-autonomy-wave21",
+      "title": "Wave 21 - Scheduled Delivery Queue Admission Delegation",
+      "status": "draft",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/scheduled-delivery-cycle-handoff-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary
- define the wave21 successor after wave20 scheduled delivery queue execution
- link wave20 to wave21 in the active-goal registry
- freeze the next control-plane gap as monday queue admission delegation

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-goal-brief.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md`, `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json`
- `planningops/` scripts/contracts: `planningops/config/active-goal-registry.json`
- `.github/` workflows: none

## Linked Issues
- Closes #495
- Related #491

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --strict`
  - `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json`

## Risks
- Risk: wave21 may be mis-scoped if queue admission turns out to need a contracts-repo delta.
- Rollback: revert the successor definition and remove the `next_goal_key` linkage from wave20.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
