### PR TITLE
feat(provider-profile): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -91,6 +91,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [MONDAY Agent Memory Wave AO Runtime-Handoff Tmp-Reconcile Root Ladder Completion Lane Packet](./plans/2026-03-26-monday-agent-memory-wave-ao-runtime-handoff-tmp-reconcile-root-ladder-completion-lane-packet.md)
 - [MONDAY Harness Projection Wave AP Suite Root-Surface Promotion Packet](./plans/2026-03-26-monday-harness-projection-wave-ap-suite-root-surface-promotion-packet.md)
 - [Runtime-Handoff Federated CI Summary Family Backfill Packet](./plans/2026-03-26-runtime-handoff-federated-ci-summary-family-backfill-packet.md)
+- [Provider-Profile Helper Family Backfill Packet](./plans/2026-03-26-provider-profile-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-provider-profile-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-provider-profile-helper-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Provider-Profile Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the provider-profile helper entrypoint and its contract and wiring regressions so the local federated matrix and GitHub workflow no longer depend on local-only helper files.
+related_docs:
+  - ./2026-03-26-runtime-handoff-federated-ci-summary-family-backfill-packet.md
+  - ./2026-03-26-monday-agent-memory-wave-y-runtime-handoff-ops-summary-lane-packet.md
+---
+
+# plan: Provider-Profile Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `provider-profile` helper family that both the local federated matrix and the GitHub workflow already invoke directly.
+- Promote the missing helper entrypoint plus contract and wiring regressions into git-tracked reality so provider-profile CI is reproducible from remote `main`.
+- Verify the helper dry-run still delegates only to the sibling `platform-provider-gateway` LiteLLM launcher surface.
+
+## Scope
+- `planningops/scripts/run_provider_profile_ci_check.sh`
+- `planningops/scripts/test_run_provider_profile_ci_check_contract.sh`
+- `planningops/scripts/test_provider_profile_helper_wiring.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_provider_profile_ci_check_contract.sh` passes
+- `test_provider_profile_helper_wiring.sh` proves local matrix and workflow blocks call only the canonical helper
+- `run_provider_profile_ci_check.sh --run-id <id>` succeeds against the sibling `platform-provider-gateway` repo

--- a/planningops/scripts/run_provider_profile_ci_check.sh
+++ b/planningops/scripts/run_provider_profile_ci_check.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_PROVIDER_ROOT="${ROOT_DIR}/../platform-provider-gateway"
+DEFAULT_RUNTIME_PROFILE_FILE="planningops/config/runtime-profiles.json"
+DEFAULT_PROFILES="local,oracle_cloud"
+RUN_ID=""
+PROVIDER_ROOT="${DEFAULT_PROVIDER_ROOT}"
+RUNTIME_PROFILE_FILE="${DEFAULT_RUNTIME_PROFILE_FILE}"
+PROFILES="${DEFAULT_PROFILES}"
+PRINT_LOCAL_INVOCATION=0
+PRINT_WORKFLOW_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_provider_profile_ci_check.sh [options]
+
+options:
+  --run-id <id>                provider-profile run id passed to the launcher dry-run
+  --provider-root <path>       provider gateway workspace root
+  --runtime-profile-file <path>
+                               planningops runtime profiles file consumed by the launcher
+  --profiles <csv>             launcher profile set
+  --print-local-invocation     print the canonical local matrix invocation
+  --print-workflow-invocation  print the canonical GitHub workflow invocation
+  --help                       show this help text
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    --provider-root)
+      PROVIDER_ROOT="$2"
+      shift 2
+      ;;
+    --runtime-profile-file)
+      RUNTIME_PROFILE_FILE="$2"
+      shift 2
+      ;;
+    --profiles)
+      PROFILES="$2"
+      shift 2
+      ;;
+    --print-local-invocation)
+      PRINT_LOCAL_INVOCATION=1
+      shift
+      ;;
+    --print-workflow-invocation)
+      PRINT_WORKFLOW_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_LOCAL_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_provider_profile_ci_check.sh --run-id \${RUN_ID}-provider --provider-root ../platform-provider-gateway --runtime-profile-file planningops/config/runtime-profiles.json --profiles local,oracle_cloud"
+  exit 0
+fi
+
+if [[ "${PRINT_WORKFLOW_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_provider_profile_ci_check.sh --run-id ci-provider-\${{ github.run_id }} --provider-root platform-provider-gateway --runtime-profile-file planningops/config/runtime-profiles.json --profiles local,oracle_cloud"
+  exit 0
+fi
+
+if [[ -z "${RUN_ID}" ]]; then
+  echo "--run-id is required" >&2
+  usage >&2
+  exit 1
+fi
+
+resolve_from_root() {
+  if [[ "$1" = /* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s/%s\n' "${ROOT_DIR}" "$1"
+  fi
+}
+
+PROVIDER_ROOT="$(resolve_from_root "${PROVIDER_ROOT}")"
+RUNTIME_PROFILE_FILE="$(resolve_from_root "${RUNTIME_PROFILE_FILE}")"
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_provider_profile_ci_check_contract.sh"
+
+cd "${PROVIDER_ROOT}"
+bash scripts/litellm_stack_launcher.sh \
+  --mode dry-run \
+  --runtime-profile-file "${RUNTIME_PROFILE_FILE}" \
+  --profiles "${PROFILES}" \
+  --run-id "${RUN_ID}"

--- a/planningops/scripts/test_provider_profile_helper_wiring.sh
+++ b/planningops/scripts/test_provider_profile_helper_wiring.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOCAL_MATRIX_PATH="$ROOT_DIR/planningops/scripts/federation/federated_ci_matrix_local.sh"
+WORKFLOW_PATH="$ROOT_DIR/.github/workflows/federated-ci-matrix.yml"
+HELPER_PATH="$ROOT_DIR/planningops/scripts/run_provider_profile_ci_check.sh"
+
+python3 - <<'PY' "$LOCAL_MATRIX_PATH" "$WORKFLOW_PATH" "$HELPER_PATH"
+import subprocess
+import sys
+from pathlib import Path
+
+local_matrix = Path(sys.argv[1]).read_text(encoding="utf-8")
+workflow = Path(sys.argv[2]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[3])
+
+local_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-local-invocation"],
+    text=True,
+).strip()
+workflow_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+
+local_block = local_matrix.split('run_check "provider-profile" "infra" \\', 1)[1].split('run_check "provider-gateway-ready" "infra" \\', 1)[0]
+workflow_block = workflow.split("  provider-profile:", 1)[1].split("  o11y-replay:", 1)[0]
+
+assert local_invocation in local_block, "local provider-profile block missing helper invocation"
+assert workflow_invocation in workflow_block, "workflow provider-profile job missing helper invocation"
+assert local_block.count(local_invocation) == 1, "local provider-profile helper invocation should appear once"
+assert workflow_block.count(workflow_invocation) == 1, "workflow provider-profile helper invocation should appear once"
+assert "litellm_stack_launcher.sh" not in local_block, "local provider-profile block should not inline launcher command"
+assert "litellm_stack_launcher.sh" not in workflow_block, "workflow provider-profile job should not inline launcher command"
+PY
+
+echo "provider profile helper wiring ok"

--- a/planningops/scripts/test_run_provider_profile_ci_check_contract.sh
+++ b/planningops/scripts/test_run_provider_profile_ci_check_contract.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_provider_profile_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+local_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-local-invocation"],
+    text=True,
+).strip()
+workflow_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+assert local_invocation == "bash planningops/scripts/run_provider_profile_ci_check.sh --run-id ${RUN_ID}-provider --provider-root ../platform-provider-gateway --runtime-profile-file planningops/config/runtime-profiles.json --profiles local,oracle_cloud", "local provider-profile helper invocation drifted"
+assert workflow_invocation == "bash planningops/scripts/run_provider_profile_ci_check.sh --run-id ci-provider-${{ github.run_id }} --provider-root platform-provider-gateway --runtime-profile-file planningops/config/runtime-profiles.json --profiles local,oracle_cloud", "workflow provider-profile helper invocation drifted"
+assert "usage: run_provider_profile_ci_check.sh [options]" in help_output, "provider-profile help usage missing"
+assert "--run-id <id>" in help_output, "provider-profile help missing run-id flag"
+assert "--provider-root <path>" in help_output, "provider-profile help missing provider-root flag"
+assert "--runtime-profile-file <path>" in help_output, "provider-profile help missing runtime-profile-file flag"
+assert "--profiles <csv>" in help_output, "provider-profile help missing profiles flag"
+assert "--print-local-invocation" in help_output, "provider-profile help missing local invocation flag"
+assert "--print-workflow-invocation" in help_output, "provider-profile help missing workflow invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_provider_profile_ci_check_contract.sh"' in script, "provider-profile helper must self-run its contract test"
+assert "bash scripts/litellm_stack_launcher.sh \\" in script, "provider-profile helper missing launcher command"
+assert '--mode dry-run \\' in script, "provider-profile helper missing dry-run mode"
+assert '--runtime-profile-file "${RUNTIME_PROFILE_FILE}" \\' in script, "provider-profile helper missing runtime profile file wiring"
+assert '--profiles "${PROFILES}" \\' in script, "provider-profile helper missing profiles wiring"
+assert '--run-id "${RUN_ID}"' in script, "provider-profile helper missing run-id wiring"
+PY
+
+echo "provider profile ci check contract ok"


### PR DESCRIPTION
## Summary
- backfill the `provider-profile` helper entrypoint and its contract and wiring regressions into git-tracked reality
- add a workbench packet and hub link for the helper-family backfill
- verify the helper still delegates only to the sibling `platform-provider-gateway` LiteLLM launcher dry-run surface

## Validation
- `bash planningops/scripts/test_run_provider_profile_ci_check_contract.sh`
- `bash planningops/scripts/test_provider_profile_helper_wiring.sh`
- `bash planningops/scripts/run_provider_profile_ci_check.sh --run-id provider-profile-helper-backfill --provider-root ../platform-provider-gateway --runtime-profile-file planningops/config/runtime-profiles.json --profiles local,oracle_cloud`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
- Watch local and workflow provider-profile invocations to ensure they still call only `planningops/scripts/run_provider_profile_ci_check.sh`.
- Healthy signal: helper dry-run emits `profiles=local,oracle_cloud verdict=pass` without inlining launcher commands in matrix/workflow surfaces.
- Failure signal: contract drift in `test_run_provider_profile_ci_check_contract.sh` or wiring drift in `test_provider_profile_helper_wiring.sh`.
- Mitigation trigger: rerun the two helper regressions and the helper dry-run command above.
- Validation window: immediate after merge.
- Owner: Codex.
