### PR TITLE
fix(planning-context): widen dependency key parsing

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -122,6 +122,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Review Interface Adoption Command Checks Packet](./plans/2026-03-28-review-interface-adoption-command-checks-packet.md)
 - [UAP Automation Operations Summary Contract Packet](./plans/2026-03-28-uap-automation-ops-summary-contract-packet.md)
 - [Artifact Sink Helper Link Packet](./plans/2026-03-28-artifact-sink-helper-link-packet.md)
+- [Planning Context Dependency Key Pattern Packet](./plans/2026-03-28-planning-context-dependency-key-pattern-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-planning-context-dependency-key-pattern-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-planning-context-dependency-key-pattern-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Planning Context Dependency Key Pattern Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Hardens planning context dependency parsing so wider plan-item key prefixes are preserved while related governance contracts expose their canonical helper lanes.
+related_docs:
+  - ./2026-03-26-control-plane-governance-helper-family-backfill-packet.md
+---
+
+# plan: Planning Context Dependency Key Pattern Packet
+
+## Summary
+- Expand `planning_context` dependency-key parsing to accept wider uppercase key prefixes.
+- Backfill the contract regression that proves mixed dependency strings preserve the broader key surface.
+- Record the corresponding governance helper lanes on the affected contracts.
+
+## Scope
+- `planningops/scripts/planning_context.py`
+- `planningops/scripts/test_planning_context_contract.sh`
+- `planningops/contracts/control-tower-ontology-contract.md`
+- `planningops/contracts/issue-quality-contract.md`
+- workbench hub link for this parsing hardening packet
+
+## Acceptance
+- `test_planning_context_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/control-tower-ontology-contract.md
+++ b/planningops/contracts/control-tower-ontology-contract.md
@@ -108,6 +108,7 @@ This contract fixes:
 8. Archived inventory records must move to `workflow_state=done`, carry `archive_ref` + `compacted_into`, and remain traceable through `docs/archive/**` plus `planningops/archive-manifest/**`.
 
 ## Verification
+- Workflow helper: `bash planningops/scripts/run_control_plane_governance_ci_check.sh --python-bin python3`
 - Backlog/project metadata quality: `python3 planningops/scripts/validate_issue_quality.py --strict`
 - Ontology contract regression: `bash planningops/scripts/test_control_tower_ontology_contract.sh`
 - Boundary consistency: `bash planningops/scripts/test_validate_repo_boundaries_contract.sh`

--- a/planningops/contracts/issue-quality-contract.md
+++ b/planningops/contracts/issue-quality-contract.md
@@ -43,3 +43,4 @@ Prevent low-quality backlog issues by enforcing deterministic structure, metadat
 - Validator: `planningops/scripts/validate_issue_quality.py`
 - Test: `bash planningops/scripts/test_validate_issue_quality_contract.sh`
 - Live check: `python3 planningops/scripts/validate_issue_quality.py --strict`
+- Workflow guardrail: `bash planningops/scripts/run_issue_quality_ci_check.sh --python-bin python3`

--- a/planningops/scripts/planning_context.py
+++ b/planningops/scripts/planning_context.py
@@ -40,7 +40,7 @@ def parse_execution_order(raw: str | None):
     return int(value) if value.isdigit() else None
 
 
-def parse_depends_on_plan_item_keys(raw: str | None, pattern: str = r"[A-Z][0-9]{2}"):
+def parse_depends_on_plan_item_keys(raw: str | None, pattern: str = r"\b[A-Z]{1,6}[0-9]{2,4}\b"):
     value = normalize_value(raw)
     if not value:
         return []

--- a/planningops/scripts/test_planning_context_contract.sh
+++ b/planningops/scripts/test_planning_context_contract.sh
@@ -21,7 +21,7 @@ body = "\n".join(
         "- loop_profile: `l1_contract_clarification`",
         "- execution_order: `9601`",
         "- plan_lane: `M3 Guardrails`",
-        "- depends_on: `E24 (rather-not-work-on/platform-planningops#142), stock-034-9602 (rather-not-work-on/platform-planningops#88)`",
+        "- depends_on: `E24 (rather-not-work-on/platform-planningops#142), AQ10 (rather-not-work-on/platform-planningops#143), stock-034-9602 (rather-not-work-on/platform-planningops#88)`",
     ]
 )
 
@@ -35,13 +35,13 @@ assert mod.parse_execution_order(meta["execution_order"]) == 9601
 assert mod.parse_execution_order("not-a-number") is None
 
 canonical_deps = mod.parse_depends_on_plan_item_keys(meta["depends_on"])
-assert canonical_deps == ["E24"], canonical_deps
+assert canonical_deps == ["AQ10", "E24"], canonical_deps
 
 mixed_deps = mod.parse_depends_on_plan_item_keys(
     meta["depends_on"],
-    pattern=r"(?:[A-Z][0-9]{2}|stock-\d{3}-\d{4})",
+    pattern=r"(?:[A-Z]{1,6}[0-9]{2,4}|stock-\d{3}-\d{4})",
 )
-assert mixed_deps == ["E24", "stock-034-9602"], mixed_deps
+assert mixed_deps == ["AQ10", "E24", "stock-034-9602"], mixed_deps
 
 print("planning_context contract tests ok")
 PY


### PR DESCRIPTION
## Summary
- widen planning context dependency key parsing for broader uppercase plan-item prefixes
- update the planning context contract regression to cover the broader dependency key surface
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_planning_context_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all