### PR TITLE
feat(supervisor-handoff): backfill bundle readiness assessor family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -109,6 +109,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Supervisor Handoff Bundle Resolver Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-resolver-family-backfill-packet.md)
 - [Supervisor Handoff Bundle Validator Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-validator-family-backfill-packet.md)
 - [Supervisor Handoff Bundle Readiness Validator Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-readiness-validator-family-backfill-packet.md)
+- [Supervisor Handoff Bundle Readiness Assessor Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-readiness-assessor-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-bundle-readiness-assessor-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-bundle-readiness-assessor-family-backfill-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Supervisor Handoff Bundle Readiness Assessor Family Backfill Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the supervisor handoff bundle readiness schema, assessor, and regression so planningops can emit canonical bundle-readiness reports from monday artifacts or resolved bundles.
+related_docs:
+  - ./2026-03-28-supervisor-handoff-bundle-readiness-validator-family-backfill-packet.md
+  - ./2026-03-28-supervisor-handoff-bundle-validator-family-backfill-packet.md
+---
+
+# plan: Supervisor Handoff Bundle Readiness Assessor Family Backfill Packet
+
+## Summary
+- Backfill the tracked `supervisor handoff bundle readiness assessor` family that sits directly above the bundle-readiness validator surface.
+- Promote the missing readiness schema, assessor, and regression into git-tracked reality so monday/planningops artifacts can emit canonical readiness reports plus embedded readiness-validation sidecars.
+- Keep this unit limited to readiness assessment only; bundle doctor and gate families remain follow-up waves.
+
+## Scope
+- `planningops/schemas/supervisor-operator-handoff-bundle-readiness.schema.json`
+- `planningops/scripts/assess_supervisor_operator_handoff_bundle_readiness.py`
+- `planningops/scripts/test_assess_supervisor_operator_handoff_bundle_readiness.sh`
+- workbench hub link for this bundle-readiness-assessor-family backfill
+
+## Acceptance
+- `test_assess_supervisor_operator_handoff_bundle_readiness.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/schemas/supervisor-operator-handoff-bundle-readiness.schema.json
+++ b/planningops/schemas/supervisor-operator-handoff-bundle-readiness.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "planningops-supervisor-operator-handoff-bundle-readiness",
+  "title": "Planningops Supervisor Operator Handoff Bundle Readiness",
+  "type": "object",
+  "required": [
+    "generated_at_utc",
+    "source_kind",
+    "validation_report_path",
+    "bundle_validation_verdict",
+    "operator_handoff_validation_verdict",
+    "operator_handoff_bundle_path",
+    "operator_handoff_bundle_validation_path",
+    "operator_handoff_bundle_readiness_path",
+    "operator_handoff_bundle_readiness_validation_path",
+    "priority_preview_ref",
+    "priority_display_packet_ref",
+    "priority_headline",
+    "priority_cta_command",
+    "display_title",
+    "cta_command",
+    "error_count",
+    "warning_count",
+    "errors",
+    "warnings",
+    "ready",
+    "readiness_status",
+    "blocking_reasons",
+    "next_step"
+  ],
+  "properties": {
+    "generated_at_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_kind": {
+      "type": "string",
+      "enum": ["artifact", "bundle"]
+    },
+    "artifact_file": {
+      "type": ["string", "null"]
+    },
+    "bundle_path": {
+      "type": ["string", "null"]
+    },
+    "validation_report_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "bundle_generated_at_utc": {
+      "type": ["string", "null"]
+    },
+    "validation_generated_at_utc": {
+      "type": ["string", "null"]
+    },
+    "bundle_validation_verdict": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "operator_handoff_validation_verdict": {
+      "type": ["string", "null"],
+      "enum": ["pass", "fail", null]
+    },
+    "operator_handoff_bundle_path": {
+      "type": ["string", "null"]
+    },
+    "operator_handoff_bundle_validation_path": {
+      "type": ["string", "null"]
+    },
+    "operator_handoff_bundle_readiness_path": {
+      "type": ["string", "null"]
+    },
+    "operator_handoff_bundle_readiness_validation_path": {
+      "type": ["string", "null"]
+    },
+    "priority_preview_ref": {
+      "type": ["string", "null"]
+    },
+    "priority_display_packet_ref": {
+      "type": ["string", "null"]
+    },
+    "priority_headline": {
+      "type": ["string", "null"]
+    },
+    "priority_cta_command": {
+      "type": ["string", "null"]
+    },
+    "display_title": {
+      "type": ["string", "null"]
+    },
+    "cta_command": {
+      "type": ["string", "null"]
+    },
+    "error_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "warning_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "ready": {
+      "type": "boolean"
+    },
+    "readiness_status": {
+      "type": "string",
+      "enum": ["ready", "blocked"]
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "next_step": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/planningops/scripts/assess_supervisor_operator_handoff_bundle_readiness.py
+++ b/planningops/scripts/assess_supervisor_operator_handoff_bundle_readiness.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from validate_supervisor_operator_handoff import append_unique, write_json
+from validate_supervisor_operator_handoff_bundle import (
+    DEFAULT_OUTPUT as DEFAULT_BUNDLE_VALIDATION_OUTPUT,
+    validate_handoff_bundle,
+)
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT = WORKSPACE_ROOT / "planningops/artifacts/validation/supervisor-operator-handoff-bundle-readiness.json"
+DEFAULT_VALIDATION_OUTPUT = (
+    WORKSPACE_ROOT / "planningops/artifacts/validation/supervisor-operator-handoff-bundle-readiness-validation.json"
+)
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_validator_module():
+    module_path = Path(__file__).resolve().parent / "validate_supervisor_operator_handoff_bundle_readiness.py"
+    spec = importlib.util.spec_from_file_location("validate_supervisor_operator_handoff_bundle_readiness", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load bundle readiness validator module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_next_step(source_kind: str, artifact_file: str | None, bundle_file: str | None) -> str:
+    if source_kind == "artifact" and artifact_file:
+        return (
+            "python3 planningops/scripts/validate_supervisor_operator_handoff_bundle.py "
+            f"--artifact-file {artifact_file} --output <handoff-bundle-validation.json> --strict"
+        )
+    return (
+        "python3 planningops/scripts/validate_supervisor_operator_handoff_bundle.py "
+        f"--bundle-file {bundle_file} --output <handoff-bundle-validation.json> --strict"
+    )
+
+
+def build_blocking_reasons(validation_report: dict) -> list[str]:
+    reasons: list[str] = []
+    if validation_report.get("verdict") != "pass":
+        append_unique(reasons, "bundle_validation_fail")
+    if validation_report.get("operator_handoff_validation_verdict") != "pass":
+        append_unique(reasons, "handoff_validation_fail")
+    for field, reason in (
+        ("operator_handoff_bundle_path", "operator_handoff_bundle_path_missing"),
+        ("operator_handoff_bundle_validation_path", "operator_handoff_bundle_validation_path_missing"),
+        ("operator_handoff_bundle_readiness_path", "operator_handoff_bundle_readiness_path_missing"),
+        ("operator_handoff_bundle_readiness_validation_path", "operator_handoff_bundle_readiness_validation_path_missing"),
+        ("priority_preview_ref", "priority_preview_ref_missing"),
+        ("priority_display_packet_ref", "priority_display_packet_ref_missing"),
+        ("priority_headline", "priority_headline_missing"),
+        ("priority_cta_command", "priority_cta_command_missing"),
+        ("display_title", "display_title_missing"),
+        ("cta_command", "display_cta_command_missing"),
+    ):
+        if not str(validation_report.get(field) or "").strip():
+            append_unique(reasons, reason)
+    return reasons
+
+
+def assess_handoff_bundle_readiness(
+    *,
+    bundle_file: str | None,
+    artifact_file: str | None,
+    bundle_schema_path: str | None,
+    validation_schema_path: str | None,
+    bundle_validation_output: str | None,
+    output: str | None,
+    readiness_validation_output: str | None,
+) -> tuple[dict, dict]:
+    validation_report = validate_handoff_bundle(
+        bundle_file=bundle_file,
+        artifact_file=artifact_file,
+        bundle_schema_path=bundle_schema_path,
+        validation_schema_path=validation_schema_path,
+        output=bundle_validation_output,
+    )
+    readiness_output_path = Path(output or DEFAULT_OUTPUT).resolve()
+    readiness_validation_output_path = Path(readiness_validation_output or DEFAULT_VALIDATION_OUTPUT).resolve()
+    source_kind = "artifact" if artifact_file else "bundle"
+    blocking_reasons = build_blocking_reasons(validation_report)
+    ready = not blocking_reasons
+    report = {
+        "generated_at_utc": now_utc(),
+        "source_kind": source_kind,
+        "artifact_file": validation_report.get("artifact_file"),
+        "bundle_path": validation_report.get("bundle_path"),
+        "validation_report_path": str(Path(validation_report.get("resolved_bundle_validation_path") or (bundle_validation_output or DEFAULT_BUNDLE_VALIDATION_OUTPUT)).resolve()),
+        "bundle_generated_at_utc": validation_report.get("bundle_generated_at_utc"),
+        "validation_generated_at_utc": validation_report.get("generated_at_utc"),
+        "bundle_validation_verdict": validation_report.get("verdict") or "fail",
+        "operator_handoff_validation_verdict": validation_report.get("operator_handoff_validation_verdict"),
+        "operator_handoff_bundle_path": validation_report.get("operator_handoff_bundle_path"),
+        "operator_handoff_bundle_validation_path": validation_report.get("operator_handoff_bundle_validation_path"),
+        "operator_handoff_bundle_readiness_path": validation_report.get("operator_handoff_bundle_readiness_path"),
+        "operator_handoff_bundle_readiness_validation_path": validation_report.get("operator_handoff_bundle_readiness_validation_path"),
+        "priority_preview_ref": validation_report.get("priority_preview_ref"),
+        "priority_display_packet_ref": validation_report.get("priority_display_packet_ref"),
+        "priority_headline": validation_report.get("priority_headline"),
+        "priority_cta_command": validation_report.get("priority_cta_command"),
+        "display_title": validation_report.get("display_title"),
+        "cta_command": validation_report.get("cta_command"),
+        "error_count": validation_report.get("error_count", 0),
+        "warning_count": validation_report.get("warning_count", 0),
+        "errors": list(validation_report.get("errors") or []),
+        "warnings": list(validation_report.get("warnings") or []),
+        "ready": ready,
+        "readiness_status": "ready" if ready else "blocked",
+        "blocking_reasons": blocking_reasons,
+        "next_step": "none" if ready else build_next_step(source_kind, artifact_file, bundle_file),
+    }
+    validator = load_validator_module()
+    schema_path = WORKSPACE_ROOT / "planningops/schemas/supervisor-operator-handoff-bundle-readiness.schema.json"
+    schema_doc = validator.load_json(schema_path)
+    readiness_validation_report = validator.build_report(readiness_output_path, schema_path, report, schema_doc)
+    validator.write_json(readiness_validation_output_path, readiness_validation_report)
+    if readiness_validation_report["verdict"] != "pass":
+        raise SystemExit(
+            "invalid supervisor operator handoff bundle readiness report: "
+            + "; ".join(readiness_validation_report["errors"])
+        )
+    write_json(readiness_output_path, report)
+    return report, readiness_validation_report
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Assess supervisor operator handoff bundle readiness")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--bundle-file")
+    group.add_argument("--artifact-file")
+    parser.add_argument("--bundle-schema", default=None)
+    parser.add_argument("--validation-schema", default=None)
+    parser.add_argument("--bundle-validation-output", default=str(DEFAULT_BUNDLE_VALIDATION_OUTPUT))
+    parser.add_argument("--output", "--readiness-report", dest="output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument(
+        "--readiness-validation-output",
+        "--validation-output",
+        dest="readiness_validation_output",
+        default=str(DEFAULT_VALIDATION_OUTPUT),
+    )
+    parser.add_argument("--strict", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report, _readiness_validation = assess_handoff_bundle_readiness(
+        bundle_file=args.bundle_file,
+        artifact_file=args.artifact_file,
+        bundle_schema_path=args.bundle_schema,
+        validation_schema_path=args.validation_schema,
+        bundle_validation_output=args.bundle_validation_output,
+        output=args.output,
+        readiness_validation_output=args.readiness_validation_output,
+    )
+    print(f"report written: {Path(args.output).resolve()}")
+    print(f"readiness_status={report['readiness_status']} ready={report['ready']}")
+    return 0 if report["ready"] or not args.strict else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/test_assess_supervisor_operator_handoff_bundle_readiness.sh
+++ b/planningops/scripts/test_assess_supervisor_operator_handoff_bundle_readiness.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MONDAY_DIR="$(cd "${ROOT_DIR}/../monday" && pwd)"
+TMP_DIR="$(mktemp -d)"
+RUNTIME_DIR="$(mktemp -d "${MONDAY_DIR}/runtime-artifacts/test-handoff-bundle-readiness.XXXXXX")"
+trap 'rm -rf "${TMP_DIR}" "${RUNTIME_DIR}"' EXIT
+
+VALIDATION="${TMP_DIR}/operator-handoff-validation.json"
+HANDOFF_BUNDLE="${TMP_DIR}/operator-handoff-bundle.json"
+HANDOFF_BUNDLE_VALIDATION="${TMP_DIR}/operator-handoff-bundle-validation.json"
+HANDOFF_BUNDLE_READINESS_SIDECAR="${TMP_DIR}/operator-handoff-bundle-readiness-sidecar.json"
+HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR="${TMP_DIR}/operator-handoff-bundle-readiness-validation-sidecar.json"
+PREVIEW="${RUNTIME_DIR}/preview.json"
+DISPLAY_PACKET="${RUNTIME_DIR}/display-packet.json"
+ARTIFACT="${RUNTIME_DIR}/artifact.json"
+READINESS="${TMP_DIR}/handoff-bundle-readiness.json"
+READINESS_VALIDATION="${TMP_DIR}/handoff-bundle-readiness-validation.json"
+BUNDLE_VALIDATION="${TMP_DIR}/handoff-bundle-validation.json"
+BUNDLE="${TMP_DIR}/handoff-bundle.json"
+BROKEN_BUNDLE="${TMP_DIR}/handoff-bundle-broken.json"
+BROKEN_READINESS="${TMP_DIR}/handoff-bundle-broken-readiness.json"
+BROKEN_READINESS_VALIDATION="${TMP_DIR}/handoff-bundle-broken-readiness-validation.json"
+BROKEN_BUNDLE_VALIDATION="${TMP_DIR}/handoff-bundle-broken-validation.json"
+
+preview_ref() {
+  python3 - <<'PY' "$MONDAY_DIR" "$1"
+from pathlib import Path
+import sys
+root = Path(sys.argv[1]).resolve()
+target = Path(sys.argv[2]).resolve()
+print(target.relative_to(root))
+PY
+}
+
+cat >"${VALIDATION}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:00Z",
+  "operator_report_path": "${TMP_DIR}/operator-report.json",
+  "inbox_payload_path": "${TMP_DIR}/inbox-payload.json",
+  "operator_report_schema_path": "${ROOT_DIR}/planningops/schemas/supervisor-operator-report.schema.json",
+  "inbox_payload_schema_path": "${ROOT_DIR}/planningops/schemas/supervisor-inbox-payload.schema.json",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "priority_display_packet_ref": "$(preview_ref "${DISPLAY_PACKET}")",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS_SIDECAR}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}",
+  "error_count": 0,
+  "warning_count": 0,
+  "errors": [],
+  "warnings": [],
+  "verdict": "pass"
+}
+JSON
+
+cat >"${PREVIEW}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:01Z",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle-readiness.source/wrapper.json",
+  "source_artifact_kind": "local_outbox_envelope",
+  "source_priority_path": "payload.metadata.priority_summary_markdown",
+  "preview_state": "present",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS_SIDECAR}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}",
+  "priority_headline": "Readiness headline.",
+  "priority_cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "priority_summary_markdown": "## Priority\n- headline: Readiness headline.\n- first action: \`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass\`"
+}
+JSON
+
+cat >"${DISPLAY_PACKET}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:02Z",
+  "input_kind": "artifact",
+  "input_ref": "runtime-artifacts/test-handoff-bundle-readiness/artifact.json",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle-readiness.source/wrapper.json",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "preview_source_artifact_kind": "local_outbox_envelope",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS_SIDECAR}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}",
+  "priority_headline": "Readiness headline.",
+  "priority_cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "priority_summary_markdown": "## Priority\n- headline: Readiness headline.\n- first action: \`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass\`",
+  "display_title": "Readiness headline.",
+  "cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "display_markdown": "## Priority\n- headline: Readiness headline.\n- first action: \`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass\`"
+}
+JSON
+
+cat >"${ARTIFACT}" <<JSON
+{
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "priority_display_packet_ref": "$(preview_ref "${DISPLAY_PACKET}")"
+}
+JSON
+
+python3 "${ROOT_DIR}/planningops/scripts/assess_supervisor_operator_handoff_bundle_readiness.py" \
+  --artifact-file "${ARTIFACT}" \
+  --bundle-validation-output "${BUNDLE_VALIDATION}" \
+  --output "${READINESS}" \
+  --readiness-validation-output "${READINESS_VALIDATION}" \
+  --strict >/dev/null
+
+python3 - <<'PY' "${READINESS}" "${READINESS_VALIDATION}" "${BUNDLE_VALIDATION}" "${HANDOFF_BUNDLE}" "${HANDOFF_BUNDLE_VALIDATION}" "${HANDOFF_BUNDLE_READINESS_SIDECAR}" "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}"
+import json
+import sys
+from pathlib import Path
+
+readiness = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+validation = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+bundle_validation = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+handoff_bundle = Path(sys.argv[4]).resolve()
+handoff_bundle_validation = Path(sys.argv[5]).resolve()
+handoff_bundle_readiness = Path(sys.argv[6]).resolve()
+handoff_bundle_readiness_validation = Path(sys.argv[7]).resolve()
+assert readiness["ready"] is True, readiness
+assert readiness["readiness_status"] == "ready", readiness
+assert readiness["blocking_reasons"] == [], readiness
+assert readiness["next_step"] == "none", readiness
+assert Path(readiness["validation_report_path"]).resolve() == Path(sys.argv[3]).resolve(), readiness
+assert Path(readiness["operator_handoff_bundle_path"]).resolve() == handoff_bundle, readiness
+assert Path(readiness["operator_handoff_bundle_validation_path"]).resolve() == handoff_bundle_validation, readiness
+assert Path(readiness["operator_handoff_bundle_readiness_path"]).resolve() == handoff_bundle_readiness, readiness
+assert Path(readiness["operator_handoff_bundle_readiness_validation_path"]).resolve() == handoff_bundle_readiness_validation, readiness
+assert validation["verdict"] == "pass", validation
+assert bundle_validation["verdict"] == "pass", bundle_validation
+PY
+
+python3 "${ROOT_DIR}/planningops/scripts/resolve_supervisor_operator_handoff_bundle.py" \
+  --artifact-file "${ARTIFACT}" \
+  --output "${BUNDLE}" >/dev/null
+
+python3 - <<'PY' "${BUNDLE}" "${BROKEN_BUNDLE}"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+doc["priority_display_packet"]["display_title"] = "Broken readiness headline."
+Path(sys.argv[2]).write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+set +e
+python3 "${ROOT_DIR}/planningops/scripts/assess_supervisor_operator_handoff_bundle_readiness.py" \
+  --bundle-file "${BROKEN_BUNDLE}" \
+  --bundle-validation-output "${BROKEN_BUNDLE_VALIDATION}" \
+  --output "${BROKEN_READINESS}" \
+  --readiness-validation-output "${BROKEN_READINESS_VALIDATION}" \
+  --strict >/dev/null
+rc=$?
+set -e
+
+if [[ "${rc}" -eq 0 ]]; then
+  echo "expected readiness assess to fail on broken bundle" >&2
+  exit 1
+fi
+
+python3 - <<'PY' "${BROKEN_READINESS}" "${BROKEN_READINESS_VALIDATION}" "${BROKEN_BUNDLE}" "${BROKEN_BUNDLE_VALIDATION}" "${HANDOFF_BUNDLE}" "${HANDOFF_BUNDLE_VALIDATION}" "${HANDOFF_BUNDLE_READINESS_SIDECAR}" "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}"
+import json
+import sys
+from pathlib import Path
+
+readiness = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+validation = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+bundle = Path(sys.argv[3])
+bundle_validation = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
+handoff_bundle = Path(sys.argv[5]).resolve()
+handoff_bundle_validation = Path(sys.argv[6]).resolve()
+handoff_bundle_readiness = Path(sys.argv[7]).resolve()
+handoff_bundle_readiness_validation = Path(sys.argv[8]).resolve()
+assert readiness["ready"] is False, readiness
+assert readiness["readiness_status"] == "blocked", readiness
+assert "bundle_validation_fail" in readiness["blocking_reasons"], readiness
+assert readiness["next_step"].startswith("python3 planningops/scripts/validate_supervisor_operator_handoff_bundle.py --bundle-file "), readiness
+assert readiness["next_step"].endswith(f"{bundle} --output <handoff-bundle-validation.json> --strict"), readiness
+assert Path(readiness["validation_report_path"]).resolve() == Path(sys.argv[4]).resolve(), readiness
+assert Path(readiness["operator_handoff_bundle_path"]).resolve() == handoff_bundle, readiness
+assert Path(readiness["operator_handoff_bundle_validation_path"]).resolve() == handoff_bundle_validation, readiness
+assert Path(readiness["operator_handoff_bundle_readiness_path"]).resolve() == handoff_bundle_readiness, readiness
+assert Path(readiness["operator_handoff_bundle_readiness_validation_path"]).resolve() == handoff_bundle_readiness_validation, readiness
+assert validation["verdict"] == "pass", validation
+assert bundle_validation["verdict"] == "fail", bundle_validation
+PY
+
+echo "assess supervisor operator handoff bundle readiness ok"


### PR DESCRIPTION
## Summary
- backfill the supervisor handoff bundle readiness schema, assessor, and regression
- add the 2026-03-28 workbench packet and hub link for the bundle-readiness-assessor family
- keep bundle doctor and gate surfaces for follow-up units

## Validation
- bash planningops/scripts/test_assess_supervisor_operator_handoff_bundle_readiness.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all