### PR TITLE
feat(issue-quality): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -94,6 +94,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Provider-Profile Helper Family Backfill Packet](./plans/2026-03-26-provider-profile-helper-family-backfill-packet.md)
 - [Provider-Gateway-Ready Helper Family Backfill Packet](./plans/2026-03-26-provider-gateway-ready-helper-family-backfill-packet.md)
 - [Runtime-Operations-Ready Helper Family Backfill Packet](./plans/2026-03-26-runtime-operations-ready-helper-family-backfill-packet.md)
+- [Issue-Quality Helper Family Backfill Packet](./plans/2026-03-26-issue-quality-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-issue-quality-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-issue-quality-helper-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Issue-Quality Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the issue-quality helper entrypoint and its contract and wiring regressions so the loop-guardrails workflow no longer depends on local-only helper files.
+related_docs:
+  - ./2026-03-26-runtime-operations-ready-helper-family-backfill-packet.md
+  - ./2026-03-26-provider-profile-helper-family-backfill-packet.md
+---
+
+# plan: Issue-Quality Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `issue-quality` helper family that the loop-guardrails workflow and helper guardrails already invoke directly.
+- Promote the missing helper entrypoint plus contract and wiring regressions into git-tracked reality so issue-quality validation is reproducible from remote `main`.
+- Verify the helper owns the contract regressions plus live issue-quality validator instead of leaving those steps inlined in the workflow job.
+
+## Scope
+- `planningops/scripts/run_issue_quality_ci_check.sh`
+- `planningops/scripts/test_run_issue_quality_ci_check_contract.sh`
+- `planningops/scripts/test_issue_quality_helper_wiring.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_issue_quality_ci_check_contract.sh` passes
+- `test_issue_quality_helper_wiring.sh` proves the workflow block calls only the canonical helper
+- `run_issue_quality_ci_check.sh --python-bin python3` succeeds from the repo root

--- a/planningops/scripts/run_issue_quality_ci_check.sh
+++ b/planningops/scripts/run_issue_quality_ci_check.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PYTHON_BIN="python3"
+PRINT_STEPS=0
+PRINT_WORKFLOW_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_issue_quality_ci_check.sh [options]
+
+options:
+  --python-bin <path>         python interpreter for the live issue-quality check
+  --print-steps              print the canonical workflow step inventory
+  --print-workflow-invocation print the canonical GitHub workflow invocation
+  --help                     show this help text
+EOF
+}
+
+print_steps() {
+  cat <<'EOF'
+bash planningops/scripts/test_validate_issue_quality_contract.sh
+bash planningops/scripts/test_validate_federated_issue_quality_contract.sh
+python3 planningops/scripts/validate_issue_quality.py --strict
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --python-bin)
+      PYTHON_BIN="$2"
+      shift 2
+      ;;
+    --print-steps)
+      PRINT_STEPS=1
+      shift
+      ;;
+    --print-workflow-invocation)
+      PRINT_WORKFLOW_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_STEPS}" -eq 1 ]]; then
+  print_steps
+  exit 0
+fi
+
+if [[ "${PRINT_WORKFLOW_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_issue_quality_ci_check.sh --python-bin python3"
+  exit 0
+fi
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_issue_quality_ci_check_contract.sh"
+
+cd "${ROOT_DIR}"
+bash planningops/scripts/test_validate_issue_quality_contract.sh
+bash planningops/scripts/test_validate_federated_issue_quality_contract.sh
+"${PYTHON_BIN}" planningops/scripts/validate_issue_quality.py --strict

--- a/planningops/scripts/test_issue_quality_helper_wiring.sh
+++ b/planningops/scripts/test_issue_quality_helper_wiring.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/federated-ci-matrix.yml"
+HELPER_PATH="${ROOT_DIR}/planningops/scripts/run_issue_quality_ci_check.sh"
+
+python3 - <<'PY' "${WORKFLOW_PATH}" "${HELPER_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[2])
+loop_guardrails = workflow.split("  loop-guardrails:", 1)[1].split("  federated-summary:", 1)[0]
+workflow_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+steps = subprocess.check_output(
+    ["bash", str(helper_path), "--print-steps"],
+    text=True,
+).splitlines()
+
+assert "test_run_issue_quality_ci_check_contract.sh" in loop_guardrails, "loop-guardrails missing issue-quality helper contract regression"
+assert "test_issue_quality_helper_wiring.sh" in loop_guardrails, "loop-guardrails missing issue-quality helper wiring regression"
+assert workflow_invocation in loop_guardrails, "loop-guardrails missing issue-quality helper invocation"
+assert loop_guardrails.count(workflow_invocation) == 1, "loop-guardrails should invoke issue-quality helper once"
+for step in steps:
+    assert step not in loop_guardrails, f"loop-guardrails should not inline issue-quality helper step once helper exists: {step}"
+PY
+
+echo "issue quality helper wiring ok"

--- a/planningops/scripts/test_run_issue_quality_ci_check_contract.sh
+++ b/planningops/scripts/test_run_issue_quality_ci_check_contract.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_issue_quality_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+steps = subprocess.check_output(
+    ["bash", str(script_path), "--print-steps"],
+    text=True,
+).splitlines()
+workflow_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+expected_steps = [
+    "bash planningops/scripts/test_validate_issue_quality_contract.sh",
+    "bash planningops/scripts/test_validate_federated_issue_quality_contract.sh",
+    "python3 planningops/scripts/validate_issue_quality.py --strict",
+]
+
+assert steps == expected_steps, "issue-quality helper step inventory drifted"
+assert workflow_invocation == "bash planningops/scripts/run_issue_quality_ci_check.sh --python-bin python3", "issue-quality helper workflow invocation drifted"
+assert "usage: run_issue_quality_ci_check.sh [options]" in help_output, "issue-quality helper usage missing"
+assert "--python-bin <path>" in help_output, "issue-quality helper help missing python-bin flag"
+assert "--print-steps" in help_output, "issue-quality helper help missing steps flag"
+assert "--print-workflow-invocation" in help_output, "issue-quality helper help missing workflow invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_issue_quality_ci_check_contract.sh"' in script, "issue-quality helper must self-run its contract test"
+assert 'bash planningops/scripts/test_validate_issue_quality_contract.sh' in script, "issue-quality helper missing issue-quality contract regression"
+assert 'bash planningops/scripts/test_validate_federated_issue_quality_contract.sh' in script, "issue-quality helper missing federated issue-quality contract regression"
+assert '"${PYTHON_BIN}" planningops/scripts/validate_issue_quality.py --strict' in script, "issue-quality helper missing live validator wiring"
+PY
+
+echo "issue quality ci check contract ok"


### PR DESCRIPTION
## Summary
- backfill the `issue-quality` helper entrypoint and its contract and wiring regressions into git-tracked reality
- add a workbench packet and hub link for the helper-family backfill
- verify the helper owns the contract regressions plus live issue-quality validator instead of leaving those steps inlined in the workflow job

## Validation
- `bash planningops/scripts/test_run_issue_quality_ci_check_contract.sh`
- `bash planningops/scripts/test_issue_quality_helper_wiring.sh`
- `bash planningops/scripts/run_issue_quality_ci_check.sh --python-bin python3`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
- Watch loop-guardrails helper coverage to ensure it still calls only `planningops/scripts/run_issue_quality_ci_check.sh`.
- Healthy signal: helper run emits `violation_count=0 verdict=pass` for the live issue-quality validator after the contract regressions pass.
- Failure signal: wiring drift that reintroduces inlined issue-quality steps in workflow YAML or a nonzero violation count from `validate_issue_quality.py --strict`.
- Mitigation trigger: rerun the two helper regressions and the helper command above.
- Validation window: immediate after merge.
- Owner: Codex.
