### PR TITLE
test(reflection-contracts): align goal-context guardrails

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -128,6 +128,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Reflection Delivery Queue Admission Packet](./plans/2026-03-28-reflection-delivery-queue-admission-packet.md)
 - [Reflection Action No Active Goal Packet](./plans/2026-03-28-reflection-action-no-active-goal-packet.md)
 - [Active Goal Registry Empty State Packet](./plans/2026-03-28-active-goal-registry-empty-state-packet.md)
+- [Reflection Contract Guardrails Packet](./plans/2026-03-28-reflection-contract-guardrails-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-reflection-contract-guardrails-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-reflection-contract-guardrails-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Reflection Contract Guardrails Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills contract regressions so reflection evaluator and action handoff contracts assert the new goal-context failure rules and monday queue-admission boundary.
+related_docs:
+  - ./2026-03-28-reflection-action-no-active-goal-packet.md
+---
+
+# plan: Reflection Contract Guardrails Packet
+
+## Summary
+- Align reflection contract regressions with the already-promoted goal-context and queue-admission contract language.
+- Keep this unit test-only: no runtime logic changes, only guardrails.
+- Preserve workbench traceability for the contract test backfill.
+
+## Scope
+- `planningops/scripts/test_worker_outcome_reflection_contract.sh`
+- `planningops/scripts/test_reflection_action_handoff_contract.sh`
+- workbench hub link for this guardrail packet
+
+## Acceptance
+- `test_worker_outcome_reflection_contract.sh` passes
+- `test_reflection_action_handoff_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/test_reflection_action_handoff_contract.sh
+++ b/planningops/scripts/test_reflection_action_handoff_contract.sh
@@ -25,7 +25,7 @@ for section in required_sections:
 required_fragments = [
     "planningops/scripts/core/goals/evaluate_worker_outcome_reflection.py",
     "planningops/scripts/core/goals/apply_worker_outcome_reflection.py",
-    "monday/scripts/run_operator_message_delivery_cycle.py",
+    "monday/scripts/enqueue_scheduled_delivery_work_item.py",
     "`record_continue`",
     "`trigger_replan_review`",
     "`prepare_goal_completion`",
@@ -39,6 +39,7 @@ required_fragments = [
     "## Goal Transition Rules",
     "PlanningOps must not own",
     "concrete Slack channel IDs",
+    "must fail closed if goal context cannot be resolved before channel projection or goal-transition side effects",
 ]
 for fragment in required_fragments:
     assert fragment in text, fragment

--- a/planningops/scripts/test_worker_outcome_reflection_contract.sh
+++ b/planningops/scripts/test_worker_outcome_reflection_contract.sh
@@ -33,6 +33,7 @@ required_fragments = [
     "`operator_notify`",
     "PlanningOps must not own",
     "queue lease updates",
+    "unresolved goal context must fail evaluation before a reflection decision is emitted",
 ]
 for fragment in required_fragments:
     assert fragment in text, fragment


### PR DESCRIPTION
## Summary
- align worker outcome reflection and reflection action handoff contract regressions with the promoted goal-context failure rules
- keep the unit test-only with no runtime logic changes
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_worker_outcome_reflection_contract.sh
- bash planningops/scripts/test_reflection_action_handoff_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all