### PR TITLE
feat(platform-contracts): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -98,6 +98,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Federated-Summary Helper Family Backfill Packet](./plans/2026-03-26-federated-summary-helper-family-backfill-packet.md)
 - [Contract-Conformance Helper Family Backfill Packet](./plans/2026-03-26-contract-conformance-helper-family-backfill-packet.md)
 - [O11y-Replay Helper Family Backfill Packet](./plans/2026-03-26-o11y-replay-helper-family-backfill-packet.md)
+- [Platform-Contracts Helper Family Backfill Packet](./plans/2026-03-26-platform-contracts-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-platform-contracts-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-platform-contracts-helper-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Platform-Contracts Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the platform-contracts helper entrypoint and its contract and wiring regressions so the GitHub contract-conformance lane no longer depends on local-only helper files.
+related_docs:
+  - ./2026-03-26-contract-conformance-helper-family-backfill-packet.md
+  - ./2026-03-26-federated-summary-helper-family-backfill-packet.md
+---
+
+# plan: Platform-Contracts Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `platform-contracts` helper family that the GitHub `contract-conformance` lane and helper guardrails already invoke directly.
+- Promote the missing helper entrypoint plus contract and wiring regressions into git-tracked reality so platform-contract validation is reproducible from remote `main`.
+- Verify the helper owns the managed-venv bootstrap, contract validation, and schema-change classification instead of leaving those commands inlined in workflow YAML.
+
+## Scope
+- `planningops/scripts/run_platform_contracts_ci_check.sh`
+- `planningops/scripts/test_run_platform_contracts_ci_check_contract.sh`
+- `planningops/scripts/test_platform_contracts_helper_wiring.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_platform_contracts_ci_check_contract.sh` passes
+- `test_platform_contracts_helper_wiring.sh` proves the workflow `contract-conformance` job calls only the canonical helper
+- `run_platform_contracts_ci_check.sh --contracts-root ../platform-contracts --python-bin python3` succeeds from the repo root

--- a/planningops/scripts/run_platform_contracts_ci_check.sh
+++ b/planningops/scripts/run_platform_contracts_ci_check.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_CONTRACTS_ROOT="${ROOT_DIR}/../platform-contracts"
+DEFAULT_PYTHON_BIN="python3"
+DEFAULT_VENV_ROOT="planningops/runtime-artifacts/tooling/platform-contracts-ci"
+CONTRACTS_ROOT="${DEFAULT_CONTRACTS_ROOT}"
+PYTHON_BIN="${DEFAULT_PYTHON_BIN}"
+VENV_ROOT="${DEFAULT_VENV_ROOT}"
+PRINT_WORKFLOW_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_platform_contracts_ci_check.sh [options]
+
+options:
+  --contracts-root <path>      platform-contracts workspace root
+  --python-bin <path>          python executable used for install and validation commands
+  --venv-root <path>           repo-local virtualenv root used for managed dependency installs
+  --print-workflow-invocation  print the canonical GitHub workflow invocation
+  --help                       show this help text
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --contracts-root)
+      CONTRACTS_ROOT="$2"
+      shift 2
+      ;;
+    --python-bin)
+      PYTHON_BIN="$2"
+      shift 2
+      ;;
+    --venv-root)
+      VENV_ROOT="$2"
+      shift 2
+      ;;
+    --print-workflow-invocation)
+      PRINT_WORKFLOW_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_WORKFLOW_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_platform_contracts_ci_check.sh --contracts-root platform-contracts --python-bin python3"
+  exit 0
+fi
+
+resolve_from_root() {
+  if [[ "$1" = /* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s/%s\n' "${ROOT_DIR}" "$1"
+  fi
+}
+
+CONTRACTS_ROOT="$(resolve_from_root "${CONTRACTS_ROOT}")"
+VENV_ROOT="$(resolve_from_root "${VENV_ROOT}")"
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_platform_contracts_ci_check_contract.sh"
+
+if [[ ! -x "${VENV_ROOT}/bin/python" ]]; then
+  rm -rf "${VENV_ROOT}"
+  "${PYTHON_BIN}" -m venv "${VENV_ROOT}"
+fi
+
+cd "${CONTRACTS_ROOT}"
+"${VENV_ROOT}/bin/python" -m pip install --upgrade pip
+"${VENV_ROOT}/bin/python" -m pip install -r requirements-dev.txt
+"${VENV_ROOT}/bin/python" scripts/validate_contracts.py --root .
+"${VENV_ROOT}/bin/python" scripts/classify_schema_change.py --enforce-expected

--- a/planningops/scripts/test_platform_contracts_helper_wiring.sh
+++ b/planningops/scripts/test_platform_contracts_helper_wiring.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW_PATH="$ROOT_DIR/.github/workflows/federated-ci-matrix.yml"
+HELPER_PATH="$ROOT_DIR/planningops/scripts/run_platform_contracts_ci_check.sh"
+
+python3 - <<'PY' "$WORKFLOW_PATH" "$HELPER_PATH"
+import subprocess
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[2])
+
+workflow_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+
+workflow_block = workflow.split("  contract-conformance:", 1)[1].split("  provider-profile:", 1)[0]
+
+assert workflow_invocation in workflow_block, "workflow contract-conformance job missing platform-contracts helper invocation"
+assert workflow_block.count(workflow_invocation) == 1, "workflow contract-conformance helper invocation should appear once"
+assert "python3 -m pip install -r requirements-dev.txt" not in workflow_block, "workflow contract-conformance job should not inline requirements install"
+assert "python3 scripts/validate_contracts.py --root ." not in workflow_block, "workflow contract-conformance job should not inline contract validator"
+assert "python3 scripts/classify_schema_change.py --enforce-expected" not in workflow_block, "workflow contract-conformance job should not inline semver classifier"
+PY
+
+echo "platform contracts helper wiring ok"

--- a/planningops/scripts/test_run_platform_contracts_ci_check_contract.sh
+++ b/planningops/scripts/test_run_platform_contracts_ci_check_contract.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_platform_contracts_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+workflow_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+assert workflow_invocation == "bash planningops/scripts/run_platform_contracts_ci_check.sh --contracts-root platform-contracts --python-bin python3", "platform-contracts helper invocation drifted"
+assert "usage: run_platform_contracts_ci_check.sh [options]" in help_output, "platform-contracts help usage missing"
+assert "--contracts-root <path>" in help_output, "platform-contracts help missing contracts-root flag"
+assert "--python-bin <path>" in help_output, "platform-contracts help missing python-bin flag"
+assert "--venv-root <path>" in help_output, "platform-contracts help missing venv-root flag"
+assert "--print-workflow-invocation" in help_output, "platform-contracts help missing workflow invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_platform_contracts_ci_check_contract.sh"' in script, "platform-contracts helper must self-run its contract test"
+assert '"${PYTHON_BIN}" -m venv "${VENV_ROOT}"' in script, "platform-contracts helper missing managed venv bootstrap"
+assert '"${VENV_ROOT}/bin/python" -m pip install --upgrade pip' in script, "platform-contracts helper missing pip bootstrap"
+assert '"${VENV_ROOT}/bin/python" -m pip install -r requirements-dev.txt' in script, "platform-contracts helper missing requirements install"
+assert '"${VENV_ROOT}/bin/python" scripts/validate_contracts.py --root .' in script, "platform-contracts helper missing contract validator"
+assert '"${VENV_ROOT}/bin/python" scripts/classify_schema_change.py --enforce-expected' in script, "platform-contracts helper missing semver classifier"
+PY
+
+echo "platform contracts ci check contract ok"


### PR DESCRIPTION
## Summary
- add the missing `run_platform_contracts_ci_check.sh` helper family used by the GitHub contract-conformance lane
- add contract and wiring regressions so workflow drift is caught without inlining validator/bootstrap commands
- add the workbench packet and hub link for the helper-family backfill

## Validation
- `bash planningops/scripts/test_run_platform_contracts_ci_check_contract.sh`
- `bash planningops/scripts/test_platform_contracts_helper_wiring.sh`
- `bash planningops/scripts/run_platform_contracts_ci_check.sh --contracts-root ../platform-contracts --python-bin python3`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change only backfills a helper entrypoint, its guardrails, and workbench documentation.