### PR TITLE
feat(supervisor-handoff): backfill bundle resolver family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -106,6 +106,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Control-Plane Governance Helper Smoke Packet](./plans/2026-03-26-control-plane-governance-helper-smoke-packet.md)
 - [Supervisor Handoff Validator Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-validator-family-backfill-packet.md)
 - [Supervisor Handoff Validation Resolver Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-validation-resolver-family-backfill-packet.md)
+- [Supervisor Handoff Bundle Resolver Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-resolver-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-bundle-resolver-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-bundle-resolver-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Supervisor Handoff Bundle Resolver Family Backfill Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the supervisor handoff bundle resolver, bundle schema, and regression so planningops can dereference canonical preview and display-packet bundle sidecars from monday artifacts.
+related_docs:
+  - ./2026-03-28-supervisor-handoff-validator-family-backfill-packet.md
+  - ./2026-03-28-supervisor-handoff-validation-resolver-family-backfill-packet.md
+---
+
+# plan: Supervisor Handoff Bundle Resolver Family Backfill Packet
+
+## Summary
+- Backfill the tracked `supervisor handoff bundle resolver` family that sits directly above the base handoff validation resolver surface.
+- Promote the missing bundle schema, bundle resolver, and regression into git-tracked reality so monday/planningops wrapper artifacts can be dereferenced to the canonical validation, priority preview, and priority display-packet bundle.
+- Keep this unit limited to bundle resolution only; bundle validation, readiness, doctor, and gate families remain follow-up waves.
+
+## Scope
+- `planningops/schemas/supervisor-operator-handoff-bundle.schema.json`
+- `planningops/scripts/resolve_supervisor_operator_handoff_bundle.py`
+- `planningops/scripts/test_resolve_supervisor_operator_handoff_bundle.sh`
+- workbench hub link for this bundle-resolver-family backfill
+
+## Acceptance
+- `test_resolve_supervisor_operator_handoff_bundle.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/schemas/supervisor-operator-handoff-bundle.schema.json
+++ b/planningops/schemas/supervisor-operator-handoff-bundle.schema.json
@@ -1,0 +1,279 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "planningops-supervisor-operator-handoff-bundle",
+  "title": "Planningops Supervisor Operator Handoff Bundle",
+  "type": "object",
+  "required": [
+    "generated_at_utc",
+    "artifact_file",
+    "operator_handoff_validation_path",
+    "operator_handoff_bundle_path",
+    "operator_handoff_bundle_validation_path",
+    "operator_handoff_bundle_readiness_path",
+    "operator_handoff_bundle_readiness_validation_path",
+    "priority_preview_ref",
+    "priority_display_packet_ref",
+    "operator_handoff_validation",
+    "priority_preview",
+    "priority_display_packet"
+  ],
+  "properties": {
+    "generated_at_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "artifact_file": {
+      "type": "string",
+      "minLength": 1
+    },
+    "operator_handoff_validation_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "operator_handoff_bundle_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "operator_handoff_bundle_validation_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "operator_handoff_bundle_readiness_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "operator_handoff_bundle_readiness_validation_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "priority_preview_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "priority_display_packet_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resolved_bundle_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "operator_handoff_validation": {
+      "type": "object",
+      "required": [
+        "generated_at_utc",
+        "operator_report_path",
+        "inbox_payload_path",
+        "operator_report_schema_path",
+        "inbox_payload_schema_path",
+        "error_count",
+        "warning_count",
+        "errors",
+        "warnings",
+        "verdict"
+      ],
+      "properties": {
+        "generated_at_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "operator_report_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "inbox_payload_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_report_schema_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "inbox_payload_schema_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "error_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warning_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "verdict": {
+          "type": "string",
+          "enum": ["pass", "fail"]
+        }
+      }
+    },
+    "priority_preview": {
+      "type": "object",
+      "required": [
+        "generated_at_utc",
+        "source_artifact_ref",
+        "source_artifact_kind",
+        "source_priority_path",
+        "preview_state",
+        "priority_cta_command",
+        "priority_summary_markdown"
+      ],
+      "properties": {
+        "generated_at_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_artifact_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_priority_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "preview_state": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_validation_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_bundle_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_bundle_validation_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_bundle_readiness_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_bundle_readiness_validation_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "priority_headline": {
+          "type": "string",
+          "minLength": 1
+        },
+        "priority_cta_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "priority_summary_markdown": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "priority_display_packet": {
+      "type": "object",
+      "required": [
+        "generated_at_utc",
+        "input_kind",
+        "input_ref",
+        "source_artifact_ref",
+        "priority_preview_ref",
+        "preview_source_artifact_kind",
+        "priority_headline",
+        "priority_cta_command",
+        "priority_summary_markdown",
+        "display_title",
+        "cta_command",
+        "display_markdown"
+      ],
+      "properties": {
+        "generated_at_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "input_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "input_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_artifact_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "priority_preview_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "preview_source_artifact_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_validation_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_bundle_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_bundle_validation_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_bundle_readiness_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator_handoff_bundle_readiness_validation_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "priority_headline": {
+          "type": "string",
+          "minLength": 1
+        },
+        "priority_cta_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "priority_summary_markdown": {
+          "type": "string",
+          "minLength": 1
+        },
+        "display_title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cta_command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "display_markdown": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/planningops/scripts/resolve_supervisor_operator_handoff_bundle.py
+++ b/planningops/scripts/resolve_supervisor_operator_handoff_bundle.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from resolve_supervisor_operator_handoff_validation import (
+    find_embedded_validation_paths,
+    load_validation_report,
+    resolve_validation_path,
+)
+from validate_supervisor_operator_handoff import load_json, validate_schema
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+MONDAY_ROOT = WORKSPACE_ROOT.parent / "monday"
+MONDAY_SCRIPTS = MONDAY_ROOT / "scripts"
+DEFAULT_SCHEMA = WORKSPACE_ROOT / "planningops/schemas/supervisor-operator-handoff-bundle.schema.json"
+
+if str(MONDAY_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(MONDAY_SCRIPTS))
+
+from export_operator_priority_display_packet import load_embedded_display_packet_from_artifact  # noqa: E402
+from local_outbox_dispatch_common import (  # noqa: E402
+    ensure_runtime_artifact_boundary,
+    repo_relative as monday_repo_relative,
+    resolve_embedded_operator_handoff_bundle_sidecar_paths,
+    resolve_operator_handoff_validation_path,
+    resolve_path as monday_resolve_path,
+)
+from resolve_operator_priority_display_packet import resolve_priority_display_packet  # noqa: E402
+from resolve_operator_priority_preview import (  # noqa: E402
+    load_embedded_preview_from_artifact,
+    load_preview_from_ref,
+    resolve_priority_preview,
+)
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Resolve the canonical handoff validation, priority preview, and priority display packet bundle from a monday artifact"
+    )
+    parser.add_argument("--artifact-file", required=True)
+    parser.add_argument("--schema", default=str(DEFAULT_SCHEMA))
+    parser.add_argument("--output", default=None)
+    return parser.parse_args()
+
+
+def append_unique(items: list[str], message: str) -> None:
+    if message not in items:
+        items.append(message)
+
+
+def write_output(output: str | None, doc: dict) -> Path | None:
+    if not output:
+        return None
+    output_path = Path(output)
+    if not output_path.is_absolute():
+        output_path = (WORKSPACE_ROOT / output_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    return output_path
+
+
+def normalize_monday_ref(ref: str) -> str:
+    resolved = ensure_runtime_artifact_boundary(monday_resolve_path(ref, root=MONDAY_ROOT), root=MONDAY_ROOT)
+    return monday_repo_relative(resolved, MONDAY_ROOT)
+
+
+def normalize_validation_path(value: object, *, base: Path) -> str | None:
+    text = str(value or "").strip()
+    if not text or text == "-":
+        return None
+    path = Path(text)
+    if not path.is_absolute():
+        path = (base / path).resolve()
+    else:
+        path = path.resolve()
+    return str(path)
+
+
+def validate_bundle(bundle: dict, *, schema_path: Path) -> None:
+    schema_doc = load_json(schema_path)
+    errors = validate_schema(bundle, schema_doc)
+    if errors:
+        raise SystemExit("invalid supervisor operator handoff bundle: " + "; ".join(errors))
+
+
+def resolve_validation_report_from_artifact(artifact_doc: dict, *, artifact_path: Path) -> tuple[Path, dict]:
+    validation_path = resolve_validation_path(*find_embedded_validation_paths(artifact_doc))
+    if validation_path is None:
+        raise SystemExit("artifact does not carry operator_handoff_validation_path")
+    return load_validation_report(
+        validation_path,
+        base=artifact_path.parent,
+        schema_path=WORKSPACE_ROOT / "planningops/schemas/supervisor-operator-handoff-validation.schema.json",
+    )
+
+
+def resolve_preview_from_artifact(artifact_doc: dict, *, artifact_path: Path) -> tuple[Path, dict]:
+    embedded_preview = load_embedded_preview_from_artifact(artifact_doc, root=MONDAY_ROOT)
+    if embedded_preview is not None:
+        return embedded_preview
+
+    embedded_display_packet = load_embedded_display_packet_from_artifact(artifact_doc, root=MONDAY_ROOT)
+    if embedded_display_packet is not None:
+        _display_packet_path, display_packet = embedded_display_packet
+        preview_ref = str(display_packet.get("priority_preview_ref") or "").strip()
+        if preview_ref:
+            return load_preview_from_ref(preview_ref, root=MONDAY_ROOT)
+
+    output_path, preview = resolve_priority_preview(
+        artifact_file=str(artifact_path),
+        preview_ref=None,
+        output=None,
+        root=MONDAY_ROOT,
+    )
+    if output_path is None:
+        raise SystemExit("unable to resolve priority preview path")
+    return ensure_runtime_artifact_boundary(output_path, root=MONDAY_ROOT), preview
+
+
+def resolve_display_packet_from_artifact(artifact_doc: dict, *, artifact_path: Path) -> tuple[Path, dict]:
+    embedded_display_packet = load_embedded_display_packet_from_artifact(artifact_doc, root=MONDAY_ROOT)
+    if embedded_display_packet is not None:
+        return embedded_display_packet
+
+    output_path, display_packet = resolve_priority_display_packet(
+        artifact_file=str(artifact_path),
+        display_packet_ref=None,
+        output=None,
+        root=MONDAY_ROOT,
+    )
+    if output_path is None:
+        raise SystemExit("unable to resolve priority display packet path")
+    return ensure_runtime_artifact_boundary(output_path, root=MONDAY_ROOT), display_packet
+
+
+def require_matching_value(*, preview: dict, display_packet: dict, field: str, errors: list[str]) -> None:
+    preview_value = str(preview.get(field) or "").strip()
+    display_value = str(display_packet.get(field) or "").strip()
+    if preview_value and display_value and preview_value != display_value:
+        append_unique(errors, f"priority display packet {field} does not match resolved priority preview")
+
+
+def resolve_handoff_bundle(*, artifact_file: str, schema_path: str | None, output: str | None) -> tuple[Path | None, dict]:
+    resolved_schema_path = Path(str(schema_path or DEFAULT_SCHEMA))
+    if not resolved_schema_path.is_absolute():
+        resolved_schema_path = (WORKSPACE_ROOT / resolved_schema_path).resolve()
+
+    artifact_path = Path(artifact_file)
+    if not artifact_path.is_absolute():
+        artifact_path = (WORKSPACE_ROOT / artifact_path).resolve()
+    else:
+        artifact_path = artifact_path.resolve()
+    artifact_doc = load_json(artifact_path)
+    if not isinstance(artifact_doc, dict):
+        raise SystemExit(f"artifact not found: {artifact_path}")
+
+    validation_path, validation_doc = resolve_validation_report_from_artifact(artifact_doc, artifact_path=artifact_path)
+    preview_path, preview_doc = resolve_preview_from_artifact(artifact_doc, artifact_path=artifact_path)
+    display_packet_path, display_packet_doc = resolve_display_packet_from_artifact(artifact_doc, artifact_path=artifact_path)
+
+    preview_ref = monday_repo_relative(preview_path, MONDAY_ROOT)
+    display_packet_ref = monday_repo_relative(display_packet_path, MONDAY_ROOT)
+    bundle_sidecar_paths = resolve_embedded_operator_handoff_bundle_sidecar_paths(
+        artifact_doc,
+        preview_doc,
+        display_packet_doc,
+    )
+
+    errors: list[str] = []
+    validation_value = resolve_operator_handoff_validation_path(
+        str(validation_path),
+        normalize_validation_path(preview_doc.get("operator_handoff_validation_path"), base=preview_path.parent),
+        normalize_validation_path(display_packet_doc.get("operator_handoff_validation_path"), base=display_packet_path.parent),
+    )
+    if validation_value != str(validation_path):
+        append_unique(errors, "resolved operator_handoff_validation_path does not match canonical validation report")
+
+    display_packet_preview_ref = str(display_packet_doc.get("priority_preview_ref") or "").strip()
+    if not display_packet_preview_ref:
+        append_unique(errors, "priority display packet missing priority_preview_ref")
+    elif normalize_monday_ref(display_packet_preview_ref) != preview_ref:
+        append_unique(errors, "priority display packet priority_preview_ref does not match resolved priority preview ref")
+
+    require_matching_value(preview=preview_doc, display_packet=display_packet_doc, field="priority_headline", errors=errors)
+    require_matching_value(preview=preview_doc, display_packet=display_packet_doc, field="priority_cta_command", errors=errors)
+    require_matching_value(preview=preview_doc, display_packet=display_packet_doc, field="priority_summary_markdown", errors=errors)
+
+    if errors:
+        raise SystemExit("; ".join(errors))
+
+    bundle = {
+        "generated_at_utc": now_utc(),
+        "artifact_file": str(artifact_path),
+        "operator_handoff_validation_path": str(validation_path),
+        "priority_preview_ref": preview_ref,
+        "priority_display_packet_ref": display_packet_ref,
+        "operator_handoff_validation": validation_doc,
+        "priority_preview": preview_doc,
+        "priority_display_packet": display_packet_doc,
+    }
+    bundle.update(bundle_sidecar_paths)
+    validate_bundle(bundle, schema_path=resolved_schema_path)
+    output_path = write_output(output, bundle)
+    return output_path, bundle
+
+
+def main() -> int:
+    args = parse_args()
+    output_path, bundle = resolve_handoff_bundle(
+        artifact_file=args.artifact_file,
+        schema_path=args.schema,
+        output=args.output,
+    )
+    if output_path is not None:
+        bundle = dict(bundle)
+        bundle["resolved_bundle_path"] = str(output_path)
+    print(json.dumps(bundle, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/test_resolve_supervisor_operator_handoff_bundle.sh
+++ b/planningops/scripts/test_resolve_supervisor_operator_handoff_bundle.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MONDAY_DIR="$(cd "${ROOT_DIR}/../monday" && pwd)"
+TMP_DIR="$(mktemp -d)"
+RUNTIME_DIR="$(mktemp -d "${MONDAY_DIR}/runtime-artifacts/test-handoff-bundle.XXXXXX")"
+trap 'rm -rf "${TMP_DIR}" "${RUNTIME_DIR}"' EXIT
+
+VALIDATION="${TMP_DIR}/operator-handoff-validation.json"
+HANDOFF_BUNDLE="${TMP_DIR}/operator-handoff-bundle.json"
+HANDOFF_BUNDLE_VALIDATION="${TMP_DIR}/operator-handoff-bundle-validation.json"
+HANDOFF_BUNDLE_READINESS="${TMP_DIR}/operator-handoff-bundle-readiness.json"
+HANDOFF_BUNDLE_READINESS_VALIDATION="${TMP_DIR}/operator-handoff-bundle-readiness-validation.json"
+PREVIEW="${RUNTIME_DIR}/preview.json"
+PREVIEW_ALT="${RUNTIME_DIR}/preview-alt.json"
+DISPLAY_PACKET="${RUNTIME_DIR}/display-packet.json"
+DISPLAY_PACKET_CONFLICT="${RUNTIME_DIR}/display-packet-conflict.json"
+ARTIFACT="${RUNTIME_DIR}/artifact.json"
+ARTIFACT_CONFLICT="${RUNTIME_DIR}/artifact-conflict.json"
+BUNDLE="${TMP_DIR}/handoff-bundle.json"
+CONFLICT_STDERR="${TMP_DIR}/conflict.stderr"
+
+preview_ref() {
+  python3 - <<'PY' "$MONDAY_DIR" "$1"
+from pathlib import Path
+import sys
+root = Path(sys.argv[1]).resolve()
+target = Path(sys.argv[2]).resolve()
+print(target.relative_to(root))
+PY
+}
+
+cat >"${VALIDATION}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:00Z",
+  "operator_report_path": "${TMP_DIR}/operator-report.json",
+  "inbox_payload_path": "${TMP_DIR}/inbox-payload.json",
+  "operator_report_schema_path": "${ROOT_DIR}/planningops/schemas/supervisor-operator-report.schema.json",
+  "inbox_payload_schema_path": "${ROOT_DIR}/planningops/schemas/supervisor-inbox-payload.schema.json",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "priority_display_packet_ref": "$(preview_ref "${DISPLAY_PACKET}")",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION}",
+  "error_count": 0,
+  "warning_count": 0,
+  "errors": [],
+  "warnings": [],
+  "verdict": "pass"
+}
+JSON
+
+cat >"${PREVIEW}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:01Z",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle.source/wrapper.json",
+  "source_artifact_kind": "local_outbox_envelope",
+  "source_priority_path": "payload.metadata.priority_summary_markdown",
+  "preview_state": "present",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION}",
+  "priority_headline": "Supervisor converged, but the latest federated runtime gate is blocked.",
+  "priority_cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "priority_summary_markdown": "## Priority\n- headline: Supervisor converged, but the latest federated runtime gate is blocked.\n- first action: \`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass\`"
+}
+JSON
+
+cat >"${PREVIEW_ALT}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:01Z",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle.source/wrapper.json",
+  "source_artifact_kind": "local_outbox_envelope",
+  "source_priority_path": "payload.metadata.priority_summary_markdown",
+  "preview_state": "present",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION}",
+  "priority_headline": "Conflicting preview headline",
+  "priority_cta_command": "bash planningops/scripts/gate_federated_ci_summary.sh",
+  "priority_summary_markdown": "## Priority\n- headline: Conflicting preview headline\n- first action: \`bash planningops/scripts/gate_federated_ci_summary.sh\`"
+}
+JSON
+
+cat >"${DISPLAY_PACKET}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:02Z",
+  "input_kind": "artifact",
+  "input_ref": "runtime-artifacts/test-handoff-bundle/artifact.json",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle.source/wrapper.json",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "preview_source_artifact_kind": "local_outbox_envelope",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION}",
+  "priority_headline": "Supervisor converged, but the latest federated runtime gate is blocked.",
+  "priority_cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "priority_summary_markdown": "## Priority\n- headline: Supervisor converged, but the latest federated runtime gate is blocked.\n- first action: \`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass\`",
+  "display_title": "Supervisor converged, but the latest federated runtime gate is blocked.",
+  "cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "display_markdown": "## Priority\n- headline: Supervisor converged, but the latest federated runtime gate is blocked.\n- first action: \`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass\`"
+}
+JSON
+
+cat >"${DISPLAY_PACKET_CONFLICT}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:02Z",
+  "input_kind": "artifact",
+  "input_ref": "runtime-artifacts/test-handoff-bundle/artifact-conflict.json",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle.source/wrapper.json",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW_ALT}")",
+  "preview_source_artifact_kind": "local_outbox_envelope",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION}",
+  "priority_headline": "Conflicting preview headline",
+  "priority_cta_command": "bash planningops/scripts/gate_federated_ci_summary.sh",
+  "priority_summary_markdown": "## Priority\n- headline: Conflicting preview headline\n- first action: \`bash planningops/scripts/gate_federated_ci_summary.sh\`",
+  "display_title": "Conflicting preview headline",
+  "cta_command": "bash planningops/scripts/gate_federated_ci_summary.sh",
+  "display_markdown": "## Priority\n- headline: Conflicting preview headline\n- first action: \`bash planningops/scripts/gate_federated_ci_summary.sh\`"
+}
+JSON
+
+cat >"${ARTIFACT}" <<JSON
+{
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "priority_display_packet_ref": "$(preview_ref "${DISPLAY_PACKET}")"
+}
+JSON
+
+cat >"${ARTIFACT_CONFLICT}" <<JSON
+{
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "priority_display_packet_ref": "$(preview_ref "${DISPLAY_PACKET_CONFLICT}")"
+}
+JSON
+
+python3 "${ROOT_DIR}/planningops/scripts/resolve_supervisor_operator_handoff_bundle.py" \
+  --artifact-file "${ARTIFACT}" \
+  --output "${BUNDLE}" >/dev/null
+
+python3 - <<'PY' "${ARTIFACT}" "${VALIDATION}" "${PREVIEW}" "${DISPLAY_PACKET}" "${BUNDLE}" "${HANDOFF_BUNDLE}" "${HANDOFF_BUNDLE_VALIDATION}" "${HANDOFF_BUNDLE_READINESS}" "${HANDOFF_BUNDLE_READINESS_VALIDATION}" "${MONDAY_DIR}"
+import json
+import sys
+from pathlib import Path
+
+artifact = Path(sys.argv[1]).resolve()
+validation = Path(sys.argv[2]).resolve()
+preview_path = Path(sys.argv[3]).resolve()
+display_packet_path = Path(sys.argv[4]).resolve()
+bundle = json.loads(Path(sys.argv[5]).read_text(encoding="utf-8"))
+handoff_bundle = Path(sys.argv[6]).resolve()
+handoff_bundle_validation = Path(sys.argv[7]).resolve()
+handoff_bundle_readiness = Path(sys.argv[8]).resolve()
+handoff_bundle_readiness_validation = Path(sys.argv[9]).resolve()
+monday_root = Path(sys.argv[10]).resolve()
+
+assert Path(bundle["artifact_file"]).resolve() == artifact, bundle
+assert Path(bundle["operator_handoff_validation_path"]).resolve() == validation, bundle
+assert Path(bundle["operator_handoff_bundle_path"]).resolve() == handoff_bundle, bundle
+assert Path(bundle["operator_handoff_bundle_validation_path"]).resolve() == handoff_bundle_validation, bundle
+assert Path(bundle["operator_handoff_bundle_readiness_path"]).resolve() == handoff_bundle_readiness, bundle
+assert Path(bundle["operator_handoff_bundle_readiness_validation_path"]).resolve() == handoff_bundle_readiness_validation, bundle
+assert bundle["priority_preview_ref"] == str(preview_path.relative_to(monday_root)), bundle
+assert bundle["priority_display_packet_ref"] == str(display_packet_path.relative_to(monday_root)), bundle
+assert bundle["operator_handoff_validation"] == json.loads(validation.read_text(encoding="utf-8")), bundle
+assert bundle["priority_preview"] == json.loads(preview_path.read_text(encoding="utf-8")), bundle
+assert bundle["priority_display_packet"] == json.loads(display_packet_path.read_text(encoding="utf-8")), bundle
+PY
+
+if python3 "${ROOT_DIR}/planningops/scripts/resolve_supervisor_operator_handoff_bundle.py" \
+  --artifact-file "${ARTIFACT_CONFLICT}" \
+  --output "${TMP_DIR}/bundle-conflict.json" >"${TMP_DIR}/conflict.stdout" 2>"${CONFLICT_STDERR}"; then
+  echo "expected conflicting bundle refs to fail" >&2
+  exit 1
+fi
+
+grep -q "priority display packet priority_preview_ref does not match resolved priority preview ref" "${CONFLICT_STDERR}"
+
+echo "resolve supervisor operator handoff bundle ok"


### PR DESCRIPTION
## Summary
- backfill the supervisor handoff bundle schema, resolver, and regression
- add the 2026-03-28 workbench packet and hub link for the bundle-resolver family
- keep bundle validation/readiness/doctor/gate surfaces for follow-up units

## Validation
- bash planningops/scripts/test_resolve_supervisor_operator_handoff_bundle.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all