### PR TITLE
feat(supervisor-handoff): backfill bundle doctor gate family

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -110,6 +110,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Supervisor Handoff Bundle Validator Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-validator-family-backfill-packet.md)
 - [Supervisor Handoff Bundle Readiness Validator Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-readiness-validator-family-backfill-packet.md)
 - [Supervisor Handoff Bundle Readiness Assessor Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-readiness-assessor-family-backfill-packet.md)
+- [Supervisor Handoff Bundle Doctor Gate Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-doctor-gate-family-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-bundle-doctor-gate-family-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-bundle-doctor-gate-family-backfill-packet.md
@@ -1,0 +1,33 @@
+---
+title: plan: Supervisor Handoff Bundle Doctor Gate Family Backfill Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the supervisor handoff bundle doctor and gate family so planningops can print and enforce canonical bundle readiness from monday artifacts or resolved bundles.
+related_docs:
+  - ./2026-03-28-supervisor-handoff-bundle-readiness-assessor-family-backfill-packet.md
+  - ./2026-03-28-supervisor-handoff-bundle-validator-family-backfill-packet.md
+---
+
+# plan: Supervisor Handoff Bundle Doctor Gate Family Backfill Packet
+
+## Summary
+- Backfill the tracked `supervisor handoff bundle doctor/gate` family that sits directly above bundle readiness assessment.
+- Promote the missing doctor, gate wrapper, and regressions into git-tracked reality so monday/planningops artifacts can print canonical bundle readiness status and fail closed when bundle state blocks handoff admission.
+- Keep this unit limited to the operator-facing doctor/gate surface; no contract-doc expansion is included here.
+
+## Scope
+- `planningops/scripts/doctor_supervisor_operator_handoff_bundle.py`
+- `planningops/scripts/gate_supervisor_operator_handoff_bundle.sh`
+- `planningops/scripts/test_doctor_supervisor_operator_handoff_bundle.sh`
+- `planningops/scripts/test_gate_supervisor_operator_handoff_bundle.sh`
+- workbench hub link for this doctor/gate-family backfill
+
+## Acceptance
+- `test_doctor_supervisor_operator_handoff_bundle.sh` passes
+- `test_gate_supervisor_operator_handoff_bundle.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/doctor_supervisor_operator_handoff_bundle.py
+++ b/planningops/scripts/doctor_supervisor_operator_handoff_bundle.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from assess_supervisor_operator_handoff_bundle_readiness import assess_handoff_bundle_readiness
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Print supervisor operator handoff bundle status")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--bundle-file")
+    group.add_argument("--artifact-file")
+    parser.add_argument("--bundle-schema", default=None)
+    parser.add_argument("--validation-schema", default=None)
+    parser.add_argument("--bundle-validation-output", "--validation-output", dest="bundle_validation_output", default=None)
+    parser.add_argument("--readiness-output", default=None)
+    parser.add_argument("--readiness-validation-output", default=None)
+    parser.add_argument("--require-pass", action="store_true")
+    return parser.parse_args()
+
+
+def render_lines(args, readiness_report: dict) -> list[str]:
+    source_kind = "artifact" if args.artifact_file else "bundle"
+    lines = [
+        f"source kind: {source_kind}",
+        f"artifact file: {readiness_report.get('artifact_file') or 'missing'}",
+        f"bundle path: {readiness_report.get('bundle_path') or 'n/a'}",
+        f"validation report path: {readiness_report.get('validation_report_path') or 'not written'}",
+        f"bundle validation verdict: {readiness_report.get('bundle_validation_verdict') or 'unknown'}",
+        f"handoff validation verdict: {readiness_report.get('operator_handoff_validation_verdict') or 'unknown'}",
+        f"handoff bundle path: {readiness_report.get('operator_handoff_bundle_path') or 'missing'}",
+        f"handoff bundle validation path: {readiness_report.get('operator_handoff_bundle_validation_path') or 'missing'}",
+        f"handoff bundle readiness path: {readiness_report.get('operator_handoff_bundle_readiness_path') or 'missing'}",
+        "handoff bundle readiness validation path: "
+        f"{readiness_report.get('operator_handoff_bundle_readiness_validation_path') or 'missing'}",
+        f"readiness status: {readiness_report.get('readiness_status') or 'unknown'}",
+        f"ready: {readiness_report.get('ready')}",
+        f"priority preview ref: {readiness_report.get('priority_preview_ref') or 'missing'}",
+        f"priority display packet ref: {readiness_report.get('priority_display_packet_ref') or 'missing'}",
+        f"priority headline: {readiness_report.get('priority_headline') or 'missing'}",
+        f"priority cta command: {readiness_report.get('priority_cta_command') or 'missing'}",
+        f"display title: {readiness_report.get('display_title') or 'missing'}",
+        f"display cta command: {readiness_report.get('cta_command') or 'missing'}",
+        f"warning count: {readiness_report.get('warning_count', 0)}",
+        f"error count: {readiness_report.get('error_count', 0)}",
+    ]
+    errors = list(readiness_report.get("errors") or [])
+    warnings = list(readiness_report.get("warnings") or [])
+    lines.append("errors: none" if not errors else f"errors: {'; '.join(errors)}")
+    lines.append("warnings: none" if not warnings else f"warnings: {'; '.join(warnings)}")
+    lines.append(f"next step: {readiness_report.get('next_step') or 'none'}")
+    return lines
+
+
+def main() -> int:
+    args = parse_args()
+    readiness_report, _readiness_validation_report = assess_handoff_bundle_readiness(
+        bundle_file=args.bundle_file,
+        artifact_file=args.artifact_file,
+        bundle_schema_path=args.bundle_schema,
+        validation_schema_path=args.validation_schema,
+        bundle_validation_output=args.bundle_validation_output,
+        output=args.readiness_output,
+        readiness_validation_output=args.readiness_validation_output,
+    )
+    for line in render_lines(args, readiness_report):
+        print(line)
+    return 1 if args.require_pass and not readiness_report.get("ready") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/planningops/scripts/gate_supervisor_operator_handoff_bundle.sh
+++ b/planningops/scripts/gate_supervisor_operator_handoff_bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 "$ROOT_DIR/scripts/doctor_supervisor_operator_handoff_bundle.py" --require-pass "$@"

--- a/planningops/scripts/test_doctor_supervisor_operator_handoff_bundle.sh
+++ b/planningops/scripts/test_doctor_supervisor_operator_handoff_bundle.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MONDAY_DIR="$(cd "${ROOT_DIR}/../monday" && pwd)"
+TMP_DIR="$(mktemp -d)"
+RUNTIME_DIR="$(mktemp -d "${MONDAY_DIR}/runtime-artifacts/test-handoff-bundle-doctor.XXXXXX")"
+trap 'rm -rf "${TMP_DIR}" "${RUNTIME_DIR}"' EXIT
+
+VALIDATION="${TMP_DIR}/operator-handoff-validation.json"
+HANDOFF_BUNDLE="${TMP_DIR}/operator-handoff-bundle.json"
+HANDOFF_BUNDLE_VALIDATION_SIDECAR="${TMP_DIR}/operator-handoff-bundle-validation-sidecar.json"
+HANDOFF_BUNDLE_READINESS_SIDECAR="${TMP_DIR}/operator-handoff-bundle-readiness.json"
+HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR="${TMP_DIR}/operator-handoff-bundle-readiness-validation.json"
+PREVIEW="${RUNTIME_DIR}/preview.json"
+DISPLAY_PACKET="${RUNTIME_DIR}/display-packet.json"
+ARTIFACT="${RUNTIME_DIR}/artifact.json"
+REPORT="${TMP_DIR}/doctor-report.txt"
+VALIDATION_REPORT="${TMP_DIR}/handoff-bundle-validation.json"
+READINESS_REPORT="${TMP_DIR}/handoff-bundle-readiness.json"
+READINESS_VALIDATION_REPORT="${TMP_DIR}/handoff-bundle-readiness-validation.json"
+BROKEN_BUNDLE="${TMP_DIR}/broken-bundle.json"
+BROKEN_OUTPUT="${TMP_DIR}/doctor-broken.txt"
+
+preview_ref() {
+  python3 - <<'PY' "$MONDAY_DIR" "$1"
+from pathlib import Path
+import sys
+root = Path(sys.argv[1]).resolve()
+target = Path(sys.argv[2]).resolve()
+print(target.relative_to(root))
+PY
+}
+
+cat >"${VALIDATION}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:00Z",
+  "operator_report_path": "${TMP_DIR}/operator-report.json",
+  "inbox_payload_path": "${TMP_DIR}/inbox-payload.json",
+  "operator_report_schema_path": "${ROOT_DIR}/planningops/schemas/supervisor-operator-report.schema.json",
+  "inbox_payload_schema_path": "${ROOT_DIR}/planningops/schemas/supervisor-inbox-payload.schema.json",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "priority_display_packet_ref": "$(preview_ref "${DISPLAY_PACKET}")",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION_SIDECAR}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS_SIDECAR}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}",
+  "error_count": 0,
+  "warning_count": 0,
+  "errors": [],
+  "warnings": [],
+  "verdict": "pass"
+}
+JSON
+
+cat >"${PREVIEW}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:01Z",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle-doctor.source/wrapper.json",
+  "source_artifact_kind": "local_outbox_envelope",
+  "source_priority_path": "payload.metadata.priority_summary_markdown",
+  "preview_state": "present",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION_SIDECAR}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS_SIDECAR}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}",
+  "priority_headline": "Doctor bundle headline.",
+  "priority_cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "priority_summary_markdown": "## Priority\n- headline: Doctor bundle headline.\n- first action: \`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass\`"
+}
+JSON
+
+cat >"${DISPLAY_PACKET}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:02Z",
+  "input_kind": "artifact",
+  "input_ref": "runtime-artifacts/test-handoff-bundle-doctor/artifact.json",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle-doctor.source/wrapper.json",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "preview_source_artifact_kind": "local_outbox_envelope",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION_SIDECAR}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS_SIDECAR}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}",
+  "priority_headline": "Doctor bundle headline.",
+  "priority_cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "priority_summary_markdown": "## Priority\n- headline: Doctor bundle headline.\n- first action: \`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass\`",
+  "display_title": "Doctor bundle headline.",
+  "cta_command": "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+  "display_markdown": "## Priority\n- headline: Doctor bundle headline.\n- first action: \`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass\`"
+}
+JSON
+
+cat >"${ARTIFACT}" <<JSON
+{
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "priority_display_packet_ref": "$(preview_ref "${DISPLAY_PACKET}")"
+}
+JSON
+
+python3 "${ROOT_DIR}/planningops/scripts/doctor_supervisor_operator_handoff_bundle.py" \
+  --artifact-file "${ARTIFACT}" \
+  --bundle-validation-output "${VALIDATION_REPORT}" \
+  --readiness-output "${READINESS_REPORT}" \
+  --readiness-validation-output "${READINESS_VALIDATION_REPORT}" >"${REPORT}"
+
+grep -q "source kind: artifact" "${REPORT}"
+grep -q "bundle validation verdict: pass" "${REPORT}"
+grep -q "readiness status: ready" "${REPORT}"
+grep -q "ready: True" "${REPORT}"
+grep -q "handoff bundle path: ${HANDOFF_BUNDLE}" "${REPORT}"
+grep -q "handoff bundle validation path: ${HANDOFF_BUNDLE_VALIDATION_SIDECAR}" "${REPORT}"
+grep -q "handoff bundle readiness path: ${HANDOFF_BUNDLE_READINESS_SIDECAR}" "${REPORT}"
+grep -q "handoff bundle readiness validation path: ${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}" "${REPORT}"
+grep -q "priority headline: Doctor bundle headline." "${REPORT}"
+grep -q "display cta command: python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass" "${REPORT}"
+grep -q "next step: none" "${REPORT}"
+
+python3 - <<'PY' "${VALIDATION_REPORT}" "${READINESS_REPORT}" "${READINESS_VALIDATION_REPORT}" "${HANDOFF_BUNDLE}" "${HANDOFF_BUNDLE_VALIDATION_SIDECAR}" "${HANDOFF_BUNDLE_READINESS_SIDECAR}" "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}"
+import json
+import sys
+from pathlib import Path
+validation = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+readiness = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+readiness_validation = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+handoff_bundle = Path(sys.argv[4]).resolve()
+handoff_bundle_validation = Path(sys.argv[5]).resolve()
+handoff_bundle_readiness = Path(sys.argv[6]).resolve()
+handoff_bundle_readiness_validation = Path(sys.argv[7]).resolve()
+assert validation["verdict"] == "pass", validation
+assert validation["display_title"] == "Doctor bundle headline.", validation
+assert Path(validation["operator_handoff_bundle_path"]).resolve() == handoff_bundle, validation
+assert Path(validation["operator_handoff_bundle_validation_path"]).resolve() == handoff_bundle_validation, validation
+assert Path(validation["operator_handoff_bundle_readiness_path"]).resolve() == handoff_bundle_readiness, validation
+assert Path(validation["operator_handoff_bundle_readiness_validation_path"]).resolve() == handoff_bundle_readiness_validation, validation
+assert readiness["ready"] is True, readiness
+assert readiness["readiness_status"] == "ready", readiness
+assert Path(readiness["operator_handoff_bundle_path"]).resolve() == handoff_bundle, readiness
+assert Path(readiness["operator_handoff_bundle_validation_path"]).resolve() == handoff_bundle_validation, readiness
+assert Path(readiness["operator_handoff_bundle_readiness_path"]).resolve() == handoff_bundle_readiness, readiness
+assert Path(readiness["operator_handoff_bundle_readiness_validation_path"]).resolve() == handoff_bundle_readiness_validation, readiness
+assert readiness_validation["verdict"] == "pass", readiness_validation
+PY
+
+python3 "${ROOT_DIR}/planningops/scripts/resolve_supervisor_operator_handoff_bundle.py" \
+  --artifact-file "${ARTIFACT}" \
+  --output "${BROKEN_BUNDLE}" >/dev/null
+
+python3 - <<'PY' "${BROKEN_BUNDLE}"
+import json
+import sys
+from pathlib import Path
+path = Path(sys.argv[1])
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["priority_display_packet"]["display_title"] = "Broken bundle headline."
+path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if python3 "${ROOT_DIR}/planningops/scripts/doctor_supervisor_operator_handoff_bundle.py" \
+  --bundle-file "${BROKEN_BUNDLE}" \
+  --require-pass >"${BROKEN_OUTPUT}" 2>&1; then
+  echo "expected doctor to fail on broken bundle" >&2
+  exit 1
+fi
+
+grep -q "bundle validation verdict: fail" "${BROKEN_OUTPUT}"
+grep -q "readiness status: blocked" "${BROKEN_OUTPUT}"
+grep -q "next step: python3 planningops/scripts/validate_supervisor_operator_handoff_bundle.py --bundle-file ${BROKEN_BUNDLE} --output <handoff-bundle-validation.json> --strict" "${BROKEN_OUTPUT}"
+
+echo "doctor supervisor operator handoff bundle ok"

--- a/planningops/scripts/test_gate_supervisor_operator_handoff_bundle.sh
+++ b/planningops/scripts/test_gate_supervisor_operator_handoff_bundle.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MONDAY_DIR="$(cd "${ROOT_DIR}/../monday" && pwd)"
+TMP_DIR="$(mktemp -d)"
+RUNTIME_DIR="$(mktemp -d "${MONDAY_DIR}/runtime-artifacts/test-handoff-bundle-gate.XXXXXX")"
+trap 'rm -rf "${TMP_DIR}" "${RUNTIME_DIR}"' EXIT
+
+VALIDATION="${TMP_DIR}/operator-handoff-validation.json"
+HANDOFF_BUNDLE="${TMP_DIR}/operator-handoff-bundle.json"
+HANDOFF_BUNDLE_VALIDATION_SIDECAR="${TMP_DIR}/operator-handoff-bundle-validation.json"
+HANDOFF_BUNDLE_READINESS_SIDECAR="${TMP_DIR}/operator-handoff-bundle-readiness.json"
+HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR="${TMP_DIR}/operator-handoff-bundle-readiness-validation.json"
+PREVIEW="${RUNTIME_DIR}/preview.json"
+DISPLAY_PACKET="${RUNTIME_DIR}/display-packet.json"
+ARTIFACT="${RUNTIME_DIR}/artifact.json"
+BUNDLE="${TMP_DIR}/bundle.json"
+BROKEN_BUNDLE="${TMP_DIR}/broken-bundle.json"
+BUNDLE_VALIDATION="${TMP_DIR}/handoff-bundle-validation.json"
+READINESS="${TMP_DIR}/handoff-bundle-readiness.json"
+READINESS_VALIDATION="${TMP_DIR}/handoff-bundle-readiness-validation.json"
+
+preview_ref() {
+  python3 - <<'PY' "$MONDAY_DIR" "$1"
+from pathlib import Path
+import sys
+root = Path(sys.argv[1]).resolve()
+target = Path(sys.argv[2]).resolve()
+print(target.relative_to(root))
+PY
+}
+
+cat >"${VALIDATION}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:00Z",
+  "operator_report_path": "${TMP_DIR}/operator-report.json",
+  "inbox_payload_path": "${TMP_DIR}/inbox-payload.json",
+  "operator_report_schema_path": "${ROOT_DIR}/planningops/schemas/supervisor-operator-report.schema.json",
+  "inbox_payload_schema_path": "${ROOT_DIR}/planningops/schemas/supervisor-inbox-payload.schema.json",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "priority_display_packet_ref": "$(preview_ref "${DISPLAY_PACKET}")",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION_SIDECAR}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS_SIDECAR}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}",
+  "error_count": 0,
+  "warning_count": 0,
+  "errors": [],
+  "warnings": [],
+  "verdict": "pass"
+}
+JSON
+
+cat >"${PREVIEW}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:01Z",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle-gate.source/wrapper.json",
+  "source_artifact_kind": "local_outbox_envelope",
+  "source_priority_path": "payload.metadata.priority_summary_markdown",
+  "preview_state": "present",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION_SIDECAR}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS_SIDECAR}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}",
+  "priority_headline": "Gate bundle headline.",
+  "priority_cta_command": "bash planningops/scripts/gate_federated_ci_summary.sh",
+  "priority_summary_markdown": "## Priority\n- headline: Gate bundle headline.\n- first action: \`bash planningops/scripts/gate_federated_ci_summary.sh\`"
+}
+JSON
+
+cat >"${DISPLAY_PACKET}" <<JSON
+{
+  "generated_at_utc": "2026-03-20T00:00:02Z",
+  "input_kind": "artifact",
+  "input_ref": "runtime-artifacts/test-handoff-bundle-gate/artifact.json",
+  "source_artifact_ref": "runtime-artifacts/test-handoff-bundle-gate.source/wrapper.json",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "preview_source_artifact_kind": "local_outbox_envelope",
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "operator_handoff_bundle_path": "${HANDOFF_BUNDLE}",
+  "operator_handoff_bundle_validation_path": "${HANDOFF_BUNDLE_VALIDATION_SIDECAR}",
+  "operator_handoff_bundle_readiness_path": "${HANDOFF_BUNDLE_READINESS_SIDECAR}",
+  "operator_handoff_bundle_readiness_validation_path": "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}",
+  "priority_headline": "Gate bundle headline.",
+  "priority_cta_command": "bash planningops/scripts/gate_federated_ci_summary.sh",
+  "priority_summary_markdown": "## Priority\n- headline: Gate bundle headline.\n- first action: \`bash planningops/scripts/gate_federated_ci_summary.sh\`",
+  "display_title": "Gate bundle headline.",
+  "cta_command": "bash planningops/scripts/gate_federated_ci_summary.sh",
+  "display_markdown": "## Priority\n- headline: Gate bundle headline.\n- first action: \`bash planningops/scripts/gate_federated_ci_summary.sh\`"
+}
+JSON
+
+cat >"${ARTIFACT}" <<JSON
+{
+  "operator_handoff_validation_path": "${VALIDATION}",
+  "priority_preview_ref": "$(preview_ref "${PREVIEW}")",
+  "priority_display_packet_ref": "$(preview_ref "${DISPLAY_PACKET}")"
+}
+JSON
+
+bash "${ROOT_DIR}/planningops/scripts/gate_supervisor_operator_handoff_bundle.sh" \
+  --artifact-file "${ARTIFACT}" \
+  --bundle-validation-output "${BUNDLE_VALIDATION}" \
+  --readiness-output "${READINESS}" \
+  --readiness-validation-output "${READINESS_VALIDATION}" >/dev/null
+
+python3 - <<'PY' "${READINESS}" "${READINESS_VALIDATION}" "${HANDOFF_BUNDLE}" "${HANDOFF_BUNDLE_VALIDATION_SIDECAR}" "${HANDOFF_BUNDLE_READINESS_SIDECAR}" "${HANDOFF_BUNDLE_READINESS_VALIDATION_SIDECAR}"
+import json
+import sys
+from pathlib import Path
+
+readiness = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+validation = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+assert readiness["ready"] is True, readiness
+assert Path(readiness["operator_handoff_bundle_path"]).resolve() == Path(sys.argv[3]).resolve(), readiness
+assert Path(readiness["operator_handoff_bundle_validation_path"]).resolve() == Path(sys.argv[4]).resolve(), readiness
+assert Path(readiness["operator_handoff_bundle_readiness_path"]).resolve() == Path(sys.argv[5]).resolve(), readiness
+assert Path(readiness["operator_handoff_bundle_readiness_validation_path"]).resolve() == Path(sys.argv[6]).resolve(), readiness
+assert validation["verdict"] == "pass", validation
+PY
+
+python3 "${ROOT_DIR}/planningops/scripts/resolve_supervisor_operator_handoff_bundle.py" \
+  --artifact-file "${ARTIFACT}" \
+  --output "${BUNDLE}" >/dev/null
+
+python3 - <<'PY' "${BUNDLE}" "${BROKEN_BUNDLE}"
+import json
+import sys
+from pathlib import Path
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+doc = json.loads(source.read_text(encoding="utf-8"))
+doc["priority_display_packet"]["priority_cta_command"] = "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass"
+target.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if bash "${ROOT_DIR}/planningops/scripts/gate_supervisor_operator_handoff_bundle.sh" \
+  --bundle-file "${BROKEN_BUNDLE}" >/dev/null 2>&1; then
+  echo "expected gate to fail on broken bundle" >&2
+  exit 1
+fi
+
+echo "gate supervisor operator handoff bundle ok"


### PR DESCRIPTION
## Summary
- backfill the supervisor handoff bundle doctor and gate family
- add the 2026-03-28 workbench packet and hub link for the doctor/gate family
- keep downstream contract-doc expansion for follow-up units

## Validation
- bash planningops/scripts/test_doctor_supervisor_operator_handoff_bundle.sh
- bash planningops/scripts/test_gate_supervisor_operator_handoff_bundle.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all