### PR TITLE
test(review-interface): backfill command checks regression

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -119,6 +119,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Scheduled Reflection Delivery Regression Hardening Packet](./plans/2026-03-28-scheduled-reflection-delivery-regression-hardening-packet.md)
 - [Federated Tooling Contract Test Family Backfill Packet](./plans/2026-03-28-federated-tooling-contract-test-family-backfill-packet.md)
 - [Inventory Issue Lifecycle Snapshot Test Backfill Packet](./plans/2026-03-28-inventory-issue-lifecycle-snapshot-test-backfill-packet.md)
+- [Review Interface Adoption Command Checks Packet](./plans/2026-03-28-review-interface-adoption-command-checks-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-review-interface-adoption-command-checks-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-review-interface-adoption-command-checks-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Review Interface Adoption Command Checks Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills command-check coverage for review interface adoption so cross-repo interface validation can assert executable checks as well as issue, gap, and file markers.
+related_docs:
+  - ./2026-03-28-federated-tooling-contract-test-family-backfill-packet.md
+---
+
+# plan: Review Interface Adoption Command Checks Packet
+
+## Summary
+- Extend `review_interface_adoption.py` with explicit `command_checks`.
+- Backfill a deterministic regression proving pass/fail command exit codes are captured in the report.
+- Keep the unit limited to the runner change, regression, and workbench references.
+
+## Scope
+- `planningops/scripts/federation/review_interface_adoption.py`
+- `planningops/scripts/test_review_interface_adoption.sh`
+- workbench hub link for this command-check backfill
+
+## Acceptance
+- `test_review_interface_adoption.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/federation/review_interface_adoption.py
+++ b/planningops/scripts/federation/review_interface_adoption.py
@@ -41,6 +41,11 @@ def run(cmd: list[str]) -> tuple[int, str, str]:
     return cp.returncode, cp.stdout.strip(), cp.stderr.strip()
 
 
+def run_in_repo(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
+    cp = subprocess.run(cmd, capture_output=True, text=True, cwd=str(cwd))
+    return cp.returncode, cp.stdout.strip(), cp.stderr.strip()
+
+
 def issue_state(repo: str, number: int) -> dict:
     rc, out, err = run(["gh", "issue", "view", str(number), "--repo", repo, "--json", "number,state,title,url"])
     if rc != 0:
@@ -83,6 +88,34 @@ def substring_check(path: Path, markers: list[str]) -> dict:
     }
 
 
+def command_check(repo_dir: Path, row: dict) -> dict:
+    command = [str(part) for part in row.get("command") or []]
+    if not command:
+        return {
+            "name": str(row.get("name") or ""),
+            "cwd": str(repo_dir),
+            "command": command,
+            "expected_exit_code": 0,
+            "actual_exit_code": None,
+            "stdout_tail": "",
+            "stderr_tail": "missing command",
+            "verdict": "fail",
+        }
+
+    expected_exit_code = int(row.get("expected_exit_code", 0))
+    rc, out, err = run_in_repo(command, repo_dir)
+    return {
+        "name": str(row.get("name") or ""),
+        "cwd": str(repo_dir),
+        "command": command,
+        "expected_exit_code": expected_exit_code,
+        "actual_exit_code": rc,
+        "stdout_tail": out[-1000:],
+        "stderr_tail": err[-1000:],
+        "verdict": "pass" if rc == expected_exit_code else "fail",
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Review cross-repo interface adoption against a wave spec")
     parser.add_argument("--spec", required=True, help="Spec JSON describing required closed issues and file markers")
@@ -114,9 +147,17 @@ def main() -> int:
         file_report["repo"] = str(row.get("repo") or "")
         file_checks.append(file_report)
 
+    command_checks = []
+    for row in spec.get("command_checks") or []:
+        repo_dir = workspace_root / str(row.get("repo_dir") or "")
+        command_report = command_check(repo_dir, row)
+        command_report["repo"] = str(row.get("repo") or "")
+        command_checks.append(command_report)
+
     failures = [row for row in issue_checks if row["verdict"] != "pass"]
     failures.extend(row for row in gap_checks if row["verdict"] != "pass")
     failures.extend(row for row in file_checks if row["verdict"] != "pass")
+    failures.extend(row for row in command_checks if row["verdict"] != "pass")
 
     report = {
         "generated_at_utc": now_utc(),
@@ -126,7 +167,8 @@ def main() -> int:
         "issue_checks": issue_checks,
         "gap_checks": gap_checks,
         "file_checks": file_checks,
-        "check_count": len(issue_checks) + len(gap_checks) + len(file_checks),
+        "command_checks": command_checks,
+        "check_count": len(issue_checks) + len(gap_checks) + len(file_checks) + len(command_checks),
         "failure_count": len(failures),
         "verdict": "pass" if not failures else "fail",
     }

--- a/planningops/scripts/test_review_interface_adoption.sh
+++ b/planningops/scripts/test_review_interface_adoption.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+cat >"$TMP_DIR/review-spec.json" <<'JSON'
+{
+  "wave_id": "test-review-interface-adoption",
+  "issues_repo": "rather-not-work-on/platform-planningops",
+  "required_closed_issues": [],
+  "gap_checks": [],
+  "file_checks": [],
+  "command_checks": [
+    {
+      "name": "pass-command",
+      "repo": "rather-not-work-on/platform-planningops",
+      "repo_dir": "platform-planningops",
+      "command": ["python3", "-c", "print('pass-command')"]
+    },
+    {
+      "name": "fail-command",
+      "repo": "rather-not-work-on/platform-planningops",
+      "repo_dir": "platform-planningops",
+      "command": ["python3", "-c", "import sys; sys.exit(3)"]
+    }
+  ]
+}
+JSON
+
+if python3 planningops/scripts/federation/review_interface_adoption.py \
+  --spec "$TMP_DIR/review-spec.json" \
+  --workspace-root .. \
+  --output "$TMP_DIR/review-report.json" >/dev/null; then
+  echo "expected review_interface_adoption.py to fail when a command check fails"
+  exit 1
+fi
+
+python3 - "$TMP_DIR/review-report.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+
+assert report["wave_id"] == "test-review-interface-adoption", report
+assert report["check_count"] == 2, report
+assert report["failure_count"] == 1, report
+assert report["verdict"] == "fail", report
+assert len(report["command_checks"]) == 2, report
+assert report["command_checks"][0]["name"] == "pass-command", report
+assert report["command_checks"][0]["verdict"] == "pass", report
+assert report["command_checks"][0]["actual_exit_code"] == 0, report
+assert report["command_checks"][1]["name"] == "fail-command", report
+assert report["command_checks"][1]["verdict"] == "fail", report
+assert report["command_checks"][1]["actual_exit_code"] == 3, report
+
+print("review interface adoption test passed")
+PY


### PR DESCRIPTION
## Summary
- extend review_interface_adoption with explicit command checks
- add a deterministic regression that exercises pass and fail command exit codes
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_review_interface_adoption.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all