### PR TITLE
test(inventory-lifecycle): backfill snapshot audit regression

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -118,6 +118,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Reflection Goal-Completion Runner Common Backfill Packet](./plans/2026-03-28-reflection-goal-completion-runner-common-backfill-packet.md)
 - [Scheduled Reflection Delivery Regression Hardening Packet](./plans/2026-03-28-scheduled-reflection-delivery-regression-hardening-packet.md)
 - [Federated Tooling Contract Test Family Backfill Packet](./plans/2026-03-28-federated-tooling-contract-test-family-backfill-packet.md)
+- [Inventory Issue Lifecycle Snapshot Test Backfill Packet](./plans/2026-03-28-inventory-issue-lifecycle-snapshot-test-backfill-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-inventory-issue-lifecycle-snapshot-test-backfill-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-inventory-issue-lifecycle-snapshot-test-backfill-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Inventory Issue Lifecycle Snapshot Test Backfill Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills the inventory issue lifecycle snapshot fixture and regression so planningops seals audit-mode behavior against a deterministic issue inventory payload.
+related_docs:
+  - ./2026-03-28-federated-tooling-contract-test-family-backfill-packet.md
+---
+
+# plan: Inventory Issue Lifecycle Snapshot Test Backfill Packet
+
+## Summary
+- Backfill the tracked `inventory issue lifecycle` snapshot regression and its deterministic fixture.
+- Promote the missing fixture and test into git-tracked reality so audit-mode behavior is sealed without requiring live issue fetches.
+- Keep this unit limited to the regression fixture/test pair only.
+
+## Scope
+- `planningops/fixtures/inventory-issue-lifecycle-audit-snapshot.json`
+- `planningops/scripts/test_inventory_issue_lifecycle_audit_snapshot.sh`
+- workbench hub link for this snapshot-test backfill
+
+## Acceptance
+- `test_inventory_issue_lifecycle_audit_snapshot.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/fixtures/inventory-issue-lifecycle-audit-snapshot.json
+++ b/planningops/fixtures/inventory-issue-lifecycle-audit-snapshot.json
@@ -1,0 +1,13 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 86,
+    "title": "[stock-034] dependency blocker seed",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/86",
+    "state": "CLOSED",
+    "createdAt": "2026-03-10T00:00:00Z",
+    "updatedAt": "2026-03-08T13:51:35.364201Z",
+    "closedAt": "2026-03-08T13:51:35.364201Z",
+    "body": "## Planning Context\n- plan_item_id: `stock-034-9599`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- execution_kind: `inventory`\n- workflow_state: `done`\n- loop_profile: `l1_contract_clarification`\n- execution_order: `9599`\n- plan_lane: `M3 Guardrails`\n- depends_on: `-`\n\n- inventory_lifecycle: `archived`\n- compacted_into: `docs/initiatives/unified-personal-agent-platform/40-quality/uap-inventory-issue-lifecycle-summary.quality.md`\n- archive_ref: `planningops/archive-manifest/github-issues/rather-not-work-on/platform-planningops/issue-86.json`\n## Problem Statement\n- Retain the dependency-root record for `stock-034` as inventory-only queue memory.\n- This card must remain non-executable and must not be pulled by the live loop.\n\n## Interfaces & Dependencies\n- project schema: `planningops/config/project-field-ids.json`\n- stock policy: `planningops/config/backlog-stock-policy.json`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/audits/2026-03-05-live-stock-replenishment-pack-audit.md`\n- `planningops/artifacts/validation/backlog-stock-live-before-034.json`\n\n## Acceptance Criteria\n- [ ] Card remains inventory-only with `workflow_state=backlog` and correct project field projection.\n- [ ] Follow-up stock history can reference this card without dependency parse errors.\n\n## Definition of Done\n- [ ] Validation report attached\n- [ ] Project fields synced with evidence\n"
+  }
+]

--- a/planningops/scripts/test_inventory_issue_lifecycle_audit_snapshot.sh
+++ b/planningops/scripts/test_inventory_issue_lifecycle_audit_snapshot.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+"${PYTHON_BIN}" "$ROOT_DIR/scripts/inventory_issue_lifecycle.py" audit \
+  --root "$ROOT_DIR/.." \
+  --issues-file "$ROOT_DIR/fixtures/inventory-issue-lifecycle-audit-snapshot.json" \
+  --repo rather-not-work-on/platform-planningops \
+  --output "$ROOT_DIR/artifacts/validation/inventory-issue-lifecycle-report.json" \
+  --strict
+
+echo "inventory issue lifecycle snapshot audit ok"


### PR DESCRIPTION
## Summary
- add a tracked inventory issue lifecycle audit snapshot fixture
- backfill the snapshot regression script for deterministic audit-mode validation
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_inventory_issue_lifecycle_audit_snapshot.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all