### PR TITLE
feat(federated-conformance): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -99,6 +99,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Contract-Conformance Helper Family Backfill Packet](./plans/2026-03-26-contract-conformance-helper-family-backfill-packet.md)
 - [O11y-Replay Helper Family Backfill Packet](./plans/2026-03-26-o11y-replay-helper-family-backfill-packet.md)
 - [Platform-Contracts Helper Family Backfill Packet](./plans/2026-03-26-platform-contracts-helper-family-backfill-packet.md)
+- [Federated-Conformance Helper Family Backfill Packet](./plans/2026-03-26-federated-conformance-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-federated-conformance-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-federated-conformance-helper-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Federated-Conformance Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the federated-conformance helper entrypoint and its contract and wiring regressions so the GitHub federated-conformance lane no longer depends on local-only helper files.
+related_docs:
+  - ./2026-03-26-platform-contracts-helper-family-backfill-packet.md
+  - ./2026-03-26-contract-conformance-helper-family-backfill-packet.md
+---
+
+# plan: Federated-Conformance Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `federated-conformance` helper family that the GitHub workflow lane and helper guardrails already invoke directly.
+- Promote the missing helper entrypoint plus contract and wiring regressions into git-tracked reality so artifact-policy rollout and cross-repo conformance checks are reproducible from remote `main`.
+- Verify the helper owns the artifact-policy rollout and managed bootstrap/conformance checker invocation instead of leaving those commands inlined in workflow YAML.
+
+## Scope
+- `planningops/scripts/run_federated_conformance_ci_check.sh`
+- `planningops/scripts/test_run_federated_conformance_ci_check_contract.sh`
+- `planningops/scripts/test_federated_conformance_helper_wiring.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_federated_conformance_ci_check_contract.sh` passes
+- `test_federated_conformance_helper_wiring.sh` proves the workflow `federated-conformance` job calls only the canonical helper
+- `run_federated_conformance_ci_check.sh --run-id <id> --workspace-root .. --python-bin python3 --policy-output planningops/artifacts/validation/federated-artifact-policy-rollout-report.json --bootstrap-mode auto --output planningops/artifacts/conformance/<id>.json` succeeds from the repo root

--- a/planningops/scripts/run_federated_conformance_ci_check.sh
+++ b/planningops/scripts/run_federated_conformance_ci_check.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_WORKSPACE_ROOT="${ROOT_DIR}/.."
+DEFAULT_PYTHON_BIN="python3"
+DEFAULT_POLICY_OUTPUT="planningops/artifacts/validation/federated-artifact-policy-rollout-report.json"
+DEFAULT_BOOTSTRAP_MODE="auto"
+RUN_ID=""
+WORKSPACE_ROOT="${DEFAULT_WORKSPACE_ROOT}"
+PYTHON_BIN="${DEFAULT_PYTHON_BIN}"
+POLICY_OUTPUT="${DEFAULT_POLICY_OUTPUT}"
+BOOTSTRAP_MODE="${DEFAULT_BOOTSTRAP_MODE}"
+OUTPUT=""
+PRINT_WORKFLOW_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_federated_conformance_ci_check.sh [options]
+
+options:
+  --run-id <id>                 federated-conformance run id passed to the cross-repo checker
+  --workspace-root <path>       federated workspace root
+  --python-bin <path>           python executable used for both planningops entrypoints
+  --policy-output <path>        output path for rollout_external_artifact_policy.py
+  --bootstrap-mode <mode>       bootstrap mode passed to cross_repo_conformance_check.py
+  --output <path>               output path for cross_repo_conformance_check.py
+  --print-workflow-invocation   print the canonical GitHub workflow invocation
+  --help                        show this help text
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    --workspace-root)
+      WORKSPACE_ROOT="$2"
+      shift 2
+      ;;
+    --python-bin)
+      PYTHON_BIN="$2"
+      shift 2
+      ;;
+    --policy-output)
+      POLICY_OUTPUT="$2"
+      shift 2
+      ;;
+    --bootstrap-mode)
+      BOOTSTRAP_MODE="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --print-workflow-invocation)
+      PRINT_WORKFLOW_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_WORKFLOW_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_federated_conformance_ci_check.sh --run-id ci-federated-\${{ github.run_id }} --workspace-root . --python-bin python3 --policy-output planningops/artifacts/validation/federated-artifact-policy-rollout-report.json --bootstrap-mode require --output planningops/artifacts/conformance/ci-federated-\${{ github.run_id }}.json"
+  exit 0
+fi
+
+if [[ -z "${RUN_ID}" ]]; then
+  echo "--run-id is required" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ -z "${OUTPUT}" ]]; then
+  echo "--output is required" >&2
+  usage >&2
+  exit 1
+fi
+
+resolve_from_root() {
+  if [[ "$1" = /* ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s/%s\n' "${ROOT_DIR}" "$1"
+  fi
+}
+
+WORKSPACE_ROOT="$(resolve_from_root "${WORKSPACE_ROOT}")"
+POLICY_OUTPUT="$(resolve_from_root "${POLICY_OUTPUT}")"
+OUTPUT="$(resolve_from_root "${OUTPUT}")"
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_federated_conformance_ci_check_contract.sh"
+
+"${PYTHON_BIN}" "${ROOT_DIR}/planningops/scripts/rollout_external_artifact_policy.py" \
+  --workspace-root "${WORKSPACE_ROOT}" \
+  --strict \
+  --output "${POLICY_OUTPUT}"
+
+"${PYTHON_BIN}" "${ROOT_DIR}/planningops/scripts/federation/cross_repo_conformance_check.py" \
+  --workspace-root "${WORKSPACE_ROOT}" \
+  --bootstrap-mode "${BOOTSTRAP_MODE}" \
+  --run-id "${RUN_ID}" \
+  --output "${OUTPUT}"

--- a/planningops/scripts/test_federated_conformance_helper_wiring.sh
+++ b/planningops/scripts/test_federated_conformance_helper_wiring.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW_PATH="$ROOT_DIR/.github/workflows/federated-ci-matrix.yml"
+HELPER_PATH="$ROOT_DIR/planningops/scripts/run_federated_conformance_ci_check.sh"
+
+python3 - <<'PY' "$WORKFLOW_PATH" "$HELPER_PATH"
+import subprocess
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[2])
+
+workflow_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+
+workflow_block = workflow.split("  federated-conformance:", 1)[1].split("  loop-guardrails:", 1)[0]
+
+assert workflow_invocation in workflow_block, "workflow federated-conformance job missing helper invocation"
+assert workflow_block.count(workflow_invocation) == 1, "workflow federated-conformance helper invocation should appear once"
+assert "python3 -m pip install -r platform-contracts/requirements-dev.txt" not in workflow_block, "workflow federated-conformance job should not inline requirements install"
+assert "python3 -m pip install -r platform-provider-gateway/requirements-dev.txt" not in workflow_block, "workflow federated-conformance job should not inline provider requirements install"
+assert "python3 -m pip install -r platform-observability-gateway/requirements-dev.txt" not in workflow_block, "workflow federated-conformance job should not inline observability requirements install"
+assert "python3 -m pip install -r monday/requirements-dev.txt" not in workflow_block, "workflow federated-conformance job should not inline monday requirements install"
+assert "rollout_external_artifact_policy.py" not in workflow_block, "workflow federated-conformance job should not inline artifact policy rollout command"
+assert "cross_repo_conformance_check.py" not in workflow_block, "workflow federated-conformance job should not inline conformance checker command"
+PY
+
+echo "federated conformance helper wiring ok"

--- a/planningops/scripts/test_run_federated_conformance_ci_check_contract.sh
+++ b/planningops/scripts/test_run_federated_conformance_ci_check_contract.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_federated_conformance_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+workflow_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+assert workflow_invocation == "bash planningops/scripts/run_federated_conformance_ci_check.sh --run-id ci-federated-${{ github.run_id }} --workspace-root . --python-bin python3 --policy-output planningops/artifacts/validation/federated-artifact-policy-rollout-report.json --bootstrap-mode require --output planningops/artifacts/conformance/ci-federated-${{ github.run_id }}.json", "workflow federated-conformance helper invocation drifted"
+assert "usage: run_federated_conformance_ci_check.sh [options]" in help_output, "federated-conformance help usage missing"
+assert "--run-id <id>" in help_output, "federated-conformance help missing run-id flag"
+assert "--workspace-root <path>" in help_output, "federated-conformance help missing workspace-root flag"
+assert "--python-bin <path>" in help_output, "federated-conformance help missing python-bin flag"
+assert "--policy-output <path>" in help_output, "federated-conformance help missing policy-output flag"
+assert "--bootstrap-mode <mode>" in help_output, "federated-conformance help missing bootstrap-mode flag"
+assert "--output <path>" in help_output, "federated-conformance help missing output flag"
+assert "--print-workflow-invocation" in help_output, "federated-conformance help missing workflow invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_federated_conformance_ci_check_contract.sh"' in script, "federated-conformance helper must self-run its contract test"
+assert '"${PYTHON_BIN}" "${ROOT_DIR}/planningops/scripts/rollout_external_artifact_policy.py" \\' in script, "federated-conformance helper missing artifact policy rollout command"
+assert '"${PYTHON_BIN}" "${ROOT_DIR}/planningops/scripts/federation/cross_repo_conformance_check.py" \\' in script, "federated-conformance helper missing conformance checker command"
+assert '--workspace-root "${WORKSPACE_ROOT}" \\' in script, "federated-conformance helper missing workspace-root wiring"
+assert '--output "${POLICY_OUTPUT}"' in script, "federated-conformance helper missing policy output wiring"
+assert '--bootstrap-mode "${BOOTSTRAP_MODE}" \\' in script, "federated-conformance helper missing bootstrap-mode wiring"
+assert '--run-id "${RUN_ID}" \\' in script, "federated-conformance helper missing run-id wiring"
+assert '--output "${OUTPUT}"' in script, "federated-conformance helper missing conformance output wiring"
+PY
+
+echo "federated conformance ci check contract ok"


### PR DESCRIPTION
## Summary
- add the missing `run_federated_conformance_ci_check.sh` helper family used by the GitHub federated-conformance lane
- add contract and wiring regressions so the workflow job no longer relies on inline artifact-policy rollout or cross-repo checker commands
- add the workbench packet and hub link for the helper-family backfill

## Validation
- `bash planningops/scripts/test_run_federated_conformance_ci_check_contract.sh`
- `bash planningops/scripts/test_federated_conformance_helper_wiring.sh`
- `bash planningops/scripts/run_federated_conformance_ci_check.sh --run-id federated-conformance-helper-backfill --workspace-root /tmp/federated-conformance-helper-2voDGF --python-bin python3 --policy-output planningops/artifacts/validation/federated-artifact-policy-rollout-report.json --bootstrap-mode auto --output planningops/artifacts/conformance/federated-conformance-helper-backfill.json`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change only backfills a helper entrypoint, its guardrails, and workbench documentation.