### PR TITLE
feat(external-artifact-residency): backfill helper family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -101,6 +101,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Platform-Contracts Helper Family Backfill Packet](./plans/2026-03-26-platform-contracts-helper-family-backfill-packet.md)
 - [Federated-Conformance Helper Family Backfill Packet](./plans/2026-03-26-federated-conformance-helper-family-backfill-packet.md)
 - [Control-Plane Governance Helper Family Backfill Packet](./plans/2026-03-26-control-plane-governance-helper-family-backfill-packet.md)
+- [External-Artifact-Residency Helper Family Backfill Packet](./plans/2026-03-26-external-artifact-residency-helper-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-external-artifact-residency-helper-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-external-artifact-residency-helper-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: External-Artifact-Residency Helper Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the external-artifact-residency helper entrypoint and its contract and wiring regressions so the GitHub loop-guardrails lane no longer depends on local-only helper files.
+related_docs:
+  - ./2026-03-26-control-plane-governance-helper-family-backfill-packet.md
+  - ./2026-03-26-federated-conformance-helper-family-backfill-packet.md
+---
+
+# plan: External-Artifact-Residency Helper Family Backfill Packet
+
+## Summary
+- Backfill the tracked `external-artifact-residency` helper family that the GitHub `loop-guardrails` lane and helper guardrails already invoke directly.
+- Promote the missing helper entrypoint plus contract and wiring regressions into git-tracked reality so external-only commit/artifact residency checks are reproducible from remote `main`.
+- Verify the helper owns the commit-guard diff and tracked audits instead of leaving those commands and base-ref fallback logic inlined in workflow YAML.
+
+## Scope
+- `planningops/scripts/run_external_artifact_residency_ci_check.sh`
+- `planningops/scripts/test_run_external_artifact_residency_ci_check_contract.sh`
+- `planningops/scripts/test_external_artifact_residency_helper_wiring.sh`
+- workbench hub link for this helper-family backfill
+
+## Acceptance
+- `test_run_external_artifact_residency_ci_check_contract.sh` passes
+- `test_external_artifact_residency_helper_wiring.sh` proves the workflow `loop-guardrails` subsection calls only the canonical helper
+- `run_external_artifact_residency_ci_check.sh --base-ref HEAD --head-ref HEAD --python-bin python3` succeeds from the repo root

--- a/planningops/scripts/run_external_artifact_residency_ci_check.sh
+++ b/planningops/scripts/run_external_artifact_residency_ci_check.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASE_REF=""
+HEAD_REF="HEAD"
+PYTHON_BIN="python3"
+PRINT_STEPS=0
+PRINT_WORKFLOW_INVOCATION=0
+
+usage() {
+  cat <<EOF
+usage: run_external_artifact_residency_ci_check.sh [options]
+
+options:
+  --base-ref <ref>            diff base ref for the external-only commit guard
+  --head-ref <ref>            diff head ref for the external-only commit guard
+  --python-bin <path>         python interpreter for the live guard checks
+  --print-steps               print the legacy workflow step inventory replaced by this helper
+  --print-workflow-invocation print the canonical GitHub workflow invocation
+  --help                      show this help text
+EOF
+}
+
+print_steps() {
+  cat <<'EOF'
+bash planningops/scripts/test_validate_external_only_commit_guard.sh
+bash planningops/scripts/test_migrate_external_only_artifacts_contract.sh
+bash planningops/scripts/test_artifact_sink_e2e.sh
+BASE_REF="${{ github.event.pull_request.base.sha }}"
+if [[ -z "$BASE_REF" || "$BASE_REF" == "null" ]]; then BASE_REF="origin/main"; fi
+python3 planningops/scripts/validate_external_only_commit_guard.py --base-ref "$BASE_REF" --head-ref "${{ github.sha }}" --strict
+python3 planningops/scripts/validate_external_only_commit_guard.py --mode tracked --strict
+EOF
+}
+
+resolve_base_ref() {
+  local candidate="$1"
+  if [[ -z "${candidate}" || "${candidate}" == "null" ]]; then
+    printf '%s\n' "origin/main"
+    return 0
+  fi
+  printf '%s\n' "${candidate}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-ref)
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --head-ref)
+      HEAD_REF="$2"
+      shift 2
+      ;;
+    --python-bin)
+      PYTHON_BIN="$2"
+      shift 2
+      ;;
+    --print-steps)
+      PRINT_STEPS=1
+      shift
+      ;;
+    --print-workflow-invocation)
+      PRINT_WORKFLOW_INVOCATION=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PRINT_STEPS}" -eq 1 ]]; then
+  print_steps
+  exit 0
+fi
+
+if [[ "${PRINT_WORKFLOW_INVOCATION}" -eq 1 ]]; then
+  printf '%s\n' 'bash planningops/scripts/run_external_artifact_residency_ci_check.sh --base-ref "${{ github.event.pull_request.base.sha }}" --head-ref "${{ github.sha }}" --python-bin python3'
+  exit 0
+fi
+
+RESOLVED_BASE_REF="$(resolve_base_ref "${BASE_REF}")"
+
+bash "${ROOT_DIR}/planningops/scripts/test_run_external_artifact_residency_ci_check_contract.sh"
+
+cd "${ROOT_DIR}"
+bash planningops/scripts/test_validate_external_only_commit_guard.sh
+bash planningops/scripts/test_migrate_external_only_artifacts_contract.sh
+bash planningops/scripts/test_artifact_sink_e2e.sh
+"${PYTHON_BIN}" planningops/scripts/validate_external_only_commit_guard.py \
+  --base-ref "${RESOLVED_BASE_REF}" \
+  --head-ref "${HEAD_REF}" \
+  --strict
+"${PYTHON_BIN}" planningops/scripts/validate_external_only_commit_guard.py \
+  --mode tracked \
+  --strict

--- a/planningops/scripts/test_external_artifact_residency_helper_wiring.sh
+++ b/planningops/scripts/test_external_artifact_residency_helper_wiring.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/federated-ci-matrix.yml"
+HELPER_PATH="${ROOT_DIR}/planningops/scripts/run_external_artifact_residency_ci_check.sh"
+
+python3 - <<'PY' "${WORKFLOW_PATH}" "${HELPER_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1]).read_text(encoding="utf-8")
+helper_path = Path(sys.argv[2])
+loop_guardrails = workflow.split("  loop-guardrails:", 1)[1].split("  federated-summary:", 1)[0]
+workflow_invocation = subprocess.check_output(
+    ["bash", str(helper_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+steps = subprocess.check_output(
+    ["bash", str(helper_path), "--print-steps"],
+    text=True,
+).splitlines()
+
+assert "test_run_external_artifact_residency_ci_check_contract.sh" in loop_guardrails, "loop-guardrails missing external-artifact residency helper contract regression"
+assert "test_external_artifact_residency_helper_wiring.sh" in loop_guardrails, "loop-guardrails missing external-artifact residency helper wiring regression"
+assert workflow_invocation in loop_guardrails, "loop-guardrails missing external-artifact residency helper invocation"
+assert loop_guardrails.count(workflow_invocation) == 1, "loop-guardrails should invoke external-artifact residency helper once"
+for step in steps:
+    assert step not in loop_guardrails, f"loop-guardrails should not inline external-artifact residency helper step once helper exists: {step}"
+PY
+
+echo "external artifact residency helper wiring ok"

--- a/planningops/scripts/test_run_external_artifact_residency_ci_check_contract.sh
+++ b/planningops/scripts/test_run_external_artifact_residency_ci_check_contract.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_external_artifact_residency_ci_check.sh"
+
+python3 - <<'PY' "${SCRIPT_PATH}"
+import subprocess
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+script = script_path.read_text(encoding="utf-8")
+steps = subprocess.check_output(
+    ["bash", str(script_path), "--print-steps"],
+    text=True,
+).splitlines()
+workflow_invocation = subprocess.check_output(
+    ["bash", str(script_path), "--print-workflow-invocation"],
+    text=True,
+).strip()
+help_output = subprocess.check_output(
+    ["bash", str(script_path), "--help"],
+    text=True,
+)
+
+expected_steps = [
+    "bash planningops/scripts/test_validate_external_only_commit_guard.sh",
+    "bash planningops/scripts/test_migrate_external_only_artifacts_contract.sh",
+    "bash planningops/scripts/test_artifact_sink_e2e.sh",
+    'BASE_REF="${{ github.event.pull_request.base.sha }}"',
+    'if [[ -z "$BASE_REF" || "$BASE_REF" == "null" ]]; then BASE_REF="origin/main"; fi',
+    'python3 planningops/scripts/validate_external_only_commit_guard.py --base-ref "$BASE_REF" --head-ref "${{ github.sha }}" --strict',
+    "python3 planningops/scripts/validate_external_only_commit_guard.py --mode tracked --strict",
+]
+
+assert steps == expected_steps, "external-artifact residency helper step inventory drifted"
+assert workflow_invocation == 'bash planningops/scripts/run_external_artifact_residency_ci_check.sh --base-ref "${{ github.event.pull_request.base.sha }}" --head-ref "${{ github.sha }}" --python-bin python3', "external-artifact residency helper workflow invocation drifted"
+assert "usage: run_external_artifact_residency_ci_check.sh [options]" in help_output, "external-artifact residency helper usage missing"
+assert "--base-ref <ref>" in help_output, "external-artifact residency helper help missing base-ref flag"
+assert "--head-ref <ref>" in help_output, "external-artifact residency helper help missing head-ref flag"
+assert "--python-bin <path>" in help_output, "external-artifact residency helper help missing python-bin flag"
+assert "--print-steps" in help_output, "external-artifact residency helper help missing steps flag"
+assert "--print-workflow-invocation" in help_output, "external-artifact residency helper help missing workflow invocation flag"
+assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_external_artifact_residency_ci_check_contract.sh"' in script, "external-artifact residency helper must self-run its contract test"
+assert 'RESOLVED_BASE_REF="$(resolve_base_ref "${BASE_REF}")"' in script, "external-artifact residency helper missing base-ref normalization"
+assert 'bash planningops/scripts/test_validate_external_only_commit_guard.sh' in script, "external-artifact residency helper missing commit-guard regression"
+assert 'bash planningops/scripts/test_migrate_external_only_artifacts_contract.sh' in script, "external-artifact residency helper missing migration regression"
+assert 'bash planningops/scripts/test_artifact_sink_e2e.sh' in script, "external-artifact residency helper missing sink regression"
+assert '"${PYTHON_BIN}" planningops/scripts/validate_external_only_commit_guard.py \\' in script, "external-artifact residency helper missing live commit guard wiring"
+assert '--base-ref "${RESOLVED_BASE_REF}"' in script, "external-artifact residency helper missing resolved base-ref wiring"
+assert '--head-ref "${HEAD_REF}"' in script, "external-artifact residency helper missing head-ref wiring"
+assert '--mode tracked \\' in script, "external-artifact residency helper missing tracked baseline wiring"
+PY
+
+echo "external artifact residency ci check contract ok"


### PR DESCRIPTION
## Summary
- add the missing `run_external_artifact_residency_ci_check.sh` helper family used by the GitHub loop-guardrails lane
- add contract and wiring regressions so the workflow subsection no longer relies on inline commit-guard and base-ref fallback logic
- add the workbench packet and hub link for the helper-family backfill

## Validation
- `bash planningops/scripts/test_run_external_artifact_residency_ci_check_contract.sh`
- `bash planningops/scripts/test_external_artifact_residency_helper_wiring.sh`
- `bash planningops/scripts/run_external_artifact_residency_ci_check.sh --base-ref HEAD --head-ref HEAD --python-bin python3`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change only backfills a helper entrypoint, its guardrails, and workbench documentation.