### PR TITLE
feat(control-plane-governance): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -100,6 +100,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [O11y-Replay Helper Family Backfill Packet](./plans/2026-03-26-o11y-replay-helper-family-backfill-packet.md)
 - [Platform-Contracts Helper Family Backfill Packet](./plans/2026-03-26-platform-contracts-helper-family-backfill-packet.md)
 - [Federated-Conformance Helper Family Backfill Packet](./plans/2026-03-26-federated-conformance-helper-family-backfill-packet.md)
+- [Control-Plane Governance Helper Family Backfill Packet](./plans/2026-03-26-control-plane-governance-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-control-plane-governance-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-control-plane-governance-helper-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Control-Plane Governance Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the control-plane-governance helper entrypoint and its contract and wiring regressions so the GitHub loop-guardrails lane no longer depends on local-only helper files.
+related_docs:
+  - ./2026-03-26-federated-conformance-helper-family-backfill-packet.md
+  - ./2026-03-26-platform-contracts-helper-family-backfill-packet.md
+---
+
+# plan: Control-Plane Governance Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `control-plane-governance` helper family that the GitHub `loop-guardrails` lane and helper guardrails already invoke directly.
+- Promote the missing helper entrypoint plus contract and wiring regressions into git-tracked reality so control-plane artifact-policy, ontology, memory, inventory, and scheduler-queue governance checks are reproducible from remote `main`.
+- Verify the helper owns the control-plane validator and audit step inventory instead of leaving those commands inlined in workflow YAML.
+
+## Scope
+- `planningops/scripts/run_control_plane_governance_ci_check.sh`
+- `planningops/scripts/test_run_control_plane_governance_ci_check_contract.sh`
+- `planningops/scripts/test_control_plane_governance_helper_wiring.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_control_plane_governance_ci_check_contract.sh` passes
+- `test_control_plane_governance_helper_wiring.sh` proves the workflow `loop-guardrails` subsection calls only the canonical helper
+- `test_run_control_plane_governance_ci_check_smoke.sh` passes with deterministic fixture inputs

--- a/planningops/scripts/run_control_plane_governance_ci_check.sh
+++ b/planningops/scripts/run_control_plane_governance_ci_check.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PYTHON_BIN="python3"
+ROOT_PATH="."
+MEMORY_OUTPUT="planningops/artifacts/validation/memory-gate-report.json"
+INVENTORY_OUTPUT="planningops/artifacts/validation/inventory-issue-lifecycle-report.json"
+INVENTORY_ISSUES_FILE=""
+PRINT_STEPS=0
+PRINT_WORKFLOW_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_control_plane_governance_ci_check.sh [options]
+
+options:
+  --python-bin <path>         python interpreter for the live governance validators
+  --root <path>               repo root used for memory and inventory governance checks
+  --memory-output <path>      output path for memory_compactor.py
+  --inventory-output <path>   output path for inventory_issue_lifecycle.py audit
+  --inventory-issues-file <path> optional issue fixture for inventory_issue_lifecycle.py audit
+  --print-steps               print the canonical workflow step inventory
+  --print-workflow-invocation print the canonical GitHub workflow invocation
+  --help                      show this help text
+EOF
+}
+
+print_steps() {
+  cat <<'EOF'
+bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh
+python3 planningops/scripts/validate_artifact_storage_policy.py --strict
+bash planningops/scripts/test_control_tower_ontology_contract.sh
+bash planningops/scripts/test_ontology_entity_map_contract.sh
+bash planningops/scripts/test_memory_tier_contract.sh
+bash planningops/scripts/test_memory_compactor_contract.sh
+bash planningops/scripts/test_memory_archive_contract.sh
+bash planningops/scripts/test_memory_rehydrate_contract.sh
+bash planningops/scripts/test_inventory_issue_lifecycle_contract.sh
+bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
+python3 planningops/scripts/memory_compactor.py --mode check --root . --rules planningops/config/memory-tier-rules.json --output planningops/artifacts/validation/memory-gate-report.json --strict
+python3 planningops/scripts/inventory_issue_lifecycle.py audit --repo rather-not-work-on/platform-planningops --strict --output planningops/artifacts/validation/inventory-issue-lifecycle-report.json
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --python-bin)
+      PYTHON_BIN="$2"
+      shift 2
+      ;;
+    --root)
+      ROOT_PATH="$2"
+      shift 2
+      ;;
+    --memory-output)
+      MEMORY_OUTPUT="$2"
+      shift 2
+      ;;
+    --inventory-output)
+      INVENTORY_OUTPUT="$2"
+      shift 2
+      ;;
+    --inventory-issues-file)
+      INVENTORY_ISSUES_FILE="$2"
+      shift 2
+      ;;
+    --print-steps)
+      PRINT_STEPS=1
+      shift
+      ;;
+    --print-workflow-invocation)
+      PRINT_WORKFLOW_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_STEPS}" -eq 1 ]]; then
+  print_steps
+  exit 0
+fi
+
+if [[ "${PRINT_WORKFLOW_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' "bash planningops/scripts/run_control_plane_governance_ci_check.sh --python-bin python3"
+  exit 0
+fi
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_control_plane_governance_ci_check_contract.sh"
+
+cd "${ROOT_DIR}"
+bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh
+"${PYTHON_BIN}" planningops/scripts/validate_artifact_storage_policy.py --strict
+bash planningops/scripts/test_control_tower_ontology_contract.sh
+bash planningops/scripts/test_ontology_entity_map_contract.sh
+bash planningops/scripts/test_memory_tier_contract.sh
+bash planningops/scripts/test_memory_compactor_contract.sh
+bash planningops/scripts/test_memory_archive_contract.sh
+bash planningops/scripts/test_memory_rehydrate_contract.sh
+bash planningops/scripts/test_inventory_issue_lifecycle_contract.sh
+bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
+"${PYTHON_BIN}" planningops/scripts/memory_compactor.py \
+  --mode check \
+  --root "${ROOT_PATH}" \
+  --rules planningops/config/memory-tier-rules.json \
+  --output "${MEMORY_OUTPUT}" \
+  --strict
+INVENTORY_ARGS=(
+  audit
+  --root "${ROOT_PATH}"
+  --repo rather-not-work-on/platform-planningops
+  --strict
+  --output "${INVENTORY_OUTPUT}"
+)
+if [[ -n "${INVENTORY_ISSUES_FILE}" ]]; then
+  INVENTORY_ARGS+=(--issues-file "${INVENTORY_ISSUES_FILE}")
+fi
+"${PYTHON_BIN}" planningops/scripts/inventory_issue_lifecycle.py "${INVENTORY_ARGS[@]}"

--- a/planningops/scripts/test_control_plane_governance_helper_wiring.sh
+++ b/planningops/scripts/test_control_plane_governance_helper_wiring.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/federated-ci-matrix.yml"
+HELPER_PATH="${ROOT_DIR}/planningops/scripts/run_control_plane_governance_ci_check.sh"
+
+python3 - <<'PY' "${WORKFLOW_PATH}" "${HELPER_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[2])
+loop_guardrails = workflow.split("  loop-guardrails:", 1)[1].split("  federated-summary:", 1)[0]
+workflow_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+steps = subprocess.check_output(
+    ["bash", str(helper_path), "--print-steps"],
+    text=True,
+).splitlines()
+
+assert "test_run_control_plane_governance_ci_check_contract.sh" in loop_guardrails, "loop-guardrails missing control-plane governance helper contract regression"
+assert "test_control_plane_governance_helper_wiring.sh" in loop_guardrails, "loop-guardrails missing control-plane governance helper wiring regression"
+assert workflow_invocation in loop_guardrails, "loop-guardrails missing control-plane governance helper invocation"
+assert loop_guardrails.count(workflow_invocation) == 1, "loop-guardrails should invoke control-plane governance helper once"
+for step in steps:
+    assert step not in loop_guardrails, f"loop-guardrails should not inline control-plane governance helper step once helper exists: {step}"
+PY
+
+echo "control plane governance helper wiring ok"

--- a/planningops/scripts/test_run_control_plane_governance_ci_check_contract.sh
+++ b/planningops/scripts/test_run_control_plane_governance_ci_check_contract.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_control_plane_governance_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+steps = subprocess.check_output(
+    ["bash", str(script_path), "--print-steps"],
+    text=True,
+).splitlines()
+workflow_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+expected_steps = [
+    "bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh",
+    "python3 planningops/scripts/validate_artifact_storage_policy.py --strict",
+    "bash planningops/scripts/test_control_tower_ontology_contract.sh",
+    "bash planningops/scripts/test_ontology_entity_map_contract.sh",
+    "bash planningops/scripts/test_memory_tier_contract.sh",
+    "bash planningops/scripts/test_memory_compactor_contract.sh",
+    "bash planningops/scripts/test_memory_archive_contract.sh",
+    "bash planningops/scripts/test_memory_rehydrate_contract.sh",
+    "bash planningops/scripts/test_inventory_issue_lifecycle_contract.sh",
+    "bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh",
+    "python3 planningops/scripts/memory_compactor.py --mode check --root . --rules planningops/config/memory-tier-rules.json --output planningops/artifacts/validation/memory-gate-report.json --strict",
+    "python3 planningops/scripts/inventory_issue_lifecycle.py audit --repo rather-not-work-on/platform-planningops --strict --output planningops/artifacts/validation/inventory-issue-lifecycle-report.json",
+]
+
+assert steps == expected_steps, "control-plane governance helper step inventory drifted"
+assert workflow_invocation == "bash planningops/scripts/run_control_plane_governance_ci_check.sh --python-bin python3", "control-plane governance helper workflow invocation drifted"
+assert "usage: run_control_plane_governance_ci_check.sh [options]" in help_output, "control-plane governance helper usage missing"
+assert "--python-bin <path>" in help_output, "control-plane governance helper help missing python-bin flag"
+assert "--root <path>" in help_output, "control-plane governance helper help missing root flag"
+assert "--memory-output <path>" in help_output, "control-plane governance helper help missing memory-output flag"
+assert "--inventory-output <path>" in help_output, "control-plane governance helper help missing inventory-output flag"
+assert "--inventory-issues-file <path>" in help_output, "control-plane governance helper help missing inventory-issues-file flag"
+assert "--print-steps" in help_output, "control-plane governance helper help missing steps flag"
+assert "--print-workflow-invocation" in help_output, "control-plane governance helper help missing workflow invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_control_plane_governance_ci_check_contract.sh"' in script, "control-plane governance helper must self-run its contract test"
+assert 'bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh' in script, "control-plane governance helper missing artifact-storage regression"
+assert '"${PYTHON_BIN}" planningops/scripts/validate_artifact_storage_policy.py --strict' in script, "control-plane governance helper missing artifact-storage validator wiring"
+assert 'bash planningops/scripts/test_control_tower_ontology_contract.sh' in script, "control-plane governance helper missing ontology contract regression"
+assert 'bash planningops/scripts/test_ontology_entity_map_contract.sh' in script, "control-plane governance helper missing ontology map regression"
+assert 'bash planningops/scripts/test_memory_tier_contract.sh' in script, "control-plane governance helper missing memory-tier regression"
+assert 'bash planningops/scripts/test_memory_compactor_contract.sh' in script, "control-plane governance helper missing memory-compactor regression"
+assert 'bash planningops/scripts/test_memory_archive_contract.sh' in script, "control-plane governance helper missing memory-archive regression"
+assert 'bash planningops/scripts/test_memory_rehydrate_contract.sh' in script, "control-plane governance helper missing memory-rehydrate regression"
+assert 'bash planningops/scripts/test_inventory_issue_lifecycle_contract.sh' in script, "control-plane governance helper missing inventory lifecycle regression"
+assert 'bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh' in script, "control-plane governance helper missing scheduler queue regression"
+assert '"${PYTHON_BIN}" planningops/scripts/memory_compactor.py \\' in script, "control-plane governance helper missing memory gate wiring"
+assert '--root "${ROOT_PATH}" \\' in script, "control-plane governance helper missing root wiring for memory gate"
+assert '--output "${MEMORY_OUTPUT}" \\' in script, "control-plane governance helper missing memory output wiring"
+assert 'INVENTORY_ARGS=(' in script, "control-plane governance helper missing inventory argument array"
+assert '--root "${ROOT_PATH}"' in script, "control-plane governance helper missing inventory root wiring"
+assert '--output "${INVENTORY_OUTPUT}"' in script, "control-plane governance helper missing inventory output wiring"
+assert 'INVENTORY_ARGS+=(--issues-file "${INVENTORY_ISSUES_FILE}")' in script, "control-plane governance helper missing inventory issues-file override"
+assert '"${PYTHON_BIN}" planningops/scripts/inventory_issue_lifecycle.py "${INVENTORY_ARGS[@]}"' in script, "control-plane governance helper missing inventory audit wiring"
+PY
+
+echo "control plane governance ci check contract ok"


### PR DESCRIPTION
## Summary
- add the missing `run_control_plane_governance_ci_check.sh` helper family used by the GitHub loop-guardrails lane
- add contract and wiring regressions so the workflow subsection no longer relies on inline governance validator commands
- add the workbench packet and hub link for the helper-family backfill

## Validation
- `bash planningops/scripts/test_run_control_plane_governance_ci_check_contract.sh`
- `bash planningops/scripts/test_control_plane_governance_helper_wiring.sh`
- `bash planningops/scripts/test_run_control_plane_governance_ci_check_smoke.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change only backfills a helper entrypoint, its guardrails, and workbench documentation.