### PR TITLE
feat(reflection-cycle): backfill goal completion runner common

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -115,6 +115,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Supervisor Handoff Common Backfill Packet](./plans/2026-03-28-supervisor-handoff-common-backfill-packet.md)
 - [Supervisor Handoff Status Bridge Test Backfill Packet](./plans/2026-03-28-supervisor-handoff-status-bridge-test-backfill-packet.md)
 - [Supervisor Handoff Goal-Completion Bridge Test Family Backfill Packet](./plans/2026-03-28-supervisor-handoff-goal-completion-bridge-test-family-backfill-packet.md)
+- [Reflection Goal-Completion Runner Common Backfill Packet](./plans/2026-03-28-reflection-goal-completion-runner-common-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-reflection-goal-completion-runner-common-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-reflection-goal-completion-runner-common-backfill-packet.md
@@ -1,0 +1,33 @@
+---
+title: plan: Reflection Goal-Completion Runner Common Backfill Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the shared reflection-cycle plumbing and goal-completion handoff runner surfaces so planningops can emit canonical reflection-driven supervisor handoffs from direct actions or monday scheduler reports.
+related_docs:
+  - ./2026-03-28-supervisor-handoff-common-backfill-packet.md
+  - ./2026-03-28-supervisor-handoff-goal-completion-bridge-test-family-backfill-packet.md
+---
+
+# plan: Reflection Goal-Completion Runner Common Backfill Packet
+
+## Summary
+- Backfill the tracked `reflection goal-completion handoff` runner family that sits between worker-outcome reflection and monday goal-completion delivery admission.
+- Promote the missing shared reflection-cycle common module, federation runner, thin wrapper, and scheduler-report regression into git-tracked reality so fresh clones preserve canonical reflection-driven handoff behavior.
+- Keep this unit limited to the runner/common family; scheduled reflection delivery regression expansion remains a separate follow-up wave.
+
+## Scope
+- `planningops/scripts/federation/reflection_cycle_common.py`
+- `planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py`
+- `planningops/scripts/run_reflection_goal_completion_handoff_cycle.py`
+- `planningops/scripts/test_worker_outcome_reflection_cycle_scheduler_report.sh`
+- workbench hub link for this runner/common backfill
+
+## Acceptance
+- `test_reflection_goal_completion_handoff_cycle.sh` passes
+- `test_worker_outcome_reflection_cycle_scheduler_report.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/federation/reflection_cycle_common.py
+++ b/planningops/scripts/federation/reflection_cycle_common.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+CORE_GOALS_DIR = SCRIPT_DIR.parent / "core" / "goals"
+if str(CORE_GOALS_DIR) not in sys.path:
+    sys.path.insert(0, str(CORE_GOALS_DIR))
+
+from resolve_active_goal import build_resolved_payload, load_json as load_goal_json, resolve_active_goal, validate_registry
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in [current] + list(current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return Path(__file__).resolve().parents[4]
+
+
+def resolve_workspace_root(planningops_repo: Path, raw_workspace_root: str) -> Path:
+    candidates = [
+        (planningops_repo / raw_workspace_root).resolve(),
+        planningops_repo,
+        planningops_repo.parent,
+    ]
+    for candidate in candidates:
+        if (candidate / "monday").exists():
+            return candidate
+    return (planningops_repo / raw_workspace_root).resolve()
+
+
+def resolve_component_repo(workspace_root: Path, repo_dir: str) -> Path:
+    path = Path(repo_dir)
+    if path.is_absolute():
+        return path
+    return (workspace_root / path).resolve()
+
+
+def resolve_repo_path(repo_root: Path, raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return (repo_root / path).resolve()
+
+
+def resolve_input_path(planningops_repo: Path, workspace_root: Path, monday_repo: Path, raw_path: str) -> Path:
+    path = Path(raw_path)
+    candidates: list[Path] = []
+    if path.is_absolute():
+        candidates.append(path)
+    else:
+        candidates.extend(
+            [
+                (planningops_repo / path).resolve(),
+                (workspace_root / path).resolve(),
+                (monday_repo / path).resolve(),
+                path.resolve(),
+            ]
+        )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"input not found: {raw_path}")
+
+
+def resolve_output_path(planningops_repo: Path, raw_path: str | None, default_path: Path) -> Path:
+    if raw_path is None:
+        return default_path
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return (planningops_repo / path).resolve()
+
+
+def normalize_repo_path(repo_root: Path, path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
+def normalize_workspace_path(workspace_root: Path, path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(workspace_root.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
+def normalize_monday_runtime_ref(workspace_root: Path, monday_repo: Path, raw_ref: str | None) -> str:
+    text = str(raw_ref or "").strip()
+    if not text or text == "-":
+        return "-"
+    path_text, separator, suffix = text.partition("#")
+    path = Path(path_text)
+    if not path.is_absolute():
+        path = (monday_repo / path).resolve()
+    normalized = normalize_workspace_path(workspace_root, path)
+    return f"{normalized}{separator}{suffix}" if separator else normalized
+
+
+def normalize_cross_repo_path(planningops_repo: Path, monday_repo: Path, path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(planningops_repo.resolve()))
+    except ValueError:
+        try:
+            return str(path.resolve().relative_to(monday_repo.resolve()))
+        except ValueError:
+            return str(path.resolve())
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_json_doc(raw: str) -> dict | None:
+    text = (raw or "").strip()
+    if not text:
+        return None
+    try:
+        doc = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def require_string(doc: dict, key: str) -> str:
+    value = doc.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value.strip()
+
+
+def write_report(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def derive_single_queue_value(queue_doc: dict, key: str) -> str:
+    values = {str(item.get(key) or "").strip() for item in queue_doc.get("queue_items", []) if str(item.get(key) or "").strip()}
+    if len(values) != 1:
+        raise ValueError(f"queue seed must provide exactly one {key}; got {sorted(values)}")
+    return next(iter(values))
+
+
+def resolve_goal_context(registry_path: Path, repo_root: Path, goal_key: str | None) -> tuple[dict | None, list[str]]:
+    if not registry_path.exists():
+        return None, [f"active goal registry not found: {registry_path}"]
+    registry = load_goal_json(registry_path)
+    errors = validate_registry(registry, repo_root=repo_root)
+    if errors:
+        return None, [f"active goal registry invalid: {error}" for error in errors]
+    try:
+        goal = build_resolved_payload(resolve_active_goal(registry, goal_key=goal_key))
+    except RuntimeError as exc:
+        return None, [str(exc)]
+    return goal, []
+
+
+def run_cmd(command: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
+    completed = subprocess.run(command, cwd=str(cwd), capture_output=True, text=True, env=env)
+    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
+
+
+def build_stage_report(stage: str, command: list[str], cwd: Path, rc: int, out: str, err: str, artifact_path: Path) -> dict:
+    return {
+        "stage": stage,
+        "command": command,
+        "cwd": str(cwd),
+        "exit_code": rc,
+        "stdout_tail": out[-1000:],
+        "stderr_tail": err[-1000:],
+        "artifact_path": str(artifact_path),
+        "artifact_exists": artifact_path.exists(),
+        "verdict": "pass" if rc == 0 else "fail",
+    }

--- a/planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py
+++ b/planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+SCRIPTS_DIR = SCRIPT_DIR.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+CORE_GOALS_DIR = SCRIPT_DIR.parent / "core" / "goals"
+if str(CORE_GOALS_DIR) not in sys.path:
+    sys.path.insert(0, str(CORE_GOALS_DIR))
+
+from federated_python_env import (  # noqa: E402
+    build_bootstrap_plan,
+    build_managed_env,
+    ensure_bootstrap_environment,
+    resolve_bootstrap_root,
+)
+from reflection_cycle_common import (  # noqa: E402
+    load_json,
+    normalize_repo_path,
+    now_utc,
+    resolve_component_repo,
+    resolve_goal_context,
+    resolve_repo_path,
+    resolve_repo_root,
+    resolve_workspace_root,
+)
+from supervisor_handoff_common import (  # noqa: E402
+    build_inbox_payload,
+    build_operator_handoff_validation_report,
+    build_operator_report,
+    build_operator_summary_markdown,
+    emit_operator_handoff_bundle_sidecars,
+    load_federated_ci_summary_snapshot,
+    run_goal_completion_delivery,
+    save_json,
+)
+
+
+RUNNER_CONTRACT_REF = "planningops/contracts/supervisor-operator-handoff-contract.md"
+ACTION_CONTRACT_REF = "planningops/contracts/reflection-action-handoff-contract.md"
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Bridge a goal-completed reflection action into supervisor handoff artifacts and monday goal-completion queue admission"
+    )
+    parser.add_argument("--workspace-root", default="..")
+    parser.add_argument("--monday-repo-dir", default="monday")
+    parser.add_argument("--monday-python", default=None)
+    parser.add_argument("--monday-profiles-config", default=None)
+    parser.add_argument(
+        "--monday-supervisor-goal-completion-script",
+        default="scripts/enqueue_scheduled_delivery_work_item.py",
+    )
+    parser.add_argument("--monday-supervisor-schedule-key", default="recurring-delivery")
+    parser.add_argument("--monday-supervisor-queue-db", default=None)
+    parser.add_argument("--active-goal-registry", default="planningops/config/active-goal-registry.json")
+    parser.add_argument("--goal-key", default=None)
+    parser.add_argument("--reflection-action-file", required=True)
+    parser.add_argument("--goal-transition-output", default=None)
+    parser.add_argument(
+        "--federated-ci-summary",
+        default="planningops/artifacts/ci/federated-ci-summary.json",
+    )
+    parser.add_argument(
+        "--federated-ci-summary-readiness",
+        default="planningops/artifacts/validation/federated-ci-summary-readiness.json",
+    )
+    parser.add_argument("--mode", choices=["dry-run", "apply"], default="dry-run")
+    parser.add_argument(
+        "--run-id",
+        default=f"reflection-goal-completion-handoff-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
+    )
+    parser.add_argument("--summary-output", default=None)
+    parser.add_argument("--output", default=None)
+    parser.add_argument(
+        "--bootstrap-mode",
+        choices=["auto", "off", "require"],
+        default="auto",
+        help="Managed Python bootstrap mode for sibling-repo leaf scripts",
+    )
+    parser.add_argument(
+        "--bootstrap-root",
+        default="planningops/runtime-artifacts/tooling/federated-conformance",
+        help="Managed virtualenv root used when bootstrap is required",
+    )
+    return parser.parse_args()
+
+def resolve_existing_path_ref(path_ref: str, *, planningops_repo: Path, workspace_root: Path) -> str:
+    text = str(path_ref or "").strip()
+    if not text or text == "-":
+        return "-"
+
+    candidate = Path(text)
+    candidates = [candidate] if candidate.is_absolute() else [planningops_repo / candidate, workspace_root / candidate]
+    for resolved_candidate in candidates:
+        if resolved_candidate.exists():
+            return str(resolved_candidate.resolve())
+    return text
+
+
+def validate_reflection_action(action: dict) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(action, dict):
+        return ["reflection action must be a JSON object"]
+    required = [
+        "handoff_contract_ref",
+        "verdict",
+        "active_goal_key",
+        "reflection_decision",
+        "action_kind",
+        "delivery_required",
+        "message_class_hint",
+        "goal_transition_required",
+        "goal_transition_report_path",
+    ]
+    for field in required:
+        if field not in action:
+            errors.append(f"missing reflection action field: {field}")
+    if action.get("handoff_contract_ref") != ACTION_CONTRACT_REF:
+        errors.append("handoff_contract_ref must match reflection action handoff contract")
+    if action.get("verdict") != "pass":
+        errors.append("reflection action verdict must be pass")
+    if action.get("reflection_decision") != "goal_achieved":
+        errors.append("reflection action must use reflection_decision=goal_achieved")
+    if action.get("action_kind") != "prepare_goal_completion":
+        errors.append("reflection action must use action_kind=prepare_goal_completion")
+    if action.get("message_class_hint") != "goal_completed":
+        errors.append("reflection action must use message_class_hint=goal_completed")
+    if action.get("delivery_required") is not True:
+        errors.append("reflection action must require delivery")
+    if action.get("goal_transition_required") is not True:
+        errors.append("reflection action must require goal transition")
+    return errors
+
+
+def maybe_apply_goal_transition(
+    *,
+    planningops_repo: Path,
+    active_goal_registry: str,
+    goal_key: str,
+    evidence_ref: str,
+    goal_transition_output: str | None,
+) -> tuple[str, list[str]]:
+    output_path = (
+        Path(goal_transition_output).resolve()
+        if goal_transition_output
+        else planningops_repo / "planningops" / "artifacts" / "validation" / f"{goal_key}-reflection-goal-transition.json"
+    )
+    command = [
+        sys.executable,
+        str(planningops_repo / "planningops" / "scripts" / "core" / "goals" / "transition_goal_state.py"),
+        "--registry",
+        active_goal_registry,
+        "--goal-key",
+        goal_key,
+        "--to-status",
+        "achieved",
+        "--reason",
+        "reflection_goal_achieved",
+        "--evidence-ref",
+        evidence_ref,
+        "--mode",
+        "apply",
+        "--output",
+        str(output_path),
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, cwd=str(planningops_repo))
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        stdout = result.stdout.strip()
+        detail = "goal transition apply failed"
+        if stderr:
+            detail = f"{detail}: {stderr}"
+        elif stdout:
+            detail = f"{detail}: {stdout}"
+        return "-", [detail]
+    return str(output_path.resolve()), []
+
+
+def failure_report(
+    *,
+    mode: str,
+    goal_key: str,
+    action_ref: str,
+    summary_ref: str,
+    report_path: Path,
+    failure_stage: str,
+    errors: list[str],
+    operator_report_ref: str = "-",
+    operator_summary_ref: str = "-",
+    inbox_payload_ref: str = "-",
+    handoff_validation_ref: str = "-",
+    goal_completion_delivery_report_ref: str = "-",
+) -> int:
+    payload = {
+        "generated_at_utc": now_utc(),
+        "mode": mode,
+        "goal_key": goal_key,
+        "reflection_action_ref": action_ref,
+        "summary_ref": summary_ref,
+        "operator_report_ref": operator_report_ref,
+        "operator_summary_ref": operator_summary_ref,
+        "inbox_payload_ref": inbox_payload_ref,
+        "operator_handoff_validation_ref": handoff_validation_ref,
+        "goal_completion_delivery_report_ref": goal_completion_delivery_report_ref,
+        "reflection_decision": "goal_achieved",
+        "action_kind": "prepare_goal_completion",
+        "message_class_hint": "goal_completed",
+        "goal_completion_delivery_enabled": None,
+        "goal_completion_delivery_verdict": None,
+        "queue_admission_verdict": None,
+        "selected_delivery_entrypoint": None,
+        "scheduled_delivery_work_item_ref": None,
+        "scheduled_queue_item_ref": None,
+        "scheduled_queue_item_id": None,
+        "delivery_idempotency_key": None,
+        "runner_contract_ref": RUNNER_CONTRACT_REF,
+        "failure_stage": failure_stage,
+        "error_count": len(errors),
+        "errors": errors,
+        "verdict": "fail",
+    }
+    save_json(report_path, payload)
+    print(f"report written: {report_path}")
+    print(f"verdict=fail failure_stage={failure_stage}")
+    return 1
+
+
+def main() -> int:
+    args = parse_args()
+    planningops_repo = resolve_repo_root()
+    workspace_root = resolve_workspace_root(planningops_repo, args.workspace_root)
+    monday_repo = resolve_component_repo(workspace_root, args.monday_repo_dir)
+
+    bootstrap_root = resolve_bootstrap_root(planningops_repo, args.bootstrap_root)
+    bootstrap_plan = build_bootstrap_plan(planningops_repo, workspace_root, bootstrap_root)
+    bootstrap_info = ensure_bootstrap_environment(bootstrap_plan, args.bootstrap_mode)
+    if bootstrap_info.get("reexec_required"):
+        child_cmd = [bootstrap_info["managed_python"], str(Path(__file__).resolve()), *sys.argv[1:]]
+        child = subprocess.run(child_cmd, env=build_managed_env(bootstrap_info))
+        return int(child.returncode)
+
+    report_dir = (
+        planningops_repo / "planningops" / "artifacts" / "validation" / "reflection-goal-completion-handoff" / args.run_id
+    )
+    summary_output = (
+        Path(args.summary_output).resolve()
+        if args.summary_output
+        else report_dir / "summary.json"
+    )
+    report_output = (
+        Path(args.output).resolve()
+        if args.output
+        else report_dir / "cycle-report.json"
+    )
+    run_dir = summary_output.parent
+
+    action_path = resolve_repo_path(planningops_repo, args.reflection_action_file)
+    action_ref = normalize_repo_path(planningops_repo, action_path)
+    if not action_path.exists():
+        return failure_report(
+            mode=args.mode,
+            goal_key=args.goal_key or "-",
+            action_ref=action_ref,
+            summary_ref=normalize_repo_path(planningops_repo, summary_output),
+            report_path=report_output,
+            failure_stage="load_reflection_action",
+            errors=[f"reflection action not found: {action_path}"],
+        )
+
+    action = load_json(action_path)
+    action_errors = validate_reflection_action(action)
+    action_goal_key = str(action.get("active_goal_key") or "").strip()
+    if args.goal_key and args.goal_key != action_goal_key:
+        action_errors.append(
+            f"reflection action goal_key mismatch: expected {args.goal_key}, got {action_goal_key or '-'}"
+        )
+    if action_errors:
+        return failure_report(
+            mode=args.mode,
+            goal_key=args.goal_key or action_goal_key or "-",
+            action_ref=action_ref,
+            summary_ref=normalize_repo_path(planningops_repo, summary_output),
+            report_path=report_output,
+            failure_stage="validate_reflection_action",
+            errors=action_errors,
+        )
+
+    resolved_goal, goal_errors = resolve_goal_context(
+        resolve_repo_path(planningops_repo, args.active_goal_registry),
+        planningops_repo,
+        args.goal_key or action_goal_key,
+    )
+    if goal_errors:
+        return failure_report(
+            mode=args.mode,
+            goal_key=args.goal_key or action_goal_key or "-",
+            action_ref=action_ref,
+            summary_ref=normalize_repo_path(planningops_repo, summary_output),
+            report_path=report_output,
+            failure_stage="resolve_goal_context",
+            errors=goal_errors,
+        )
+
+    resolved_goal_key = str((resolved_goal or {}).get("goal_key") or "").strip()
+    if resolved_goal_key and action_goal_key and resolved_goal_key != action_goal_key:
+        return failure_report(
+            mode=args.mode,
+            goal_key=resolved_goal_key,
+            action_ref=action_ref,
+            summary_ref=normalize_repo_path(planningops_repo, summary_output),
+            report_path=report_output,
+            failure_stage="resolve_goal_context",
+            errors=[
+                "reflection action goal_key must match the resolved active goal",
+                f"expected={resolved_goal_key}",
+                f"actual={action_goal_key}",
+            ],
+        )
+
+    federated_ci_summary = load_federated_ci_summary_snapshot(
+        resolve_repo_path(planningops_repo, args.federated_ci_summary),
+        resolve_repo_path(planningops_repo, args.federated_ci_summary_readiness),
+    )
+
+    output_path = report_output
+    operator_report_path = run_dir / "operator-report.json"
+    last_operator_report_path = output_path.with_name(f"{output_path.stem}-operator-report.json")
+    operator_summary_path = run_dir / "operator-summary.md"
+    last_operator_summary_path = output_path.with_name(f"{output_path.stem}-operator-summary.md")
+    inbox_payload_path = run_dir / "inbox-payload.json"
+    last_inbox_payload_path = output_path.with_name(f"{output_path.stem}-inbox-payload.json")
+    operator_handoff_validation_path = run_dir / "operator-handoff-validation.json"
+    last_operator_handoff_validation_path = output_path.with_name(f"{output_path.stem}-operator-handoff-validation.json")
+    monday_priority_preview_root = monday_repo / "runtime-artifacts" / "messaging" / "operator-priority-previews"
+    monday_priority_display_packet_root = monday_repo / "runtime-artifacts" / "messaging" / "operator-priority-display-packets"
+    operator_priority_preview_path = monday_priority_preview_root / f"{args.run_id}-operator-priority-preview.json"
+    last_operator_priority_preview_path = monday_priority_preview_root / f"{output_path.stem}-operator-priority-preview.json"
+    operator_priority_display_packet_path = monday_priority_display_packet_root / f"{args.run_id}-operator-priority-display-packet.json"
+    last_operator_priority_display_packet_path = (
+        monday_priority_display_packet_root / f"{output_path.stem}-operator-priority-display-packet.json"
+    )
+    operator_handoff_bundle_path = run_dir / "operator-handoff-bundle.json"
+    last_operator_handoff_bundle_path = output_path.with_name(f"{output_path.stem}-operator-handoff-bundle.json")
+    operator_handoff_bundle_validation_path = run_dir / "operator-handoff-bundle-validation.json"
+    last_operator_handoff_bundle_validation_path = output_path.with_name(
+        f"{output_path.stem}-operator-handoff-bundle-validation.json"
+    )
+    operator_handoff_bundle_readiness_path = run_dir / "operator-handoff-bundle-readiness.json"
+    last_operator_handoff_bundle_readiness_path = output_path.with_name(
+        f"{output_path.stem}-operator-handoff-bundle-readiness.json"
+    )
+    operator_handoff_bundle_readiness_validation_path = run_dir / "operator-handoff-bundle-readiness-validation.json"
+    last_operator_handoff_bundle_readiness_validation_path = output_path.with_name(
+        f"{output_path.stem}-operator-handoff-bundle-readiness-validation.json"
+    )
+    last_goal_completion_delivery_path = output_path.with_name(f"{output_path.stem}-goal-completion-delivery-report.json")
+
+    goal_transition_report_path = str(action.get("goal_transition_report_path") or "").strip()
+    if (
+        args.mode == "apply"
+        and bool(action.get("goal_transition_required")) is True
+        and (not goal_transition_report_path or goal_transition_report_path == "-")
+    ):
+        goal_transition_report_path, transition_errors = maybe_apply_goal_transition(
+            planningops_repo=planningops_repo,
+            active_goal_registry=args.active_goal_registry,
+            goal_key=resolved_goal_key or action_goal_key,
+            evidence_ref=str(action.get("reflection_evaluation_ref") or action_ref),
+            goal_transition_output=args.goal_transition_output,
+        )
+        if transition_errors:
+            return failure_report(
+                mode=args.mode,
+                goal_key=resolved_goal_key or action_goal_key or "-",
+                action_ref=action_ref,
+                summary_ref=normalize_repo_path(planningops_repo, summary_output),
+                report_path=report_output,
+                failure_stage="apply_goal_transition",
+                errors=transition_errors,
+            )
+    goal_transition_report_path = resolve_existing_path_ref(
+        goal_transition_report_path,
+        planningops_repo=planningops_repo,
+        workspace_root=workspace_root,
+    )
+    summary = {
+        "generated_at_utc": now_utc(),
+        "run_id": args.run_id,
+        "supervisor_verdict": "pass",
+        "stop_reason": "goal_completed",
+        "stop_details": {
+            "goal_transition": {
+                "output_path": goal_transition_report_path,
+                "goal_key": resolved_goal_key or action_goal_key,
+            },
+            "source_reflection_action_ref": action_ref,
+            "source_reflection_decision": str(action.get("reflection_decision") or ""),
+        },
+        "cycles": [],
+        "resolved_active_goal": resolved_goal or {},
+        "operator_report_path": str(operator_report_path),
+        "operator_report_last_path": str(last_operator_report_path),
+        "operator_summary_path": str(operator_summary_path),
+        "operator_summary_last_path": str(last_operator_summary_path),
+        "inbox_payload_path": str(inbox_payload_path),
+        "inbox_payload_last_path": str(last_inbox_payload_path),
+        "operator_handoff_validation_path": str(operator_handoff_validation_path),
+        "operator_handoff_validation_last_path": str(last_operator_handoff_validation_path),
+        "operator_priority_preview_path": str(operator_priority_preview_path),
+        "operator_priority_preview_last_path": str(last_operator_priority_preview_path),
+        "operator_priority_display_packet_path": str(operator_priority_display_packet_path),
+        "operator_priority_display_packet_last_path": str(last_operator_priority_display_packet_path),
+        "operator_handoff_bundle_path": str(operator_handoff_bundle_path),
+        "operator_handoff_bundle_last_path": str(last_operator_handoff_bundle_path),
+        "operator_handoff_bundle_validation_path": str(operator_handoff_bundle_validation_path),
+        "operator_handoff_bundle_validation_last_path": str(last_operator_handoff_bundle_validation_path),
+        "operator_handoff_bundle_readiness_path": str(operator_handoff_bundle_readiness_path),
+        "operator_handoff_bundle_readiness_last_path": str(last_operator_handoff_bundle_readiness_path),
+        "operator_handoff_bundle_readiness_validation_path": str(operator_handoff_bundle_readiness_validation_path),
+        "operator_handoff_bundle_readiness_validation_last_path": str(
+            last_operator_handoff_bundle_readiness_validation_path
+        ),
+    }
+    if federated_ci_summary:
+        summary["federated_ci_summary"] = federated_ci_summary
+
+    save_json(summary_output, summary)
+
+    operator_report = build_operator_report(summary, summary_output, run_dir)
+    save_json(operator_report_path, operator_report)
+    save_json(last_operator_report_path, operator_report)
+    operator_summary = build_operator_summary_markdown(
+        operator_report,
+        handoff_validation_path=last_operator_handoff_validation_path,
+    )
+    write_text(operator_summary_path, operator_summary)
+    write_text(last_operator_summary_path, operator_summary)
+
+    goal_completion_delivery = run_goal_completion_delivery(args, run_dir, operator_report_path, operator_summary_path)
+    summary["goal_completion_delivery_path"] = str(goal_completion_delivery.get("output_path") or "-")
+    summary["goal_completion_delivery_last_path"] = str(last_goal_completion_delivery_path)
+    summary["goal_completion_delivery"] = goal_completion_delivery
+    if goal_completion_delivery.get("enabled") and isinstance(goal_completion_delivery.get("report"), dict) and goal_completion_delivery["report"]:
+        save_json(last_goal_completion_delivery_path, goal_completion_delivery["report"])
+    if goal_completion_delivery.get("enabled") and goal_completion_delivery.get("verdict") != "pass":
+        summary["supervisor_verdict"] = "fail"
+        summary["stop_reason"] = "goal_completion_delivery_failed"
+        summary["stop_details"] = {
+            "previous_stop_reason": "goal_completed",
+            "goal_transition": summary["stop_details"].get("goal_transition") or {},
+            "goal_completion_delivery": goal_completion_delivery,
+            "source_reflection_action_ref": action_ref,
+            "source_reflection_decision": str(action.get("reflection_decision") or ""),
+        }
+
+    save_json(summary_output, summary)
+    operator_report = build_operator_report(summary, summary_output, run_dir)
+    save_json(operator_report_path, operator_report)
+    save_json(last_operator_report_path, operator_report)
+    operator_summary = build_operator_summary_markdown(
+        operator_report,
+        handoff_validation_path=last_operator_handoff_validation_path,
+    )
+    write_text(operator_summary_path, operator_summary)
+    write_text(last_operator_summary_path, operator_summary)
+
+    inbox_payload = build_inbox_payload(
+        operator_report,
+        last_operator_summary_path,
+        handoff_validation_path=last_operator_handoff_validation_path,
+    )
+    save_json(inbox_payload_path, inbox_payload)
+    save_json(last_inbox_payload_path, inbox_payload)
+
+    operator_handoff_validation = build_operator_handoff_validation_report(
+        operator_report_path=operator_report_path,
+        inbox_payload_path=inbox_payload_path,
+        operator_summary_path=last_operator_summary_path,
+    )
+    save_json(operator_handoff_validation_path, operator_handoff_validation)
+    save_json(last_operator_handoff_validation_path, operator_handoff_validation)
+
+    if operator_handoff_validation.get("verdict") != "pass":
+        return failure_report(
+            mode=args.mode,
+            goal_key=resolved_goal_key or action_goal_key or "-",
+            action_ref=action_ref,
+            summary_ref=normalize_repo_path(planningops_repo, summary_output),
+            report_path=report_output,
+            failure_stage="validate_supervisor_operator_handoff",
+            errors=list(operator_handoff_validation.get("errors") or ["unknown handoff validation failure"]),
+            operator_report_ref=normalize_repo_path(planningops_repo, operator_report_path),
+            operator_summary_ref=normalize_repo_path(planningops_repo, last_operator_summary_path),
+            inbox_payload_ref=normalize_repo_path(planningops_repo, inbox_payload_path),
+            handoff_validation_ref=normalize_repo_path(planningops_repo, operator_handoff_validation_path),
+            goal_completion_delivery_report_ref=str(goal_completion_delivery.get("output_path") or "-"),
+        )
+
+    _preview_doc, _display_packet_doc, handoff_bundle_readiness = emit_operator_handoff_bundle_sidecars(
+        operator_report_path=operator_report_path,
+        monday_repo=monday_repo,
+        preview_path=last_operator_priority_preview_path,
+        display_packet_path=last_operator_priority_display_packet_path,
+        bundle_path=last_operator_handoff_bundle_path,
+        bundle_validation_path=last_operator_handoff_bundle_validation_path,
+        readiness_path=last_operator_handoff_bundle_readiness_path,
+        readiness_validation_path=last_operator_handoff_bundle_readiness_validation_path,
+    )
+    if handoff_bundle_readiness.get("ready") is not True:
+        return failure_report(
+            mode=args.mode,
+            goal_key=resolved_goal_key or action_goal_key or "-",
+            action_ref=action_ref,
+            summary_ref=normalize_repo_path(planningops_repo, summary_output),
+            report_path=report_output,
+            failure_stage="assess_supervisor_operator_handoff_bundle_readiness",
+            errors=list(handoff_bundle_readiness.get("blocking_reasons") or ["unknown bundle readiness failure"]),
+            operator_report_ref=normalize_repo_path(planningops_repo, operator_report_path),
+            operator_summary_ref=normalize_repo_path(planningops_repo, last_operator_summary_path),
+            inbox_payload_ref=normalize_repo_path(planningops_repo, inbox_payload_path),
+            handoff_validation_ref=normalize_repo_path(planningops_repo, operator_handoff_validation_path),
+            goal_completion_delivery_report_ref=str(goal_completion_delivery.get("output_path") or "-"),
+        )
+
+    operator_summary = build_operator_summary_markdown(
+        operator_report,
+        handoff_validation_path=last_operator_handoff_validation_path,
+    )
+    write_text(operator_summary_path, operator_summary)
+    write_text(last_operator_summary_path, operator_summary)
+    inbox_payload = build_inbox_payload(
+        operator_report,
+        last_operator_summary_path,
+        handoff_validation_path=last_operator_handoff_validation_path,
+    )
+    save_json(inbox_payload_path, inbox_payload)
+    save_json(last_inbox_payload_path, inbox_payload)
+    operator_handoff_validation = build_operator_handoff_validation_report(
+        operator_report_path=operator_report_path,
+        inbox_payload_path=inbox_payload_path,
+        operator_summary_path=last_operator_summary_path,
+    )
+    save_json(operator_handoff_validation_path, operator_handoff_validation)
+    save_json(last_operator_handoff_validation_path, operator_handoff_validation)
+
+    if operator_handoff_validation.get("verdict") != "pass":
+        return failure_report(
+            mode=args.mode,
+            goal_key=resolved_goal_key or action_goal_key or "-",
+            action_ref=action_ref,
+            summary_ref=normalize_repo_path(planningops_repo, summary_output),
+            report_path=report_output,
+            failure_stage="validate_supervisor_operator_handoff_after_bundle",
+            errors=list(operator_handoff_validation.get("errors") or ["unknown post-bundle handoff validation failure"]),
+            operator_report_ref=normalize_repo_path(planningops_repo, operator_report_path),
+            operator_summary_ref=normalize_repo_path(planningops_repo, last_operator_summary_path),
+            inbox_payload_ref=normalize_repo_path(planningops_repo, inbox_payload_path),
+            handoff_validation_ref=normalize_repo_path(planningops_repo, operator_handoff_validation_path),
+            goal_completion_delivery_report_ref=str(goal_completion_delivery.get("output_path") or "-"),
+        )
+
+    save_json(summary_output, summary)
+
+    delivery_enabled = bool(goal_completion_delivery.get("enabled"))
+    delivery_verdict = str(goal_completion_delivery.get("delivery_verdict") or "-")
+    queue_admission_verdict = str(goal_completion_delivery.get("queue_admission_verdict") or "-")
+    payload = {
+        "generated_at_utc": now_utc(),
+        "mode": args.mode,
+        "goal_key": resolved_goal_key or action_goal_key or "-",
+        "reflection_action_ref": action_ref,
+        "summary_ref": normalize_repo_path(planningops_repo, summary_output),
+        "operator_report_ref": normalize_repo_path(planningops_repo, operator_report_path),
+        "operator_summary_ref": normalize_repo_path(planningops_repo, last_operator_summary_path),
+        "inbox_payload_ref": normalize_repo_path(planningops_repo, inbox_payload_path),
+        "operator_handoff_validation_ref": normalize_repo_path(planningops_repo, operator_handoff_validation_path),
+        "operator_handoff_bundle_ref": normalize_repo_path(planningops_repo, last_operator_handoff_bundle_path),
+        "operator_handoff_bundle_validation_ref": normalize_repo_path(
+            planningops_repo, last_operator_handoff_bundle_validation_path
+        ),
+        "operator_handoff_bundle_readiness_ref": normalize_repo_path(
+            planningops_repo, last_operator_handoff_bundle_readiness_path
+        ),
+        "operator_handoff_bundle_readiness_validation_ref": normalize_repo_path(
+            planningops_repo, last_operator_handoff_bundle_readiness_validation_path
+        ),
+        "goal_completion_delivery_report_ref": str(goal_completion_delivery.get("output_path") or "-"),
+        "reflection_decision": str(action.get("reflection_decision") or ""),
+        "action_kind": str(action.get("action_kind") or ""),
+        "message_class_hint": str(action.get("message_class_hint") or ""),
+        "goal_completion_delivery_enabled": delivery_enabled,
+        "goal_completion_delivery_verdict": delivery_verdict,
+        "queue_admission_verdict": queue_admission_verdict,
+        "selected_delivery_entrypoint": goal_completion_delivery.get("selected_delivery_entrypoint"),
+        "scheduled_delivery_work_item_ref": goal_completion_delivery.get("scheduled_delivery_work_item_ref"),
+        "scheduled_queue_item_ref": goal_completion_delivery.get("scheduled_queue_item_ref"),
+        "scheduled_queue_item_id": goal_completion_delivery.get("scheduled_queue_item_id"),
+        "delivery_idempotency_key": goal_completion_delivery.get("delivery_idempotency_key"),
+        "runner_contract_ref": RUNNER_CONTRACT_REF,
+        "error_count": 0,
+        "errors": [],
+        "verdict": "pass",
+    }
+    if delivery_enabled and goal_completion_delivery.get("verdict") != "pass":
+        payload["verdict"] = "fail"
+        payload["error_count"] = len(goal_completion_delivery.get("errors") or [])
+        payload["errors"] = list(goal_completion_delivery.get("errors") or ["goal completion delivery failed"])
+    save_json(report_output, payload)
+    print(f"report written: {report_output}")
+    print(f"verdict={payload['verdict']} delivery_verdict={delivery_verdict}")
+    return 0 if payload["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/run_reflection_goal_completion_handoff_cycle.py
+++ b/planningops/scripts/run_reflection_goal_completion_handoff_cycle.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import runpy
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    target = Path(__file__).resolve().parent / "federation" / "run_reflection_goal_completion_handoff_cycle.py"
+    runpy.run_path(str(target), run_name="__main__")

--- a/planningops/scripts/test_worker_outcome_reflection_cycle_scheduler_report.sh
+++ b/planningops/scripts/test_worker_outcome_reflection_cycle_scheduler_report.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKSPACE_ROOT="$(cd "$ROOT_DIR/.." && pwd)"
+MONDAY_REPO="$WORKSPACE_ROOT/monday"
+TMP_DIR="$(mktemp -d)"
+RUN_ID="test-wave28-memory-reflection-cycle"
+QUEUE_ITEM_ID="memory-consolidation-job-mission-28-job-run-28"
+REPORT_PATH="$MONDAY_REPO/runtime-artifacts/scheduler-cycle/${RUN_ID}.json"
+CYCLE_REPORT_PATH="$MONDAY_REPO/runtime-artifacts/scheduler-cycle/${RUN_ID}-memory-cycle.json"
+JOB_REPORT_PATH="$MONDAY_REPO/runtime-artifacts/scheduler-cycle/${RUN_ID}-memory-cycle-job.json"
+WORKER_OUTCOME_ARTIFACT="$MONDAY_REPO/runtime-artifacts/worker-outcome/${RUN_ID}-${QUEUE_ITEM_ID}.json"
+JOB_INPUT_ARTIFACT="$MONDAY_REPO/runtime-artifacts/memory/scheduled-consolidation-job-inputs/$QUEUE_ITEM_ID.json"
+WORK_ITEM_ARTIFACT="$MONDAY_REPO/runtime-artifacts/memory/scheduled-consolidation-work-items/$QUEUE_ITEM_ID.json"
+QUEUE_REF_ARTIFACT="$MONDAY_REPO/runtime-artifacts/scheduler-queue/item-refs/$QUEUE_ITEM_ID.json"
+trap 'rm -rf "$TMP_DIR" "$REPORT_PATH" "$CYCLE_REPORT_PATH" "$JOB_REPORT_PATH" "$WORKER_OUTCOME_ARTIFACT" "$JOB_INPUT_ARTIFACT" "$WORK_ITEM_ARTIFACT" "$QUEUE_REF_ARTIFACT"' EXIT
+
+cd "$ROOT_DIR"
+
+python3 - <<'PY'
+from pathlib import Path
+
+runner = Path("planningops/scripts/federation/run_worker_outcome_reflection_cycle.py").read_text(encoding="utf-8")
+common = Path("planningops/scripts/federation/reflection_cycle_common.py").read_text(encoding="utf-8")
+
+assert "from reflection_cycle_common import (" in runner, runner
+assert "def resolve_repo_root(" not in runner, runner
+assert "def resolve_workspace_root(" not in runner, runner
+assert "def resolve_goal_context(" not in runner, runner
+assert "def resolve_repo_root(" in common, common
+assert "def resolve_workspace_root(" in common, common
+assert "def resolve_goal_context(" in common, common
+PY
+
+if [[ ! -f "$MONDAY_REPO/scripts/export_scheduler_worker_outcome_reflection_packet.py" ]]; then
+  echo "worker outcome reflection cycle scheduler-report test skipped: sibling monday repo unavailable"
+  exit 0
+fi
+
+DB_PATH="$TMP_DIR/runtime-queue.sqlite3"
+IDEMPOTENCY_PATH="$TMP_DIR/idempotency.json"
+TRANSITION_LOG="$TMP_DIR/transition.ndjson"
+MEMORY_ROOT="$TMP_DIR/memory-root"
+JOB_INPUT="$TMP_DIR/memory-consolidation-job-input.json"
+QUEUE_ADMISSION_REPORT="$TMP_DIR/memory-consolidation-admission-report.json"
+GOAL_REGISTRY="$TMP_DIR/active-goal-registry.json"
+PACKET_OUTPUT="$TMP_DIR/packet.json"
+EVALUATION_OUTPUT="$TMP_DIR/evaluation.json"
+ACTION_OUTPUT="$TMP_DIR/action.json"
+REFLECTION_REPORT="$TMP_DIR/reflection-cycle-report.json"
+
+mkdir -p "$MEMORY_ROOT"
+
+cat >"$MEMORY_ROOT/session-memory.json" <<'JSON'
+[
+  {
+    "schemaVersion": 1,
+    "id": "seed-turn-1",
+    "memoryType": "session_memory",
+    "tenantId": "tenant-alpha",
+    "userId": "user-primary",
+    "projectId": "project-runtime",
+    "threadId": "thread-runtime",
+    "createdAtUtc": "2026-03-25T06:00:00.000Z",
+    "updatedAtUtc": "2026-03-25T06:00:00.000Z",
+    "role": "user",
+    "content": "Earlier thread context should be compacted later.",
+    "tokenCount": 7
+  },
+  {
+    "schemaVersion": 1,
+    "id": "seed-turn-2",
+    "memoryType": "session_memory",
+    "tenantId": "tenant-alpha",
+    "userId": "user-primary",
+    "projectId": "project-runtime",
+    "threadId": "thread-runtime",
+    "createdAtUtc": "2026-03-25T06:00:01.000Z",
+    "updatedAtUtc": "2026-03-25T06:00:01.000Z",
+    "role": "assistant",
+    "content": "Acknowledged earlier context.",
+    "tokenCount": 4
+  },
+  {
+    "schemaVersion": 1,
+    "id": "session-user:job-run-28",
+    "memoryType": "session_memory",
+    "tenantId": "tenant-alpha",
+    "userId": "user-primary",
+    "projectId": "project-runtime",
+    "threadId": "thread-runtime",
+    "runId": "job-run-28",
+    "sessionId": "job-run-28:session:primary",
+    "createdAtUtc": "2026-03-25T06:00:02.000Z",
+    "updatedAtUtc": "2026-03-25T06:00:02.000Z",
+    "role": "user",
+    "content": "I prefer concise markdown summaries. Please prepare the blocker note.",
+    "tokenCount": 11
+  },
+  {
+    "schemaVersion": 1,
+    "id": "session-assistant:job-run-28",
+    "memoryType": "session_memory",
+    "tenantId": "tenant-alpha",
+    "userId": "user-primary",
+    "projectId": "project-runtime",
+    "threadId": "thread-runtime",
+    "runId": "job-run-28",
+    "sessionId": "job-run-28:session:primary",
+    "createdAtUtc": "2026-03-25T06:00:03.000Z",
+    "updatedAtUtc": "2026-03-25T06:00:03.000Z",
+    "role": "assistant",
+    "content": "Still blocked on finance sign-off for the release. Keep the update short.",
+    "tokenCount": 12
+  }
+]
+JSON
+
+cat >"$JOB_INPUT" <<JSON
+{
+  "memoryRootDir": "$MEMORY_ROOT",
+  "mission": {
+    "missionId": "job-mission-28",
+    "objective": "I prefer concise markdown summaries. Please prepare the blocker note.",
+    "memoryScope": {
+      "tenantId": "tenant-alpha",
+      "userId": "user-primary",
+      "projectId": "project-runtime",
+      "threadId": "thread-runtime"
+    }
+  },
+  "intakeRecord": {
+    "schemaVersion": 1,
+    "missionId": "job-mission-28",
+    "objective": "I prefer concise markdown summaries. Please prepare the blocker note.",
+    "runId": "job-run-28",
+    "sessionId": "job-run-28:session:primary",
+    "startingPhase": "plan",
+    "createdAtUtc": "2026-03-25T06:00:02.000Z"
+  },
+  "handoff": {
+    "handoffId": "job-run-28:handoff:task:1",
+    "taskId": "job-mission-28:task:1"
+  },
+  "outcome": {
+    "resultType": "complete",
+    "outputText": "Still blocked on finance sign-off for the release. Keep the update short.",
+    "reasonCode": "reflection_cycle_scheduler_report_test"
+  },
+  "policy": {
+    "maxUnsummarizedTurns": 1,
+    "promoteExplicitPreferences": true,
+    "consolidatedAtUtc": "2026-03-25T06:00:10.000Z"
+  },
+  "generatedAtUtc": "2026-03-25T06:00:11.000Z"
+}
+JSON
+
+(
+  cd "$MONDAY_REPO"
+  python3 scripts/enqueue_memory_consolidation_work_item.py \
+    --job-input-file "$JOB_INPUT" \
+    --schedule-key memory-background \
+    --mode apply \
+    --queue-db "$DB_PATH" \
+    --output "$QUEUE_ADMISSION_REPORT" >/dev/null
+
+  python3 scripts/run_scheduled_queue_cycle.py \
+    --queue-db "$DB_PATH" \
+    --run-id "$RUN_ID" \
+    --idempotency "$IDEMPOTENCY_PATH" \
+    --report "$REPORT_PATH" \
+    --transition-log "$TRANSITION_LOG" >/dev/null
+)
+
+cat >"$GOAL_REGISTRY" <<'JSON'
+{
+  "registry_version": 1,
+  "active_goal_key": "agent-memory-consolidation:job-mission-28",
+  "goals": [
+    {
+      "goal_key": "agent-memory-consolidation:job-mission-28",
+      "title": "MONDAY agent memory scheduled consolidation reflection",
+      "status": "active",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-25-monday-agent-memory-wave-g-reflection-packet.md",
+      "execution_contract_file": "planningops/contracts/worker-outcome-reflection-contract.md",
+      "completion_contract_refs": [
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/worker-outcome-reflection-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    }
+  ]
+}
+JSON
+
+python3 planningops/scripts/run_worker_outcome_reflection_cycle.py \
+  --workspace-root .. \
+  --scheduler-report-json "$REPORT_PATH" \
+  --active-goal-registry "$GOAL_REGISTRY" \
+  --goal-key "agent-memory-consolidation:job-mission-28" \
+  --run-id "test-reflection-cycle-memory-scheduler-report" \
+  --packet-output "$PACKET_OUTPUT" \
+  --evaluation-output "$EVALUATION_OUTPUT" \
+  --action-output "$ACTION_OUTPUT" \
+  --output "$REFLECTION_REPORT" >/dev/null
+
+python3 - "$REPORT_PATH" "$PACKET_OUTPUT" "$EVALUATION_OUTPUT" "$ACTION_OUTPUT" "$REFLECTION_REPORT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+scheduler_report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+packet = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+evaluation = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+action = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
+report = json.loads(Path(sys.argv[5]).read_text(encoding="utf-8"))
+
+expected_source_outcome_ref = (
+    "runtime-artifacts/worker-outcome/"
+    "test-wave28-memory-reflection-cycle-memory-consolidation-job-mission-28-job-run-28.json"
+)
+
+assert scheduler_report["worker_outcome_ref"] == expected_source_outcome_ref, scheduler_report
+assert report["verdict"] == "pass", report
+assert report["source_outcome_ref"] == expected_source_outcome_ref, report
+assert report["reflection_decision"] == "goal_achieved", report
+assert report["control_plane_action"] == "evaluate_goal_completion", report
+assert report["action_kind"] == "prepare_goal_completion", report
+assert report["delivery_required"] is True, report
+assert report["goal_transition_required"] is True, report
+assert report["goal_transition_report_path"] == "-", report
+assert [row["stage"] for row in report["stage_reports"]] == [
+    "packet_export",
+    "reflection_evaluation",
+    "reflection_action_application",
+], report
+assert all(row["verdict"] == "pass" for row in report["stage_reports"]), report
+assert report["stage_reports"][0]["command"][1] == "scripts/export_scheduler_worker_outcome_reflection_packet.py", report
+
+assert packet["source_outcome_ref"] == expected_source_outcome_ref, packet
+assert packet["reflection_hints"]["outcome_class"] == "completion", packet
+assert evaluation["verdict"] == "pass", evaluation
+assert evaluation["reflection_decision"] == "goal_achieved", evaluation
+assert evaluation["control_plane_action"] == "evaluate_goal_completion", evaluation
+assert action["reflection_decision"] == "goal_achieved", action
+assert action["action_kind"] == "prepare_goal_completion", action
+PY
+
+echo "worker outcome reflection cycle scheduler report test passed"


### PR DESCRIPTION
## Summary
- backfill the shared reflection-cycle common module, goal-completion federation runner, thin wrapper, and scheduler-report regression
- add the 2026-03-28 workbench packet and hub link for this runner/common family
- keep scheduled reflection delivery regression expansion for follow-up work

## Validation
- bash planningops/scripts/test_reflection_goal_completion_handoff_cycle.sh
- bash planningops/scripts/test_worker_outcome_reflection_cycle_scheduler_report.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all