### PR TITLE
feat(active-goal-registry): harden empty active state

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -127,6 +127,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Scheduled Reflection Goal Context Packet](./plans/2026-03-28-scheduled-reflection-goal-context-packet.md)
 - [Reflection Delivery Queue Admission Packet](./plans/2026-03-28-reflection-delivery-queue-admission-packet.md)
 - [Reflection Action No Active Goal Packet](./plans/2026-03-28-reflection-action-no-active-goal-packet.md)
+- [Active Goal Registry Empty State Packet](./plans/2026-03-28-active-goal-registry-empty-state-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-active-goal-registry-empty-state-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-active-goal-registry-empty-state-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Active Goal Registry Empty State Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Hardens the active goal registry contract around the empty-active-goal state so goal resolution fails closed instead of inferring a replacement goal.
+related_docs:
+  - ./2026-03-28-reflection-action-no-active-goal-packet.md
+---
+
+# plan: Active Goal Registry Empty State Packet
+
+## Summary
+- Promote the canonical registry into an explicit no-active-goal state after Wave 21 completion.
+- Backfill contract coverage so `resolve_active_goal.py` must fail when `active_goal_key` is empty and no explicit `--goal-key` is supplied.
+- Keep the unit limited to registry state, contract language, regression coverage, and workbench references.
+
+## Scope
+- `planningops/config/active-goal-registry.json`
+- `planningops/contracts/active-goal-registry-contract.md`
+- `planningops/scripts/test_active_goal_registry_contract.sh`
+- workbench hub link for this empty-state packet
+
+## Acceptance
+- `test_active_goal_registry_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/config/active-goal-registry.json
+++ b/planningops/config/active-goal-registry.json
@@ -1,6 +1,6 @@
 {
   "registry_version": 1,
-  "active_goal_key": "uap-goal-driven-autonomy-wave21",
+  "active_goal_key": "",
   "goals": [
     {
       "goal_key": "uap-goal-driven-autonomy-wave1",
@@ -532,10 +532,35 @@
     {
       "goal_key": "uap-goal-driven-autonomy-wave21",
       "title": "Wave 21 - Scheduled Delivery Queue Admission Delegation",
-      "status": "active",
+      "status": "achieved",
       "owner_repo": "rather-not-work-on/platform-planningops",
       "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-goal-brief.md",
       "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json",
+      "completion_contract_refs": [
+        "planningops/contracts/operator-channel-adapter-contract.md",
+        "planningops/contracts/goal-completion-contract.md",
+        "planningops/contracts/scheduled-delivery-cycle-handoff-contract.md"
+      ],
+      "operator_channels": {
+        "primary_operator_channel": {
+          "kind": "slack_skill_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        },
+        "terminal_notification_channel": {
+          "kind": "email_cli",
+          "execution_repo": "rather-not-work-on/monday",
+          "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
+        }
+      }
+    },
+    {
+      "goal_key": "uap-runtime-mission-wave22",
+      "title": "Wave 22 - PlanningOps rate-limit guidance hardening",
+      "status": "achieved",
+      "owner_repo": "rather-not-work-on/platform-planningops",
+      "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
+      "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave22.execution-contract.json",
       "completion_contract_refs": [
         "planningops/contracts/operator-channel-adapter-contract.md",
         "planningops/contracts/goal-completion-contract.md",

--- a/planningops/contracts/active-goal-registry-contract.md
+++ b/planningops/contracts/active-goal-registry-contract.md
@@ -42,6 +42,7 @@ Provide one canonical machine-readable pointer to the current active goal so aut
 ## Usage Rules
 - Supervisor/materialization automation must prefer the active goal registry over hard-coded contract paths when both are available.
 - If the registry has no active goal, automation must stop with a review-required outcome instead of inventing a goal.
+- `planningops/scripts/core/goals/resolve_active_goal.py` must fail without `--goal-key` when `active_goal_key` is empty.
 - Registry state changes must follow `planningops/contracts/goal-lifecycle-transition-contract.md`.
 - An achieved goal may keep `next_goal_key` as historical evidence of which successor was promoted next.
 

--- a/planningops/scripts/test_active_goal_registry_contract.sh
+++ b/planningops/scripts/test_active_goal_registry_contract.sh
@@ -15,8 +15,35 @@ python3 planningops/scripts/validate_active_goal_registry.py \
   --output "$report_path" \
   --strict >/dev/null
 
-resolved_contract="$(python3 planningops/scripts/core/goals/resolve_active_goal.py --registry "$valid_registry" --field execution_contract_file)"
-expected_contract="$(python3 - <<'PY' "$valid_registry"
+python3 - <<'PY' "$valid_registry" "$report_path"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+report = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+active_goal_key = str(doc.get("active_goal_key") or "").strip()
+
+assert report["verdict"] == "pass", report
+if active_goal_key:
+    assert report["resolved_goal"]["goal_key"] == active_goal_key, report
+else:
+    assert report["resolved_goal"] is None, report
+PY
+
+current_active_goal_key="$(python3 - <<'PY' "$valid_registry"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(str(doc.get("active_goal_key") or "").strip())
+PY
+)"
+
+if [ -n "$current_active_goal_key" ]; then
+  resolved_contract="$(python3 planningops/scripts/core/goals/resolve_active_goal.py --registry "$valid_registry" --field execution_contract_file)"
+  expected_contract="$(python3 - <<'PY' "$valid_registry"
 import json
 import sys
 from pathlib import Path
@@ -27,7 +54,13 @@ active_goal = next(goal for goal in doc["goals"] if str(goal.get("goal_key") or 
 print(active_goal["execution_contract_file"])
 PY
 )"
-[ "$resolved_contract" = "$expected_contract" ]
+  [ "$resolved_contract" = "$expected_contract" ]
+else
+  if python3 planningops/scripts/core/goals/resolve_active_goal.py --registry "$valid_registry" >/dev/null 2>&1; then
+    echo "expected resolve_active_goal.py to fail when no active goal is configured"
+    exit 1
+  fi
+fi
 
 cat >"$invalid_registry" <<'JSON'
 {


### PR DESCRIPTION
## Summary
- promote the canonical registry into an explicit no-active-goal state after Wave 21 completion
- require resolve_active_goal.py to fail without --goal-key when active_goal_key is empty
- backfill contract coverage for the empty-state path and link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_active_goal_registry_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all