### PR TITLE
feat(supervisor-handoff): backfill validation resolver family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -105,6 +105,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Runtime-Profiles Validator Family Backfill Packet](./plans/2026-03-26-runtime-profiles-validator-family-backfill-packet.md)
 - [Control-Plane Governance Helper Smoke Packet](./plans/2026-03-26-control-plane-governance-helper-smoke-packet.md)
 - [Supervisor Handoff Validator Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-validator-family-backfill-packet.md)
+- [Supervisor Handoff Validation Resolver Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-validation-resolver-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-validation-resolver-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-validation-resolver-family-backfill-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Supervisor Handoff Validation Resolver Family Backfill Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the supervisor handoff validation resolver and its regression so planningops can dereference canonical handoff validation sidecars from monday or planningops artifacts.
+related_docs:
+  - ./2026-03-28-supervisor-handoff-validator-family-backfill-packet.md
+  - ./2026-03-26-control-plane-governance-helper-smoke-packet.md
+---
+
+# plan: Supervisor Handoff Validation Resolver Family Backfill Packet
+
+## Summary
+- Backfill the tracked `supervisor handoff validation resolver` family that sits directly above the base handoff validator surface.
+- Promote the missing resolver plus regression into git-tracked reality so monday/planningops wrapper artifacts can be dereferenced to the canonical `operator-handoff-validation.json` sidecar.
+- Keep this unit limited to validation resolution only; bundle and readiness resolver families remain follow-up waves.
+
+## Scope
+- `planningops/scripts/resolve_supervisor_operator_handoff_validation.py`
+- `planningops/scripts/test_resolve_supervisor_operator_handoff_validation.sh`
+- workbench hub link for this resolver-family backfill
+
+## Acceptance
+- `test_resolve_supervisor_operator_handoff_validation.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/resolve_supervisor_operator_handoff_validation.py
+++ b/planningops/scripts/resolve_supervisor_operator_handoff_validation.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from validate_supervisor_operator_handoff import load_json, validate_schema
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA = WORKSPACE_ROOT / "planningops/schemas/supervisor-operator-handoff-validation.schema.json"
+DEFAULT_OUTPUT = WORKSPACE_ROOT / "planningops/artifacts/validation/supervisor-operator-handoff-validation-resolved.json"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Resolve a canonical supervisor operator handoff validation report from either a monday/planningops artifact or a validation report path"
+    )
+    parser.add_argument("--artifact-file", default=None)
+    parser.add_argument("--validation-report-path", default=None)
+    parser.add_argument("--schema", default=str(DEFAULT_SCHEMA))
+    parser.add_argument("--output", default=None)
+    return parser.parse_args()
+
+
+def resolve_doc_path(value: object, *, base: Path) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    path = Path(value.strip())
+    if not path.is_absolute():
+        path = (base / path).resolve()
+    else:
+        path = path.resolve()
+    return path
+
+
+def string_at_path(doc: dict, path: tuple[str, ...]) -> str | None:
+    current: object = doc
+    for segment in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(segment)
+    value = str(current or "").strip()
+    return value or None
+
+
+def append_unique(items: list[str], message: str) -> None:
+    if message not in items:
+        items.append(message)
+
+
+def find_embedded_validation_paths(doc: dict) -> list[str]:
+    candidate_paths = [
+        ("operator_handoff_validation_path",),
+        ("operatorHandoffValidationPath",),
+        ("payload", "metadata", "operator_handoff_validation_path"),
+        ("payload", "metadata", "operatorHandoffValidationPath"),
+        ("delivery_report", "operator_handoff_validation_path"),
+        ("delivery_report", "operatorHandoffValidationPath"),
+        ("delegate_report", "operator_handoff_validation_path"),
+        ("delegate_report", "operatorHandoffValidationPath"),
+        ("delegate_report", "delivery_report", "operator_handoff_validation_path"),
+        ("delegate_report", "delivery_report", "operatorHandoffValidationPath"),
+        ("ack_checkpoint", "operator_handoff_validation_path"),
+        ("ack_checkpoint", "operatorHandoffValidationPath"),
+    ]
+    values: list[str] = []
+    for path in candidate_paths:
+        if value := string_at_path(doc, path):
+            values.append(value)
+    return values
+
+
+def resolve_validation_path(*candidates: object) -> str | None:
+    resolved: str | None = None
+    for candidate in candidates:
+        value = str(candidate or "").strip()
+        if not value or value == "-":
+            continue
+        if resolved is None:
+            resolved = value
+            continue
+        if value != resolved:
+            raise SystemExit("conflicting operator_handoff_validation_path values")
+    return resolved
+
+
+def write_output(output: str | None, doc: dict) -> Path | None:
+    if not output:
+        return None
+    output_path = Path(output)
+    if not output_path.is_absolute():
+        output_path = (WORKSPACE_ROOT / output_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    return output_path
+
+
+def validate_report_schema(report_doc: dict, schema_path: Path) -> None:
+    schema_doc = load_json(schema_path)
+    errors = validate_schema(report_doc, schema_doc)
+    if errors:
+        raise SystemExit("invalid supervisor operator handoff validation report: " + "; ".join(errors))
+
+
+def load_validation_report(path_value: str, *, base: Path, schema_path: Path) -> tuple[Path, dict]:
+    report_path = resolve_doc_path(path_value, base=base)
+    if report_path is None:
+        raise SystemExit("missing operator_handoff_validation_path")
+    report_doc = load_json(report_path)
+    if not isinstance(report_doc, dict):
+        raise SystemExit(f"validation report not found: {report_path}")
+    validate_report_schema(report_doc, schema_path)
+    return report_path, report_doc
+
+
+def resolve_handoff_validation_report(
+    *,
+    artifact_file: str | None,
+    validation_report_path: str | None,
+    schema_path: str | None,
+    output: str | None,
+) -> tuple[Path | None, dict]:
+    resolved_schema_path = Path(str(schema_path or DEFAULT_SCHEMA))
+    if not resolved_schema_path.is_absolute():
+        resolved_schema_path = (WORKSPACE_ROOT / resolved_schema_path).resolve()
+
+    if bool(artifact_file) == bool(validation_report_path):
+        raise SystemExit("provide exactly one of --artifact-file or --validation-report-path")
+
+    if validation_report_path:
+        report_path, report_doc = load_validation_report(
+            str(validation_report_path),
+            base=WORKSPACE_ROOT,
+            schema_path=resolved_schema_path,
+        )
+        output_path = write_output(output, report_doc)
+        if output_path is not None:
+            report_doc = dict(report_doc)
+            report_doc["resolved_operator_handoff_validation_path"] = str(output_path)
+        return output_path, report_doc
+
+    artifact_path = Path(str(artifact_file or "").strip())
+    if not artifact_path.is_absolute():
+        artifact_path = (WORKSPACE_ROOT / artifact_path).resolve()
+    else:
+        artifact_path = artifact_path.resolve()
+    artifact_doc = load_json(artifact_path)
+    if not isinstance(artifact_doc, dict):
+        raise SystemExit(f"artifact not found: {artifact_path}")
+
+    embedded_paths = find_embedded_validation_paths(artifact_doc)
+    validation_path = resolve_validation_path(*embedded_paths)
+    if validation_path is None:
+        raise SystemExit("artifact does not carry operator_handoff_validation_path")
+    _report_path, report_doc = load_validation_report(
+        validation_path,
+        base=artifact_path.parent,
+        schema_path=resolved_schema_path,
+    )
+    output_path = write_output(output, report_doc)
+    if output_path is not None:
+        report_doc = dict(report_doc)
+        report_doc["resolved_operator_handoff_validation_path"] = str(output_path)
+    return output_path, report_doc
+
+
+def main() -> int:
+    args = parse_args()
+    _output_path, report_doc = resolve_handoff_validation_report(
+        artifact_file=args.artifact_file,
+        validation_report_path=args.validation_report_path,
+        schema_path=args.schema,
+        output=args.output,
+    )
+    print(json.dumps(report_doc, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/test_resolve_supervisor_operator_handoff_validation.sh
+++ b/planningops/scripts/test_resolve_supervisor_operator_handoff_validation.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+report="$tmpdir/operator-report.json"
+payload="$tmpdir/inbox-payload.json"
+summary_md="$tmpdir/operator-summary.md"
+validation="$tmpdir/operator-handoff-validation.json"
+bundle="$tmpdir/operator-handoff-bundle.json"
+bundle_validation="$tmpdir/operator-handoff-bundle-validation.json"
+bundle_readiness="$tmpdir/operator-handoff-bundle-readiness.json"
+bundle_readiness_validation="$tmpdir/operator-handoff-bundle-readiness-validation.json"
+artifact="$tmpdir/wrapper.json"
+resolved_from_artifact="$tmpdir/resolved-from-artifact.json"
+resolved_from_ref="$tmpdir/resolved-from-ref.json"
+conflicting_artifact="$tmpdir/conflicting-wrapper.json"
+conflicting_stderr="$tmpdir/conflicting.stderr.log"
+
+cat >"$report" <<'JSON'
+{
+  "generated_at_utc": "2026-03-20T01:02:03+00:00",
+  "run_id": "supervisor-handoff-resolver-test",
+  "summary_path": "/tmp/supervisor-summary.json",
+  "cycle_report_path": null,
+  "supervisor_verdict": "pass",
+  "stop_reason": "converged",
+  "status": "ok",
+  "headline": "Supervisor run converged with live project data.",
+  "priority_headline": "Supervisor run converged with live project data.",
+  "operator_action": "none",
+  "recommended_wait_minutes": 0,
+  "retry_mode": "none",
+  "allowed_modes": [],
+  "blocked_modes": [],
+  "needs_human_attention": false,
+  "reason": "No cooldown or retry guidance required.",
+  "guidance": {},
+  "message_class_hint": "status_update",
+  "handoff_contract_ref": "planningops/contracts/supervisor-operator-handoff-contract.md",
+  "operator_handoff_validation_path": "HANDOFF_VALIDATION_PLACEHOLDER",
+  "priority_preview_ref": "/tmp/operator-priority-preview.json",
+  "priority_display_packet_ref": "/tmp/operator-priority-display-packet.json",
+  "operator_handoff_bundle_path": "HANDOFF_BUNDLE_PLACEHOLDER",
+  "operator_handoff_bundle_validation_path": "HANDOFF_BUNDLE_VALIDATION_PLACEHOLDER",
+  "operator_handoff_bundle_readiness_path": "HANDOFF_BUNDLE_READINESS_PLACEHOLDER",
+  "operator_handoff_bundle_readiness_validation_path": "HANDOFF_BUNDLE_READINESS_VALIDATION_PLACEHOLDER",
+  "priority_summary_markdown": "## Priority\n- headline: Supervisor run converged with live project data."
+}
+JSON
+
+cat >"$payload" <<JSON
+{
+  "generated_at_utc": "2026-03-20T01:02:04+00:00",
+  "title": "[OK] Supervisor run converged with live project data.",
+  "status": "ok",
+  "headline": "Supervisor run converged with live project data.",
+  "priority_headline": "Supervisor run converged with live project data.",
+  "operator_action": "none",
+  "recommended_wait_minutes": 0,
+  "retry_mode": "none",
+  "needs_human_attention": false,
+  "attachments": [
+    "$summary_md",
+    "/tmp/supervisor-summary.json",
+    "$validation",
+    "$bundle",
+    "$bundle_validation",
+    "$bundle_readiness",
+    "$bundle_readiness_validation"
+  ],
+  "body_markdown": "Status: ok\n\n## Priority\n- headline: Supervisor run converged with live project data.\n",
+  "message_class_hint": "status_update",
+  "handoff_contract_ref": "planningops/contracts/supervisor-operator-handoff-contract.md",
+  "priority_summary_markdown": "## Priority\n- headline: Supervisor run converged with live project data.",
+  "operator_handoff_validation_path": "HANDOFF_VALIDATION_PLACEHOLDER",
+  "priority_preview_ref": "/tmp/operator-priority-preview.json",
+  "priority_display_packet_ref": "/tmp/operator-priority-display-packet.json",
+  "operator_handoff_bundle_path": "HANDOFF_BUNDLE_PLACEHOLDER",
+  "operator_handoff_bundle_validation_path": "HANDOFF_BUNDLE_VALIDATION_PLACEHOLDER",
+  "operator_handoff_bundle_readiness_path": "HANDOFF_BUNDLE_READINESS_PLACEHOLDER",
+  "operator_handoff_bundle_readiness_validation_path": "HANDOFF_BUNDLE_READINESS_VALIDATION_PLACEHOLDER"
+}
+JSON
+
+cat >"$summary_md" <<MD
+# Supervisor Operator Summary
+
+- Status: ok
+- Headline: Supervisor run converged with live project data.
+
+## Priority
+- headline: Supervisor run converged with live project data.
+
+- Handoff Validation Path: HANDOFF_VALIDATION_PLACEHOLDER
+- Handoff Bundle Path: HANDOFF_BUNDLE_PLACEHOLDER
+- Handoff Bundle Validation Path: HANDOFF_BUNDLE_VALIDATION_PLACEHOLDER
+- Handoff Bundle Readiness Path: HANDOFF_BUNDLE_READINESS_PLACEHOLDER
+- Handoff Bundle Readiness Validation Path: HANDOFF_BUNDLE_READINESS_VALIDATION_PLACEHOLDER
+MD
+
+python3 - <<'PY' "$report" "$payload" "$summary_md" "$validation" "$bundle" "$bundle_validation" "$bundle_readiness" "$bundle_readiness_validation"
+from pathlib import Path
+import sys
+
+replacements = {
+    "HANDOFF_VALIDATION_PLACEHOLDER": str(Path(sys.argv[4]).resolve()),
+    "HANDOFF_BUNDLE_PLACEHOLDER": str(Path(sys.argv[5]).resolve()),
+    "HANDOFF_BUNDLE_VALIDATION_PLACEHOLDER": str(Path(sys.argv[6]).resolve()),
+    "HANDOFF_BUNDLE_READINESS_PLACEHOLDER": str(Path(sys.argv[7]).resolve()),
+    "HANDOFF_BUNDLE_READINESS_VALIDATION_PLACEHOLDER": str(Path(sys.argv[8]).resolve()),
+}
+for raw_path in sys.argv[1:4]:
+    path = Path(raw_path)
+    text = path.read_text(encoding="utf-8")
+    for before, after in replacements.items():
+        text = text.replace(before, after)
+    path.write_text(text, encoding="utf-8")
+PY
+
+python3 planningops/scripts/validate_supervisor_operator_handoff.py \
+  --operator-report "$report" \
+  --inbox-payload "$payload" \
+  --operator-summary "$summary_md" \
+  --output "$validation" \
+  --strict
+
+cat >"$artifact" <<JSON
+{
+  "operator_handoff_validation_path": "$validation",
+  "delegate_report": {
+    "delivery_report": {
+      "operatorHandoffValidationPath": "$validation"
+    }
+  }
+}
+JSON
+
+python3 planningops/scripts/resolve_supervisor_operator_handoff_validation.py \
+  --artifact-file "$artifact" \
+  --output "$resolved_from_artifact" >/dev/null
+
+python3 planningops/scripts/resolve_supervisor_operator_handoff_validation.py \
+  --validation-report-path "$validation" \
+  --output "$resolved_from_ref" >/dev/null
+
+python3 - <<'PY' "$validation" "$resolved_from_artifact" "$resolved_from_ref"
+import json
+import sys
+from pathlib import Path
+
+canonical = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+from_artifact = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+from_ref = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+
+assert canonical["verdict"] == "pass", canonical
+assert from_artifact["verdict"] == "pass", from_artifact
+assert from_ref["verdict"] == "pass", from_ref
+
+artifact_doc = dict(from_artifact)
+artifact_doc.pop("resolved_operator_handoff_validation_path", None)
+ref_doc = dict(from_ref)
+ref_doc.pop("resolved_operator_handoff_validation_path", None)
+assert artifact_doc == canonical, (artifact_doc, canonical)
+assert ref_doc == canonical, (ref_doc, canonical)
+PY
+
+cat >"$conflicting_artifact" <<JSON
+{
+  "operator_handoff_validation_path": "$validation",
+  "delegate_report": {
+    "delivery_report": {
+      "operatorHandoffValidationPath": "$tmpdir/conflicting-operator-handoff-validation.json"
+    }
+  }
+}
+JSON
+
+if python3 planningops/scripts/resolve_supervisor_operator_handoff_validation.py \
+  --artifact-file "$conflicting_artifact" \
+  --output "$tmpdir/should-not-exist.json" >/dev/null 2>"$conflicting_stderr"; then
+  echo "expected conflicting operator_handoff_validation_path values to fail" >&2
+  exit 1
+fi
+
+grep -q "conflicting operator_handoff_validation_path values" "$conflicting_stderr"
+
+echo "resolve supervisor operator handoff validation regression passed"


### PR DESCRIPTION
## Summary
- add the missing supervisor handoff validation resolver and regression family
- allow monday or planningops wrapper artifacts to dereference the canonical `operator-handoff-validation.json` sidecar without reopening nested payload structures by hand
- add the workbench packet and hub link for the resolver-family backfill

## Validation
- `bash planningops/scripts/test_resolve_supervisor_operator_handoff_validation.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change adds a local resolver and regression family for canonical handoff validation sidecars.