### PR TITLE
feat(reflection-delivery): admit scheduled delivery work items

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -125,6 +125,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Planning Context Dependency Key Pattern Packet](./plans/2026-03-28-planning-context-dependency-key-pattern-packet.md)
 - [Worker Outcome Reflection Goal Context Packet](./plans/2026-03-28-worker-outcome-reflection-goal-context-packet.md)
 - [Scheduled Reflection Goal Context Packet](./plans/2026-03-28-scheduled-reflection-goal-context-packet.md)
+- [Reflection Delivery Queue Admission Packet](./plans/2026-03-28-reflection-delivery-queue-admission-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-reflection-delivery-queue-admission-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-reflection-delivery-queue-admission-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Reflection Delivery Queue Admission Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Moves direct reflection delivery from monday one-shot transport execution to monday-owned scheduled delivery queue admission with canonical queue evidence.
+related_docs:
+  - ./2026-03-28-scheduled-reflection-goal-context-packet.md
+---
+
+# plan: Reflection Delivery Queue Admission Packet
+
+## Summary
+- Move direct reflection delivery from one-shot monday transport execution to scheduled delivery queue admission.
+- Preserve planningops as queue-admission orchestrator only, while monday keeps downstream delivery-entrypoint ownership.
+- Backfill the delivery cycle contract and regression around queue-item evidence and queued apply-mode behavior.
+
+## Scope
+- `planningops/scripts/federation/run_reflection_delivery_cycle.py`
+- `planningops/contracts/reflection-delivery-cycle-contract.md`
+- `planningops/scripts/test_reflection_delivery_cycle.sh`
+- workbench hub link for this delivery queue-admission packet
+
+## Acceptance
+- `test_reflection_delivery_cycle.sh` passes
+- `test_reflection_delivery_cycle_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/reflection-delivery-cycle-contract.md
+++ b/planningops/contracts/reflection-delivery-cycle-contract.md
@@ -3,21 +3,22 @@
 ## Purpose
 Define the deterministic boundary for the second half of the reflection loop:
 
-- `reflection action artifact -> monday delivery execution -> delivery evidence`
+- `reflection action artifact -> monday queue admission -> queued delivery evidence`
 
 This contract exists so:
-- `planningops` can orchestrate the delivery cycle without embedding Slack/email logic
-- `monday` keeps ownership of the delivery entrypoint and transport-facing evidence
-- later scheduler and queue work can treat operator delivery as one auditable stage instead of prompt-local glue
+- `planningops` can orchestrate recurring delivery intent without embedding Slack/email logic
+- `monday` keeps ownership of queue admission, downstream delivery-entrypoint selection, and runtime mutation
+- later scheduler work can treat reflection-triggered delivery as one auditable queue-admission stage instead of prompt-local glue
 
 ## Canonical Boundary
 - reflection action producer: `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
+- shared control-plane plumbing: `planningops/scripts/federation/reflection_cycle_common.py`
 - delivery-cycle runner: `planningops/scripts/federation/run_reflection_delivery_cycle.py`
-- monday delivery entrypoint: `monday/scripts/run_operator_message_delivery_cycle.py`
+- monday delivery entrypoint: `monday/scripts/enqueue_scheduled_delivery_work_item.py`
 - action handoff contract: `planningops/contracts/reflection-action-handoff-contract.md`
+- scheduled delivery queue admission contract: `planningops/contracts/scheduled-delivery-queue-admission-contract.md`
 - local delivery-cycle orchestration contract: `planningops/contracts/local-delivery-cycle-orchestration-contract.md`
 - operator channel adapter contract: `planningops/contracts/operator-channel-adapter-contract.md`
-- local target resolution contract: `planningops/contracts/local-operator-target-resolution-contract.md`
 - supervisor handoff contract: `planningops/contracts/supervisor-operator-handoff-contract.md`
 
 ## Cycle Scope
@@ -25,19 +26,21 @@ The reflection delivery cycle starts only after a valid reflection action artifa
 
 The cycle includes:
 - loading the action artifact emitted by `planningops`
-- invoking the monday-owned delivery entrypoint
-- collecting monday delivery evidence
+- invoking the monday-owned queue-admission entrypoint
+- collecting monday queue-admission evidence
 - writing one planningops-owned aggregate cycle report
 
 The cycle does not include:
 - reflection packet export
 - reflection evaluation
-- queue mutation
+- monday queue-row mutation inside `planningops`
 - direct Slack or email transport logic inside `planningops`
+- direct planningops invocation of monday one-shot delivery-cycle entrypoints
 
 ## Required Inputs
 Every delivery-cycle run must accept:
 - `--action-file`
+- `--schedule-key`
 - `--mode` with `dry-run` or `apply`
 - `--output`
 
@@ -49,29 +52,32 @@ Optional execution inputs may include:
 - `--monday-repo-dir`
 - `--monday-python`
 - `--monday-profiles-config`
+- `--monday-queue-db`
 
 Input rules:
 - `--action-file` must point to a `verdict=pass` artifact governed by `planningops/contracts/reflection-action-handoff-contract.md`
-- the primary local autonomous path must work without a caller-supplied concrete `delivery-target`
+- the primary recurring path must work without a caller-supplied concrete `delivery-target`
 - `planningops` may forward a concrete `delivery-target` only when it is supplied externally; it must not resolve the target from control-plane policy
-- when no explicit `delivery-target` is supplied, monday may resolve a local target under `planningops/contracts/local-operator-target-resolution-contract.md`
 - `planningops` may forward `channel-kind` and `thread-ref` hints, but must not derive concrete Slack channel IDs or email recipients on its own
 - `planningops` may forward a monday-owned local profile config hint only for deterministic testing or local environment selection; it must not author recipient policy inside that config
+- `planningops` may forward a monday-owned queue-db override only for deterministic testing; it must not author monday queue mutation fields directly
 
 ## Delivery Invocation
 The delivery-cycle runner must invoke only:
-- `monday/scripts/run_operator_message_delivery_cycle.py`
+- `monday/scripts/enqueue_scheduled_delivery_work_item.py`
 
 The runner must not call:
+- `monday/scripts/run_operator_message_delivery_cycle.py`
+- `monday/scripts/run_goal_completion_delivery_cycle.py`
 - `monday/scripts/send_operator_message.py`
 - `monday/scripts/send_goal_completion_notification.py`
 - `monday/scripts/send_reflection_decision_update.py`
-directly from `planningops` on the primary local path
+directly from `planningops` on the primary recurring path
 
 The monday entrypoint remains responsible for:
-- translating the reflection action into the final operator payload
-- emitting delivery evidence
-- emitting delivery-cycle evidence under the monday runtime-artifacts boundary
+- translating the reflection action into one scheduled delivery work item
+- selecting the downstream monday delivery-cycle entrypoint
+- emitting queue-admission evidence under the monday runtime-artifacts boundary
 
 ## Required Outputs
 Every delivery-cycle run must emit one aggregate report that includes:
@@ -87,10 +93,12 @@ Every delivery-cycle run must emit one aggregate report that includes:
 - `monday_delivery_entrypoint`
 - `monday_delivery_report_ref`
 - `delivery_verdict`
-- `delivery_target_resolution_mode`
-- `delivery_target_profile_ref`
-- `delivery_transport_kind`
-- `delivery_outbox_message_ref`
+- `queue_admission_verdict`
+- `selected_delivery_entrypoint`
+- `scheduled_delivery_work_item_ref`
+- `scheduled_queue_item_ref`
+- `scheduled_queue_item_id`
+- `delivery_idempotency_key`
 - `goal_transition_report_path`
 - `runner_contract_ref`
 - `stage_reports`
@@ -105,25 +113,27 @@ When `delivery_required = false`, the report must still include:
 - `monday_delivery_report_ref = -`
 
 When `delivery_required = true`, the report must include:
-- `monday_delivery_entrypoint = monday/scripts/run_operator_message_delivery_cycle.py`
+- `monday_delivery_entrypoint = monday/scripts/enqueue_scheduled_delivery_work_item.py`
 - `monday_delivery_report_ref`
-- a projected `delivery_verdict` copied from monday delivery evidence
-- a projected `delivery_target_resolution_mode` copied from monday delivery evidence
-- a projected `delivery_target_profile_ref` copied from monday delivery evidence when monday resolved a local profile
-- a projected `delivery_transport_kind` copied from monday delivery evidence
-- a projected `delivery_outbox_message_ref` copied from monday delivery evidence when apply mode wrote a local outbox artifact
+- a projected `delivery_verdict` that distinguishes `dry_run` from `queued`
+- `queue_admission_verdict` copied from monday queue-admission evidence
+- `selected_delivery_entrypoint`
+- `scheduled_delivery_work_item_ref`
+- `scheduled_queue_item_ref`
+- `scheduled_queue_item_id`
+- `delivery_idempotency_key`
 
 ## Cycle Report
 The aggregate cycle report is the planningops-owned evidence layer for this stage.
 
 The report must:
-- stay repo-root relative when pointing at artifacts
-- preserve the action artifact path and the monday delivery report path
-- summarize local target-resolution and outbox routing without copying concrete recipients or raw transport payloads
-- remain deterministic for the same action artifact plus delivery arguments
+- stay workspace-relative when pointing at monday-owned runtime artifacts
+- preserve the action artifact path and the monday queue-admission report path
+- summarize queue-admission and downstream entrypoint selection without copying concrete recipients or raw transport payloads
+- remain deterministic for the same action artifact plus queue-admission arguments
 
 `stage_reports` must contain at least:
-- `delivery_execution`
+- `queue_admission`
 
 Each stage report must include:
 - `stage`
@@ -138,12 +148,12 @@ Each stage report must include:
 
 ## Deterministic Orchestration Rules
 - the runner must fail closed if the action artifact does not reference `planningops/contracts/reflection-action-handoff-contract.md`
-- the runner must call the monday delivery entrypoint instead of invoking lower-level monday delivery CLIs from `planningops`
-- `reflection_decision = continue` must not force delivery execution; the cycle may end with `delivery_skipped = true`
-- `message_class_hint = goal_completed` must fail closed in this runner because goal-completion delivery belongs to `monday/scripts/run_goal_completion_delivery_cycle.py`
+- the runner must call the monday queue-admission entrypoint instead of invoking monday delivery-cycle CLIs from `planningops`
+- `reflection_decision = continue` must not force queue admission; the cycle may end with `delivery_skipped = true`
+- `message_class_hint = goal_completed` must fail closed in this runner because goal-completion queue admission belongs to the supervisor handoff path
 - `goal_transition_report_path` must be preserved from the action artifact into the aggregate report
-- `planningops` may orchestrate the monday CLI, but transport behavior and delivery verdict semantics remain monday-owned
-- the aggregate report must preserve monday-owned local target resolution evidence without promoting concrete `deliveryTarget` values into planningops-owned fields
+- `planningops` may orchestrate the monday CLI, but downstream delivery entrypoint selection and queue mutation semantics remain monday-owned
+- the aggregate report must preserve monday-owned queue-item identity and selected delivery-entrypoint evidence without promoting concrete `deliveryTarget` values into planningops-owned fields
 - identical `dry-run` inputs must produce the same aggregate verdict and stage structure apart from timestamps
 
 ## Ownership Boundary
@@ -151,31 +161,34 @@ Each stage report must include:
 - delivery-cycle orchestration
 - aggregate cycle evidence
 - control-plane path normalization
-- validation that the action artifact and monday delivery evidence are wired together correctly
+- validation that the action artifact and monday queue-admission evidence are wired together correctly
 
 ### Monday owns
 - reflection-action-to-payload translation for operator-message classes
-- local delivery-cycle execution
-- Slack/email adapter execution
-- transport-facing delivery evidence
+- scheduled delivery work-item creation
+- queue-row mutation
+- downstream local delivery-cycle entrypoint selection
+- transport-facing delivery execution and runtime evidence
 
 ### PlanningOps must not own
 - concrete Slack or email transport execution
 - target resolution from operator policy
+- monday queue insertion mutation
 - monday messaging payload schema redesign
-- queue mutation or retry/dead-letter lifecycle changes
+- retry/dead-letter lifecycle changes
 
 ## Failure Rules
 - missing monday entrypoint or missing action artifact must fail the cycle
-- `delivery_required = true` with missing `delivery-target` must fail only when monday cannot resolve a valid local target under `planningops/contracts/local-operator-target-resolution-contract.md`
-- the runner must fail if monday returns non-zero or emits a non-pass delivery report in `dry-run`
-- the runner must fail if the monday delivery report cannot be loaded
-- the runner must fail if aggregate evidence would drop `goal_transition_report_path` for a goal-completion action
-- the runner must not silently downgrade a delivery failure into `delivery_skipped`
+- the runner must fail if monday returns non-zero or emits a non-pass queue-admission report
+- the runner must fail if the monday queue-admission report cannot be loaded
+- the runner must fail if queue-admission evidence omits the selected downstream delivery entrypoint or queue-item identity
+- the runner must fail if aggregate evidence would drop `goal_transition_report_path`
+- the runner must not silently downgrade a queue-admission failure into `delivery_skipped`
 
 ## Validation
 - `planningops/scripts/test_reflection_delivery_cycle_contract.sh`
+- `planningops/scripts/federation/reflection_cycle_common.py`
 - `planningops/scripts/federation/run_reflection_delivery_cycle.py`
 - `planningops/scripts/test_reflection_delivery_cycle.sh`
 - `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
-- `monday/scripts/run_operator_message_delivery_cycle.py`
+- `monday/scripts/enqueue_scheduled_delivery_work_item.py`

--- a/planningops/scripts/federation/run_reflection_delivery_cycle.py
+++ b/planningops/scripts/federation/run_reflection_delivery_cycle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -19,11 +18,28 @@ from federated_python_env import (
     ensure_bootstrap_environment,
     resolve_bootstrap_root,
 )
+from reflection_cycle_common import (
+    build_stage_report,
+    load_json,
+    normalize_monday_runtime_ref,
+    normalize_repo_path,
+    normalize_workspace_path,
+    now_utc,
+    parse_json_doc,
+    resolve_component_repo,
+    resolve_input_path,
+    resolve_output_path,
+    resolve_repo_root,
+    resolve_workspace_root,
+    run_cmd,
+    write_report,
+)
 
 
 RUNNER_CONTRACT_REF = "planningops/contracts/reflection-delivery-cycle-contract.md"
 ACTION_CONTRACT_REF = "planningops/contracts/reflection-action-handoff-contract.md"
-MONDAY_DELIVERY_ENTRYPOINT = "monday/scripts/run_operator_message_delivery_cycle.py"
+MONDAY_DELIVERY_ENTRYPOINT = "monday/scripts/enqueue_scheduled_delivery_work_item.py"
+DEFAULT_SCHEDULE_KEY = "recurring-delivery"
 
 REQUIRED_ACTION_FIELDS = [
     "active_goal_key",
@@ -36,121 +52,6 @@ REQUIRED_ACTION_FIELDS = [
     "handoff_contract_ref",
     "verdict",
 ]
-
-
-def now_utc() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-def resolve_repo_root() -> Path:
-    current = Path(__file__).resolve()
-    for candidate in [current] + list(current.parents):
-        if (candidate / ".git").exists():
-            return candidate
-    return Path(__file__).resolve().parents[4]
-
-
-def resolve_workspace_root(planningops_repo: Path, raw_workspace_root: str) -> Path:
-    candidates = [
-        (planningops_repo / raw_workspace_root).resolve(),
-        planningops_repo,
-        planningops_repo.parent,
-    ]
-    for candidate in candidates:
-        if (candidate / "monday").exists():
-            return candidate
-    return (planningops_repo / raw_workspace_root).resolve()
-
-
-def resolve_component_repo(workspace_root: Path, repo_dir: str) -> Path:
-    path = Path(repo_dir)
-    if path.is_absolute():
-        return path
-    return (workspace_root / path).resolve()
-
-
-def resolve_input_path(planningops_repo: Path, workspace_root: Path, monday_repo: Path, raw_path: str) -> Path:
-    path = Path(raw_path)
-    candidates: list[Path] = []
-    if path.is_absolute():
-        candidates.append(path)
-    else:
-        candidates.extend(
-            [
-                (planningops_repo / path).resolve(),
-                (workspace_root / path).resolve(),
-                (monday_repo / path).resolve(),
-                path.resolve(),
-            ]
-        )
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-    raise FileNotFoundError(f"reflection action input not found: {raw_path}")
-
-
-def resolve_output_path(planningops_repo: Path, raw_path: str | None, default_path: Path) -> Path:
-    if raw_path is None:
-        return default_path
-    path = Path(raw_path)
-    if path.is_absolute():
-        return path
-    return (planningops_repo / path).resolve()
-
-
-def normalize_repo_path(repo_root: Path, path: Path) -> str:
-    try:
-        return str(path.resolve().relative_to(repo_root.resolve()))
-    except ValueError:
-        return str(path.resolve())
-
-
-def normalize_workspace_path(workspace_root: Path, path: Path) -> str:
-    try:
-        return str(path.resolve().relative_to(workspace_root.resolve()))
-    except ValueError:
-        return str(path.resolve())
-
-
-def load_json(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def write_report(path: Path, payload: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
-
-
-def parse_json_doc(raw: str) -> dict | None:
-    text = (raw or "").strip()
-    if not text:
-        return None
-    try:
-        doc = json.loads(text)
-    except json.JSONDecodeError:
-        return None
-    return doc if isinstance(doc, dict) else None
-
-
-def run_cmd(command: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
-    completed = subprocess.run(command, cwd=str(cwd), capture_output=True, text=True, env=env)
-    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
-
-
-def build_stage_report(stage: str, command: list[str], cwd: Path, rc: int, out: str, err: str, artifact_path: Path) -> dict:
-    return {
-        "stage": stage,
-        "command": command,
-        "cwd": str(cwd),
-        "exit_code": rc,
-        "stdout_tail": out[-1000:],
-        "stderr_tail": err[-1000:],
-        "artifact_path": str(artifact_path),
-        "artifact_exists": artifact_path.exists(),
-        "verdict": "pass" if rc == 0 else "fail",
-    }
-
-
 def parse_args():
     parser = argparse.ArgumentParser(description="Run the planningops -> monday reflection delivery cycle")
     parser.add_argument("--workspace-root", default="..", help="Workspace root containing sibling repositories")
@@ -163,13 +64,19 @@ def parse_args():
     )
     parser.add_argument(
         "--monday-delivery-script",
-        default="scripts/run_operator_message_delivery_cycle.py",
-        help="monday delivery script path relative to the monday repo",
+        default="scripts/enqueue_scheduled_delivery_work_item.py",
+        help="monday scheduled delivery queue admission script path relative to the monday repo",
+    )
+    parser.add_argument(
+        "--monday-queue-db",
+        default=None,
+        help="Optional monday queue-db override passed through to monday queue admission",
     )
     parser.add_argument("--action-file", required=True, help="Reflection action artifact path")
     parser.add_argument("--delivery-target", default=None)
     parser.add_argument("--channel-kind", default=None)
     parser.add_argument("--thread-ref", default=None)
+    parser.add_argument("--schedule-key", default=DEFAULT_SCHEDULE_KEY)
     parser.add_argument("--mode", choices=["dry-run", "apply"], default="dry-run")
     parser.add_argument(
         "--run-id",
@@ -205,6 +112,12 @@ def base_report_fields(action_ref: str, action: dict | None) -> dict:
         "monday_delivery_entrypoint": "-",
         "monday_delivery_report_ref": "-",
         "delivery_verdict": "-",
+        "queue_admission_verdict": "-",
+        "selected_delivery_entrypoint": "-",
+        "scheduled_delivery_work_item_ref": "-",
+        "scheduled_queue_item_ref": "-",
+        "scheduled_queue_item_id": "-",
+        "delivery_idempotency_key": "-",
         "delivery_target_resolution_mode": "-",
         "delivery_target_profile_ref": "-",
         "delivery_transport_kind": "-",
@@ -214,27 +127,31 @@ def base_report_fields(action_ref: str, action: dict | None) -> dict:
     }
 
 
-def extract_delivery_summary(delivery_cycle_report: dict, monday_repo: Path) -> dict:
-    delivery_report_ref = str(delivery_cycle_report.get("delivery_report_ref") or "-")
-    nested_report: dict = {}
-    if delivery_report_ref != "-":
-        delivery_report_path = (monday_repo / delivery_report_ref).resolve()
-        if delivery_report_path.exists():
-            loaded = load_json(delivery_report_path)
-            if isinstance(loaded, dict):
-                nested_report = loaded.get("delivery_report") or loaded
-    outbox_message_ref = nested_report.get("outboxMessageRef") or nested_report.get("outbox_message_ref") or "-"
+def extract_queue_admission_summary(queue_admission_report: dict, workspace_root: Path, monday_repo: Path) -> dict:
+    mode = str(queue_admission_report.get("mode") or "").strip()
+    admitted_count = int(queue_admission_report.get("admitted_count") or 0)
+    projected_delivery_verdict = "queued" if mode == "apply" and admitted_count > 0 else "dry_run"
     return {
-        "delivery_verdict": str(delivery_cycle_report.get("delivery_verdict") or nested_report.get("deliveryVerdict") or "-"),
-        "delivery_target_resolution_mode": str(nested_report.get("targetResolutionMode") or "-"),
-        "delivery_target_profile_ref": str(nested_report.get("targetProfileRef") or "-"),
-        "delivery_transport_kind": str(nested_report.get("transportKind") or "-"),
-        "delivery_outbox_message_ref": str(outbox_message_ref or "-"),
+        "delivery_verdict": projected_delivery_verdict,
+        "queue_admission_verdict": str(queue_admission_report.get("verdict") or "-"),
+        "selected_delivery_entrypoint": str(queue_admission_report.get("selected_delivery_entrypoint") or "-"),
+        "scheduled_delivery_work_item_ref": normalize_monday_runtime_ref(
+            workspace_root, monday_repo, queue_admission_report.get("scheduled_delivery_work_item_ref")
+        ),
+        "scheduled_queue_item_ref": normalize_monday_runtime_ref(
+            workspace_root, monday_repo, queue_admission_report.get("scheduled_queue_item_ref")
+        ),
+        "scheduled_queue_item_id": str(queue_admission_report.get("queue_item_id") or "-"),
+        "delivery_idempotency_key": str(queue_admission_report.get("delivery_idempotency_key") or "-"),
+        "delivery_target_resolution_mode": "-",
+        "delivery_target_profile_ref": "-",
+        "delivery_transport_kind": "-",
+        "delivery_outbox_message_ref": "-",
     }
 
 
 def resolve_monday_output(raw_path: str | None, run_id: str, monday_repo: Path) -> tuple[str, Path]:
-    default_rel = Path("runtime-artifacts") / "messaging" / "delivery-cycles" / f"reflection-delivery-cycle-{run_id}.json"
+    default_rel = Path("runtime-artifacts") / "scheduler-queue" / "admission-reports" / f"reflection-delivery-cycle-{run_id}.json"
     if raw_path is None:
         return str(default_rel), (monday_repo / default_rel).resolve()
     output_path = Path(raw_path)
@@ -258,6 +175,12 @@ def failure_report(
     delivery_target_profile_ref: str = "-",
     delivery_transport_kind: str = "-",
     delivery_outbox_message_ref: str = "-",
+    queue_admission_verdict: str = "-",
+    selected_delivery_entrypoint: str = "-",
+    scheduled_delivery_work_item_ref: str = "-",
+    scheduled_queue_item_ref: str = "-",
+    scheduled_queue_item_id: str = "-",
+    delivery_idempotency_key: str = "-",
 ) -> int:
     payload = {
         "generated_at_utc": now_utc(),
@@ -266,6 +189,12 @@ def failure_report(
         "delivery_skipped": False,
         "monday_delivery_report_ref": monday_delivery_report_ref,
         "delivery_verdict": delivery_verdict,
+        "queue_admission_verdict": queue_admission_verdict,
+        "selected_delivery_entrypoint": selected_delivery_entrypoint,
+        "scheduled_delivery_work_item_ref": scheduled_delivery_work_item_ref,
+        "scheduled_queue_item_ref": scheduled_queue_item_ref,
+        "scheduled_queue_item_id": scheduled_queue_item_id,
+        "delivery_idempotency_key": delivery_idempotency_key,
         "delivery_target_resolution_mode": delivery_target_resolution_mode,
         "delivery_target_profile_ref": delivery_target_profile_ref,
         "delivery_transport_kind": delivery_transport_kind,
@@ -347,6 +276,17 @@ def main() -> int:
             report_path=report_output,
         )
 
+    if action.get("message_class_hint") == "goal_completed":
+        return failure_report(
+            args=args,
+            action_ref=action_ref,
+            action=action,
+            stage_reports=stage_reports,
+            failure_stage="validate_queue_admission_handoff",
+            errors=["goal_completed reflection actions must flow through the supervisor goal-completion handoff"],
+            report_path=report_output,
+        )
+
     if not action["delivery_required"]:
         payload = {
             "generated_at_utc": now_utc(),
@@ -383,6 +323,8 @@ def main() -> int:
         args.monday_delivery_script,
         "--reflection-action-file",
         str(action_path),
+        "--schedule-key",
+        args.schedule_key,
         "--mode",
         args.mode,
         "--output",
@@ -396,6 +338,8 @@ def main() -> int:
         command.extend(["--thread-ref", args.thread_ref])
     if args.monday_profiles_config:
         command.extend(["--profiles-config", args.monday_profiles_config])
+    if args.monday_queue_db:
+        command.extend(["--queue-db", args.monday_queue_db])
 
     rc, out, err = run_cmd(command, monday_repo, env)
     parsed_stdout_report = parse_json_doc(out)
@@ -404,7 +348,7 @@ def main() -> int:
         reported_ref = str(parsed_stdout_report.get("report_ref") or "").strip()
         if reported_ref:
             delivery_output = (monday_repo / reported_ref).resolve()
-    stage_reports.append(build_stage_report("delivery_execution", command, monday_repo, rc, out, err, delivery_output))
+    stage_reports.append(build_stage_report("queue_admission", command, monday_repo, rc, out, err, delivery_output))
 
     delivery_report_ref = normalize_workspace_path(workspace_root, delivery_output)
     if not delivery_output.exists():
@@ -413,23 +357,23 @@ def main() -> int:
             action_ref=action_ref,
             action=action,
             stage_reports=stage_reports,
-            failure_stage="delivery_execution",
-            errors=["monday delivery report missing"],
+            failure_stage="queue_admission",
+            errors=["monday queue admission report missing"],
             report_path=report_output,
             monday_delivery_report_ref=delivery_report_ref,
         )
 
     delivery_report = load_json(delivery_output)
-    delivery_summary = extract_delivery_summary(delivery_report, monday_repo)
+    delivery_summary = extract_queue_admission_summary(delivery_report, workspace_root, monday_repo)
     errors = list(delivery_report.get("errors") or [])
     if rc != 0:
-        errors = errors or ["monday delivery entrypoint returned non-zero"]
+        errors = errors or ["monday queue admission returned non-zero"]
         return failure_report(
             args=args,
             action_ref=action_ref,
             action=action,
             stage_reports=stage_reports,
-            failure_stage="delivery_execution",
+            failure_stage="queue_admission",
             errors=errors,
             report_path=report_output,
             monday_delivery_report_ref=delivery_report_ref,
@@ -441,8 +385,8 @@ def main() -> int:
             action_ref=action_ref,
             action=action,
             stage_reports=stage_reports,
-            failure_stage="delivery_execution",
-            errors=errors or ["monday delivery report verdict must be pass"],
+            failure_stage="queue_admission",
+            errors=errors or ["monday queue admission report verdict must be pass"],
             report_path=report_output,
             monday_delivery_report_ref=delivery_report_ref,
             **delivery_summary,

--- a/planningops/scripts/test_reflection_delivery_cycle.sh
+++ b/planningops/scripts/test_reflection_delivery_cycle.sh
@@ -5,15 +5,35 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKSPACE_ROOT="$(cd "$ROOT_DIR/.." && pwd)"
 MONDAY_REPO="$WORKSPACE_ROOT/monday"
 MONDAY_TEST_OUTBOX_ROOT="$MONDAY_REPO/runtime-artifacts/test-reflection-delivery-cycle/local-outbox"
+MONDAY_QUEUE_DB="$MONDAY_REPO/runtime-artifacts/test-reflection-delivery-cycle/runtime-queue.sqlite3"
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR" "$MONDAY_REPO/runtime-artifacts/test-reflection-delivery-cycle" "$MONDAY_REPO/runtime-artifacts/messaging/delivery-reports" "$MONDAY_REPO/runtime-artifacts/messaging/delivery-cycles" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-packets" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-acks" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-execution-packets" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-receipts"' EXIT
+trap 'rm -rf "$TMP_DIR" "$MONDAY_REPO/runtime-artifacts/test-reflection-delivery-cycle" "$MONDAY_REPO/runtime-artifacts/messaging/delivery-reports" "$MONDAY_REPO/runtime-artifacts/messaging/delivery-cycles" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-packets" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-acks" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-execution-packets" "$MONDAY_REPO/runtime-artifacts/messaging/dispatch-receipts" "$MONDAY_REPO/runtime-artifacts/messaging/scheduled-delivery-work-items" "$MONDAY_REPO/runtime-artifacts/scheduler-queue"' EXIT
 
 cd "$ROOT_DIR"
 
-if [[ ! -f "$MONDAY_REPO/scripts/run_operator_message_delivery_cycle.py" ]]; then
+if [[ ! -f "$MONDAY_REPO/scripts/enqueue_scheduled_delivery_work_item.py" ]]; then
   echo "reflection delivery cycle test skipped: sibling monday repo unavailable"
   exit 0
 fi
+
+python3 - <<'PY'
+from pathlib import Path
+
+runner = Path("planningops/scripts/federation/run_reflection_delivery_cycle.py").read_text(encoding="utf-8")
+common = Path("planningops/scripts/federation/reflection_cycle_common.py").read_text(encoding="utf-8")
+
+assert "from reflection_cycle_common import (" in runner, runner
+assert "def resolve_repo_root(" not in runner, runner
+assert "def resolve_workspace_root(" not in runner, runner
+assert "def resolve_input_path(" not in runner, runner
+assert "def normalize_monday_runtime_ref(" not in runner, runner
+assert "def parse_json_doc(" not in runner, runner
+assert "def resolve_repo_root(" in common, common
+assert "def resolve_workspace_root(" in common, common
+assert "def resolve_input_path(" in common, common
+assert "def normalize_monday_runtime_ref(" in common, common
+assert "def parse_json_doc(" in common, common
+PY
 
 cat >"$TMP_DIR/local-operator-channel-profiles.json" <<JSON
 {
@@ -133,6 +153,7 @@ python3 planningops/scripts/run_reflection_delivery_cycle.py \
 python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/replan-action.json" \
+  --monday-queue-db "$MONDAY_QUEUE_DB" \
   --thread-ref "thread-wave10" \
   --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --run-id "test-reflection-delivery-replan" \
@@ -141,6 +162,7 @@ python3 planningops/scripts/run_reflection_delivery_cycle.py \
 if python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/goal-completed-action.json" \
+  --monday-queue-db "$MONDAY_QUEUE_DB" \
   --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --run-id "test-reflection-delivery-complete" \
   --output "$TMP_DIR/goal-completed-report.json" >/dev/null; then
@@ -151,6 +173,7 @@ fi
 python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/replan-action.json" \
+  --monday-queue-db "$MONDAY_QUEUE_DB" \
   --thread-ref "thread-wave10" \
   --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --mode apply \
@@ -160,6 +183,7 @@ python3 planningops/scripts/run_reflection_delivery_cycle.py \
 if python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/goal-completed-action.json" \
+  --monday-queue-db "$MONDAY_QUEUE_DB" \
   --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --mode apply \
   --run-id "test-reflection-delivery-complete-apply-local" \
@@ -168,29 +192,29 @@ if python3 planningops/scripts/run_reflection_delivery_cycle.py \
   exit 1
 fi
 
-if python3 planningops/scripts/run_reflection_delivery_cycle.py \
+python3 planningops/scripts/run_reflection_delivery_cycle.py \
   --workspace-root .. \
   --action-file "$TMP_DIR/replan-action.json" \
+  --monday-queue-db "$MONDAY_QUEUE_DB" \
   --delivery-target "slack://monday/thread-wave10" \
   --monday-profiles-config "$TMP_DIR/local-operator-channel-profiles.json" \
   --mode apply \
   --run-id "test-reflection-delivery-replan-apply" \
-  --output "$TMP_DIR/replan-apply-report.json" >/dev/null; then
-  echo "expected reflection delivery cycle apply to fail without monday transport"
-  exit 1
-fi
+  --output "$TMP_DIR/replan-apply-report.json" >/dev/null
 
-python3 - "$TMP_DIR/continue-report.json" "$TMP_DIR/replan-report.json" "$TMP_DIR/goal-completed-report.json" "$TMP_DIR/replan-apply-local-report.json" "$TMP_DIR/goal-completed-apply-local-report.json" "$TMP_DIR/replan-apply-report.json" <<'PY'
+python3 - "$MONDAY_QUEUE_DB" "$TMP_DIR/continue-report.json" "$TMP_DIR/replan-report.json" "$TMP_DIR/goal-completed-report.json" "$TMP_DIR/replan-apply-local-report.json" "$TMP_DIR/goal-completed-apply-local-report.json" "$TMP_DIR/replan-apply-report.json" <<'PY'
 import json
+import sqlite3
 import sys
 from pathlib import Path
 
-continue_report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-replan_report = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
-goal_completed_report = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
-replan_apply_local_report = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
-goal_completed_apply_local_report = json.loads(Path(sys.argv[5]).read_text(encoding="utf-8"))
-replan_apply_report = json.loads(Path(sys.argv[6]).read_text(encoding="utf-8"))
+queue_db_path, continue_report_path, replan_report_path, goal_completed_report_path, replan_apply_local_report_path, goal_completed_apply_local_report_path, replan_apply_report_path = sys.argv[1:]
+continue_report = json.loads(Path(continue_report_path).read_text(encoding="utf-8"))
+replan_report = json.loads(Path(replan_report_path).read_text(encoding="utf-8"))
+goal_completed_report = json.loads(Path(goal_completed_report_path).read_text(encoding="utf-8"))
+replan_apply_local_report = json.loads(Path(replan_apply_local_report_path).read_text(encoding="utf-8"))
+goal_completed_apply_local_report = json.loads(Path(goal_completed_apply_local_report_path).read_text(encoding="utf-8"))
+replan_apply_report = json.loads(Path(replan_apply_report_path).read_text(encoding="utf-8"))
 
 assert continue_report["verdict"] == "pass", continue_report
 assert continue_report["delivery_required"] is False, continue_report
@@ -201,36 +225,51 @@ assert continue_report["monday_delivery_report_ref"] == "-", continue_report
 assert replan_report["verdict"] == "pass", replan_report
 assert replan_report["delivery_required"] is True, replan_report
 assert replan_report["delivery_skipped"] is False, replan_report
-assert replan_report["monday_delivery_entrypoint"] == "monday/scripts/run_operator_message_delivery_cycle.py", replan_report
+assert replan_report["monday_delivery_entrypoint"] == "monday/scripts/enqueue_scheduled_delivery_work_item.py", replan_report
 assert replan_report["delivery_verdict"] == "dry_run", replan_report
-assert replan_report["delivery_target_resolution_mode"] == "local_profile", replan_report
-assert replan_report["delivery_target_profile_ref"].endswith("local-operator-channel-profiles.json#/profiles/slack_skill_cli"), replan_report
-assert replan_report["delivery_transport_kind"] == "local_outbox", replan_report
+assert replan_report["queue_admission_verdict"] == "pass", replan_report
+assert replan_report["selected_delivery_entrypoint"] == "scripts/run_operator_message_delivery_cycle.py", replan_report
+assert replan_report["scheduled_delivery_work_item_ref"].startswith("monday/runtime-artifacts/messaging/scheduled-delivery-work-items/"), replan_report
+assert replan_report["scheduled_queue_item_ref"].startswith("monday/runtime-artifacts/scheduler-queue/item-refs/"), replan_report
+assert replan_report["scheduled_queue_item_ref"].endswith(f'{replan_report["scheduled_queue_item_id"]}.json'), replan_report
 assert replan_report["delivery_outbox_message_ref"] == "-", replan_report
-assert replan_report["stage_reports"][0]["stage"] == "delivery_execution", replan_report
+assert replan_report["stage_reports"][0]["stage"] == "queue_admission", replan_report
 assert replan_report["stage_reports"][0]["verdict"] == "pass", replan_report
 
 assert goal_completed_report["verdict"] == "fail", goal_completed_report
 assert goal_completed_report["message_class_hint"] == "goal_completed", goal_completed_report
-assert goal_completed_report["failure_stage"] == "delivery_execution", goal_completed_report
+assert goal_completed_report["failure_stage"] == "validate_queue_admission_handoff", goal_completed_report
 assert goal_completed_report["error_count"] >= 1, goal_completed_report
 
 assert replan_apply_local_report["verdict"] == "pass", replan_apply_local_report
-assert replan_apply_local_report["delivery_verdict"] == "delivered_local_outbox", replan_apply_local_report
-assert replan_apply_local_report["delivery_target_resolution_mode"] == "local_profile", replan_apply_local_report
-assert replan_apply_local_report["delivery_outbox_message_ref"].endswith(".json"), replan_apply_local_report
+assert replan_apply_local_report["delivery_verdict"] == "queued", replan_apply_local_report
+assert replan_apply_local_report["queue_admission_verdict"] == "pass", replan_apply_local_report
+assert replan_apply_local_report["selected_delivery_entrypoint"] == "scripts/run_operator_message_delivery_cycle.py", replan_apply_local_report
+assert replan_apply_local_report["scheduled_delivery_work_item_ref"].startswith("monday/runtime-artifacts/messaging/scheduled-delivery-work-items/"), replan_apply_local_report
+assert replan_apply_local_report["scheduled_queue_item_ref"].startswith("monday/runtime-artifacts/scheduler-queue/item-refs/"), replan_apply_local_report
+assert replan_apply_local_report["scheduled_queue_item_ref"].endswith(f'{replan_apply_local_report["scheduled_queue_item_id"]}.json'), replan_apply_local_report
 
 assert goal_completed_apply_local_report["verdict"] == "fail", goal_completed_apply_local_report
-assert goal_completed_apply_local_report["failure_stage"] == "delivery_execution", goal_completed_apply_local_report
+assert goal_completed_apply_local_report["failure_stage"] == "validate_queue_admission_handoff", goal_completed_apply_local_report
 assert goal_completed_apply_local_report["error_count"] >= 1, goal_completed_apply_local_report
 
-assert replan_apply_report["verdict"] == "fail", replan_apply_report
+assert replan_apply_report["verdict"] == "pass", replan_apply_report
 assert replan_apply_report["delivery_skipped"] is False, replan_apply_report
-assert replan_apply_report["delivery_verdict"] == "blocked", replan_apply_report
-assert replan_apply_report["delivery_target_resolution_mode"] == "explicit_argument", replan_apply_report
-assert replan_apply_report["delivery_target_profile_ref"] == "-", replan_apply_report
-assert replan_apply_report["failure_stage"] == "delivery_execution", replan_apply_report
-assert replan_apply_report["error_count"] >= 1, replan_apply_report
+assert replan_apply_report["delivery_verdict"] == "queued", replan_apply_report
+assert replan_apply_report["queue_admission_verdict"] == "pass", replan_apply_report
+assert replan_apply_report["selected_delivery_entrypoint"] == "scripts/run_operator_message_delivery_cycle.py", replan_apply_report
+
+conn = sqlite3.connect(queue_db_path)
+rows = conn.execute("SELECT queue_item_id, schedule_key, work_payload_ref FROM queue_items ORDER BY queue_item_id").fetchall()
+conn.close()
+assert len(rows) >= 1, rows
+queue_ids = {row[0] for row in rows}
+assert replan_apply_local_report["scheduled_queue_item_id"] in queue_ids, rows
+assert replan_apply_report["scheduled_queue_item_id"] in queue_ids, rows
+assert replan_apply_local_report["scheduled_queue_item_id"] == replan_apply_report["scheduled_queue_item_id"], rows
+for row in rows:
+    assert row[1] == "recurring-delivery", row
+    assert row[2].startswith("runtime-artifacts/messaging/scheduled-delivery-work-items/"), row
 
 print("reflection delivery cycle test passed")
 PY


### PR DESCRIPTION
## Summary
- move direct reflection delivery from one-shot monday transport execution to monday-owned scheduled delivery queue admission
- project queue item and selected delivery entrypoint evidence into the aggregate delivery report
- backfill the delivery cycle contract and regression around queued apply-mode behavior

## Validation
- bash planningops/scripts/test_reflection_delivery_cycle.sh
- bash planningops/scripts/test_reflection_delivery_cycle_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all