### PR TITLE
feat(scheduled-reflection): resolve goal context before admission

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -124,6 +124,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Artifact Sink Helper Link Packet](./plans/2026-03-28-artifact-sink-helper-link-packet.md)
 - [Planning Context Dependency Key Pattern Packet](./plans/2026-03-28-planning-context-dependency-key-pattern-packet.md)
 - [Worker Outcome Reflection Goal Context Packet](./plans/2026-03-28-worker-outcome-reflection-goal-context-packet.md)
+- [Scheduled Reflection Goal Context Packet](./plans/2026-03-28-scheduled-reflection-goal-context-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-scheduled-reflection-goal-context-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-scheduled-reflection-goal-context-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Scheduled Reflection Goal Context Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Hardens the scheduled reflection delivery cycle so goal context is resolved before queue admission and terminal goal-completed actions route through the dedicated handoff bridge.
+related_docs:
+  - ./2026-03-28-worker-outcome-reflection-goal-context-packet.md
+---
+
+# plan: Scheduled Reflection Goal Context Packet
+
+## Summary
+- Move the scheduled reflection delivery runner onto shared reflection plumbing.
+- Resolve goal context before queue admission and enforce queue-seed/goal consistency.
+- Route terminal `goal_completed` actions through the dedicated goal-completion handoff bridge.
+
+## Scope
+- `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`
+- `planningops/contracts/scheduled-reflection-delivery-cycle-contract.md`
+- `planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
+- workbench hub link for this scheduled-cycle hardening packet
+
+## Acceptance
+- `test_scheduled_reflection_delivery_cycle.sh` passes
+- `test_scheduled_reflection_delivery_cycle_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
+++ b/planningops/contracts/scheduled-reflection-delivery-cycle-contract.md
@@ -17,8 +17,10 @@ This contract exists so:
 - scheduler-native selection contract: `planningops/contracts/scheduler-native-worker-outcome-selection-contract.md`
 - scheduled worker-outcome handoff contract: `planningops/contracts/scheduled-worker-outcome-handoff-contract.md`
 - monday reflection exporter: `monday/scripts/export_worker_outcome_reflection_packet.py`
+- shared control-plane plumbing: `planningops/scripts/federation/reflection_cycle_common.py`
 - planningops reflection-cycle runner: `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
 - planningops delivery-cycle runner: `planningops/scripts/federation/run_reflection_delivery_cycle.py`
+- planningops goal-completion bridge runner: `planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py`
 - planningops scheduled-cycle runner: `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`
 - scheduler boundary contract: `planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md`
 - reflection boundary contract: `planningops/contracts/reflection-cycle-orchestration-contract.md`
@@ -32,7 +34,7 @@ The cycle includes:
 2. invoking one monday scheduled queue cycle against monday-owned queue-store state
 3. loading one monday worker outcome artifact from that scheduled run
 4. running the planningops-owned reflection cycle over that worker outcome
-5. running the planningops-owned delivery cycle over the emitted reflection action artifact
+5. running the planningops-owned delivery cycle over the emitted reflection action artifact, or the goal-completion bridge when the emitted action is terminal `goal_completed`
 6. writing one planningops-owned aggregate scheduled cycle report
 
 The cycle does not include:
@@ -67,6 +69,10 @@ Input rules:
 - the runner must invoke `monday/scripts/admit_scheduled_queue_packet.py` before `monday/scripts/run_scheduled_queue_cycle.py`
 - the runner must invoke `monday/scripts/run_scheduled_queue_cycle.py` instead of recreating queue dequeue logic in `planningops`
 - when `--goal-key` is supplied, it must be forwarded consistently through the scheduled run, reflection cycle, and delivery cycle
+- before queue admission starts, the runner must resolve one deterministic goal context from `--goal-key` or the active-goal registry
+- when `--goal-key` is omitted, the runner must fail before queue admission if the active-goal registry has no active goal
+- the queue seed `goal_key` must match the resolved goal context before queue admission starts
+- once goal context is resolved, the runner must forward that resolved goal key to the reflection cycle even when the caller omitted `--goal-key`
 - `planningops` may forward operator-channel hints such as `delivery-target`, `channel-kind`, and `thread-ref`, but must not derive concrete transport recipients on its own
 - `planningops` may pass only a monday-owned worker outcome root hint and must not supply a canonical worker outcome file path for the primary path
 - the primary path must resolve the worker outcome through monday scheduler-native selection and monday-emitted handoff evidence rather than a control-plane-owned worker-outcome file path
@@ -129,6 +135,7 @@ Each stage report must include:
 - the runner must derive `worker_outcome_ref` from the resolved handoff artifact instead of reconstructing worker outcome paths inline
 - the runner must call the planningops reflection-cycle runner instead of re-implementing reflection export, evaluation, or action mapping inline
 - the runner must call the planningops delivery-cycle runner instead of re-implementing monday delivery invocation inline
+- goal-completed actions must flow through `planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py` instead of `planningops/scripts/federation/run_reflection_delivery_cycle.py`
 - the runner must preserve `goal_transition_report_path` from the reflection action artifact through the delivery cycle and aggregate report
 - `delivery_required = false` must still produce a successful aggregate report with `delivery_skipped = true`
 - identical `dry-run` inputs must produce the same stage structure and verdicts apart from timestamps
@@ -159,6 +166,7 @@ Each stage report must include:
 ## Failure Rules
 - missing monday scheduled entrypoint or missing scheduled evidence must fail the cycle
 - missing monday admission entrypoint or missing queue admission evidence must fail the cycle
+- unresolved goal context must fail the cycle before queue admission starts
 - the runner must fail if monday scheduled queue evidence does not resolve exactly one worker outcome artifact for the current cycle
 - reflection-cycle failure must fail the aggregate cycle before delivery starts
 - delivery-cycle failure must fail the aggregate cycle even if scheduled and reflection stages passed
@@ -173,5 +181,8 @@ Each stage report must include:
 - `monday/scripts/admit_scheduled_queue_packet.py`
 - `monday/scripts/run_scheduled_queue_cycle.py`
 - `planningops/scripts/federation/run_worker_outcome_reflection_cycle.py`
+- `planningops/scripts/federation/reflection_cycle_common.py`
 - `planningops/scripts/federation/run_reflection_delivery_cycle.py`
+- `planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py`
 - `planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py`
+- `planningops/scripts/test_scheduled_reflection_delivery_cycle.sh`

--- a/planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py
+++ b/planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -12,12 +11,35 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
+SCRIPTS_DIR = SCRIPT_DIR.parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+CORE_GOALS_DIR = SCRIPT_DIR.parent / "core" / "goals"
+if str(CORE_GOALS_DIR) not in sys.path:
+    sys.path.insert(0, str(CORE_GOALS_DIR))
 
 from federated_python_env import (  # noqa: E402
     build_bootstrap_plan,
     build_managed_env,
     ensure_bootstrap_environment,
     resolve_bootstrap_root,
+)
+from reflection_cycle_common import (  # noqa: E402
+    build_stage_report,
+    derive_single_queue_value,
+    load_json,
+    normalize_cross_repo_path,
+    normalize_repo_path,
+    now_utc,
+    require_string,
+    resolve_component_repo,
+    resolve_goal_context,
+    resolve_input_path,
+    resolve_output_path,
+    resolve_repo_root,
+    resolve_workspace_root,
+    run_cmd,
+    write_report,
 )
 
 
@@ -28,125 +50,7 @@ MONDAY_ADMISSION_ENTRYPOINT = "monday/scripts/admit_scheduled_queue_packet.py"
 MONDAY_SCHEDULED_ENTRYPOINT = "monday/scripts/run_scheduled_queue_cycle.py"
 REFLECTION_RUNNER = "planningops/scripts/federation/run_worker_outcome_reflection_cycle.py"
 DELIVERY_RUNNER = "planningops/scripts/federation/run_reflection_delivery_cycle.py"
-
-
-def now_utc() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-def resolve_repo_root() -> Path:
-    current = Path(__file__).resolve()
-    for candidate in [current] + list(current.parents):
-        if (candidate / ".git").exists():
-            return candidate
-    return Path(__file__).resolve().parents[4]
-
-
-def resolve_workspace_root(planningops_repo: Path, raw_workspace_root: str) -> Path:
-    candidates = [
-        (planningops_repo / raw_workspace_root).resolve(),
-        planningops_repo,
-        planningops_repo.parent,
-    ]
-    for candidate in candidates:
-        if (candidate / "monday").exists():
-            return candidate
-    return (planningops_repo / raw_workspace_root).resolve()
-
-
-def resolve_component_repo(workspace_root: Path, repo_dir: str) -> Path:
-    path = Path(repo_dir)
-    if path.is_absolute():
-        return path
-    return (workspace_root / path).resolve()
-
-
-def resolve_input_path(planningops_repo: Path, workspace_root: Path, monday_repo: Path, raw_path: str) -> Path:
-    path = Path(raw_path)
-    candidates: list[Path] = []
-    if path.is_absolute():
-        candidates.append(path)
-    else:
-        candidates.extend(
-            [
-                (planningops_repo / path).resolve(),
-                (workspace_root / path).resolve(),
-                (monday_repo / path).resolve(),
-                path.resolve(),
-            ]
-        )
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-    raise FileNotFoundError(f"input not found: {raw_path}")
-
-
-def resolve_output_path(planningops_repo: Path, raw_path: str | None, default_path: Path) -> Path:
-    if raw_path is None:
-        return default_path
-    path = Path(raw_path)
-    if path.is_absolute():
-        return path
-    return (planningops_repo / path).resolve()
-
-
-def normalize_repo_path(repo_root: Path, path: Path) -> str:
-    try:
-        return str(path.resolve().relative_to(repo_root.resolve()))
-    except ValueError:
-        return str(path.resolve())
-
-
-def normalize_cross_repo_path(planningops_repo: Path, monday_repo: Path, path: Path) -> str:
-    try:
-        return str(path.resolve().relative_to(planningops_repo.resolve()))
-    except ValueError:
-        try:
-            return str(path.resolve().relative_to(monday_repo.resolve()))
-        except ValueError:
-            return str(path.resolve())
-
-
-def load_json(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def require_string(doc: dict, key: str) -> str:
-    value = doc.get(key)
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{key} must be a non-empty string")
-    return value.strip()
-
-
-def write_report(path: Path, payload: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
-
-
-def derive_single_queue_value(queue_doc: dict, key: str) -> str:
-    values = {str(item.get(key) or "").strip() for item in queue_doc.get("queue_items", []) if str(item.get(key) or "").strip()}
-    if len(values) != 1:
-        raise ValueError(f"queue seed must provide exactly one {key}; got {sorted(values)}")
-    return next(iter(values))
-
-
-def run_cmd(command: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
-    completed = subprocess.run(command, cwd=str(cwd), capture_output=True, text=True, env=env)
-    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
-
-
-def build_stage_report(stage: str, command: list[str], cwd: Path, rc: int, out: str, err: str, artifact_path: Path) -> dict:
-    return {
-        "stage": stage,
-        "command": command,
-        "cwd": str(cwd),
-        "exit_code": rc,
-        "stdout_tail": out[-1000:],
-        "stderr_tail": err[-1000:],
-        "artifact_path": str(artifact_path),
-        "artifact_exists": artifact_path.exists(),
-        "verdict": "pass" if rc == 0 else "fail",
-    }
+GOAL_COMPLETION_HANDOFF_RUNNER = "planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py"
 
 
 def parse_args():
@@ -156,6 +60,11 @@ def parse_args():
     parser.add_argument("--workspace-root", default="..", help="Workspace root containing sibling repositories")
     parser.add_argument("--monday-repo-dir", default="monday", help="monday repo directory relative to workspace root")
     parser.add_argument("--monday-python", default=None, help="Optional Python interpreter override for monday leaf scripts")
+    parser.add_argument(
+        "--monday-profiles-config",
+        default=None,
+        help="Optional monday local operator profile config override passed through to monday delivery CLIs",
+    )
     parser.add_argument(
         "--monday-admission-script",
         default="scripts/admit_scheduled_queue_packet.py",
@@ -173,6 +82,7 @@ def parse_args():
         help="monday-owned worker outcome root used for scheduler-native selection",
     )
     parser.add_argument("--active-goal-registry", default="planningops/config/active-goal-registry.json")
+    parser.add_argument("--schedule-key", default=None)
     parser.add_argument("--queue-db", default=None)
     parser.add_argument("--idempotency", default=None)
     parser.add_argument("--transition-log", default=None)
@@ -208,6 +118,15 @@ def parse_args():
         help="Managed virtualenv root used when bootstrap is required",
     )
     return parser.parse_args()
+
+
+def requires_goal_completion_handoff(reflection_report: dict) -> bool:
+    message_class_hint = str(reflection_report.get("message_class_hint") or "").strip()
+    return (
+        str(reflection_report.get("reflection_decision") or "").strip() == "goal_achieved"
+        and str(reflection_report.get("action_kind") or "").strip() == "prepare_goal_completion"
+        and (not message_class_hint or message_class_hint == "goal_completed")
+    )
 
 
 def failure_report(
@@ -369,6 +288,47 @@ def main() -> int:
             report_path=report_output,
         )
     goal_key = args.goal_key or derived_goal_key
+    delivery_schedule_key = args.schedule_key or derived_schedule_key
+
+    resolved_goal = None
+    resolved_goal_key = None
+    if args.active_goal_registry:
+        resolved_goal, goal_errors = resolve_goal_context(planningops_repo / args.active_goal_registry, planningops_repo, args.goal_key)
+        if goal_errors:
+            return failure_report(
+                args=args,
+                goal_key=goal_key,
+                queue_admission_report_ref=queue_admission_report_ref,
+                scheduled_cycle_report_ref=scheduled_report_ref,
+                worker_outcome_ref=worker_outcome_ref,
+                reflection_cycle_report_ref=reflection_report_ref,
+                reflection_action_ref=action_ref,
+                delivery_cycle_report_ref=delivery_report_ref,
+                stage_reports=stage_reports,
+                failure_stage="resolve_goal_context",
+                errors=goal_errors,
+                report_path=report_output,
+            )
+        resolved_goal_key = str((resolved_goal or {}).get("goal_key") or "").strip()
+        if resolved_goal_key and resolved_goal_key != goal_key:
+            return failure_report(
+                args=args,
+                goal_key=goal_key,
+                queue_admission_report_ref=queue_admission_report_ref,
+                scheduled_cycle_report_ref=scheduled_report_ref,
+                worker_outcome_ref=worker_outcome_ref,
+                reflection_cycle_report_ref=reflection_report_ref,
+                reflection_action_ref=action_ref,
+                delivery_cycle_report_ref=delivery_report_ref,
+                stage_reports=stage_reports,
+                failure_stage="resolve_goal_context",
+                errors=[
+                    "queue seed goal_key must match the resolved goal context",
+                    f"expected={resolved_goal_key}",
+                    f"actual={goal_key}",
+                ],
+                report_path=report_output,
+            )
 
     admission_packet = {
         "admission_version": 1,
@@ -687,8 +647,8 @@ def main() -> int:
         "--output",
         str(reflection_output),
     ]
-    if args.goal_key:
-        reflection_command.extend(["--goal-key", args.goal_key])
+    if resolved_goal_key:
+        reflection_command.extend(["--goal-key", resolved_goal_key])
 
     rc, out, err = run_cmd(reflection_command, planningops_repo, env)
     stage_reports.append(build_stage_report("reflection_cycle", reflection_command, planningops_repo, rc, out, err, reflection_output))
@@ -730,28 +690,64 @@ def main() -> int:
     reflection_report = load_json(reflection_output)
     action_ref = str(reflection_report.get("reflection_action_ref") or action_ref)
 
-    delivery_command = [
-        bootstrap_info["preferred_python"],
-        str(planningops_repo / "planningops" / "scripts" / "federation" / "run_reflection_delivery_cycle.py"),
-        "--workspace-root",
-        str(workspace_root),
-        "--monday-repo-dir",
-        str(monday_repo),
-        "--action-file",
-        str(action_output),
-        "--mode",
-        args.mode,
-        "--run-id",
-        f"{args.run_id}-delivery",
-        "--output",
-        str(delivery_output),
-    ]
-    if args.delivery_target:
-        delivery_command.extend(["--delivery-target", args.delivery_target])
-    if args.channel_kind:
-        delivery_command.extend(["--channel-kind", args.channel_kind])
-    if args.thread_ref:
-        delivery_command.extend(["--thread-ref", args.thread_ref])
+    if requires_goal_completion_handoff(reflection_report):
+        delivery_command = [
+            bootstrap_info["preferred_python"],
+            str(planningops_repo / "planningops" / "scripts" / "federation" / "run_reflection_goal_completion_handoff_cycle.py"),
+            "--workspace-root",
+            str(workspace_root),
+            "--monday-repo-dir",
+            str(monday_repo),
+            "--reflection-action-file",
+            str(action_output),
+            "--active-goal-registry",
+            args.active_goal_registry,
+            "--mode",
+            args.mode,
+            "--run-id",
+            f"{args.run_id}-delivery",
+            "--output",
+            str(delivery_output),
+            "--monday-supervisor-queue-db",
+            str(queue_db_path),
+        ]
+        if resolved_goal_key:
+            delivery_command.extend(["--goal-key", resolved_goal_key])
+        if args.monday_python:
+            delivery_command.extend(["--monday-python", args.monday_python])
+        if args.monday_profiles_config:
+            delivery_command.extend(["--monday-profiles-config", args.monday_profiles_config])
+    else:
+        delivery_command = [
+            bootstrap_info["preferred_python"],
+            str(planningops_repo / "planningops" / "scripts" / "federation" / "run_reflection_delivery_cycle.py"),
+            "--workspace-root",
+            str(workspace_root),
+            "--monday-repo-dir",
+            str(monday_repo),
+            "--action-file",
+            str(action_output),
+            "--schedule-key",
+            delivery_schedule_key,
+            "--mode",
+            args.mode,
+            "--run-id",
+            f"{args.run_id}-delivery",
+            "--output",
+            str(delivery_output),
+            "--monday-queue-db",
+            str(queue_db_path),
+        ]
+        if args.monday_python:
+            delivery_command.extend(["--monday-python", args.monday_python])
+        if args.monday_profiles_config:
+            delivery_command.extend(["--monday-profiles-config", args.monday_profiles_config])
+        if args.delivery_target:
+            delivery_command.extend(["--delivery-target", args.delivery_target])
+        if args.channel_kind:
+            delivery_command.extend(["--channel-kind", args.channel_kind])
+        if args.thread_ref:
+            delivery_command.extend(["--thread-ref", args.thread_ref])
 
     rc, out, err = run_cmd(delivery_command, planningops_repo, env)
     stage_reports.append(build_stage_report("delivery_cycle", delivery_command, planningops_repo, rc, out, err, delivery_output))
@@ -791,6 +787,13 @@ def main() -> int:
         )
 
     delivery_report = load_json(delivery_output)
+    delivery_required = delivery_report.get("delivery_required")
+    if delivery_required is None:
+        delivery_required = reflection_report.get("delivery_required")
+    delivery_skipped = delivery_report.get("delivery_skipped")
+    if delivery_skipped is None:
+        delivery_skipped = False if delivery_required else True
+
     payload = {
         "generated_at_utc": now_utc(),
         "mode": args.mode,
@@ -803,8 +806,8 @@ def main() -> int:
         "delivery_cycle_report_ref": delivery_report_ref,
         "reflection_decision": reflection_report.get("reflection_decision"),
         "action_kind": reflection_report.get("action_kind"),
-        "delivery_required": delivery_report.get("delivery_required"),
-        "delivery_skipped": delivery_report.get("delivery_skipped"),
+        "delivery_required": delivery_required,
+        "delivery_skipped": delivery_skipped,
         "goal_transition_required": reflection_report.get("goal_transition_required"),
         "goal_transition_report_path": delivery_report.get("goal_transition_report_path")
         or reflection_report.get("goal_transition_report_path")

--- a/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
+++ b/planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
@@ -30,8 +30,10 @@ required_fragments = [
     "planningops/contracts/scheduler-native-worker-outcome-selection-contract.md",
     "planningops/contracts/scheduled-worker-outcome-handoff-contract.md",
     "monday/scripts/export_worker_outcome_reflection_packet.py",
+    "planningops/scripts/federation/reflection_cycle_common.py",
     "planningops/scripts/federation/run_worker_outcome_reflection_cycle.py",
     "planningops/scripts/federation/run_reflection_delivery_cycle.py",
+    "planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py",
     "planningops/scripts/federation/run_scheduled_reflection_delivery_cycle.py",
     "planningops/contracts/autonomous-scheduler-queue-control-plane-contract.md",
     "planningops/contracts/reflection-cycle-orchestration-contract.md",
@@ -50,10 +52,16 @@ required_fragments = [
     "`reflection_cycle`",
     "`delivery_cycle`",
     "must invoke `monday/scripts/admit_scheduled_queue_packet.py` before `monday/scripts/run_scheduled_queue_cycle.py`",
+    "before queue admission starts, the runner must resolve one deterministic goal context",
+    "when `--goal-key` is omitted, the runner must fail before queue admission if the active-goal registry has no active goal",
+    "queue seed `goal_key` must match the resolved goal context before queue admission starts",
+    "once goal context is resolved, the runner must forward that resolved goal key to the reflection cycle even when the caller omitted `--goal-key`",
+    "goal-completed actions must flow through `planningops/scripts/federation/run_reflection_goal_completion_handoff_cycle.py` instead of `planningops/scripts/federation/run_reflection_delivery_cycle.py`",
     "queue row mutation or lease heartbeat logic",
     "must not supply a canonical worker outcome file path",
     "must not forward a direct `--queue` seed input into monday scheduled execution",
     "must not require `--worker-outcome-json` for the primary path",
+    "unresolved goal context must fail the cycle before queue admission starts",
 ]
 for fragment in required_fragments:
     assert fragment in text, fragment


### PR DESCRIPTION
## Summary
- move the scheduled reflection delivery runner onto shared reflection plumbing
- resolve goal context before queue admission and enforce queue-seed/goal consistency
- route terminal goal-completed actions through the dedicated goal-completion handoff bridge

## Validation
- bash planningops/scripts/test_scheduled_reflection_delivery_cycle.sh
- bash planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all