### PR TITLE
test(control-plane-governance): add helper smoke regression

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -103,6 +103,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Control-Plane Governance Helper Family Backfill Packet](./plans/2026-03-26-control-plane-governance-helper-family-backfill-packet.md)
 - [External-Artifact-Residency Helper Family Backfill Packet](./plans/2026-03-26-external-artifact-residency-helper-family-backfill-packet.md)
 - [Runtime-Profiles Validator Family Backfill Packet](./plans/2026-03-26-runtime-profiles-validator-family-backfill-packet.md)
+- [Control-Plane Governance Helper Smoke Packet](./plans/2026-03-26-control-plane-governance-helper-smoke-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-control-plane-governance-helper-smoke-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-control-plane-governance-helper-smoke-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Control-Plane Governance Helper Smoke Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Adds a deterministic smoke regression for the control-plane-governance helper so helper validation no longer depends on the live repo root state.
+related_docs:
+  - ./2026-03-26-control-plane-governance-helper-family-backfill-packet.md
+  - ./2026-03-26-runtime-profiles-validator-family-backfill-packet.md
+---
+
+# plan: Control-Plane Governance Helper Smoke Packet
+
+## Summary
+- Add the tracked smoke regression that exercises `run_control_plane_governance_ci_check.sh` against deterministic fixture inputs.
+- Seal the helper with a clean-root memory gate and inventory audit path so helper validation does not depend on the current repo root's compaction state.
+- Publish the smoke hardening step in the workbench hub alongside the base helper-family packet.
+
+## Scope
+- `planningops/scripts/test_run_control_plane_governance_ci_check_smoke.sh`
+- workbench hub link for this smoke packet
+
+## Acceptance
+- `test_run_control_plane_governance_ci_check_smoke.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/test_run_control_plane_governance_ci_check_smoke.sh
+++ b/planningops/scripts/test_run_control_plane_governance_ci_check_smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/repo"
+mkdir -p "$fixture_root/docs/workbench/unified-personal-agent-platform/plans"
+
+cat > "$fixture_root/docs/workbench/unified-personal-agent-platform/plans/2026-03-24-clean-plan.md" <<'EOF_PLAN'
+---
+title: plan: Clean Governance Smoke
+type: plan
+date: 2026-03-24
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Clean governance smoke fixture.
+topic: governance-smoke
+---
+EOF_PLAN
+
+cat > "$tmp_dir/inventory-issues.json" <<'EOF_JSON'
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 901,
+    "title": "[stock-901] governance smoke inventory",
+    "url": "https://example.local/issues/901",
+    "state": "OPEN",
+    "createdAt": "2026-03-24T00:00:00Z",
+    "body": "## Planning Context\n- plan_item_id: `stock-901-9001`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- execution_kind: `inventory`\n- inventory_lifecycle: `active`\n- workflow_state: `backlog`\n- loop_profile: `l1_contract_clarification`\n- execution_order: `9001`\n- plan_lane: `M3 Guardrails`\n- depends_on: `-`\n\n## Problem Statement\n- Preserve governance smoke issue.\n\n## Interfaces & Dependencies\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/example.md`\n\n## Acceptance Criteria\n- [ ] remains inventory only\n\n## Definition of Done\n- [ ] validation report attached\n"
+  }
+]
+EOF_JSON
+
+memory_output="$tmp_dir/memory-gate-report.json"
+inventory_output="$tmp_dir/inventory-issue-lifecycle-report.json"
+
+bash "$ROOT_DIR/planningops/scripts/run_control_plane_governance_ci_check.sh" \
+  --python-bin python3 \
+  --root "$fixture_root" \
+  --memory-output "$memory_output" \
+  --inventory-output "$inventory_output" \
+  --inventory-issues-file "$tmp_dir/inventory-issues.json"
+
+python3 - <<'PY' "$memory_output" "$inventory_output"
+import json
+import sys
+from pathlib import Path
+
+memory_report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+inventory_report = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+
+assert memory_report["verdict"] == "pass", memory_report
+assert memory_report["trigger_count"] == 0, memory_report
+assert inventory_report["verdict"] == "pass", inventory_report
+assert inventory_report["violation_count"] == 0, inventory_report
+PY
+
+echo "control plane governance ci check smoke ok"


### PR DESCRIPTION
## Summary
- add the missing deterministic smoke regression for `run_control_plane_governance_ci_check.sh`
- validate the helper against a clean fixture root so memory gate and inventory audit checks are no longer tied to the live repo root state
- add the workbench packet and hub link for this helper hardening step

## Validation
- `bash planningops/scripts/test_run_control_plane_governance_ci_check_smoke.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change only adds a deterministic local smoke regression and workbench documentation.