### PR TITLE
docs(supervisor-handoff): promote contract surface

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -111,6 +111,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Supervisor Handoff Bundle Readiness Validator Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-readiness-validator-family-backfill-packet.md)
 - [Supervisor Handoff Bundle Readiness Assessor Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-readiness-assessor-family-backfill-packet.md)
 - [Supervisor Handoff Bundle Doctor Gate Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-bundle-doctor-gate-family-backfill-packet.md)
+- [Supervisor Handoff Contract Surface Promotion Packet](./plans/2026-03-28-supervisor-handoff-contract-surface-promotion-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-contract-surface-promotion-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-supervisor-handoff-contract-surface-promotion-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Supervisor Handoff Contract Surface Promotion Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes the canonical supervisor handoff contract and contract regression to reflect the newly tracked validation, bundle, readiness, and doctor/gate surfaces.
+related_docs:
+  - ./2026-03-28-supervisor-handoff-bundle-doctor-gate-family-backfill-packet.md
+  - ./2026-03-28-supervisor-handoff-bundle-readiness-assessor-family-backfill-packet.md
+---
+
+# plan: Supervisor Handoff Contract Surface Promotion Packet
+
+## Summary
+- Promote the canonical `supervisor operator handoff` contract so it matches the now-tracked validation, bundle, readiness, preview/display, and doctor/gate surfaces.
+- Lock the contract regression to real emitted supervisor artifacts, including degraded federated-ci blocked handoffs, bundle sidecar attachment propagation, and first-action/CTA carry-through.
+- Keep this unit limited to the contract doc and its regression; no new implementation surfaces are introduced here.
+
+## Scope
+- `planningops/contracts/supervisor-operator-handoff-contract.md`
+- `planningops/scripts/test_supervisor_operator_handoff_contract.sh`
+- workbench hub link for this contract-surface promotion
+
+## Acceptance
+- `test_supervisor_operator_handoff_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/supervisor-operator-handoff-contract.md
+++ b/planningops/contracts/supervisor-operator-handoff-contract.md
@@ -34,6 +34,7 @@ Every supervisor run must continue to emit:
 - `operator-report.json`
 - `operator-summary.md`
 - `inbox-payload.json`
+- `operator-handoff-validation.json`
 
 When goal lifecycle transition data is relevant, the handoff may also reference:
 - `cycle-<nn>/goal-transition-report.json`
@@ -50,6 +51,7 @@ Required fields:
 - `stop_reason`
 - `status`
 - `headline`
+- `priority_headline`
 - `operator_action`
 - `recommended_wait_minutes`
 - `retry_mode`
@@ -58,16 +60,27 @@ Required fields:
 - `guidance`
 - `message_class_hint`
 - `handoff_contract_ref`
+- `operator_handoff_validation_path`
+- `priority_preview_ref`
+- `priority_display_packet_ref`
+- `operator_handoff_bundle_path`
+- `operator_handoff_bundle_validation_path`
+- `operator_handoff_bundle_readiness_path`
+- `operator_handoff_bundle_readiness_validation_path`
+- `priority_summary_markdown`
 
 Optional fields:
 - `cycle_report_path`
 - `allowed_modes`
 - `blocked_modes`
+- `first_action_command`
+- `priority_cta_command`
 - `goal_key`
 - `primary_operator_channel`
 - `terminal_notification_channel`
 - `goal_transition_report_path`
 - `goal_completion_delivery_report_path`
+- `federated_ci_summary`
 
 ### `operator-summary.md`
 Human-readable attachment for the operator surface.
@@ -76,6 +89,7 @@ Requirements:
 - must summarize status, headline, action, and reason
 - must remain attachment-friendly and transport-agnostic
 - must not become the only machine-readable handoff source
+- should surface the canonical `operator-handoff-validation.json` path so downstream operators can inspect emitted handoff validation evidence directly
 
 ### `inbox-payload.json`
 Normalized payload companion for monday-owned delivery surfaces.
@@ -84,6 +98,7 @@ Required fields:
 - `title`
 - `status`
 - `headline`
+- `priority_headline`
 - `operator_action`
 - `recommended_wait_minutes`
 - `retry_mode`
@@ -92,12 +107,32 @@ Required fields:
 - `body_markdown`
 - `message_class_hint`
 - `handoff_contract_ref`
+- `operator_handoff_validation_path`
+- `priority_preview_ref`
+- `priority_display_packet_ref`
+- `operator_handoff_bundle_path`
+- `operator_handoff_bundle_validation_path`
+- `operator_handoff_bundle_readiness_path`
+- `operator_handoff_bundle_readiness_validation_path`
+- `priority_summary_markdown`
 
 Optional fields:
+- `first_action_command`
+- `priority_cta_command`
 - `goal_key`
 - `goal_transition_report_path`
 - `primary_operator_channel`
 - `terminal_notification_channel`
+
+### `operator-handoff-validation.json`
+Machine-readable validator report for the generated handoff sidecars.
+
+Requirements:
+- must be emitted by `planningops/scripts/autonomous_supervisor_loop.py`
+- must validate `operator-report.json` and `inbox-payload.json` against:
+  - `planningops/schemas/supervisor-operator-report.schema.json`
+  - `planningops/schemas/supervisor-inbox-payload.schema.json`
+- must fail closed when cross-artifact equality, attachment membership, or promoted CTA propagation regresses
 
 ## Goal-Aware Requirement
 
@@ -138,6 +173,16 @@ When `message_class_hint=goal_completed`:
   - `operator-summary.md`
   - the referenced `goal-transition-report.json`
 - monday must use `terminal_notification_channel`, not `primary_operator_channel`, for terminal delivery
+- when planningops supplies `first_action_command` or `federated_ci_summary.remediation_commands`, monday should preserve `headline`, `first_action_command`, and the first remediation command as terminal-delivery convenience fields and inject a `## First Action` block into the delivered markdown body unless that section already exists
+- monday-owned goal-completion wrappers and downstream delivery evidence should preserve root-level `operator_handoff_validation_path`, `priority_preview_ref`, and `priority_display_packet_ref` so consumers can dereference the canonical handoff validation sidecar plus preview/display packets without reopening nested delivery reports
+- monday-owned goal-completion wrappers and downstream delivery evidence should also preserve `operator_handoff_bundle_path`, `operator_handoff_bundle_validation_path`, `operator_handoff_bundle_readiness_path`, and `operator_handoff_bundle_readiness_validation_path` so consumers can dereference the planningops bundle and readiness sidecars without reopening nested delivery reports
+- CTA consumers should use monday's canonical preview/display consumer path:
+  - `scripts/resolve_operator_priority_preview.py`
+  - `scripts/resolve_operator_priority_display_packet.py`
+- canonical bundle validation consumer path: `python3 planningops/scripts/validate_supervisor_operator_handoff_bundle.py --artifact-file <wrapper-or-scheduler-report> --output <handoff-bundle-validation.json> --strict`
+- canonical bundle doctor command: `python3 planningops/scripts/doctor_supervisor_operator_handoff_bundle.py --artifact-file <wrapper-or-scheduler-report> --require-pass`
+- canonical bundle gate command: `bash planningops/scripts/gate_supervisor_operator_handoff_bundle.sh --artifact-file <wrapper-or-scheduler-report>`
+- if multiple goal-completion artifacts from one delivery path dereference different preview/display packet JSON, that is a contract regression and must fail closed
 - when planningops invokes monday-owned terminal delivery, `operator-report.json` may also include `goal_completion_delivery_report_path`
 
 ## Status/Decision Handoff Rule
@@ -151,6 +196,18 @@ monday must treat:
 - `inbox-payload.json` as the normalized operator-facing source
 - `operator-summary.md` as the primary human attachment
 - `operator-report.json` as machine evidence and policy context
+- monday-owned status wrappers and downstream dispatch evidence should preserve root-level `operator_handoff_validation_path`, `priority_preview_ref`, and `priority_display_packet_ref` so consumers can dereference the canonical handoff validation sidecar plus preview/display packets without reparsing nested delivery reports
+- monday-owned status wrappers and downstream dispatch evidence should also preserve `operator_handoff_bundle_path`, `operator_handoff_bundle_validation_path`, `operator_handoff_bundle_readiness_path`, and `operator_handoff_bundle_readiness_validation_path` so consumers can dereference the planningops bundle and readiness sidecars without reparsing nested delivery reports
+- canonical handoff-validation consumer path: `python3 planningops/scripts/resolve_supervisor_operator_handoff_validation.py --artifact-file <wrapper-or-scheduler-report> --output <handoff-validation.json>`
+- canonical bundle consumer path: `python3 planningops/scripts/resolve_supervisor_operator_handoff_bundle.py --artifact-file <wrapper-or-scheduler-report> --output <handoff-bundle.json>`
+- canonical bundle validation consumer path: `python3 planningops/scripts/validate_supervisor_operator_handoff_bundle.py --artifact-file <wrapper-or-scheduler-report> --output <handoff-bundle-validation.json> --strict`
+- canonical bundle readiness consumer path: `python3 planningops/scripts/assess_supervisor_operator_handoff_bundle_readiness.py --artifact-file <wrapper-or-scheduler-report> --bundle-validation-output <handoff-bundle-validation.json> --output <handoff-bundle-readiness.json> --readiness-validation-output <handoff-bundle-readiness-validation.json> --strict`
+- canonical bundle doctor command: `python3 planningops/scripts/doctor_supervisor_operator_handoff_bundle.py --artifact-file <wrapper-or-scheduler-report> --require-pass`
+- canonical bundle gate command: `bash planningops/scripts/gate_supervisor_operator_handoff_bundle.sh --artifact-file <wrapper-or-scheduler-report>`
+- CTA consumers should use monday's canonical preview/display consumer path:
+  - `scripts/resolve_operator_priority_preview.py`
+  - `scripts/resolve_operator_priority_display_packet.py`
+- if multiple status/dispatch artifacts from one delivery path dereference different preview/display packet JSON, that is a contract regression and must fail closed
 
 ## Channel Policy Rule
 
@@ -167,7 +224,54 @@ PlanningOps must not set:
 
 Monday resolves delivery targets from local configuration, skill context, or operator-specified arguments under `planningops/contracts/local-operator-target-resolution-contract.md`.
 
+## Federated CI Evidence Rule
+
+When the latest cross-repo runtime-gate evidence is available, `planningops` may include a `federated_ci_summary` snapshot inside `operator-report.json`.
+
+If present, that snapshot must:
+- reference the canonical latest readiness artifact instead of reconstructing readiness from raw summary data
+- carry enough fields for operator triage:
+  - `summary_path`
+  - `readiness_path`
+  - `validation_report_path`
+  - `summary_run_id`
+  - `summary_verdict`
+  - `readiness_status`
+  - `ready`
+  - `next_step`
+  - `first_action_command`
+  - `remediation_commands`
+
+When `federated_ci_summary` is present:
+- `operator-summary.md` should include a short Federated CI section
+- `inbox-payload.json` attachments should include the canonical `operator_handoff_validation_path` and may include the federated summary and readiness artifact refs
+- `operator-summary.md` and `inbox-payload.json` should surface `first_action_command`, `remediation_commands`, and `priority_summary_markdown` when federated readiness is blocked
+- `operator-report.json` and `inbox-payload.json` should carry `priority_headline`, `priority_cta_command`, and `priority_summary_markdown` so downstream operator surfaces do not need to recompute CTA precedence
+
+If `federated_ci_summary.ready=false` while the supervisor would otherwise emit `status=ok`:
+- `operator-report.json` should downgrade that handoff to `status=degraded`
+- `operator_action` should point to federated gate inspection rather than `none`
+- the human-readable reason should surface the canonical federated readiness `next_step`
+- `operator-report.json`, `operator-summary.md`, and `inbox-payload.json` should promote the first remediation command as `first_action_command`
+
 ## Validation
 - implementation: `planningops/scripts/autonomous_supervisor_loop.py`
+- machine validator: `planningops/scripts/validate_supervisor_operator_handoff.py`
+- bundle validator: `planningops/scripts/validate_supervisor_operator_handoff_bundle.py`
+- bundle readiness assessor: `planningops/scripts/assess_supervisor_operator_handoff_bundle_readiness.py`
+- bundle readiness validator: `planningops/scripts/validate_supervisor_operator_handoff_bundle_readiness.py`
+- bundle doctor: `planningops/scripts/doctor_supervisor_operator_handoff_bundle.py`
+- bundle gate: `planningops/scripts/gate_supervisor_operator_handoff_bundle.sh`
+- machine schemas:
+  - `planningops/schemas/supervisor-operator-report.schema.json`
+  - `planningops/schemas/supervisor-inbox-payload.schema.json`
+  - `planningops/schemas/supervisor-operator-handoff-bundle.schema.json`
+  - `planningops/schemas/supervisor-operator-handoff-bundle-validation.schema.json`
 - contract regression: `planningops/scripts/test_supervisor_operator_handoff_contract.sh`
+- validator regression: `planningops/scripts/test_validate_supervisor_operator_handoff_contract.sh`
+- bundle-validator regression: `planningops/scripts/test_validate_supervisor_operator_handoff_bundle.sh`
+- bundle-readiness regression: `planningops/scripts/test_assess_supervisor_operator_handoff_bundle_readiness.sh`
+- bundle-readiness-validator regression: `planningops/scripts/test_validate_supervisor_operator_handoff_bundle_readiness.sh`
+- bundle-doctor regression: `planningops/scripts/test_doctor_supervisor_operator_handoff_bundle.sh`
+- bundle-gate regression: `planningops/scripts/test_gate_supervisor_operator_handoff_bundle.sh`
 - broader supervisor regression: `planningops/scripts/test_autonomous_supervisor_loop_contract.sh`

--- a/planningops/scripts/test_supervisor_operator_handoff_contract.sh
+++ b/planningops/scripts/test_supervisor_operator_handoff_contract.sh
@@ -1,20 +1,119 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 run_id="supervisor-handoff-contract"
 summary_path="$tmpdir/summary.json"
 artifacts_root="$tmpdir/artifacts"
+goal_registry="$tmpdir/goal-registry.json"
+federated_summary="$tmpdir/federated-ci-summary.json"
+federated_readiness="$tmpdir/federated-ci-summary-readiness.json"
+federated_readiness_blocked="$tmpdir/federated-ci-summary-readiness-blocked.json"
+
+cat >"$goal_registry" <<'JSON'
+{
+  "registry_version": 1,
+  "active_goal_key": "goal-a",
+  "goals": [
+    {
+      "goal_key": "goal-a",
+      "title": "Goal A",
+      "status": "active",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave1-goal-brief.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-13-goal-driven-autonomy-wave1.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    }
+  ]
+}
+JSON
+
+cat >"$federated_readiness_blocked" <<JSON
+{
+  "generated_at_utc": "2026-03-19T11:42:14.545303+00:00",
+  "summary_path": "$federated_summary",
+  "validation_report_path": "/tmp/federated-ci-summary-validation.json",
+  "summary_present": true,
+  "validation_present": true,
+  "summary_run_id": "federated-ci-runtime-gates-test",
+  "summary_generated_at_utc": "2026-03-19T11:42:10.341286+00:00",
+  "summary_verdict": "pass",
+  "overall_status": "complete",
+  "check_count": 7,
+  "failed_checks": [],
+  "missing_required_checks": [],
+  "validation_verdict": "pass",
+  "validation_state": "fresh",
+  "ready": false,
+  "readiness_status": "blocked",
+  "blocking_reasons": ["runtime-operations-ready"],
+  "next_step": "bash planningops/scripts/gate_federated_ci_summary.sh"
+}
+JSON
+
+cat >"$federated_summary" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-test",
+  "generated_at_utc": "2026-03-19T11:42:10.341286+00:00",
+  "verdict": "pass",
+  "overall_status": "complete",
+  "check_count": 7
+}
+JSON
+
+cat >"$federated_readiness" <<JSON
+{
+  "generated_at_utc": "2026-03-19T11:42:14.545303+00:00",
+  "summary_path": "$federated_summary",
+  "validation_report_path": "/tmp/federated-ci-summary-validation.json",
+  "summary_present": true,
+  "validation_present": true,
+  "summary_run_id": "federated-ci-runtime-gates-test",
+  "summary_generated_at_utc": "2026-03-19T11:42:10.341286+00:00",
+  "summary_verdict": "pass",
+  "overall_status": "complete",
+  "check_count": 7,
+  "failed_checks": [],
+  "missing_required_checks": [],
+  "validation_verdict": "pass",
+  "validation_state": "fresh",
+  "ready": true,
+  "readiness_status": "ready",
+  "blocking_reasons": [],
+  "next_step": "none"
+}
+JSON
 
 python3 planningops/scripts/autonomous_supervisor_loop.py \
   --mode dry-run \
-  --max-cycles 1 \
+  --max-cycles 3 \
+  --convergence-pass-streak 2 \
+  --continue-on-experiment \
   --items-file planningops/fixtures/backlog-stock-items-sample.json \
   --offline \
-  --active-goal-registry planningops/config/active-goal-registry.json \
+  --active-goal-registry "$goal_registry" \
   --loop-result-sequence-file planningops/fixtures/supervisor-loop-sequence-sample.json \
+  --federated-ci-summary "$federated_summary" \
+  --federated-ci-summary-readiness "$federated_readiness" \
   --run-id "$run_id" \
   --artifacts-root "$artifacts_root" \
   --output "$summary_path" >/dev/null 2>&1 || true
@@ -22,8 +121,30 @@ python3 planningops/scripts/autonomous_supervisor_loop.py \
 operator_report="$artifacts_root/$run_id/operator-report.json"
 operator_summary="$artifacts_root/$run_id/operator-summary.md"
 inbox_payload="$artifacts_root/$run_id/inbox-payload.json"
+operator_summary_last="${summary_path%.json}-operator-summary.md"
+blocked_summary_path="$tmpdir/summary-blocked.json"
+blocked_run_id="${run_id}-blocked"
+blocked_operator_report="$artifacts_root/$blocked_run_id/operator-report.json"
+blocked_operator_summary="$artifacts_root/$blocked_run_id/operator-summary.md"
+blocked_inbox_payload="$artifacts_root/$blocked_run_id/inbox-payload.json"
+blocked_operator_summary_last="${blocked_summary_path%.json}-operator-summary.md"
 
-python3 - <<'PY' "$summary_path" "$operator_report" "$operator_summary" "$inbox_payload"
+python3 planningops/scripts/autonomous_supervisor_loop.py \
+  --mode dry-run \
+  --max-cycles 3 \
+  --convergence-pass-streak 2 \
+  --continue-on-experiment \
+  --items-file planningops/fixtures/backlog-stock-items-sample.json \
+  --offline \
+  --active-goal-registry "$goal_registry" \
+  --loop-result-sequence-file planningops/fixtures/supervisor-loop-sequence-sample.json \
+  --federated-ci-summary "$federated_summary" \
+  --federated-ci-summary-readiness "$federated_readiness_blocked" \
+  --run-id "$blocked_run_id" \
+  --artifacts-root "$artifacts_root" \
+  --output "$blocked_summary_path" >/dev/null 2>&1 || true
+
+python3 - <<'PY' "$summary_path" "$operator_report" "$operator_summary" "$inbox_payload" "$blocked_summary_path" "$blocked_operator_report" "$blocked_operator_summary" "$blocked_inbox_payload"
 import json
 import sys
 from pathlib import Path
@@ -32,28 +153,149 @@ summary_path = Path(sys.argv[1])
 operator_report_path = Path(sys.argv[2])
 operator_summary_path = Path(sys.argv[3])
 inbox_payload_path = Path(sys.argv[4])
+blocked_summary_path = Path(sys.argv[5])
+blocked_operator_report_path = Path(sys.argv[6])
+blocked_operator_summary_path = Path(sys.argv[7])
+blocked_inbox_payload_path = Path(sys.argv[8])
 
 summary = json.loads(summary_path.read_text(encoding="utf-8"))
 operator_report = json.loads(operator_report_path.read_text(encoding="utf-8"))
 inbox_payload = json.loads(inbox_payload_path.read_text(encoding="utf-8"))
 operator_summary = operator_summary_path.read_text(encoding="utf-8")
+blocked_summary = json.loads(blocked_summary_path.read_text(encoding="utf-8"))
+blocked_operator_report = json.loads(blocked_operator_report_path.read_text(encoding="utf-8"))
+blocked_inbox_payload = json.loads(blocked_inbox_payload_path.read_text(encoding="utf-8"))
+blocked_operator_summary = blocked_operator_summary_path.read_text(encoding="utf-8")
+contract_text = Path("planningops/contracts/supervisor-operator-handoff-contract.md").read_text(encoding="utf-8")
 
 assert Path("planningops/contracts/supervisor-operator-handoff-contract.md").exists()
+assert "priority_display_packet_ref" in contract_text, contract_text
+assert "priority_preview_ref" in contract_text, contract_text
+assert "operator_handoff_bundle_path" in contract_text, contract_text
+assert "operator_handoff_bundle_validation_path" in contract_text, contract_text
+assert "operator_handoff_bundle_readiness_path" in contract_text, contract_text
+assert "operator_handoff_bundle_readiness_validation_path" in contract_text, contract_text
+assert "resolve_supervisor_operator_handoff_bundle.py" in contract_text, contract_text
+assert "validate_supervisor_operator_handoff_bundle.py" in contract_text, contract_text
+assert "assess_supervisor_operator_handoff_bundle_readiness.py" in contract_text, contract_text
+assert "validate_supervisor_operator_handoff_bundle_readiness.py" in contract_text, contract_text
+assert "doctor_supervisor_operator_handoff_bundle.py" in contract_text, contract_text
+assert "gate_supervisor_operator_handoff_bundle.sh" in contract_text, contract_text
+assert "resolve_operator_priority_preview.py" in contract_text, contract_text
+assert "resolve_operator_priority_display_packet.py" in contract_text, contract_text
+assert "validate_supervisor_operator_handoff.py" in contract_text, contract_text
+assert "supervisor-operator-report.schema.json" in contract_text, contract_text
+assert "supervisor-inbox-payload.schema.json" in contract_text, contract_text
+assert "operator-handoff-validation.json" in contract_text, contract_text
+assert "must fail closed" in contract_text, contract_text
 assert operator_report["run_id"] == summary["run_id"], operator_report
 assert operator_report["handoff_contract_ref"] == "planningops/contracts/supervisor-operator-handoff-contract.md", operator_report
 assert operator_report["message_class_hint"] in {"status_update", "decision_request", "blocked_report", "goal_completed"}, operator_report
 assert operator_report["goal_key"], operator_report
 assert operator_report["primary_operator_channel"]["kind"].startswith("slack_skill"), operator_report
 assert operator_report["terminal_notification_channel"]["kind"].startswith("email"), operator_report
+assert operator_report["federated_ci_summary"]["summary_run_id"] == "federated-ci-runtime-gates-test", operator_report
+assert operator_report["federated_ci_summary"]["ready"] is True, operator_report
+assert operator_report["federated_ci_summary"]["remediation_commands"] == [], operator_report
+assert operator_report["priority_headline"] == operator_report["headline"], operator_report
+assert operator_report["priority_preview_ref"] == summary["operator_priority_preview_last_path"], operator_report
+assert operator_report["priority_display_packet_ref"] == summary["operator_priority_display_packet_last_path"], operator_report
+assert operator_report["operator_handoff_bundle_path"] == summary["operator_handoff_bundle_last_path"], operator_report
+assert operator_report["operator_handoff_bundle_validation_path"] == summary["operator_handoff_bundle_validation_last_path"], operator_report
+assert operator_report["operator_handoff_bundle_readiness_path"] == summary["operator_handoff_bundle_readiness_last_path"], operator_report
+assert operator_report["operator_handoff_bundle_readiness_validation_path"] == summary["operator_handoff_bundle_readiness_validation_last_path"], operator_report
+assert "## Priority" in operator_report["priority_summary_markdown"], operator_report
+assert summary["operator_handoff_validation_path"].endswith("operator-handoff-validation.json"), summary
+assert summary["operator_handoff_validation_last_path"].endswith("-operator-handoff-validation.json"), summary
+handoff_validation = json.loads(Path(summary["operator_handoff_validation_last_path"]).read_text(encoding="utf-8"))
+assert handoff_validation["verdict"] == "pass", handoff_validation
 
 assert inbox_payload["handoff_contract_ref"] == operator_report["handoff_contract_ref"], inbox_payload
 assert inbox_payload["goal_key"] == operator_report["goal_key"], inbox_payload
 assert inbox_payload["message_class_hint"] == operator_report["message_class_hint"], inbox_payload
+assert inbox_payload["priority_headline"] == operator_report["priority_headline"], inbox_payload
+assert inbox_payload["priority_summary_markdown"] == operator_report["priority_summary_markdown"], inbox_payload
+assert inbox_payload["operator_handoff_validation_path"] == summary["operator_handoff_validation_last_path"], inbox_payload
+assert inbox_payload["priority_preview_ref"] == summary["operator_priority_preview_last_path"], inbox_payload
+assert inbox_payload["priority_display_packet_ref"] == summary["operator_priority_display_packet_last_path"], inbox_payload
+assert inbox_payload["operator_handoff_bundle_path"] == summary["operator_handoff_bundle_last_path"], inbox_payload
+assert inbox_payload["operator_handoff_bundle_validation_path"] == summary["operator_handoff_bundle_validation_last_path"], inbox_payload
+assert inbox_payload["operator_handoff_bundle_readiness_path"] == summary["operator_handoff_bundle_readiness_last_path"], inbox_payload
+assert inbox_payload["operator_handoff_bundle_readiness_validation_path"] == summary["operator_handoff_bundle_readiness_validation_last_path"], inbox_payload
 assert any(str(attachment).endswith("summary-operator-summary.md") for attachment in inbox_payload["attachments"]), inbox_payload
 assert any(str(attachment).endswith("summary.json") for attachment in inbox_payload["attachments"]), inbox_payload
+assert any(str(attachment).endswith("summary-operator-handoff-validation.json") for attachment in inbox_payload["attachments"]), inbox_payload
+assert any(str(attachment).endswith("summary-operator-handoff-bundle.json") for attachment in inbox_payload["attachments"]), inbox_payload
+assert any(str(attachment).endswith("summary-operator-handoff-bundle-validation.json") for attachment in inbox_payload["attachments"]), inbox_payload
+assert any(str(attachment).endswith("summary-operator-handoff-bundle-readiness.json") for attachment in inbox_payload["attachments"]), inbox_payload
+assert any(str(attachment).endswith("summary-operator-handoff-bundle-readiness-validation.json") for attachment in inbox_payload["attachments"]), inbox_payload
+assert any("federated-ci-summary-readiness.json" in str(attachment) for attachment in inbox_payload["attachments"]), inbox_payload
+assert any("federated-ci-summary-validation.json" in str(attachment) for attachment in inbox_payload["attachments"]), inbox_payload
 
 assert "# Supervisor Operator Summary" in operator_summary, operator_summary
 assert "Headline:" in operator_summary, operator_summary
+assert "Handoff Validation Path:" in operator_summary, operator_summary
+assert "summary-operator-handoff-validation.json" in operator_summary, operator_summary
+assert "## Priority" in operator_summary, operator_summary
+assert "## Federated CI" in operator_summary, operator_summary
+
+assert blocked_operator_report["run_id"] == blocked_summary["run_id"], blocked_operator_report
+assert blocked_operator_report["status"] == "degraded", blocked_operator_report
+assert blocked_operator_report["operator_action"] == "inspect_federated_ci_gates", blocked_operator_report
+assert blocked_operator_report["federated_ci_summary"]["ready"] is False, blocked_operator_report
+assert blocked_operator_report["federated_ci_summary"]["readiness_status"] == "blocked", blocked_operator_report
+assert blocked_operator_report["federated_ci_summary"]["remediation_commands"] == [
+    "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+    "bash planningops/scripts/gate_federated_ci_summary.sh",
+], blocked_operator_report
+assert blocked_operator_report["federated_ci_summary"]["first_action_command"] == "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass", blocked_operator_report
+assert blocked_operator_report["first_action_command"] == "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass", blocked_operator_report
+assert blocked_operator_report["priority_headline"] == "Supervisor converged, but the latest federated runtime gate is blocked.", blocked_operator_report
+assert blocked_operator_report["priority_cta_command"] == "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass", blocked_operator_report
+assert blocked_operator_report["priority_preview_ref"] == blocked_summary["operator_priority_preview_last_path"], blocked_operator_report
+assert blocked_operator_report["priority_display_packet_ref"] == blocked_summary["operator_priority_display_packet_last_path"], blocked_operator_report
+assert blocked_operator_report["operator_handoff_bundle_path"] == blocked_summary["operator_handoff_bundle_last_path"], blocked_operator_report
+assert blocked_operator_report["operator_handoff_bundle_validation_path"] == blocked_summary["operator_handoff_bundle_validation_last_path"], blocked_operator_report
+assert blocked_operator_report["operator_handoff_bundle_readiness_path"] == blocked_summary["operator_handoff_bundle_readiness_last_path"], blocked_operator_report
+assert blocked_operator_report["operator_handoff_bundle_readiness_validation_path"] == blocked_summary["operator_handoff_bundle_readiness_validation_last_path"], blocked_operator_report
+assert "`python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass`" in blocked_operator_report["priority_summary_markdown"], blocked_operator_report
+assert "gate_federated_ci_summary.sh" in blocked_operator_report["reason"], blocked_operator_report
+assert blocked_operator_report["guidance"]["federated_ci_remediation_commands"] == [
+    "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass",
+    "bash planningops/scripts/gate_federated_ci_summary.sh",
+], blocked_operator_report
+assert blocked_operator_report["guidance"]["first_action_command"] == "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass", blocked_operator_report
+assert blocked_summary["operator_handoff_validation_path"].endswith("operator-handoff-validation.json"), blocked_summary
+assert blocked_summary["operator_handoff_validation_last_path"].endswith("-operator-handoff-validation.json"), blocked_summary
+blocked_handoff_validation = json.loads(Path(blocked_summary["operator_handoff_validation_last_path"]).read_text(encoding="utf-8"))
+assert blocked_handoff_validation["verdict"] == "pass", blocked_handoff_validation
+assert blocked_inbox_payload["status"] == "degraded", blocked_inbox_payload
+assert blocked_inbox_payload["first_action_command"] == "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass", blocked_inbox_payload
+assert blocked_inbox_payload["priority_headline"] == "Supervisor converged, but the latest federated runtime gate is blocked.", blocked_inbox_payload
+assert blocked_inbox_payload["priority_cta_command"] == "python3 planningops/scripts/doctor_federated_ci_summary.py --require-pass", blocked_inbox_payload
+assert blocked_inbox_payload["priority_summary_markdown"] == blocked_operator_report["priority_summary_markdown"], blocked_inbox_payload
+assert blocked_inbox_payload["operator_handoff_validation_path"] == blocked_summary["operator_handoff_validation_last_path"], blocked_inbox_payload
+assert blocked_inbox_payload["priority_preview_ref"] == blocked_summary["operator_priority_preview_last_path"], blocked_inbox_payload
+assert blocked_inbox_payload["priority_display_packet_ref"] == blocked_summary["operator_priority_display_packet_last_path"], blocked_inbox_payload
+assert blocked_inbox_payload["operator_handoff_bundle_path"] == blocked_summary["operator_handoff_bundle_last_path"], blocked_inbox_payload
+assert blocked_inbox_payload["operator_handoff_bundle_validation_path"] == blocked_summary["operator_handoff_bundle_validation_last_path"], blocked_inbox_payload
+assert blocked_inbox_payload["operator_handoff_bundle_readiness_path"] == blocked_summary["operator_handoff_bundle_readiness_last_path"], blocked_inbox_payload
+assert blocked_inbox_payload["operator_handoff_bundle_readiness_validation_path"] == blocked_summary["operator_handoff_bundle_readiness_validation_last_path"], blocked_inbox_payload
+assert "inspect_federated_ci_gates" in blocked_inbox_payload["body_markdown"], blocked_inbox_payload
+assert "First Action:" in blocked_inbox_payload["body_markdown"], blocked_inbox_payload
+assert "doctor_federated_ci_summary.py --require-pass" in blocked_inbox_payload["body_markdown"], blocked_inbox_payload
+assert any(str(attachment).endswith("summary-blocked-operator-handoff-validation.json") for attachment in blocked_inbox_payload["attachments"]), blocked_inbox_payload
+assert any(str(attachment).endswith("summary-blocked-operator-handoff-bundle.json") for attachment in blocked_inbox_payload["attachments"]), blocked_inbox_payload
+assert any(str(attachment).endswith("summary-blocked-operator-handoff-bundle-validation.json") for attachment in blocked_inbox_payload["attachments"]), blocked_inbox_payload
+assert any(str(attachment).endswith("summary-blocked-operator-handoff-bundle-readiness.json") for attachment in blocked_inbox_payload["attachments"]), blocked_inbox_payload
+assert any(str(attachment).endswith("summary-blocked-operator-handoff-bundle-readiness-validation.json") for attachment in blocked_inbox_payload["attachments"]), blocked_inbox_payload
+assert any("federated-ci-summary-validation.json" in str(attachment) for attachment in blocked_inbox_payload["attachments"]), blocked_inbox_payload
+assert "## Federated CI" in blocked_operator_summary, blocked_operator_summary
+assert "Handoff Validation Path:" in blocked_operator_summary, blocked_operator_summary
+assert "summary-blocked-operator-handoff-validation.json" in blocked_operator_summary, blocked_operator_summary
+assert "## Priority" in blocked_operator_summary, blocked_operator_summary
+assert "## First Action" in blocked_operator_summary, blocked_operator_summary
+assert "doctor_federated_ci_summary.py --require-pass" in blocked_operator_summary, blocked_operator_summary
 PY
 
 echo "supervisor operator handoff contract ok"


### PR DESCRIPTION
## Summary
- promote the supervisor handoff contract to match the tracked validation, bundle, readiness, and doctor/gate surfaces
- lock the contract regression to emitted supervisor artifacts, including degraded federated-ci blocked handoffs
- add the 2026-03-28 workbench packet and hub link for this contract-surface promotion

## Validation
- bash planningops/scripts/test_supervisor_operator_handoff_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all