### PR TITLE
feat(reflection-cycle): resolve goal context before export

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -123,6 +123,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [UAP Automation Operations Summary Contract Packet](./plans/2026-03-28-uap-automation-ops-summary-contract-packet.md)
 - [Artifact Sink Helper Link Packet](./plans/2026-03-28-artifact-sink-helper-link-packet.md)
 - [Planning Context Dependency Key Pattern Packet](./plans/2026-03-28-planning-context-dependency-key-pattern-packet.md)
+- [Worker Outcome Reflection Goal Context Packet](./plans/2026-03-28-worker-outcome-reflection-goal-context-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-worker-outcome-reflection-goal-context-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-worker-outcome-reflection-goal-context-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Worker Outcome Reflection Goal Context Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Hardens worker outcome reflection orchestration so goal context is resolved up front and reflected consistently across direct outcome and scheduler-report entry paths.
+related_docs:
+  - ./2026-03-28-review-interface-adoption-command-checks-packet.md
+---
+
+# plan: Worker Outcome Reflection Goal Context Packet
+
+## Summary
+- Move worker outcome reflection orchestration onto shared reflection plumbing.
+- Resolve goal context before export/evaluation so inferred-goal and no-active-goal cases are deterministic.
+- Extend the cycle contract and regression coverage for scheduler-report and goal-completion bridge aware flow.
+
+## Scope
+- `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
+- `planningops/scripts/test_worker_outcome_reflection_cycle.sh`
+- `planningops/contracts/reflection-cycle-orchestration-contract.md`
+- `planningops/contracts/worker-outcome-reflection-contract.md`
+- workbench hub link for this orchestration hardening packet
+
+## Acceptance
+- `test_worker_outcome_reflection_cycle.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/reflection-cycle-orchestration-contract.md
+++ b/planningops/contracts/reflection-cycle-orchestration-contract.md
@@ -5,25 +5,30 @@ Freeze the thin control-plane orchestration path that turns one monday worker ou
 
 This contract exists so:
 - `planningops` can run the reflection chain end to end without prompt-local glue
-- `monday` remains the owner of runtime outcome export and downstream operator delivery
+- `monday` remains the owner of runtime outcome export and downstream queue admission
 - later scheduler and queue work can reuse one deterministic cycle runner instead of re-stitching the same steps in ad hoc scripts
 
 ## Canonical Boundary
 - runtime exporter: `monday/scripts/export_worker_outcome_reflection_packet.py`
+- scheduler-evidence exporter: `monday/scripts/export_scheduler_worker_outcome_reflection_packet.py`
 - control-plane evaluator: `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
 - control-plane applier: `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
+- shared control-plane plumbing: `planningops/scripts/federation/reflection_cycle_common.py`
 - orchestration runner: `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
-- downstream monday consumer: `monday/scripts/run_operator_message_delivery_cycle.py`
+- goal-completion bridge: `planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py`
+- downstream monday consumer: `monday/scripts/enqueue_scheduled_delivery_work_item.py`
 
 ## Cycle Scope
 The reflection cycle covered by this contract is:
-1. read one monday worker outcome artifact
+1. read one monday worker outcome artifact or one monday scheduler report that resolves to exactly one worker outcome
 2. export one reflection packet through the monday-owned exporter
 3. evaluate the packet into one planningops reflection decision
 4. apply the decision into one planningops action artifact
 5. emit one planningops-owned cycle report
 
 The cycle ends at the action artifact.
+
+Goal-completed actions must flow through `planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py` for the follow-on handoff into supervisor artifacts and monday goal-completion queue admission.
 
 The cycle must not:
 - mutate monday queue state directly
@@ -32,7 +37,7 @@ The cycle must not:
 
 ## Required Inputs
 The orchestration runner must accept enough input to resolve the full cycle deterministically:
-- a worker outcome artifact path
+- either a worker outcome artifact path or a monday scheduler report path that resolves to one worker outcome
 - an active-goal registry path
 - a goal key or a deterministic active-goal resolution path
 - an execution mode: `dry-run` or `apply`
@@ -76,7 +81,9 @@ Optional cycle report fields may include:
 - `operator_channel_execution_repo`
 
 ## Deterministic Orchestration Rules
-- the runner must call the monday exporter instead of recreating packet logic inside planningops
+- the runner must resolve goal context before packet export starts
+- the runner must call the matching monday exporter instead of recreating packet logic inside planningops
+- scheduler-report inputs must flow through `monday/scripts/export_scheduler_worker_outcome_reflection_packet.py`
 - the runner must call the planningops evaluator instead of deriving decisions inline
 - the runner must call the planningops applier instead of deriving action mappings inline
 - the runner must pass the same goal context to the evaluator and applier within one cycle
@@ -85,7 +92,9 @@ Optional cycle report fields may include:
 - `apply` mode may allow the applier to perform goal transition side effects, but only through `planningops/scripts/core/goals/transition_goal_state.py`
 
 ## Failure Rules
+- unresolved goal context must fail the cycle before packet export starts
 - exporter failure must fail the cycle before evaluation starts
+- scheduler reports that do not resolve to one worker outcome must fail the cycle before evaluation starts
 - evaluator failure must fail the cycle before action application starts
 - applier failure must fail the cycle before the runner reports success
 - the runner must fail closed and emit deterministic failure evidence instead of silently skipping a stage
@@ -101,7 +110,7 @@ Optional cycle report fields may include:
 ### Monday owns
 - worker outcome production
 - reflection packet export implementation
-- operator-channel delivery implementation
+- scheduled delivery queue admission and downstream delivery implementation
 - queue persistence and lease mutation
 
 ### PlanningOps must not own
@@ -112,7 +121,12 @@ Optional cycle report fields may include:
 ## Validation
 - `planningops/scripts/test_reflection_cycle_orchestration_contract.sh`
 - `monday/scripts/export_worker_outcome_reflection_packet.py`
+- `monday/scripts/export_scheduler_worker_outcome_reflection_packet.py`
 - `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
 - `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
+- `planningops/scripts/federation/reflection_cycle_common.py`
 - `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
+- `planningops/scripts/test_worker_outcome_reflection_cycle_scheduler_report.sh`
+- `planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py`
+- `planningops/scripts/test_reflection_goal_completion_handoff_cycle.sh`
 - `planningops/scripts/federation/run_reflection_delivery_cycle.py`

--- a/planningops/contracts/worker-outcome-reflection-contract.md
+++ b/planningops/contracts/worker-outcome-reflection-contract.md
@@ -107,6 +107,7 @@ Every evaluator result must include:
 ## Failure Rules
 - missing or malformed runtime source fields must fail packet export
 - malformed `reflection_hints` must fail evaluation
+- unresolved goal context must fail evaluation before a reflection decision is emitted
 - evaluators must return deterministic failure evidence instead of silently defaulting to `continue`
 - control-plane evaluation must not mutate monday queue state directly
 

--- a/planningops/scripts/federation/run_worker_outcome_reflection_cycle.py
+++ b/planningops/scripts/federation/run_worker_outcome_reflection_cycle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -12,6 +11,9 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
+CORE_GOALS_DIR = SCRIPT_DIR.parent / "core" / "goals"
+if str(CORE_GOALS_DIR) not in sys.path:
+    sys.path.insert(0, str(CORE_GOALS_DIR))
 
 from federated_python_env import (
     build_bootstrap_plan,
@@ -19,104 +21,23 @@ from federated_python_env import (
     ensure_bootstrap_environment,
     resolve_bootstrap_root,
 )
+from reflection_cycle_common import (
+    build_stage_report,
+    load_json,
+    normalize_repo_path,
+    now_utc,
+    resolve_component_repo,
+    resolve_goal_context,
+    resolve_input_path,
+    resolve_output_path,
+    resolve_repo_root,
+    resolve_workspace_root,
+    run_cmd,
+    write_report,
+)
 
 
 RUNNER_CONTRACT_REF = "planningops/contracts/reflection-cycle-orchestration-contract.md"
-
-
-def now_utc() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-def resolve_repo_root() -> Path:
-    current = Path(__file__).resolve()
-    for candidate in [current] + list(current.parents):
-        if (candidate / ".git").exists():
-            return candidate
-    return Path(__file__).resolve().parents[4]
-
-
-def resolve_workspace_root(planningops_repo: Path, raw_workspace_root: str) -> Path:
-    candidates = [
-        (planningops_repo / raw_workspace_root).resolve(),
-        planningops_repo,
-        planningops_repo.parent,
-    ]
-    for candidate in candidates:
-        if (candidate / "monday").exists():
-            return candidate
-    return (planningops_repo / raw_workspace_root).resolve()
-
-
-def resolve_component_repo(workspace_root: Path, repo_dir: str) -> Path:
-    path = Path(repo_dir)
-    if path.is_absolute():
-        return path
-    return (workspace_root / path).resolve()
-
-
-def resolve_input_path(planningops_repo: Path, workspace_root: Path, monday_repo: Path, raw_path: str) -> Path:
-    path = Path(raw_path)
-    candidates: list[Path] = []
-    if path.is_absolute():
-        candidates.append(path)
-    else:
-        candidates.extend(
-            [
-                (planningops_repo / path).resolve(),
-                (workspace_root / path).resolve(),
-                (monday_repo / path).resolve(),
-                path.resolve(),
-            ]
-        )
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-    raise FileNotFoundError(f"worker outcome input not found: {raw_path}")
-
-
-def resolve_output_path(planningops_repo: Path, raw_path: str | None, default_path: Path) -> Path:
-    if raw_path is None:
-        return default_path
-    path = Path(raw_path)
-    if path.is_absolute():
-        return path
-    return (planningops_repo / path).resolve()
-
-
-def normalize_repo_path(repo_root: Path, path: Path) -> str:
-    try:
-        return str(path.resolve().relative_to(repo_root.resolve()))
-    except ValueError:
-        return str(path.resolve())
-
-
-def load_json(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def build_stage_report(stage: str, command: list[str], cwd: Path, rc: int, out: str, err: str, artifact_path: Path) -> dict:
-    return {
-        "stage": stage,
-        "command": command,
-        "cwd": str(cwd),
-        "exit_code": rc,
-        "stdout_tail": out[-1000:],
-        "stderr_tail": err[-1000:],
-        "artifact_path": str(artifact_path),
-        "artifact_exists": artifact_path.exists(),
-        "verdict": "pass" if rc == 0 else "fail",
-    }
-
-
-def run_cmd(command: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
-    completed = subprocess.run(command, cwd=str(cwd), capture_output=True, text=True, env=env)
-    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
-
-
-def write_report(path: Path, payload: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 
 
 def parse_args():
@@ -124,12 +45,19 @@ def parse_args():
     parser.add_argument("--workspace-root", default="..", help="Workspace root containing sibling repositories")
     parser.add_argument("--monday-repo-dir", default="monday", help="monday repo directory relative to workspace root")
     parser.add_argument("--monday-python", default=None, help="Optional Python interpreter override for monday leaf scripts")
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--outcome-json", help="Worker outcome artifact path")
+    input_group.add_argument("--scheduler-report-json", help="monday scheduler report path that resolves to one worker outcome")
     parser.add_argument(
         "--monday-exporter-script",
         default="scripts/export_worker_outcome_reflection_packet.py",
         help="monday exporter script path relative to the monday repo",
     )
-    parser.add_argument("--outcome-json", required=True, help="Worker outcome artifact path")
+    parser.add_argument(
+        "--monday-scheduler-exporter-script",
+        default="scripts/export_scheduler_worker_outcome_reflection_packet.py",
+        help="monday scheduler-report exporter script path relative to the monday repo",
+    )
     parser.add_argument("--source-outcome-ref", default=None, help="Explicit source outcome reference to preserve in packet output")
     parser.add_argument("--active-goal-registry", default="planningops/config/active-goal-registry.json")
     parser.add_argument("--goal-key", default=None)
@@ -215,28 +143,81 @@ def main() -> int:
     if not args.monday_python:
         python_bin = bootstrap_info["preferred_python"]
 
-    outcome_path = resolve_input_path(planningops_repo, workspace_root, monday_repo, args.outcome_json)
     report_dir = planningops_repo / "planningops" / "artifacts" / "validation" / "worker-outcome-reflection-cycle" / args.run_id
     packet_output = resolve_output_path(planningops_repo, args.packet_output, report_dir / "packet.json")
     evaluation_output = resolve_output_path(planningops_repo, args.evaluation_output, report_dir / "evaluation.json")
     action_output = resolve_output_path(planningops_repo, args.action_output, report_dir / "action.json")
     report_output = resolve_output_path(planningops_repo, args.output, report_dir / "cycle-report.json")
 
-    source_outcome_ref = args.source_outcome_ref or normalize_repo_path(monday_repo, outcome_path)
+    source_outcome_ref = "-"
     goal_key = args.goal_key or "-"
+    resolved_goal_key = None
 
     stage_reports: list[dict] = []
 
-    exporter_command = [
-        python_bin,
-        args.monday_exporter_script,
-        "--outcome-json",
-        str(outcome_path),
-        "--source-outcome-ref",
-        source_outcome_ref,
-        "--output",
-        str(packet_output),
-    ]
+    if args.active_goal_registry:
+        resolved_goal, goal_errors = resolve_goal_context(
+            planningops_repo / args.active_goal_registry, planningops_repo, args.goal_key
+        )
+        if goal_errors:
+            return failure_report(
+                args=args,
+                goal_key=goal_key,
+                outcome_ref=source_outcome_ref,
+                packet_ref=normalize_repo_path(planningops_repo, packet_output),
+                evaluation_ref=normalize_repo_path(planningops_repo, evaluation_output),
+                action_ref=normalize_repo_path(planningops_repo, action_output),
+                stage_reports=stage_reports,
+                failure_stage="resolve_goal_context",
+                errors=goal_errors,
+                report_path=report_output,
+            )
+        resolved_goal_key = str((resolved_goal or {}).get("goal_key") or "").strip() or None
+        goal_key = resolved_goal_key or goal_key
+
+    if args.scheduler_report_json and args.source_outcome_ref:
+        return failure_report(
+            args=args,
+            goal_key=goal_key,
+            outcome_ref=source_outcome_ref,
+            packet_ref=normalize_repo_path(planningops_repo, packet_output),
+            evaluation_ref=normalize_repo_path(planningops_repo, evaluation_output),
+            action_ref=normalize_repo_path(planningops_repo, action_output),
+            stage_reports=stage_reports,
+            failure_stage="resolve_packet_source",
+            errors=["--source-outcome-ref is not allowed with --scheduler-report-json"],
+            report_path=report_output,
+        )
+
+    if args.outcome_json:
+        outcome_path = resolve_input_path(planningops_repo, workspace_root, monday_repo, args.outcome_json)
+        source_outcome_ref = args.source_outcome_ref or normalize_repo_path(monday_repo, outcome_path)
+        exporter_command = [
+            python_bin,
+            args.monday_exporter_script,
+            "--outcome-json",
+            str(outcome_path),
+            "--source-outcome-ref",
+            source_outcome_ref,
+            "--output",
+            str(packet_output),
+        ]
+    else:
+        scheduler_report_path = resolve_input_path(planningops_repo, workspace_root, monday_repo, args.scheduler_report_json)
+        try:
+            scheduler_report = load_json(scheduler_report_path)
+        except json.JSONDecodeError:
+            scheduler_report = {}
+        if isinstance(scheduler_report, dict):
+            source_outcome_ref = str(scheduler_report.get("worker_outcome_ref") or "").strip() or "-"
+        exporter_command = [
+            python_bin,
+            args.monday_scheduler_exporter_script,
+            "--scheduler-report",
+            str(scheduler_report_path),
+            "--output",
+            str(packet_output),
+        ]
     rc, out, err = run_cmd(exporter_command, monday_repo, env)
     stage_reports.append(build_stage_report("packet_export", exporter_command, monday_repo, rc, out, err, packet_output))
     if rc != 0:
@@ -253,6 +234,11 @@ def main() -> int:
             report_path=report_output,
         )
 
+    packet = load_json(packet_output)
+    packet_source_outcome_ref = str(packet.get("source_outcome_ref") or "").strip()
+    if packet_source_outcome_ref:
+        source_outcome_ref = packet_source_outcome_ref
+
     evaluator_command = [
         bootstrap_info["preferred_python"],
         str(planningops_repo / "planningops" / "scripts" / "core" / "goals" / "evaluate_worker_outcome_reflection.py"),
@@ -263,8 +249,8 @@ def main() -> int:
         "--output",
         str(evaluation_output),
     ]
-    if args.goal_key:
-        evaluator_command.extend(["--goal-key", args.goal_key])
+    if resolved_goal_key:
+        evaluator_command.extend(["--goal-key", resolved_goal_key])
     rc, out, err = run_cmd(evaluator_command, planningops_repo, env)
     stage_reports.append(
         build_stage_report("reflection_evaluation", evaluator_command, planningops_repo, rc, out, err, evaluation_output)
@@ -298,8 +284,8 @@ def main() -> int:
         "--output",
         str(action_output),
     ]
-    if args.goal_key:
-        applier_command.extend(["--goal-key", args.goal_key])
+    if resolved_goal_key:
+        applier_command.extend(["--goal-key", resolved_goal_key])
     if args.goal_transition_output:
         applier_command.extend(["--goal-transition-output", args.goal_transition_output])
     rc, out, err = run_cmd(applier_command, planningops_repo, env)

--- a/planningops/scripts/test_worker_outcome_reflection_cycle.sh
+++ b/planningops/scripts/test_worker_outcome_reflection_cycle.sh
@@ -36,9 +36,9 @@ PY
 for scenario in completed retry-wait dead-letter; do
   SCENARIO_DIR="$TMP_DIR/$scenario"
   mkdir -p "$SCENARIO_DIR"
-  python3 planningops/scripts/run_worker_outcome_reflection_cycle.py \
-    --workspace-root .. \
-    --outcome-json "monday/fixtures/runtime-queue-worker-outcome.${scenario}.sample.json" \
+python3 planningops/scripts/run_worker_outcome_reflection_cycle.py \
+  --workspace-root .. \
+  --outcome-json "monday/fixtures/runtime-queue-worker-outcome.${scenario}.sample.json" \
     --active-goal-registry "$TMP_DIR/registry.json" \
     --goal-key uap-goal-driven-autonomy-wave6 \
     --run-id "test-reflection-cycle-${scenario}" \
@@ -48,7 +48,41 @@ for scenario in completed retry-wait dead-letter; do
     --output "$SCENARIO_DIR/report.json" >/dev/null
 done
 
-python3 - "$TMP_DIR/completed/report.json" "$TMP_DIR/completed/action.json" "$TMP_DIR/retry-wait/report.json" "$TMP_DIR/retry-wait/action.json" "$TMP_DIR/dead-letter/report.json" "$TMP_DIR/dead-letter/action.json" <<'PY'
+python3 planningops/scripts/run_worker_outcome_reflection_cycle.py \
+  --workspace-root .. \
+  --outcome-json "monday/fixtures/runtime-queue-worker-outcome.completed.sample.json" \
+  --active-goal-registry "$TMP_DIR/registry.json" \
+  --run-id "test-reflection-cycle-inferred-goal" \
+  --packet-output "$TMP_DIR/inferred-goal-packet.json" \
+  --evaluation-output "$TMP_DIR/inferred-goal-evaluation.json" \
+  --action-output "$TMP_DIR/inferred-goal-action.json" \
+  --output "$TMP_DIR/inferred-goal-report.json" >/dev/null
+
+python3 - "$TMP_DIR/no-active-registry.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path("planningops/config/active-goal-registry.json")
+doc = json.loads(source.read_text(encoding="utf-8"))
+doc["active_goal_key"] = ""
+for goal in doc["goals"]:
+    if goal.get("status") == "active":
+        goal["status"] = "achieved"
+Path(sys.argv[1]).write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+python3 planningops/scripts/run_worker_outcome_reflection_cycle.py \
+  --workspace-root .. \
+  --outcome-json "monday/fixtures/runtime-queue-worker-outcome.completed.sample.json" \
+  --active-goal-registry "$TMP_DIR/no-active-registry.json" \
+  --run-id "test-reflection-cycle-no-active-goal" \
+  --packet-output "$TMP_DIR/no-active-packet.json" \
+  --evaluation-output "$TMP_DIR/no-active-evaluation.json" \
+  --action-output "$TMP_DIR/no-active-action.json" \
+  --output "$TMP_DIR/no-active-report.json" >/dev/null 2>&1 || true
+
+python3 - "$TMP_DIR/completed/report.json" "$TMP_DIR/completed/action.json" "$TMP_DIR/retry-wait/report.json" "$TMP_DIR/retry-wait/action.json" "$TMP_DIR/dead-letter/report.json" "$TMP_DIR/dead-letter/action.json" "$TMP_DIR/no-active-report.json" "$TMP_DIR/inferred-goal-report.json" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -59,6 +93,8 @@ retry_report = json.loads(Path(sys.argv[3]).read_text())
 retry_action = json.loads(Path(sys.argv[4]).read_text())
 dead_letter_report = json.loads(Path(sys.argv[5]).read_text())
 dead_letter_action = json.loads(Path(sys.argv[6]).read_text())
+no_active_report = json.loads(Path(sys.argv[7]).read_text())
+inferred_goal_report = json.loads(Path(sys.argv[8]).read_text())
 
 for report in [completed_report, retry_report, dead_letter_report]:
     assert report["verdict"] == "pass", report
@@ -89,6 +125,18 @@ assert dead_letter_report["action_kind"] == "trigger_replan_review", dead_letter
 assert dead_letter_report["delivery_required"] is True, dead_letter_report
 assert dead_letter_report["goal_transition_required"] is False, dead_letter_report
 assert dead_letter_action["operator_channel_kind"] == "slack_skill_cli", dead_letter_action
+
+assert inferred_goal_report["verdict"] == "pass", inferred_goal_report
+assert inferred_goal_report["goal_key"] == "uap-goal-driven-autonomy-wave6", inferred_goal_report
+assert "--goal-key" in inferred_goal_report["stage_reports"][1]["command"], inferred_goal_report
+assert "uap-goal-driven-autonomy-wave6" in inferred_goal_report["stage_reports"][1]["command"], inferred_goal_report
+assert "--goal-key" in inferred_goal_report["stage_reports"][2]["command"], inferred_goal_report
+assert "uap-goal-driven-autonomy-wave6" in inferred_goal_report["stage_reports"][2]["command"], inferred_goal_report
+
+assert no_active_report["verdict"] == "fail", no_active_report
+assert no_active_report["failure_stage"] == "resolve_goal_context", no_active_report
+assert no_active_report["stage_reports"] == [], no_active_report
+assert no_active_report["errors"] == ["no active goal configured"], no_active_report
 
 print("worker outcome reflection cycle test passed")
 PY


### PR DESCRIPTION
## Summary
- move worker outcome reflection orchestration onto shared reflection plumbing
- resolve goal context before packet export so inferred-goal and no-active-goal cases fail deterministically
- extend the regression and contract surface for scheduler-report aware reflection flow

## Validation
- bash planningops/scripts/test_worker_outcome_reflection_cycle.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all