### PR TITLE
feat(supervisor-handoff): backfill bundle readiness validator family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -108,6 +108,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Supervisor Handoff Validation Resolver Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-validation-resolver-family-backfill-packet.md)
 - [Supervisor Handoff Bundle Resolver Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-resolver-family-backfill-packet.md)
 - [Supervisor Handoff Bundle Validator Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-validator-family-backfill-packet.md)
+- [Supervisor Handoff Bundle Readiness Validator Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-readiness-validator-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-bundle-readiness-validator-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-bundle-readiness-validator-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Supervisor Handoff Bundle Readiness Validator Family Backfill Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the supervisor handoff bundle readiness validation schema, validator, and regression so planningops can validate canonical bundle-readiness reports resolved from monday artifacts.
+related_docs:
+  - ./2026-03-28-supervisor-handoff-bundle-validator-family-backfill-packet.md
+  - ./2026-03-28-supervisor-handoff-bundle-resolver-family-backfill-packet.md
+---
+
+# plan: Supervisor Handoff Bundle Readiness Validator Family Backfill Packet
+
+## Summary
+- Backfill the tracked `supervisor handoff bundle readiness validator` family that sits directly above the bundle validator surface.
+- Promote the missing readiness-validation schema, machine validator, and regression into git-tracked reality so bundle-readiness reports can be validated as canonical sidecars.
+- Keep this unit limited to readiness validation only; readiness assessment, doctor, and gate families remain follow-up waves.
+
+## Scope
+- `planningops/schemas/supervisor-operator-handoff-bundle-readiness-validation.schema.json`
+- `planningops/scripts/validate_supervisor_operator_handoff_bundle_readiness.py`
+- `planningops/scripts/test_validate_supervisor_operator_handoff_bundle_readiness.sh`
+- workbench hub link for this bundle-readiness-validator-family backfill
+
+## Acceptance
+- `test_validate_supervisor_operator_handoff_bundle_readiness.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/schemas/supervisor-operator-handoff-bundle-readiness-validation.schema.json
+++ b/planningops/schemas/supervisor-operator-handoff-bundle-readiness-validation.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "planningops-supervisor-operator-handoff-bundle-readiness-validation",
+  "title": "Planningops Supervisor Operator Handoff Bundle Readiness Validation",
+  "type": "object",
+  "required": [
+    "generated_at_utc",
+    "readiness_path",
+    "readiness_generated_at_utc",
+    "source_kind",
+    "validation_report_path",
+    "operator_handoff_bundle_path",
+    "operator_handoff_bundle_validation_path",
+    "operator_handoff_bundle_readiness_path",
+    "operator_handoff_bundle_readiness_validation_path",
+    "readiness_status",
+    "readiness_ready",
+    "schema_path",
+    "error_count",
+    "warning_count",
+    "errors",
+    "warnings",
+    "verdict"
+  ],
+  "properties": {
+    "generated_at_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "readiness_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "readiness_generated_at_utc": {
+      "type": ["string", "null"]
+    },
+    "source_kind": {
+      "type": ["string", "null"],
+      "enum": ["artifact", "bundle", null]
+    },
+    "artifact_file": {
+      "type": ["string", "null"]
+    },
+    "bundle_path": {
+      "type": ["string", "null"]
+    },
+    "validation_report_path": {
+      "type": ["string", "null"]
+    },
+    "operator_handoff_bundle_path": {
+      "type": ["string", "null"]
+    },
+    "operator_handoff_bundle_validation_path": {
+      "type": ["string", "null"]
+    },
+    "operator_handoff_bundle_readiness_path": {
+      "type": ["string", "null"]
+    },
+    "operator_handoff_bundle_readiness_validation_path": {
+      "type": ["string", "null"]
+    },
+    "readiness_status": {
+      "type": ["string", "null"],
+      "enum": ["ready", "blocked", null]
+    },
+    "readiness_ready": {
+      "type": "boolean"
+    },
+    "schema_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "error_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "warning_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/planningops/scripts/test_validate_supervisor_operator_handoff_bundle_readiness.sh
+++ b/planningops/scripts/test_validate_supervisor_operator_handoff_bundle_readiness.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+READINESS="${TMP_DIR}/handoff-bundle-readiness.json"
+REPORT="${TMP_DIR}/handoff-bundle-readiness-validation.json"
+BROKEN="${TMP_DIR}/handoff-bundle-readiness-broken.json"
+BROKEN_REPORT="${TMP_DIR}/handoff-bundle-readiness-broken-validation.json"
+HANDOFF_BUNDLE="${TMP_DIR}/operator-handoff-bundle.json"
+HANDOFF_BUNDLE_VALIDATION="${TMP_DIR}/operator-handoff-bundle-validation.json"
+HANDOFF_BUNDLE_READINESS="${TMP_DIR}/operator-handoff-bundle-readiness.json"
+HANDOFF_BUNDLE_READINESS_VALIDATION="${TMP_DIR}/operator-handoff-bundle-readiness-validation.json"
+
+cat >"${READINESS}" <<'JSON'
+{
+  "generated_at_utc": "2026-03-20T00:00:00Z",
+  "source_kind": "artifact",
+  "artifact_file": "/tmp/supervisor-wrapper.json",
+  "bundle_path": null,
+  "validation_report_path": "/tmp/handoff-bundle-validation.json",
+  "bundle_generated_at_utc": "2026-03-20T00:00:01Z",
+  "validation_generated_at_utc": "2026-03-20T00:00:02Z",
+  "bundle_validation_verdict": "pass",
+  "operator_handoff_validation_verdict": "pass",
+  "operator_handoff_bundle_path": "__HANDOFF_BUNDLE__",
+  "operator_handoff_bundle_validation_path": "__HANDOFF_BUNDLE_VALIDATION__",
+  "operator_handoff_bundle_readiness_path": "__HANDOFF_BUNDLE_READINESS__",
+  "operator_handoff_bundle_readiness_validation_path": "__HANDOFF_BUNDLE_READINESS_VALIDATION__",
+  "priority_preview_ref": "runtime-artifacts/messaging/operator-priority-previews/sample.json",
+  "priority_display_packet_ref": "runtime-artifacts/messaging/operator-priority-displays/sample.json",
+  "priority_headline": "Readiness headline.",
+  "priority_cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "display_title": "Readiness headline.",
+  "cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "error_count": 0,
+  "warning_count": 0,
+  "errors": [],
+  "warnings": [],
+  "ready": true,
+  "readiness_status": "ready",
+  "blocking_reasons": [],
+  "next_step": "none"
+}
+JSON
+
+python3 - <<'PY' "${READINESS}" "${HANDOFF_BUNDLE}" "${HANDOFF_BUNDLE_VALIDATION}" "${HANDOFF_BUNDLE_READINESS}" "${HANDOFF_BUNDLE_READINESS_VALIDATION}"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace("__HANDOFF_BUNDLE__", str(Path(sys.argv[2]).resolve()))
+text = text.replace("__HANDOFF_BUNDLE_VALIDATION__", str(Path(sys.argv[3]).resolve()))
+text = text.replace("__HANDOFF_BUNDLE_READINESS__", str(Path(sys.argv[4]).resolve()))
+text = text.replace("__HANDOFF_BUNDLE_READINESS_VALIDATION__", str(Path(sys.argv[5]).resolve()))
+path.write_text(text, encoding="utf-8")
+PY
+
+python3 "${ROOT_DIR}/planningops/scripts/validate_supervisor_operator_handoff_bundle_readiness.py" \
+  --readiness "${READINESS}" \
+  --output "${REPORT}" \
+  --strict >/dev/null
+
+python3 - <<'PY' "${REPORT}" "${HANDOFF_BUNDLE}" "${HANDOFF_BUNDLE_VALIDATION}" "${HANDOFF_BUNDLE_READINESS}" "${HANDOFF_BUNDLE_READINESS_VALIDATION}"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "pass", report
+assert report["readiness_status"] == "ready", report
+assert report["readiness_ready"] is True, report
+assert Path(report["operator_handoff_bundle_path"]).resolve() == Path(sys.argv[2]).resolve(), report
+assert Path(report["operator_handoff_bundle_validation_path"]).resolve() == Path(sys.argv[3]).resolve(), report
+assert Path(report["operator_handoff_bundle_readiness_path"]).resolve() == Path(sys.argv[4]).resolve(), report
+assert Path(report["operator_handoff_bundle_readiness_validation_path"]).resolve() == Path(sys.argv[5]).resolve(), report
+PY
+
+python3 - <<'PY' "${READINESS}" "${BROKEN}"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+doc["ready"] = True
+doc["readiness_status"] = "blocked"
+doc["blocking_reasons"] = ["bundle_validation_fail"]
+doc["next_step"] = "python3 planningops/scripts/validate_supervisor_operator_handoff_bundle.py --artifact-file /tmp/supervisor-wrapper.json --output <handoff-bundle-validation.json> --strict"
+Path(sys.argv[2]).write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if python3 "${ROOT_DIR}/planningops/scripts/validate_supervisor_operator_handoff_bundle_readiness.py" \
+  --readiness "${BROKEN}" \
+  --output "${BROKEN_REPORT}" \
+  --strict >/dev/null 2>&1; then
+  echo "expected readiness validator to fail on inconsistent ready state" >&2
+  exit 1
+fi
+
+python3 - <<'PY' "${BROKEN_REPORT}"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "fail", report
+assert any("ready=true requires readiness_status=ready" in error for error in report["errors"]), report
+PY
+
+echo "validate supervisor operator handoff bundle readiness ok"

--- a/planningops/scripts/validate_supervisor_operator_handoff_bundle_readiness.py
+++ b/planningops/scripts/validate_supervisor_operator_handoff_bundle_readiness.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from validate_supervisor_operator_handoff import (
+    append_unique,
+    load_json,
+    validate_schema,
+    write_json,
+)
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA = WORKSPACE_ROOT / "planningops/schemas/supervisor-operator-handoff-bundle-readiness.schema.json"
+DEFAULT_OUTPUT = WORKSPACE_ROOT / "planningops/artifacts/validation/supervisor-operator-handoff-bundle-readiness-validation.json"
+HANDOFF_BUNDLE_SIDECAR_FIELDS = (
+    ("operator_handoff_bundle_path", "operator_handoff_bundle_path_missing"),
+    ("operator_handoff_bundle_validation_path", "operator_handoff_bundle_validation_path_missing"),
+    ("operator_handoff_bundle_readiness_path", "operator_handoff_bundle_readiness_path_missing"),
+    ("operator_handoff_bundle_readiness_validation_path", "operator_handoff_bundle_readiness_validation_path_missing"),
+)
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_iso8601(value: str, field: str, errors: list[str]) -> None:
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        append_unique(errors, f"{field} must be an ISO-8601 timestamp")
+
+
+def validate_semantics(doc: dict) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    generated_at_utc = doc.get("generated_at_utc")
+    if isinstance(generated_at_utc, str):
+        _validate_iso8601(generated_at_utc, "generated_at_utc", errors)
+
+    source_kind = doc.get("source_kind")
+    artifact_file = doc.get("artifact_file")
+    bundle_path = doc.get("bundle_path")
+    validation_report_path = doc.get("validation_report_path")
+    bundle_validation_verdict = doc.get("bundle_validation_verdict")
+    operator_handoff_validation_verdict = doc.get("operator_handoff_validation_verdict")
+    ready = doc.get("ready")
+    readiness_status = doc.get("readiness_status")
+    blocking_reasons = list(doc.get("blocking_reasons") or [])
+    next_step = doc.get("next_step")
+    error_count = doc.get("error_count")
+    warning_count = doc.get("warning_count")
+    errors_list = list(doc.get("errors") or [])
+    warnings_list = list(doc.get("warnings") or [])
+
+    if source_kind == "artifact":
+        if not isinstance(artifact_file, str) or not artifact_file:
+            append_unique(errors, "artifact source_kind requires artifact_file")
+    if source_kind == "bundle":
+        if not isinstance(bundle_path, str) or not bundle_path:
+            append_unique(errors, "bundle source_kind requires bundle_path")
+
+    if not isinstance(validation_report_path, str) or not validation_report_path:
+        append_unique(errors, "validation_report_path must be present")
+
+    if error_count != len(errors_list):
+        append_unique(errors, "error_count must match errors length")
+    if warning_count != len(warnings_list):
+        append_unique(errors, "warning_count must match warnings length")
+
+    if bundle_validation_verdict == "pass" and error_count not in (0, None):
+        append_unique(errors, "bundle_validation_verdict=pass requires error_count=0")
+    if bundle_validation_verdict == "fail" and error_count == 0:
+        append_unique(errors, "bundle_validation_verdict=fail requires error_count>0")
+
+    for field, reason in HANDOFF_BUNDLE_SIDECAR_FIELDS + (
+        ("priority_preview_ref", "priority_preview_ref_missing"),
+        ("priority_display_packet_ref", "priority_display_packet_ref_missing"),
+        ("priority_headline", "priority_headline_missing"),
+        ("priority_cta_command", "priority_cta_command_missing"),
+        ("display_title", "display_title_missing"),
+        ("cta_command", "display_cta_command_missing"),
+    ):
+        if not isinstance(doc.get(field), str) or not str(doc.get(field) or "").strip():
+            if reason not in blocking_reasons:
+                append_unique(errors, f"missing {field} requires {reason} blocking reason")
+
+    if operator_handoff_validation_verdict == "fail" and "handoff_validation_fail" not in blocking_reasons:
+        append_unique(errors, "handoff_validation_verdict=fail requires handoff_validation_fail blocking reason")
+    if bundle_validation_verdict == "fail" and "bundle_validation_fail" not in blocking_reasons:
+        append_unique(errors, "bundle_validation_verdict=fail requires bundle_validation_fail blocking reason")
+
+    if ready is True:
+        if readiness_status != "ready":
+            append_unique(errors, "ready=true requires readiness_status=ready")
+        if blocking_reasons:
+            append_unique(errors, "ready=true requires no blocking_reasons")
+        if bundle_validation_verdict != "pass":
+            append_unique(errors, "ready=true requires bundle_validation_verdict=pass")
+        if operator_handoff_validation_verdict != "pass":
+            append_unique(errors, "ready=true requires operator_handoff_validation_verdict=pass")
+        if next_step != "none":
+            append_unique(errors, "ready=true requires next_step=none")
+    else:
+        if readiness_status != "blocked":
+            append_unique(errors, "ready=false requires readiness_status=blocked")
+        if not blocking_reasons:
+            append_unique(errors, "ready=false requires at least one blocking reason")
+        if next_step == "none":
+            append_unique(errors, "ready=false requires a remediation next_step")
+
+    return errors, warnings
+
+
+def build_report(readiness_path: Path, schema_path: Path, readiness_doc: dict, schema_doc: dict) -> dict:
+    schema_errors = validate_schema(readiness_doc, schema_doc)
+    semantic_errors, semantic_warnings = validate_semantics(readiness_doc)
+    errors = schema_errors + semantic_errors
+    warnings = semantic_warnings
+    return {
+        "generated_at_utc": now_utc(),
+        "readiness_path": str(readiness_path.resolve()),
+        "readiness_generated_at_utc": readiness_doc.get("generated_at_utc"),
+        "source_kind": readiness_doc.get("source_kind"),
+        "artifact_file": readiness_doc.get("artifact_file"),
+        "bundle_path": readiness_doc.get("bundle_path"),
+        "validation_report_path": readiness_doc.get("validation_report_path"),
+        "operator_handoff_bundle_path": readiness_doc.get("operator_handoff_bundle_path"),
+        "operator_handoff_bundle_validation_path": readiness_doc.get("operator_handoff_bundle_validation_path"),
+        "operator_handoff_bundle_readiness_path": readiness_doc.get("operator_handoff_bundle_readiness_path"),
+        "operator_handoff_bundle_readiness_validation_path": readiness_doc.get("operator_handoff_bundle_readiness_validation_path"),
+        "readiness_status": readiness_doc.get("readiness_status"),
+        "readiness_ready": bool(readiness_doc.get("ready")),
+        "schema_path": str(schema_path.resolve()),
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "errors": errors,
+        "warnings": warnings,
+        "verdict": "pass" if not errors else "fail",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate supervisor operator handoff bundle readiness artifact")
+    parser.add_argument("--readiness", required=True)
+    parser.add_argument("--schema-file", default=str(DEFAULT_SCHEMA))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    readiness_path = Path(args.readiness).resolve()
+    schema_path = Path(args.schema_file).resolve()
+    output_path = Path(args.output).resolve()
+
+    readiness_doc = load_json(readiness_path)
+    schema_doc = load_json(schema_path)
+    report = build_report(readiness_path, schema_path, readiness_doc, schema_doc)
+    write_json(output_path, report)
+    print(f"report written: {output_path}")
+    print(f"verdict={report['verdict']} error_count={report['error_count']}")
+    return 0 if report["verdict"] == "pass" or not args.strict else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- backfill the supervisor handoff bundle readiness validation schema, validator, and regression
- add the 2026-03-28 workbench packet and hub link for the bundle-readiness-validator family
- keep readiness assessment, doctor, and gate surfaces for follow-up units

## Validation
- bash planningops/scripts/test_validate_supervisor_operator_handoff_bundle_readiness.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all