### PR TITLE
feat(provider-gateway-ready): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -92,6 +92,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [MONDAY Harness Projection Wave AP Suite Root-Surface Promotion Packet](./plans/2026-03-26-monday-harness-projection-wave-ap-suite-root-surface-promotion-packet.md)
 - [Runtime-Handoff Federated CI Summary Family Backfill Packet](./plans/2026-03-26-runtime-handoff-federated-ci-summary-family-backfill-packet.md)
 - [Provider-Profile Helper Family Backfill Packet](./plans/2026-03-26-provider-profile-helper-family-backfill-packet.md)
+- [Provider-Gateway-Ready Helper Family Backfill Packet](./plans/2026-03-26-provider-gateway-ready-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-provider-gateway-ready-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-provider-gateway-ready-helper-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Provider-Gateway-Ready Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the provider-gateway-ready helper entrypoint and its contract and wiring regressions so the local federated matrix and CI guardrails no longer depend on local-only helper files.
+related_docs:
+  - ./2026-03-26-provider-profile-helper-family-backfill-packet.md
+  - ./2026-03-26-runtime-handoff-federated-ci-summary-family-backfill-packet.md
+---
+
+# plan: Provider-Gateway-Ready Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `provider-gateway-ready` helper family that the local federated matrix and CI helper guardrails already invoke directly.
+- Promote the missing helper entrypoint plus contract and wiring regressions into git-tracked reality so provider-gateway readiness checks are reproducible from remote `main`.
+- Verify the helper owns stack bootstrap and cleanup instead of leaving launcher commands inlined in the matrix lane.
+
+## Scope
+- `planningops/scripts/run_provider_gateway_ready_ci_check.sh`
+- `planningops/scripts/test_run_provider_gateway_ready_ci_check_contract.sh`
+- `planningops/scripts/test_provider_gateway_ready_helper_wiring.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_provider_gateway_ready_ci_check_contract.sh` passes
+- `test_provider_gateway_ready_helper_wiring.sh` proves the local matrix block calls only the canonical helper
+- `run_provider_gateway_ready_ci_check.sh --run-id <id>` succeeds against the sibling `platform-provider-gateway` repo and leaves no stale LiteLLM stack behind

--- a/planningops/scripts/run_provider_gateway_ready_ci_check.sh
+++ b/planningops/scripts/run_provider_gateway_ready_ci_check.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_PROVIDER_ROOT="${ROOT_DIR}/../platform-provider-gateway"
+RUN_ID=""
+PROVIDER_ROOT="${DEFAULT_PROVIDER_ROOT}"
+PRINT_LOCAL_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_provider_gateway_ready_ci_check.sh [options]
+
+options:
+  --run-id <id>             provider-gateway-ready run id passed to the LiteLLM launcher
+  --provider-root <path>    provider gateway workspace root
+  --print-local-invocation  print the canonical local matrix invocation
+  --help                    show this help text
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    --provider-root)
+      PROVIDER_ROOT="$2"
+      shift 2
+      ;;
+    --print-local-invocation)
+      PRINT_LOCAL_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_LOCAL_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_provider_gateway_ready_ci_check.sh --run-id \${RUN_ID}-provider-gateway-ready --provider-root ../platform-provider-gateway"
+  exit 0
+fi
+
+if [[ -z "${RUN_ID}" ]]; then
+  echo "--run-id is required" >&2
+  usage >&2
+  exit 1
+fi
+
+resolve_from_root() {
+  if [[ "$1" = /* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s/%s\n' "${ROOT_DIR}" "$1"
+  fi
+}
+
+cleanup() {
+  if [[ -d "${PROVIDER_ROOT}" ]]; then
+    (
+      cd "${PROVIDER_ROOT}"
+      bash scripts/litellm_stack_launcher.sh --mode stop >/dev/null 2>&1 || true
+    )
+  fi
+}
+
+PROVIDER_ROOT="$(resolve_from_root "${PROVIDER_ROOT}")"
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_provider_gateway_ready_ci_check_contract.sh"
+
+trap cleanup EXIT
+
+cd "${PROVIDER_ROOT}"
+bash scripts/litellm_stack_launcher.sh --mode start --run-id "${RUN_ID}"
+npm run gate:litellm-stack-ready

--- a/planningops/scripts/test_provider_gateway_ready_helper_wiring.sh
+++ b/planningops/scripts/test_provider_gateway_ready_helper_wiring.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOCAL_MATRIX_PATH="$ROOT_DIR/planningops/scripts/federation/federated_ci_matrix_local.sh"
+HELPER_PATH="$ROOT_DIR/planningops/scripts/run_provider_gateway_ready_ci_check.sh"
+
+python3 - <<'PY' "$LOCAL_MATRIX_PATH" "$HELPER_PATH"
+import subprocess
+import sys
+from pathlib import Path
+
+local_matrix = Path(sys.argv[1]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[2])
+
+local_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-local-invocation"],
+    text=True,
+).strip()
+
+local_block = local_matrix.split('run_check "provider-gateway-ready" "infra" \\', 1)[1].split('run_check "o11y-replay" "infra" \\', 1)[0]
+
+assert local_invocation in local_block, "local provider-gateway-ready block missing helper invocation"
+assert local_block.count(local_invocation) == 1, "local provider-gateway-ready helper invocation should appear once"
+assert "run_with_litellm_stack" not in local_block, "local provider-gateway-ready block should not inline stack wrapper"
+assert "litellm_stack_launcher.sh" not in local_block, "local provider-gateway-ready block should not inline launcher command"
+assert "gate:litellm-stack-ready" not in local_block, "local provider-gateway-ready block should not inline readiness gate command"
+PY
+
+echo "provider gateway ready helper wiring ok"

--- a/planningops/scripts/test_run_provider_gateway_ready_ci_check_contract.sh
+++ b/planningops/scripts/test_run_provider_gateway_ready_ci_check_contract.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_provider_gateway_ready_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+local_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-local-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+assert local_invocation == "bash planningops/scripts/run_provider_gateway_ready_ci_check.sh --run-id ${RUN_ID}-provider-gateway-ready --provider-root ../platform-provider-gateway", "local provider-gateway-ready helper invocation drifted"
+assert "usage: run_provider_gateway_ready_ci_check.sh [options]" in help_output, "provider-gateway-ready help usage missing"
+assert "--run-id <id>" in help_output, "provider-gateway-ready help missing run-id flag"
+assert "--provider-root <path>" in help_output, "provider-gateway-ready help missing provider-root flag"
+assert "--print-local-invocation" in help_output, "provider-gateway-ready help missing local invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_provider_gateway_ready_ci_check_contract.sh"' in script, "provider-gateway-ready helper must self-run its contract test"
+assert "trap cleanup EXIT" in script, "provider-gateway-ready helper missing cleanup trap"
+assert 'bash scripts/litellm_stack_launcher.sh --mode start --run-id "${RUN_ID}"' in script, "provider-gateway-ready helper missing stack start wiring"
+assert 'bash scripts/litellm_stack_launcher.sh --mode stop >/dev/null 2>&1 || true' in script, "provider-gateway-ready helper missing stack stop wiring"
+assert "npm run gate:litellm-stack-ready" in script, "provider-gateway-ready helper missing readiness gate command"
+PY
+
+echo "provider gateway ready ci check contract ok"


### PR DESCRIPTION
## Summary
- backfill the `provider-gateway-ready` helper entrypoint and its contract and wiring regressions into git-tracked reality
- add a workbench packet and hub link for the helper-family backfill
- verify the helper owns LiteLLM stack bootstrap and cleanup instead of leaving launcher commands inlined in the matrix lane

## Validation
- `bash planningops/scripts/test_run_provider_gateway_ready_ci_check_contract.sh`
- `bash planningops/scripts/test_provider_gateway_ready_helper_wiring.sh`
- `bash planningops/scripts/run_provider_gateway_ready_ci_check.sh --run-id provider-gateway-ready-helper-backfill --provider-root ../platform-provider-gateway`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
- Watch local provider-gateway-ready invocations to ensure they still call only `planningops/scripts/run_provider_gateway_ready_ci_check.sh`.
- Healthy signal: helper run emits LiteLLM readiness `verdict=pass reason_code=ok` and exits after cleaning the local stack.
- Failure signal: wiring drift that reintroduces inline launcher commands or readiness gate failures from the sibling gateway repo.
- Mitigation trigger: rerun the two helper regressions and the helper command above.
- Validation window: immediate after merge.
- Owner: Codex.
