### PR TITLE
feat(runtime-profiles): backfill validator family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -102,6 +102,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Federated-Conformance Helper Family Backfill Packet](./plans/2026-03-26-federated-conformance-helper-family-backfill-packet.md)
 - [Control-Plane Governance Helper Family Backfill Packet](./plans/2026-03-26-control-plane-governance-helper-family-backfill-packet.md)
 - [External-Artifact-Residency Helper Family Backfill Packet](./plans/2026-03-26-external-artifact-residency-helper-family-backfill-packet.md)
+- [Runtime-Profiles Validator Family Backfill Packet](./plans/2026-03-26-runtime-profiles-validator-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-runtime-profiles-validator-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-runtime-profiles-validator-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Runtime-Profiles Validator Family Backfill Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the runtime-profiles schema, validator, regression, and catalog update so planningops can validate runtime profile semantics from remote main.
+related_docs:
+  - ./2026-03-26-control-plane-governance-helper-family-backfill-packet.md
+  - ./2026-03-26-provider-profile-helper-family-backfill-packet.md
+---
+
+# plan: Runtime-Profiles Validator Family Backfill Packet
+
+## Summary
+- Backfill the tracked `runtime-profiles` validator family that `planningops/scripts/README.md` already documents.
+- Promote the missing schema, validator, regression, and runtime profile catalog changes into git-tracked reality so runtime profile semantics are reproducible from remote `main`.
+- Validate the catalog against a strict schema and semantic rule set, including planner policy, provider policy, and worker policy surfaces.
+
+## Scope
+- `planningops/config/runtime-profiles.json`
+- `planningops/schemas/runtime-profiles.schema.json`
+- `planningops/scripts/validate_runtime_profiles.py`
+- `planningops/scripts/test_validate_runtime_profiles_contract.sh`
+- workbench hub link for this validator-family backfill
+
+## Acceptance
+- `test_validate_runtime_profiles_contract.sh` passes
+- `validate_runtime_profiles.py --runtime-profile-file planningops/config/runtime-profiles.json --schema-file planningops/schemas/runtime-profiles.schema.json --output planningops/artifacts/validation/runtime-profiles-report.json --strict` succeeds from the repo root

--- a/planningops/config/runtime-profiles.json
+++ b/planningops/config/runtime-profiles.json
@@ -5,14 +5,22 @@
       "execution_mode": "local",
       "litellm_base_url": "http://127.0.0.1:4000",
       "langfuse_host": "http://127.0.0.1:3001",
-      "nanoclaw_endpoint": "http://127.0.0.1:8787",
+      "planner_policy": {
+        "engine_hint": "deepagents",
+        "execution_mode": "embedded",
+        "capability_profile": "repo_local_skills"
+      },
       "notes": "Default local stack for planningops loop development."
     },
     "oracle_cloud": {
       "execution_mode": "hybrid",
       "litellm_base_url": "https://litellm.example.oracle.cloud",
       "langfuse_host": "https://langfuse.example.oracle.cloud",
-      "nanoclaw_endpoint": "https://nanoclaw.example.oracle.cloud",
+      "planner_policy": {
+        "engine_hint": "deepagents",
+        "execution_mode": "embedded",
+        "capability_profile": "repo_local_skills"
+      },
       "notes": "Migration target profile for OCI deployment."
     }
   },
@@ -20,9 +28,9 @@
     "default": {
       "runtime_profile": "local",
       "provider_policy": {
-        "model": "task-default",
+        "model": "gemini-2.5-flash-lite",
         "fallback_models": [
-          "task-default-fallback"
+          "llama-3.1:8b"
         ],
         "max_retries": 2,
         "timeout_ms": 60000

--- a/planningops/schemas/runtime-profiles.schema.json
+++ b/planningops/schemas/runtime-profiles.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PlanningOps Runtime Profiles",
+  "type": "object",
+  "required": ["active_profile", "profiles", "task_overrides"],
+  "properties": {
+    "active_profile": {
+      "type": "string",
+      "minLength": 1
+    },
+    "profiles": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/profile"
+      }
+    },
+    "task_overrides": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/taskOverride"
+      }
+    }
+  },
+  "$defs": {
+    "plannerPolicy": {
+      "type": "object",
+      "required": ["engine_hint", "execution_mode", "capability_profile"],
+      "properties": {
+        "engine_hint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "execution_mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "capability_profile": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "profile": {
+      "type": "object",
+      "required": ["execution_mode", "litellm_base_url", "langfuse_host"],
+      "properties": {
+        "execution_mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "litellm_base_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "langfuse_host": {
+          "type": "string",
+          "minLength": 1
+        },
+        "planner_policy": {
+          "$ref": "#/$defs/plannerPolicy"
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "providerPolicy": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fallback_models": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "max_retries": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "timeout_ms": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "workerPolicy": {
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["parser_diff_dry_run", "python_script", "shell"]
+        },
+        "script": {
+          "type": "string",
+          "minLength": 1
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "taskOverride": {
+      "type": "object",
+      "properties": {
+        "runtime_profile": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider_policy": {
+          "$ref": "#/$defs/providerPolicy"
+        },
+        "worker_policy": {
+          "$ref": "#/$defs/workerPolicy"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/planningops/scripts/test_validate_runtime_profiles_contract.sh
+++ b/planningops/scripts/test_validate_runtime_profiles_contract.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+module_path = Path("planningops/scripts/validate_runtime_profiles.py")
+spec = importlib.util.spec_from_file_location("validate_runtime_profiles", module_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+with tempfile.TemporaryDirectory() as td:
+    td_path = Path(td)
+    runtime_file = td_path / "runtime-profiles.json"
+    output_file = td_path / "report.json"
+
+    runtime_file.write_text(
+        json.dumps(
+            {
+                "active_profile": "local",
+                "profiles": {
+                    "local": {
+                        "execution_mode": "local",
+                        "litellm_base_url": "http://127.0.0.1:4000",
+                        "langfuse_host": "http://127.0.0.1:3001",
+                        "planner_policy": {
+                            "engine_hint": "deepagents",
+                            "execution_mode": "embedded",
+                            "capability_profile": "repo_local_skills",
+                        }
+                    }
+                },
+                "task_overrides": {
+                    "default": {
+                        "runtime_profile": "local",
+                        "provider_policy": {"max_retries": 2, "timeout_ms": 60000},
+                        "worker_policy": {"kind": "parser_diff_dry_run"},
+                    }
+                },
+            },
+            ensure_ascii=True,
+        ),
+        encoding="utf-8",
+    )
+
+    argv_before = list(sys.argv)
+    sys.argv = [
+        "validate_runtime_profiles.py",
+        "--runtime-profile-file",
+        str(runtime_file),
+        "--schema-file",
+        "planningops/schemas/runtime-profiles.schema.json",
+        "--output",
+        str(output_file),
+        "--strict",
+    ]
+    rc = mod.main()
+    sys.argv = argv_before
+    assert rc == 0, rc
+    report = json.loads(output_file.read_text(encoding="utf-8"))
+    assert report["verdict"] == "pass", report
+    assert report["reason"] == "ok", report
+
+    invalid = json.loads(runtime_file.read_text(encoding="utf-8"))
+    invalid["active_profile"] = "missing"
+    invalid["profiles"]["local"]["planner_policy"]["engine_hint"] = ""
+    invalid["profiles"]["local"]["nanoclaw_endpoint"] = "http://127.0.0.1:8787"
+    invalid["task_overrides"]["default"]["runtime_profile"] = "missing"
+    invalid["task_overrides"]["default"]["worker_policy"] = {"kind": "unknown"}
+    runtime_file.write_text(json.dumps(invalid, ensure_ascii=True), encoding="utf-8")
+
+    argv_before = list(sys.argv)
+    sys.argv = [
+        "validate_runtime_profiles.py",
+        "--runtime-profile-file",
+        str(runtime_file),
+        "--schema-file",
+        "planningops/schemas/runtime-profiles.schema.json",
+        "--output",
+        str(output_file),
+        "--strict",
+    ]
+    rc_bad = mod.main()
+    sys.argv = argv_before
+    assert rc_bad == 1, rc_bad
+    bad_report = json.loads(output_file.read_text(encoding="utf-8"))
+    assert bad_report["verdict"] == "fail", bad_report
+    assert bad_report["reason"] == "runtime_profiles_invalid", bad_report
+    errors = "\n".join(bad_report["validation_errors"])
+    assert "active_profile 'missing' is not defined in profiles" in errors, bad_report
+    assert "schema: $.profiles.local unexpected key: nanoclaw_endpoint" in errors, bad_report
+    assert "planner_policy.engine_hint must be a non-empty string" in errors, bad_report
+    assert "runtime_profile 'missing' is not defined" in errors, bad_report
+    assert "worker_policy.kind must be parser_diff_dry_run, python_script, or shell" in errors, bad_report
+
+print("validate_runtime_profiles contract ok")
+PY

--- a/planningops/scripts/validate_runtime_profiles.py
+++ b/planningops/scripts/validate_runtime_profiles.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def now_utc():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, doc):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def append_error(errors, message):
+    if message not in errors:
+        errors.append(message)
+
+
+def _resolve_ref(root_schema, ref):
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        raise ValueError(f"unsupported schema ref: {ref}")
+    cursor = root_schema
+    for token in ref[2:].split("/"):
+        cursor = cursor[token]
+    return cursor
+
+
+def _is_type(value, type_name):
+    if type_name == "object":
+        return isinstance(value, dict)
+    if type_name == "array":
+        return isinstance(value, list)
+    if type_name == "string":
+        return isinstance(value, str)
+    if type_name == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_name == "boolean":
+        return isinstance(value, bool)
+    return True
+
+
+def _validate_schema_value(value, schema, root_schema, path, errors):
+    if not isinstance(schema, dict):
+        return
+
+    if "$ref" in schema:
+        schema = _resolve_ref(root_schema, schema["$ref"])
+
+    expected_type = schema.get("type")
+    if expected_type and not _is_type(value, expected_type):
+        append_error(errors, f"schema: {path} expected type {expected_type}")
+        return
+
+    if "enum" in schema and value not in schema["enum"]:
+        append_error(errors, f"schema: {path} invalid enum value: {value}")
+
+    if expected_type == "string":
+        min_len = schema.get("minLength")
+        if isinstance(min_len, int) and len(value) < min_len:
+            append_error(errors, f"schema: {path} minLength violation")
+        pattern = schema.get("pattern")
+        if pattern and not re.match(pattern, value):
+            append_error(errors, f"schema: {path} does not match pattern")
+
+    if expected_type == "integer":
+        minimum = schema.get("minimum")
+        if isinstance(minimum, int) and value < minimum:
+            append_error(errors, f"schema: {path} below minimum {minimum}")
+
+    if expected_type == "object":
+        required = schema.get("required", [])
+        props = schema.get("properties", {})
+        for key in required:
+            if key not in value:
+                append_error(errors, f"schema: {path}.{key} is required")
+        additional_props = schema.get("additionalProperties", True)
+        for key, child_value in value.items():
+            if key in props:
+                continue
+            if additional_props is False:
+                append_error(errors, f"schema: {path} unexpected key: {key}")
+                continue
+            if isinstance(additional_props, dict):
+                _validate_schema_value(child_value, additional_props, root_schema, f"{path}.{key}", errors)
+        for key, prop_schema in props.items():
+            if key in value:
+                _validate_schema_value(value[key], prop_schema, root_schema, f"{path}.{key}", errors)
+
+    if expected_type == "array":
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for idx, row in enumerate(value):
+                _validate_schema_value(row, item_schema, root_schema, f"{path}[{idx}]", errors)
+
+
+def validate_schema(doc, schema_doc):
+    errors = []
+    if not isinstance(doc, dict):
+        return ["document must be object"]
+    if not isinstance(schema_doc, dict):
+        return ["schema document must be object"]
+    _validate_schema_value(doc, schema_doc, schema_doc, "$", errors)
+    return errors
+
+
+def validate_profile(name: str, profile: dict, errors: list[str]):
+    if not isinstance(name, str) or not name.strip():
+        append_error(errors, "profile key must be a non-empty string")
+    if not isinstance(profile, dict):
+        append_error(errors, f"profile '{name}' must be an object")
+        return
+
+    for field in ("execution_mode", "litellm_base_url", "langfuse_host"):
+        value = profile.get(field)
+        if not isinstance(value, str) or not value.strip():
+            append_error(errors, f"profile '{name}' missing non-empty string field '{field}'")
+
+    planner_policy = profile.get("planner_policy")
+    if planner_policy is not None:
+        if not isinstance(planner_policy, dict):
+            append_error(errors, f"profile '{name}' planner_policy must be an object")
+        else:
+            for field in ("engine_hint", "execution_mode", "capability_profile"):
+                value = planner_policy.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    append_error(errors, f"profile '{name}' planner_policy.{field} must be a non-empty string")
+
+    notes = profile.get("notes")
+    if notes is not None and not isinstance(notes, str):
+        append_error(errors, f"profile '{name}' notes must be a string when present")
+
+
+def validate_provider_policy(task_key: str, provider_policy: dict, errors: list[str]):
+    if not isinstance(provider_policy, dict):
+        append_error(errors, f"task_overrides.{task_key}.provider_policy must be an object")
+        return
+    model = provider_policy.get("model")
+    if model is not None and (not isinstance(model, str) or not model.strip()):
+        append_error(errors, f"task_overrides.{task_key}.provider_policy.model must be a non-empty string")
+    fallback_models = provider_policy.get("fallback_models")
+    if fallback_models is not None:
+        if not isinstance(fallback_models, list) or any(not isinstance(v, str) or not v.strip() for v in fallback_models):
+            append_error(errors, f"task_overrides.{task_key}.provider_policy.fallback_models must be a list of strings")
+    max_retries = provider_policy.get("max_retries")
+    if max_retries is not None and (not isinstance(max_retries, int) or isinstance(max_retries, bool) or max_retries < 0):
+        append_error(errors, f"task_overrides.{task_key}.provider_policy.max_retries must be an integer >= 0")
+    timeout_ms = provider_policy.get("timeout_ms")
+    if timeout_ms is not None and (not isinstance(timeout_ms, int) or isinstance(timeout_ms, bool) or timeout_ms < 1):
+        append_error(errors, f"task_overrides.{task_key}.provider_policy.timeout_ms must be a positive integer")
+
+
+def validate_worker_policy(task_key: str, worker_policy: dict, errors: list[str]):
+    if not isinstance(worker_policy, dict):
+        append_error(errors, f"task_overrides.{task_key}.worker_policy must be an object")
+        return
+    kind = worker_policy.get("kind")
+    if kind not in {"parser_diff_dry_run", "python_script", "shell"}:
+        append_error(errors, f"task_overrides.{task_key}.worker_policy.kind must be parser_diff_dry_run, python_script, or shell")
+        return
+    if kind == "python_script":
+        script = worker_policy.get("script")
+        if not isinstance(script, str) or not script.strip():
+            append_error(errors, f"task_overrides.{task_key}.worker_policy.script must be a non-empty string")
+        args = worker_policy.get("args")
+        if args is not None and (not isinstance(args, list) or any(not isinstance(v, str) for v in args)):
+            append_error(errors, f"task_overrides.{task_key}.worker_policy.args must be a list of strings when present")
+    if kind == "shell":
+        command = worker_policy.get("command")
+        if not isinstance(command, str) or not command.strip():
+            append_error(errors, f"task_overrides.{task_key}.worker_policy.command must be a non-empty string")
+
+
+def validate_semantics(doc: dict):
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    profiles = doc.get("profiles")
+    active_profile = doc.get("active_profile")
+    task_overrides = doc.get("task_overrides")
+
+    if not isinstance(profiles, dict) or not profiles:
+        append_error(errors, "profiles must be a non-empty object")
+        return errors, warnings
+    if not isinstance(active_profile, str) or not active_profile.strip():
+        append_error(errors, "active_profile must be a non-empty string")
+    elif active_profile not in profiles:
+        append_error(errors, f"active_profile '{active_profile}' is not defined in profiles")
+
+    for name, profile in profiles.items():
+        validate_profile(name, profile, errors)
+
+    if not isinstance(task_overrides, dict):
+        append_error(errors, "task_overrides must be an object")
+        return errors, warnings
+
+    for task_key, override in task_overrides.items():
+        if not isinstance(task_key, str) or not task_key.strip():
+            append_error(errors, "task override keys must be non-empty strings")
+            continue
+        if not isinstance(override, dict):
+            append_error(errors, f"task_overrides.{task_key} must be an object")
+            continue
+        runtime_profile = override.get("runtime_profile")
+        if runtime_profile is not None:
+            if not isinstance(runtime_profile, str) or not runtime_profile.strip():
+                append_error(errors, f"task_overrides.{task_key}.runtime_profile must be a non-empty string")
+            elif runtime_profile not in profiles:
+                append_error(errors, f"task_overrides.{task_key}.runtime_profile '{runtime_profile}' is not defined")
+        if "provider_policy" in override:
+            validate_provider_policy(task_key, override["provider_policy"], errors)
+        if "worker_policy" in override:
+            validate_worker_policy(task_key, override["worker_policy"], errors)
+
+    if "default" not in task_overrides:
+        warnings.append("task_overrides.default is not defined; fallback behavior will rely on active_profile only")
+
+    return errors, warnings
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate planningops runtime profile catalog")
+    parser.add_argument("--runtime-profile-file", default="planningops/config/runtime-profiles.json")
+    parser.add_argument("--schema-file", default="planningops/schemas/runtime-profiles.schema.json")
+    parser.add_argument("--output", default="planningops/artifacts/validation/runtime-profiles-report.json")
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "runtime_profile_file": args.runtime_profile_file,
+        "schema_file": args.schema_file,
+        "validation_errors": [],
+        "warnings": [],
+    }
+
+    try:
+        runtime_doc = read_json(Path(args.runtime_profile_file))
+        schema_doc = read_json(Path(args.schema_file))
+    except Exception as exc:  # noqa: BLE001
+        report["verdict"] = "fail"
+        report["reason"] = "load_failed"
+        report["validation_errors"] = [str(exc)]
+        write_json(Path(args.output), report)
+        print(json.dumps(report, ensure_ascii=True, indent=2))
+        return 1 if args.strict else 0
+
+    validation_errors = validate_schema(runtime_doc, schema_doc)
+    semantic_errors, warnings = validate_semantics(runtime_doc)
+    validation_errors.extend(semantic_errors)
+
+    report["active_profile"] = runtime_doc.get("active_profile")
+    report["profile_names"] = sorted(runtime_doc.get("profiles", {}).keys()) if isinstance(runtime_doc.get("profiles"), dict) else []
+    report["task_override_keys"] = sorted(runtime_doc.get("task_overrides", {}).keys()) if isinstance(runtime_doc.get("task_overrides"), dict) else []
+    report["validation_errors"] = validation_errors
+    report["warnings"] = warnings
+
+    if validation_errors:
+        report["verdict"] = "fail"
+        report["reason"] = "runtime_profiles_invalid"
+        write_json(Path(args.output), report)
+        print(json.dumps(report, ensure_ascii=True, indent=2))
+        return 1 if args.strict else 0
+
+    report["verdict"] = "pass"
+    report["reason"] = "ok"
+    write_json(Path(args.output), report)
+    print(json.dumps(report, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add the missing runtime profiles schema, validator, and regression family already referenced by planningops script inventory
- update the runtime profile catalog to use planner policy fields that match the validator contract
- add the workbench packet and hub link for the validator-family backfill

## Validation
- `bash planningops/scripts/test_validate_runtime_profiles_contract.sh`
- `python3 planningops/scripts/validate_runtime_profiles.py --runtime-profile-file planningops/config/runtime-profiles.json --schema-file planningops/schemas/runtime-profiles.schema.json --output planningops/artifacts/validation/runtime-profiles-report.json --strict`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change adds a local validator family and aligns the checked-in runtime profile catalog to that contract.