### PR TITLE
fix(reflection-action): fail closed without active goal

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -126,6 +126,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Worker Outcome Reflection Goal Context Packet](./plans/2026-03-28-worker-outcome-reflection-goal-context-packet.md)
 - [Scheduled Reflection Goal Context Packet](./plans/2026-03-28-scheduled-reflection-goal-context-packet.md)
 - [Reflection Delivery Queue Admission Packet](./plans/2026-03-28-reflection-delivery-queue-admission-packet.md)
+- [Reflection Action No Active Goal Packet](./plans/2026-03-28-reflection-action-no-active-goal-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-reflection-action-no-active-goal-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-reflection-action-no-active-goal-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Reflection Action No Active Goal Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Hardens reflection action handoff so action application fails closed when no active goal context is available, matching the evaluator's behavior.
+related_docs:
+  - ./2026-03-28-worker-outcome-reflection-goal-context-packet.md
+---
+
+# plan: Reflection Action No Active Goal Packet
+
+## Summary
+- Align reflection action application with evaluator-side no-active-goal failure behavior.
+- Simplify the applier's post-processing error handling so existing validation errors stay authoritative.
+- Update the handoff contract and regression coverage for missing active-goal context.
+
+## Scope
+- `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
+- `planningops/scripts/test_apply_worker_outcome_reflection.sh`
+- `planningops/contracts/reflection-action-handoff-contract.md`
+- workbench hub link for this no-active-goal hardening packet
+
+## Acceptance
+- `test_apply_worker_outcome_reflection.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/reflection-action-handoff-contract.md
+++ b/planningops/contracts/reflection-action-handoff-contract.md
@@ -1,7 +1,7 @@
 # Reflection Action Handoff Contract
 
 ## Purpose
-Define the deterministic boundary between planningops-owned reflection evaluation outputs and the next action artifacts consumed by supervisor policy and monday-owned operator delivery entrypoints.
+Define the deterministic boundary between planningops-owned reflection evaluation outputs and the next action artifacts consumed by supervisor policy and monday-owned scheduled delivery queue admission.
 
 This contract exists so:
 - `planningops` can turn reflection decisions into explicit control-plane action intent without mutating monday queue state
@@ -11,7 +11,7 @@ This contract exists so:
 ## Canonical Boundary
 - reflection evaluator: `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
 - action applier: `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
-- monday operator delivery entrypoint: `monday/scripts/run_operator_message_delivery_cycle.py`
+- monday scheduled delivery queue admission entrypoint: `monday/scripts/enqueue_scheduled_delivery_work_item.py`
 - operator channel policy: `planningops/contracts/operator-channel-adapter-contract.md`
 - goal completion policy: `planningops/contracts/goal-completion-contract.md`
 
@@ -119,11 +119,11 @@ PlanningOps may emit only these `operator_channel_role` values:
 - control-plane evidence and handoff summaries
 
 ### Monday owns
-- translating action artifacts into concrete operator delivery payloads
-- local delivery-cycle execution for operator-message classes
+- translating action artifacts into scheduled delivery work items
+- scheduled queue admission and downstream local delivery-cycle execution
 - resolving concrete delivery targets from local config or skill context
 - invoking Slack/email transport through CLI or MCP adapters
-- returning delivery evidence
+- returning queue-admission and runtime delivery evidence
 
 ### PlanningOps must not own
 - queue lease mutation
@@ -134,6 +134,7 @@ PlanningOps may emit only these `operator_channel_role` values:
 
 ## Failure Rules
 - the applier must fail closed if `reflection_decision` is outside the allowed vocabulary
+- the applier must fail closed if goal context cannot be resolved before channel projection or goal-transition side effects
 - the applier must fail if the action artifact would violate the deterministic mapping rules above
 - `delivery_required = true` must never pair with `operator_channel_role = none`
 - `goal_transition_required = true` must only pair with `requested_goal_status = achieved`
@@ -144,4 +145,4 @@ PlanningOps may emit only these `operator_channel_role` values:
 - `planningops/scripts/test_reflection_action_handoff_contract.sh`
 - `planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py`
 - `planningops/scripts/core/goals/apply_worker_outcome_reflection.py`
-- `monday/scripts/run_operator_message_delivery_cycle.py`
+- `monday/scripts/enqueue_scheduled_delivery_work_item.py`

--- a/planningops/scripts/core/goals/apply_worker_outcome_reflection.py
+++ b/planningops/scripts/core/goals/apply_worker_outcome_reflection.py
@@ -294,32 +294,19 @@ def main() -> int:
         "errors": errors,
     }
 
-    if (
-        payload["delivery_required"] is True
-        and payload["operator_channel_role"] == "none"
-        and "delivery_required=true requires operator_channel_role" not in errors
-    ):
-        payload["verdict"] = "fail"
-        payload["error_count"] += 1
-        payload["errors"].append("delivery_required=true requires operator_channel_role")
+    if not payload["errors"]:
+        if payload["delivery_required"] is True and payload["operator_channel_role"] == "none":
+            payload["errors"].append("delivery_required=true requires operator_channel_role")
 
-    if (
-        payload["goal_transition_required"] is True
-        and payload["requested_goal_status"] != "achieved"
-        and "goal_transition_required requires requested_goal_status=achieved" not in payload["errors"]
-    ):
-        payload["verdict"] = "fail"
-        payload["error_count"] += 1
-        payload["errors"].append("goal_transition_required requires requested_goal_status=achieved")
+        if payload["goal_transition_required"] is True and payload["requested_goal_status"] != "achieved":
+            payload["errors"].append("goal_transition_required requires requested_goal_status=achieved")
 
-    if (
-        payload["operator_channel_role"] != "none"
-        and payload["operator_channel_kind"] == "-"
-        and "operator_channel_role requires channel projection" not in payload["errors"]
-    ):
-        payload["verdict"] = "fail"
-        payload["error_count"] += 1
-        payload["errors"].append("operator_channel_role requires channel projection")
+        if payload["operator_channel_role"] != "none" and payload["operator_channel_kind"] == "-":
+            payload["errors"].append("operator_channel_role requires channel projection")
+
+        if payload["errors"]:
+            payload["verdict"] = "fail"
+            payload["error_count"] = len(payload["errors"])
 
     output_path = repo_root / args.output
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/planningops/scripts/test_apply_worker_outcome_reflection.sh
+++ b/planningops/scripts/test_apply_worker_outcome_reflection.sh
@@ -84,7 +84,37 @@ python3 planningops/scripts/core/goals/apply_worker_outcome_reflection.py \
   --mode apply \
   --output "$TMP_DIR/completed-action-apply.json" >/dev/null
 
-python3 - "$TMP_DIR/completed-action-dry.json" "$TMP_DIR/retry-action.json" "$TMP_DIR/dead-letter-action.json" "$TMP_DIR/goal-mismatch-action.json" "$TMP_DIR/completed-action-apply.json" "$TMP_DIR/registry-wave7-active-apply.json" <<'PY'
+python3 - "$TMP_DIR/registry-no-active.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source = Path("planningops/config/active-goal-registry.json")
+doc = json.loads(source.read_text(encoding="utf-8"))
+doc["active_goal_key"] = ""
+for goal in doc["goals"]:
+    if goal.get("status") == "active":
+        goal["status"] = "achieved"
+Path(sys.argv[1]).write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+if python3 planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py \
+  --packet-json planningops/fixtures/worker-outcome-reflection-packet.completed.sample.json \
+  --active-goal-registry "$TMP_DIR/registry-no-active.json" \
+  --output "$TMP_DIR/no-active-eval.json" >/dev/null 2>&1; then
+  echo "expected no-active reflection evaluation to fail"
+  exit 1
+fi
+
+if python3 planningops/scripts/core/goals/apply_worker_outcome_reflection.py \
+  --evaluation-json "$TMP_DIR/completed-eval.json" \
+  --active-goal-registry "$TMP_DIR/registry-no-active.json" \
+  --output "$TMP_DIR/no-active-action.json" >/dev/null 2>&1; then
+  echo "expected no-active reflection action application to fail"
+  exit 1
+fi
+
+python3 - "$TMP_DIR/completed-action-dry.json" "$TMP_DIR/retry-action.json" "$TMP_DIR/dead-letter-action.json" "$TMP_DIR/goal-mismatch-action.json" "$TMP_DIR/completed-action-apply.json" "$TMP_DIR/registry-wave7-active-apply.json" "$TMP_DIR/no-active-eval.json" "$TMP_DIR/no-active-action.json" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -95,6 +125,8 @@ dead_letter = json.loads(Path(sys.argv[3]).read_text())
 goal_mismatch = json.loads(Path(sys.argv[4]).read_text())
 completed_apply = json.loads(Path(sys.argv[5]).read_text())
 apply_registry = json.loads(Path(sys.argv[6]).read_text())
+no_active_eval = json.loads(Path(sys.argv[7]).read_text())
+no_active_action = json.loads(Path(sys.argv[8]).read_text())
 
 assert completed_dry["verdict"] == "pass", completed_dry
 assert completed_dry["action_kind"] == "prepare_goal_completion", completed_dry
@@ -132,6 +164,12 @@ assert transition["verdict"] == "pass", transition
 assert apply_registry["active_goal_key"] == "", apply_registry
 wave7 = next(goal for goal in apply_registry["goals"] if goal["goal_key"] == "uap-goal-driven-autonomy-wave7")
 assert wave7["status"] == "achieved", wave7
+
+assert no_active_eval["verdict"] == "fail", no_active_eval
+assert no_active_eval["errors"] == ["no active goal configured"], no_active_eval
+
+assert no_active_action["verdict"] == "fail", no_active_action
+assert no_active_action["errors"] == ["no active goal configured"], no_active_action
 
 print("apply worker outcome reflection test passed")
 PY


### PR DESCRIPTION
## Summary
- align reflection action application with evaluator-side no-active-goal failure behavior
- simplify applier post-processing so earlier validation errors remain authoritative
- update the handoff contract and regression coverage for missing active-goal context

## Validation
- bash planningops/scripts/test_apply_worker_outcome_reflection.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all