### PR TITLE
feat(federated-summary): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -95,6 +95,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Provider-Gateway-Ready Helper Family Backfill Packet](./plans/2026-03-26-provider-gateway-ready-helper-family-backfill-packet.md)
 - [Runtime-Operations-Ready Helper Family Backfill Packet](./plans/2026-03-26-runtime-operations-ready-helper-family-backfill-packet.md)
 - [Issue-Quality Helper Family Backfill Packet](./plans/2026-03-26-issue-quality-helper-family-backfill-packet.md)
+- [Federated-Summary Helper Family Backfill Packet](./plans/2026-03-26-federated-summary-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-federated-summary-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-federated-summary-helper-family-backfill-packet.md
@@ -1,0 +1,32 @@
+---
+title: plan: Federated-Summary Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the federated-summary helper entrypoint and its contract, wiring, and smoke regressions so the workflow summary lane no longer depends on local-only helper files.
+related_docs:
+  - ./2026-03-26-runtime-handoff-federated-ci-summary-family-backfill-packet.md
+  - ./2026-03-26-issue-quality-helper-family-backfill-packet.md
+---
+
+# plan: Federated-Summary Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `federated-summary` helper family that the federated matrix workflow already invokes directly.
+- Promote the missing helper entrypoint plus contract, wiring, and smoke regressions into git-tracked reality so summary synthesis and readiness sidecars are reproducible from remote `main`.
+- Verify the helper owns summary init/append/finalize and readiness generation instead of leaving those steps inlined in workflow YAML.
+
+## Scope
+- `planningops/scripts/run_federated_summary_ci_check.sh`
+- `planningops/scripts/test_run_federated_summary_ci_check_contract.sh`
+- `planningops/scripts/test_federated_summary_helper_wiring.sh`
+- `planningops/scripts/test_run_federated_summary_ci_check_smoke.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_federated_summary_ci_check_contract.sh` passes
+- `test_federated_summary_helper_wiring.sh` proves the workflow job calls only the canonical helper
+- `test_run_federated_summary_ci_check_smoke.sh` passes for both pass and fail summary cases

--- a/planningops/scripts/run_federated_summary_ci_check.sh
+++ b/planningops/scripts/run_federated_summary_ci_check.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SUMMARY_HELPER="${ROOT_DIR}/planningops/scripts/federation/federated_ci_summary.py"
+READINESS_HELPER="${ROOT_DIR}/planningops/scripts/assess_federated_ci_summary_readiness.py"
+
+RUN_ID=""
+CONTRACT_CONFORMANCE_RESULT=""
+RUNTIME_HANDOFF_RESULT=""
+MONDAY_HARNESS_PROJECTION_RESULT=""
+O11Y_REPLAY_RESULT=""
+PROVIDER_PROFILE_RESULT=""
+FEDERATED_CONFORMANCE_RESULT=""
+LOOP_GUARDRAILS_RESULT=""
+SUMMARY_TMP=""
+STAMPED_PATH=""
+LATEST_PATH=""
+STAMPED_VALIDATION_PATH=""
+LATEST_VALIDATION_PATH=""
+STAMPED_READINESS_PATH=""
+LATEST_READINESS_PATH=""
+STAMPED_READINESS_VALIDATION_PATH=""
+LATEST_READINESS_VALIDATION_PATH=""
+PRINT_WORKFLOW_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_federated_summary_ci_check.sh [options]
+
+options:
+  --run-id <id>                               federated summary run id
+  --contract-conformance-result <result>      GitHub needs result for contract-conformance
+  --runtime-handoff-result <result>           GitHub needs result for runtime-handoff
+  --monday-harness-projection-result <result> GitHub needs result for monday-harness-projection
+  --o11y-replay-result <result>               GitHub needs result for o11y-replay
+  --provider-profile-result <result>          GitHub needs result for provider-profile
+  --federated-conformance-result <result>     GitHub needs result for federated-conformance
+  --loop-guardrails-result <result>           GitHub needs result for loop-guardrails
+  --summary-tmp <path>                        tmp summary artifact path
+  --stamped-path <path>                       stamped summary artifact path
+  --latest-path <path>                        latest summary artifact path
+  --stamped-validation-path <path>            stamped summary validation artifact path
+  --latest-validation-path <path>             latest summary validation artifact path
+  --stamped-readiness-path <path>             stamped readiness artifact path
+  --latest-readiness-path <path>              latest readiness artifact path
+  --stamped-readiness-validation-path <path>  stamped readiness validation artifact path
+  --latest-readiness-validation-path <path>   latest readiness validation artifact path
+  --print-workflow-invocation                 print the canonical GitHub workflow invocation
+  --help                                      show this help text
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    --contract-conformance-result)
+      CONTRACT_CONFORMANCE_RESULT="$2"
+      shift 2
+      ;;
+    --runtime-handoff-result)
+      RUNTIME_HANDOFF_RESULT="$2"
+      shift 2
+      ;;
+    --monday-harness-projection-result)
+      MONDAY_HARNESS_PROJECTION_RESULT="$2"
+      shift 2
+      ;;
+    --o11y-replay-result)
+      O11Y_REPLAY_RESULT="$2"
+      shift 2
+      ;;
+    --provider-profile-result)
+      PROVIDER_PROFILE_RESULT="$2"
+      shift 2
+      ;;
+    --federated-conformance-result)
+      FEDERATED_CONFORMANCE_RESULT="$2"
+      shift 2
+      ;;
+    --loop-guardrails-result)
+      LOOP_GUARDRAILS_RESULT="$2"
+      shift 2
+      ;;
+    --summary-tmp)
+      SUMMARY_TMP="$2"
+      shift 2
+      ;;
+    --stamped-path)
+      STAMPED_PATH="$2"
+      shift 2
+      ;;
+    --latest-path)
+      LATEST_PATH="$2"
+      shift 2
+      ;;
+    --stamped-validation-path)
+      STAMPED_VALIDATION_PATH="$2"
+      shift 2
+      ;;
+    --latest-validation-path)
+      LATEST_VALIDATION_PATH="$2"
+      shift 2
+      ;;
+    --stamped-readiness-path)
+      STAMPED_READINESS_PATH="$2"
+      shift 2
+      ;;
+    --latest-readiness-path)
+      LATEST_READINESS_PATH="$2"
+      shift 2
+      ;;
+    --stamped-readiness-validation-path)
+      STAMPED_READINESS_VALIDATION_PATH="$2"
+      shift 2
+      ;;
+    --latest-readiness-validation-path)
+      LATEST_READINESS_VALIDATION_PATH="$2"
+      shift 2
+      ;;
+    --print-workflow-invocation)
+      PRINT_WORKFLOW_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_WORKFLOW_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_federated_summary_ci_check.sh --run-id ci-\${{ github.run_id }} --contract-conformance-result \${{ needs.contract-conformance.result }} --runtime-handoff-result \${{ needs.runtime-handoff.result }} --monday-harness-projection-result \${{ needs.monday-harness-projection.result }} --o11y-replay-result \${{ needs.o11y-replay.result }} --provider-profile-result \${{ needs.provider-profile.result }} --federated-conformance-result \${{ needs.federated-conformance.result }} --loop-guardrails-result \${{ needs.loop-guardrails.result }}"
+  exit 0
+fi
+
+required_flags=(
+  RUN_ID
+  CONTRACT_CONFORMANCE_RESULT
+  RUNTIME_HANDOFF_RESULT
+  MONDAY_HARNESS_PROJECTION_RESULT
+  O11Y_REPLAY_RESULT
+  PROVIDER_PROFILE_RESULT
+  FEDERATED_CONFORMANCE_RESULT
+  LOOP_GUARDRAILS_RESULT
+)
+
+for flag in "${required_flags[@]}"; do
+  if [[ -z "${!flag}" ]]; then
+    echo "missing required argument for ${flag}" >&2
+    usage >&2
+    exit 1
+  fi
+done
+
+resolve_from_root() {
+  if [[ "$1" = /* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s/%s\n' "${ROOT_DIR}" "$1"
+  fi
+}
+
+SUMMARY_TMP="${SUMMARY_TMP:-planningops/artifacts/ci/${RUN_ID}.tmp.json}"
+STAMPED_PATH="${STAMPED_PATH:-planningops/artifacts/ci/${RUN_ID}.json}"
+LATEST_PATH="${LATEST_PATH:-planningops/artifacts/ci/federated-ci-summary.json}"
+STAMPED_VALIDATION_PATH="${STAMPED_VALIDATION_PATH:-planningops/artifacts/validation/${RUN_ID}-summary-validation.json}"
+LATEST_VALIDATION_PATH="${LATEST_VALIDATION_PATH:-planningops/artifacts/validation/federated-ci-summary-validation.json}"
+STAMPED_READINESS_PATH="${STAMPED_READINESS_PATH:-planningops/artifacts/validation/${RUN_ID}-summary-readiness.json}"
+LATEST_READINESS_PATH="${LATEST_READINESS_PATH:-planningops/artifacts/validation/federated-ci-summary-readiness.json}"
+STAMPED_READINESS_VALIDATION_PATH="${STAMPED_READINESS_VALIDATION_PATH:-planningops/artifacts/validation/${RUN_ID}-summary-readiness-validation.json}"
+LATEST_READINESS_VALIDATION_PATH="${LATEST_READINESS_VALIDATION_PATH:-planningops/artifacts/validation/federated-ci-summary-readiness-validation.json}"
+
+SUMMARY_TMP="$(resolve_from_root "${SUMMARY_TMP}")"
+STAMPED_PATH="$(resolve_from_root "${STAMPED_PATH}")"
+LATEST_PATH="$(resolve_from_root "${LATEST_PATH}")"
+STAMPED_VALIDATION_PATH="$(resolve_from_root "${STAMPED_VALIDATION_PATH}")"
+LATEST_VALIDATION_PATH="$(resolve_from_root "${LATEST_VALIDATION_PATH}")"
+STAMPED_READINESS_PATH="$(resolve_from_root "${STAMPED_READINESS_PATH}")"
+LATEST_READINESS_PATH="$(resolve_from_root "${LATEST_READINESS_PATH}")"
+STAMPED_READINESS_VALIDATION_PATH="$(resolve_from_root "${STAMPED_READINESS_VALIDATION_PATH}")"
+LATEST_READINESS_VALIDATION_PATH="$(resolve_from_root "${LATEST_READINESS_VALIDATION_PATH}")"
+
+mkdir -p "$(dirname "${SUMMARY_TMP}")" "$(dirname "${STAMPED_PATH}")" "$(dirname "${LATEST_PATH}")" "$(dirname "${STAMPED_VALIDATION_PATH}")" "$(dirname "${LATEST_VALIDATION_PATH}")" "$(dirname "${STAMPED_READINESS_PATH}")" "$(dirname "${LATEST_READINESS_PATH}")" "$(dirname "${STAMPED_READINESS_VALIDATION_PATH}")" "$(dirname "${LATEST_READINESS_VALIDATION_PATH}")"
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_federated_summary_ci_check_contract.sh"
+
+python3 "${SUMMARY_HELPER}" init \
+  --summary "${SUMMARY_TMP}" \
+  --run-id "${RUN_ID}" \
+  --required-check contract-conformance \
+  --required-check runtime-handoff \
+  --required-check monday-harness-projection \
+  --required-check o11y-replay \
+  --required-check provider-profile \
+  --required-check federated-conformance \
+  --required-check loop-guardrails
+
+append_job_result() {
+  local name="$1"
+  local domain="$2"
+  local result="$3"
+  local exit_code=1
+  local stdout_log="${ROOT_DIR}/planningops/artifacts/ci/${name}.stdout.log"
+  local stderr_log="${ROOT_DIR}/planningops/artifacts/ci/${name}.stderr.log"
+
+  mkdir -p "$(dirname "${stdout_log}")"
+  if [[ "${result}" == "success" ]]; then
+    exit_code=0
+  fi
+  printf 'job=%s\nresult=%s\n' "${name}" "${result}" >"${stdout_log}"
+  : >"${stderr_log}"
+
+  python3 "${SUMMARY_HELPER}" append-check \
+    --summary "${SUMMARY_TMP}" \
+    --name "${name}" \
+    --domain "${domain}" \
+    --exit-code "${exit_code}" \
+    --result "${result}" \
+    --stdout-log "${stdout_log}" \
+    --stderr-log "${stderr_log}"
+}
+
+append_job_result "contract-conformance" "contract" "${CONTRACT_CONFORMANCE_RESULT}"
+append_job_result "runtime-handoff" "runtime" "${RUNTIME_HANDOFF_RESULT}"
+append_job_result "monday-harness-projection" "runtime" "${MONDAY_HARNESS_PROJECTION_RESULT}"
+append_job_result "o11y-replay" "infra" "${O11Y_REPLAY_RESULT}"
+append_job_result "provider-profile" "infra" "${PROVIDER_PROFILE_RESULT}"
+append_job_result "federated-conformance" "federation" "${FEDERATED_CONFORMANCE_RESULT}"
+append_job_result "loop-guardrails" "policy" "${LOOP_GUARDRAILS_RESULT}"
+
+set +e
+python3 "${SUMMARY_HELPER}" finalize \
+  --summary "${SUMMARY_TMP}" \
+  --stamped-path "${STAMPED_PATH}" \
+  --latest-path "${LATEST_PATH}" \
+  --status complete \
+  --stamped-validation-output "${STAMPED_VALIDATION_PATH}" \
+  --latest-validation-output "${LATEST_VALIDATION_PATH}" \
+  --shell-exit-code 0
+summary_rc=$?
+set -e
+
+if [[ -f "${STAMPED_PATH}" && -f "${STAMPED_VALIDATION_PATH}" ]]; then
+  python3 "${READINESS_HELPER}" \
+    --summary "${STAMPED_PATH}" \
+    --validation-report "${STAMPED_VALIDATION_PATH}" \
+    --output "${STAMPED_READINESS_PATH}" \
+    --validation-output "${STAMPED_READINESS_VALIDATION_PATH}"
+fi
+
+if [[ -f "${LATEST_PATH}" && -f "${LATEST_VALIDATION_PATH}" ]]; then
+  python3 "${READINESS_HELPER}" \
+    --summary "${LATEST_PATH}" \
+    --validation-report "${LATEST_VALIDATION_PATH}" \
+    --output "${LATEST_READINESS_PATH}" \
+    --validation-output "${LATEST_READINESS_VALIDATION_PATH}"
+fi
+
+exit "${summary_rc}"

--- a/planningops/scripts/test_federated_summary_helper_wiring.sh
+++ b/planningops/scripts/test_federated_summary_helper_wiring.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW_PATH="$ROOT_DIR/.github/workflows/federated-ci-matrix.yml"
+HELPER_PATH="$ROOT_DIR/planningops/scripts/run_federated_summary_ci_check.sh"
+
+python3 - <<'PY' "$WORKFLOW_PATH" "$HELPER_PATH"
+import subprocess
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[2])
+
+workflow_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+
+workflow_block = workflow.split("  federated-summary:", 1)[1].split("      - name: Upload federated summary artifact", 1)[0]
+
+assert workflow_invocation in workflow_block, "workflow federated-summary job missing helper invocation"
+assert workflow_block.count(workflow_invocation) == 1, "workflow federated-summary helper invocation should appear once"
+assert "append_job_result()" not in workflow_block, "workflow federated-summary job should not inline append_job_result shell function"
+assert "federated_ci_summary.py" not in workflow_block, "workflow federated-summary job should not inline summary helper path"
+assert "assess_federated_ci_summary_readiness.py" not in workflow_block, "workflow federated-summary job should not inline readiness helper path"
+PY
+
+echo "federated summary helper wiring ok"

--- a/planningops/scripts/test_run_federated_summary_ci_check_contract.sh
+++ b/planningops/scripts/test_run_federated_summary_ci_check_contract.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_federated_summary_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+workflow_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+expected = "bash planningops/scripts/run_federated_summary_ci_check.sh --run-id ci-${{ github.run_id }} --contract-conformance-result ${{ needs.contract-conformance.result }} --runtime-handoff-result ${{ needs.runtime-handoff.result }} --monday-harness-projection-result ${{ needs.monday-harness-projection.result }} --o11y-replay-result ${{ needs.o11y-replay.result }} --provider-profile-result ${{ needs.provider-profile.result }} --federated-conformance-result ${{ needs.federated-conformance.result }} --loop-guardrails-result ${{ needs.loop-guardrails.result }}"
+assert workflow_invocation == expected, "federated-summary helper invocation drifted"
+assert "usage: run_federated_summary_ci_check.sh [options]" in help_output, "federated-summary help usage missing"
+assert "--run-id <id>" in help_output, "federated-summary help missing run-id flag"
+assert "--contract-conformance-result <result>" in help_output, "federated-summary help missing contract result flag"
+assert "--loop-guardrails-result <result>" in help_output, "federated-summary help missing loop-guardrails result flag"
+assert "--stamped-readiness-validation-path <path>" in help_output, "federated-summary help missing readiness validation path flag"
+assert "--print-workflow-invocation" in help_output, "federated-summary help missing workflow invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_federated_summary_ci_check_contract.sh"' in script, "federated-summary helper must self-run its contract test"
+assert 'python3 "${SUMMARY_HELPER}" init \\' in script, "federated-summary helper missing init command"
+assert 'python3 "${SUMMARY_HELPER}" append-check \\' in script, "federated-summary helper missing append-check command"
+assert 'python3 "${SUMMARY_HELPER}" finalize \\' in script, "federated-summary helper missing finalize command"
+assert 'append_job_result "federated-conformance" "federation" "${FEDERATED_CONFORMANCE_RESULT}"' in script, "federated-summary helper missing federated-conformance mapping"
+assert 'append_job_result "monday-harness-projection" "runtime" "${MONDAY_HARNESS_PROJECTION_RESULT}"' in script, "federated-summary helper missing monday projection mapping"
+assert 'python3 "${READINESS_HELPER}" \\' in script, "federated-summary helper missing readiness helper call"
+PY
+
+echo "federated summary ci check contract ok"

--- a/planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
+++ b/planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_federated_summary_ci_check.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+bash "$SCRIPT_PATH" \
+  --run-id ci-pass \
+  --contract-conformance-result success \
+  --runtime-handoff-result success \
+  --monday-harness-projection-result success \
+  --o11y-replay-result success \
+  --provider-profile-result success \
+  --federated-conformance-result success \
+  --loop-guardrails-result success \
+  --summary-tmp "$tmp_dir/ci-pass.tmp.json" \
+  --stamped-path "$tmp_dir/ci-pass.json" \
+  --latest-path "$tmp_dir/federated-ci-summary.json" \
+  --stamped-validation-path "$tmp_dir/ci-pass-summary-validation.json" \
+  --latest-validation-path "$tmp_dir/federated-ci-summary-validation.json" \
+  --stamped-readiness-path "$tmp_dir/ci-pass-summary-readiness.json" \
+  --latest-readiness-path "$tmp_dir/federated-ci-summary-readiness.json" \
+  --stamped-readiness-validation-path "$tmp_dir/ci-pass-summary-readiness-validation.json" \
+  --latest-readiness-validation-path "$tmp_dir/federated-ci-summary-readiness-validation.json"
+
+python3 - <<'PY' "$tmp_dir/ci-pass.json" "$tmp_dir/federated-ci-summary-readiness.json"
+import json
+import sys
+from pathlib import Path
+
+summary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+readiness = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+
+assert summary["run_id"] == "ci-pass", summary
+assert summary["verdict"] == "pass", summary
+assert summary["overall_status"] == "complete", summary
+assert summary["check_count"] == 7, summary
+assert readiness["summary_run_id"] == "ci-pass", readiness
+assert readiness["readiness_status"] == "ready", readiness
+assert readiness["ready"] is True, readiness
+assert readiness["next_step"] == "none", readiness
+PY
+
+set +e
+bash "$SCRIPT_PATH" \
+  --run-id ci-fail \
+  --contract-conformance-result success \
+  --runtime-handoff-result success \
+  --monday-harness-projection-result success \
+  --o11y-replay-result success \
+  --provider-profile-result failure \
+  --federated-conformance-result success \
+  --loop-guardrails-result success \
+  --summary-tmp "$tmp_dir/ci-fail.tmp.json" \
+  --stamped-path "$tmp_dir/ci-fail.json" \
+  --latest-path "$tmp_dir/federated-ci-summary-fail.json" \
+  --stamped-validation-path "$tmp_dir/ci-fail-summary-validation.json" \
+  --latest-validation-path "$tmp_dir/federated-ci-summary-fail-validation.json" \
+  --stamped-readiness-path "$tmp_dir/ci-fail-summary-readiness.json" \
+  --latest-readiness-path "$tmp_dir/federated-ci-summary-fail-readiness.json" \
+  --stamped-readiness-validation-path "$tmp_dir/ci-fail-summary-readiness-validation.json" \
+  --latest-readiness-validation-path "$tmp_dir/federated-ci-summary-fail-readiness-validation.json"
+rc=$?
+set -e
+
+test "$rc" -eq 1
+
+python3 - <<'PY' "$tmp_dir/ci-fail.json" "$tmp_dir/federated-ci-summary-fail-readiness.json"
+import json
+import sys
+from pathlib import Path
+
+summary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+readiness = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+
+assert summary["run_id"] == "ci-fail", summary
+assert summary["verdict"] == "fail", summary
+assert summary["overall_status"] == "complete", summary
+assert summary["failure_classification"]["count"] == 1, summary
+assert readiness["summary_run_id"] == "ci-fail", readiness
+assert readiness["readiness_status"] == "blocked", readiness
+assert readiness["ready"] is False, readiness
+assert readiness["next_step"] != "none", readiness
+PY
+
+echo "federated summary ci check smoke ok"


### PR DESCRIPTION
## Summary
- backfill the `federated-summary` helper entrypoint and its contract, wiring, and smoke regressions into git-tracked reality
- add a workbench packet and hub link for the helper-family backfill
- verify the helper owns summary init/append/finalize plus readiness generation instead of leaving those steps inlined in workflow YAML

## Validation
- `bash planningops/scripts/test_run_federated_summary_ci_check_contract.sh`
- `bash planningops/scripts/test_federated_summary_helper_wiring.sh`
- `bash planningops/scripts/test_run_federated_summary_ci_check_smoke.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
- Watch the federated-summary workflow lane to ensure it still calls only `planningops/scripts/run_federated_summary_ci_check.sh`.
- Healthy signal: smoke continues to produce a `pass` summary/readiness pair and a blocked fail case with non-`none` next step.
- Failure signal: wiring drift that reintroduces inlined summary helper commands in workflow YAML or smoke drift in either pass/fail path.
- Mitigation trigger: rerun the contract, wiring, and smoke commands above.
- Validation window: immediate after merge.
- Owner: Codex.
