### PR TITLE
feat(o11y-replay): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -97,6 +97,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Issue-Quality Helper Family Backfill Packet](./plans/2026-03-26-issue-quality-helper-family-backfill-packet.md)
 - [Federated-Summary Helper Family Backfill Packet](./plans/2026-03-26-federated-summary-helper-family-backfill-packet.md)
 - [Contract-Conformance Helper Family Backfill Packet](./plans/2026-03-26-contract-conformance-helper-family-backfill-packet.md)
+- [O11y-Replay Helper Family Backfill Packet](./plans/2026-03-26-o11y-replay-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-o11y-replay-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-o11y-replay-helper-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: O11y-Replay Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the o11y-replay helper entrypoint and its contract and wiring regressions so the local matrix and workflow no longer depend on local-only helper files.
+related_docs:
+  - ./2026-03-26-contract-conformance-helper-family-backfill-packet.md
+  - ./2026-03-26-runtime-operations-ready-helper-family-backfill-packet.md
+---
+
+# plan: O11y-Replay Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `o11y-replay` helper family that the local federated matrix, workflow job, and helper guardrails already invoke directly.
+- Promote the missing helper entrypoint plus contract and wiring regressions into git-tracked reality so observability replay dry-runs are reproducible from remote `main`.
+- Verify the helper owns the Langfuse stack launcher dry-run instead of leaving launcher commands inlined in matrix or workflow YAML.
+
+## Scope
+- `planningops/scripts/run_o11y_replay_ci_check.sh`
+- `planningops/scripts/test_run_o11y_replay_ci_check_contract.sh`
+- `planningops/scripts/test_o11y_replay_helper_wiring.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_o11y_replay_ci_check_contract.sh` passes
+- `test_o11y_replay_helper_wiring.sh` proves local matrix and workflow blocks call only the canonical helper
+- `run_o11y_replay_ci_check.sh --run-id <id> --o11y-root ../platform-observability-gateway` succeeds from the repo root

--- a/planningops/scripts/run_o11y_replay_ci_check.sh
+++ b/planningops/scripts/run_o11y_replay_ci_check.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_O11Y_ROOT="${ROOT_DIR}/../platform-observability-gateway"
+RUN_ID=""
+O11Y_ROOT="${DEFAULT_O11Y_ROOT}"
+PRINT_LOCAL_INVOCATION=0
+PRINT_WORKFLOW_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_o11y_replay_ci_check.sh [options]
+
+options:
+  --run-id <id>                o11y replay run id passed to the dry-run launcher
+  --o11y-root <path>           observability gateway workspace root
+  --print-local-invocation     print the canonical local matrix invocation
+  --print-workflow-invocation  print the canonical GitHub workflow invocation
+  --help                       show this help text
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    --o11y-root)
+      O11Y_ROOT="$2"
+      shift 2
+      ;;
+    --print-local-invocation)
+      PRINT_LOCAL_INVOCATION=1
+      shift
+      ;;
+    --print-workflow-invocation)
+      PRINT_WORKFLOW_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_LOCAL_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_o11y_replay_ci_check.sh --run-id \${RUN_ID}-o11y --o11y-root ../platform-observability-gateway"
+  exit 0
+fi
+
+if [[ "${PRINT_WORKFLOW_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_o11y_replay_ci_check.sh --run-id ci-o11y-\${{ github.run_id }} --o11y-root platform-observability-gateway"
+  exit 0
+fi
+
+if [[ -z "${RUN_ID}" ]]; then
+  echo "--run-id is required" >&2
+  usage >&2
+  exit 1
+fi
+
+resolve_from_root() {
+  if [[ "$1" = /* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s/%s\n' "${ROOT_DIR}" "$1"
+  fi
+}
+
+O11Y_ROOT="$(resolve_from_root "${O11Y_ROOT}")"
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_o11y_replay_ci_check_contract.sh"
+
+cd "${O11Y_ROOT}"
+bash scripts/langfuse_stack_launcher.sh --mode dry-run --run-id "${RUN_ID}"

--- a/planningops/scripts/test_o11y_replay_helper_wiring.sh
+++ b/planningops/scripts/test_o11y_replay_helper_wiring.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOCAL_MATRIX_PATH="$ROOT_DIR/planningops/scripts/federation/federated_ci_matrix_local.sh"
+WORKFLOW_PATH="$ROOT_DIR/.github/workflows/federated-ci-matrix.yml"
+HELPER_PATH="$ROOT_DIR/planningops/scripts/run_o11y_replay_ci_check.sh"
+
+python3 - <<'PY' "$LOCAL_MATRIX_PATH" "$WORKFLOW_PATH" "$HELPER_PATH"
+import subprocess
+import sys
+from pathlib import Path
+
+local_matrix = Path(sys.argv[1]).read_text(encoding="utf-8")
+workflow = Path(sys.argv[2]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[3])
+
+local_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-local-invocation"],
+    text=True,
+).strip()
+workflow_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+
+local_block = local_matrix.split('run_check "o11y-replay" "infra" \\', 1)[1].split('run_check "runtime-handoff" "runtime" \\', 1)[0]
+workflow_block = workflow.split("  o11y-replay:", 1)[1].split("  runtime-handoff:", 1)[0]
+
+assert local_invocation in local_block, "local o11y-replay block missing helper invocation"
+assert workflow_invocation in workflow_block, "workflow o11y-replay job missing helper invocation"
+assert local_block.count(local_invocation) == 1, "local o11y-replay helper invocation should appear once"
+assert workflow_block.count(workflow_invocation) == 1, "workflow o11y-replay helper invocation should appear once"
+assert "langfuse_stack_launcher.sh" not in local_block, "local o11y-replay block should not inline launcher command"
+assert "langfuse_stack_launcher.sh" not in workflow_block, "workflow o11y-replay job should not inline launcher command"
+PY
+
+echo "o11y replay helper wiring ok"

--- a/planningops/scripts/test_run_o11y_replay_ci_check_contract.sh
+++ b/planningops/scripts/test_run_o11y_replay_ci_check_contract.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_o11y_replay_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+local_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-local-invocation"],
+    text=True,
+).strip()
+workflow_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+assert local_invocation == "bash planningops/scripts/run_o11y_replay_ci_check.sh --run-id ${RUN_ID}-o11y --o11y-root ../platform-observability-gateway", "local o11y helper invocation drifted"
+assert workflow_invocation == "bash planningops/scripts/run_o11y_replay_ci_check.sh --run-id ci-o11y-${{ github.run_id }} --o11y-root platform-observability-gateway", "workflow o11y helper invocation drifted"
+assert "usage: run_o11y_replay_ci_check.sh [options]" in help_output, "o11y helper help usage missing"
+assert "--run-id <id>" in help_output, "o11y helper help missing run-id flag"
+assert "--o11y-root <path>" in help_output, "o11y helper help missing o11y-root flag"
+assert "--print-local-invocation" in help_output, "o11y helper help missing local invocation flag"
+assert "--print-workflow-invocation" in help_output, "o11y helper help missing workflow invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_o11y_replay_ci_check_contract.sh"' in script, "o11y helper must self-run its contract test"
+assert "bash scripts/langfuse_stack_launcher.sh --mode dry-run --run-id \"${RUN_ID}\"" in script, "o11y helper missing dry-run launcher command"
+PY
+
+echo "o11y replay ci check contract ok"


### PR DESCRIPTION
## Summary
- backfill the `o11y-replay` helper entrypoint and its contract and wiring regressions into git-tracked reality
- add a workbench packet and hub link for the helper-family backfill
- verify the helper owns the Langfuse stack launcher dry-run instead of leaving launcher commands inlined in matrix or workflow YAML

## Validation
- `bash planningops/scripts/test_run_o11y_replay_ci_check_contract.sh`
- `bash planningops/scripts/test_o11y_replay_helper_wiring.sh`
- `bash planningops/scripts/run_o11y_replay_ci_check.sh --run-id o11y-replay-helper-backfill --o11y-root ../platform-observability-gateway`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
- Watch local and workflow o11y-replay invocations to ensure they still call only `planningops/scripts/run_o11y_replay_ci_check.sh`.
- Healthy signal: helper run emits two replay drill reports with `verdict=pass` and a launcher manifest with `continuity_ok=True`.
- Failure signal: wiring drift that reintroduces `langfuse_stack_launcher.sh` inline in matrix/workflow YAML or a non-pass replay drill verdict.
- Mitigation trigger: rerun the two helper regressions and the helper command above.
- Validation window: immediate after merge.
- Owner: Codex.
