### PR TITLE
feat(contract-conformance): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -96,6 +96,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Runtime-Operations-Ready Helper Family Backfill Packet](./plans/2026-03-26-runtime-operations-ready-helper-family-backfill-packet.md)
 - [Issue-Quality Helper Family Backfill Packet](./plans/2026-03-26-issue-quality-helper-family-backfill-packet.md)
 - [Federated-Summary Helper Family Backfill Packet](./plans/2026-03-26-federated-summary-helper-family-backfill-packet.md)
+- [Contract-Conformance Helper Family Backfill Packet](./plans/2026-03-26-contract-conformance-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-contract-conformance-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-contract-conformance-helper-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Contract-Conformance Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the contract-conformance helper entrypoint and its contract and wiring regressions so the local federated matrix no longer depends on local-only helper files.
+related_docs:
+  - ./2026-03-26-federated-summary-helper-family-backfill-packet.md
+  - ./2026-03-26-runtime-operations-ready-helper-family-backfill-packet.md
+---
+
+# plan: Contract-Conformance Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `contract-conformance` helper family that the local federated matrix and CI helper guardrails already invoke directly.
+- Promote the missing helper entrypoint plus contract and wiring regressions into git-tracked reality so cross-repo conformance checking is reproducible from remote `main`.
+- Verify the helper owns the cross-repo checker invocation instead of leaving the raw checker command inlined in the matrix lane.
+
+## Scope
+- `planningops/scripts/run_contract_conformance_ci_check.sh`
+- `planningops/scripts/test_run_contract_conformance_ci_check_contract.sh`
+- `planningops/scripts/test_contract_conformance_helper_wiring.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_contract_conformance_ci_check_contract.sh` passes
+- `test_contract_conformance_helper_wiring.sh` proves the local matrix block calls only the canonical helper
+- `run_contract_conformance_ci_check.sh --run-id <id> --workspace-root .. --bootstrap-mode auto --python-bin python3` succeeds from the repo root

--- a/planningops/scripts/run_contract_conformance_ci_check.sh
+++ b/planningops/scripts/run_contract_conformance_ci_check.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_WORKSPACE_ROOT="${ROOT_DIR}/.."
+DEFAULT_BOOTSTRAP_MODE="auto"
+DEFAULT_PYTHON_BIN="python3"
+RUN_ID=""
+WORKSPACE_ROOT="${DEFAULT_WORKSPACE_ROOT}"
+BOOTSTRAP_MODE="${DEFAULT_BOOTSTRAP_MODE}"
+PYTHON_BIN="${DEFAULT_PYTHON_BIN}"
+PRINT_LOCAL_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_contract_conformance_ci_check.sh [options]
+
+options:
+  --run-id <id>             contract-conformance run id passed to the federated checker
+  --workspace-root <path>   federated workspace root
+  --bootstrap-mode <mode>   cross-repo bootstrap mode
+  --python-bin <path>       python executable used to invoke the conformance checker
+  --print-local-invocation  print the canonical local matrix invocation
+  --help                    show this help text
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    --workspace-root)
+      WORKSPACE_ROOT="$2"
+      shift 2
+      ;;
+    --bootstrap-mode)
+      BOOTSTRAP_MODE="$2"
+      shift 2
+      ;;
+    --python-bin)
+      PYTHON_BIN="$2"
+      shift 2
+      ;;
+    --print-local-invocation)
+      PRINT_LOCAL_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_LOCAL_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_contract_conformance_ci_check.sh --run-id \${RUN_ID}-contract --workspace-root .. --bootstrap-mode auto --python-bin \\\"\${PYTHON_BIN}\\\""
+  exit 0
+fi
+
+if [[ -z "${RUN_ID}" ]]; then
+  echo "--run-id is required" >&2
+  usage >&2
+  exit 1
+fi
+
+resolve_from_root() {
+  if [[ "$1" = /* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s/%s\n' "${ROOT_DIR}" "$1"
+  fi
+}
+
+WORKSPACE_ROOT="$(resolve_from_root "${WORKSPACE_ROOT}")"
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_contract_conformance_ci_check_contract.sh"
+
+"${PYTHON_BIN}" "${ROOT_DIR}/planningops/scripts/federation/cross_repo_conformance_check.py" \
+  --workspace-root "${WORKSPACE_ROOT}" \
+  --bootstrap-mode "${BOOTSTRAP_MODE}" \
+  --run-id "${RUN_ID}"

--- a/planningops/scripts/test_contract_conformance_helper_wiring.sh
+++ b/planningops/scripts/test_contract_conformance_helper_wiring.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOCAL_MATRIX_PATH="$ROOT_DIR/planningops/scripts/federation/federated_ci_matrix_local.sh"
+HELPER_PATH="$ROOT_DIR/planningops/scripts/run_contract_conformance_ci_check.sh"
+
+python3 - <<'PY' "$LOCAL_MATRIX_PATH" "$HELPER_PATH"
+import subprocess
+import sys
+from pathlib import Path
+
+local_matrix = Path(sys.argv[1]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[2])
+
+local_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-local-invocation"],
+    text=True,
+).strip()
+
+local_block = local_matrix.split('run_check "contract-conformance" "contract" \\', 1)[1].split('run_check "provider-profile" "infra" \\', 1)[0]
+
+assert local_invocation in local_block, "local contract-conformance block missing helper invocation"
+assert local_block.count(local_invocation) == 1, "local contract-conformance helper invocation should appear once"
+assert "cross_repo_conformance_check.py" not in local_block, "local contract-conformance block should not inline conformance checker command"
+PY
+
+echo "contract conformance helper wiring ok"

--- a/planningops/scripts/test_run_contract_conformance_ci_check_contract.sh
+++ b/planningops/scripts/test_run_contract_conformance_ci_check_contract.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_contract_conformance_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+local_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-local-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+assert local_invocation == "bash planningops/scripts/run_contract_conformance_ci_check.sh --run-id ${RUN_ID}-contract --workspace-root .. --bootstrap-mode auto --python-bin \\\"${PYTHON_BIN}\\\"", "local contract-conformance helper invocation drifted"
+assert "usage: run_contract_conformance_ci_check.sh [options]" in help_output, "contract-conformance help usage missing"
+assert "--run-id <id>" in help_output, "contract-conformance help missing run-id flag"
+assert "--workspace-root <path>" in help_output, "contract-conformance help missing workspace-root flag"
+assert "--bootstrap-mode <mode>" in help_output, "contract-conformance help missing bootstrap-mode flag"
+assert "--python-bin <path>" in help_output, "contract-conformance help missing python-bin flag"
+assert "--print-local-invocation" in help_output, "contract-conformance help missing local invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_contract_conformance_ci_check_contract.sh"' in script, "contract-conformance helper must self-run its contract test"
+assert '"${PYTHON_BIN}" "${ROOT_DIR}/planningops/scripts/federation/cross_repo_conformance_check.py" \\' in script, "contract-conformance helper missing checker command"
+assert '--workspace-root "${WORKSPACE_ROOT}" \\' in script, "contract-conformance helper missing workspace-root wiring"
+assert '--bootstrap-mode "${BOOTSTRAP_MODE}" \\' in script, "contract-conformance helper missing bootstrap-mode wiring"
+assert '--run-id "${RUN_ID}"' in script, "contract-conformance helper missing run-id wiring"
+PY
+
+echo "contract conformance ci check contract ok"


### PR DESCRIPTION
## Summary
- backfill the `contract-conformance` helper entrypoint and its contract and wiring regressions into git-tracked reality
- add a workbench packet and hub link for the helper-family backfill
- verify the helper owns the cross-repo conformance checker invocation instead of leaving the raw checker command inlined in the matrix lane

## Validation
- `bash planningops/scripts/test_run_contract_conformance_ci_check_contract.sh`
- `bash planningops/scripts/test_contract_conformance_helper_wiring.sh`
- `bash planningops/scripts/run_contract_conformance_ci_check.sh --run-id contract-conformance-helper-backfill --workspace-root .. --bootstrap-mode auto --python-bin python3`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
- Watch local contract-conformance invocations to ensure they still call only `planningops/scripts/run_contract_conformance_ci_check.sh`.
- Healthy signal: helper run emits `check_count=23 assertion_count=10 incompatibility_example=pass verdict=pass`.
- Failure signal: wiring drift that reintroduces the raw `cross_repo_conformance_check.py` command in the matrix lane or a non-pass conformance report.
- Mitigation trigger: rerun the two helper regressions and the helper command above.
- Validation window: immediate after merge.
- Owner: Codex.
