### PR TITLE
feat(artifact-sink): link residency helper workflow

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -121,6 +121,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Inventory Issue Lifecycle Snapshot Test Backfill Packet](./plans/2026-03-28-inventory-issue-lifecycle-snapshot-test-backfill-packet.md)
 - [Review Interface Adoption Command Checks Packet](./plans/2026-03-28-review-interface-adoption-command-checks-packet.md)
 - [UAP Automation Operations Summary Contract Packet](./plans/2026-03-28-uap-automation-ops-summary-contract-packet.md)
+- [Artifact Sink Helper Link Packet](./plans/2026-03-28-artifact-sink-helper-link-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-artifact-sink-helper-link-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-artifact-sink-helper-link-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Artifact Sink Helper Link Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Captures the artifact sink contract hardening that links the external artifact residency helper as a canonical workflow surface.
+related_docs:
+  - ./2026-03-26-external-artifact-residency-helper-family-backfill-packet.md
+---
+
+# plan: Artifact Sink Helper Link Packet
+
+## Summary
+- Backfill the tiny artifact sink contract/doc hardening unit.
+- Record the external artifact residency helper as a canonical workflow surface on the artifact sink contract.
+- Keep scope limited to the contract note, Python compatibility import, and workbench references.
+
+## Scope
+- `planningops/contracts/artifact-sink-contract.md`
+- `planningops/scripts/artifact_sink.py`
+- workbench hub link for this helper-link packet
+
+## Acceptance
+- `test_artifact_sink_e2e.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/artifact-sink-contract.md
+++ b/planningops/contracts/artifact-sink-contract.md
@@ -31,6 +31,7 @@ Provide a deterministic write/read/rehydrate abstraction for artifact storage ba
 - E2E sink test: `bash planningops/scripts/test_artifact_sink_e2e.sh`
 - Commit guard test: `bash planningops/scripts/test_validate_external_only_commit_guard.sh`
 - Migration test: `bash planningops/scripts/test_migrate_external_only_artifacts_contract.sh`
+- Workflow helper: `bash planningops/scripts/run_external_artifact_residency_ci_check.sh --base-ref <base> --head-ref <head> --python-bin python3`
 - Policy validation: `python3 planningops/scripts/validate_artifact_storage_policy.py --strict`
 
 ## Related Contracts

--- a/planningops/scripts/artifact_sink.py
+++ b/planningops/scripts/artifact_sink.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os


### PR DESCRIPTION
## Summary
- add the external artifact residency helper as a canonical artifact sink workflow surface
- backfill the tiny artifact sink compatibility/doc hardening unit
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_artifact_sink_e2e.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all