### PR TITLE
feat(loop-runner): normalize snapshot intake states

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -129,6 +129,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Reflection Action No Active Goal Packet](./plans/2026-03-28-reflection-action-no-active-goal-packet.md)
 - [Active Goal Registry Empty State Packet](./plans/2026-03-28-active-goal-registry-empty-state-packet.md)
 - [Reflection Contract Guardrails Packet](./plans/2026-03-28-reflection-contract-guardrails-packet.md)
+- [Loop Runner Snapshot Intake Normalization Packet](./plans/2026-03-28-loop-runner-snapshot-intake-normalization-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-loop-runner-snapshot-intake-normalization-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-loop-runner-snapshot-intake-normalization-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Loop Runner Snapshot Intake Normalization Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Hardens loop-runner intake so workflow-state variants, issue snapshots, and manifest fallback snapshots normalize into one deterministic selector surface.
+related_docs:
+  - ./2026-03-28-planning-context-dependency-key-pattern-packet.md
+---
+
+# plan: Loop Runner Snapshot Intake Normalization Packet
+
+## Summary
+- Normalize workflow-state tokens before candidate selection.
+- Synthesize selector-ready project items from issue snapshots and manifest-style snapshots.
+- Keep the unit limited to loop-runner intake normalization, regression coverage, and workbench traceability.
+
+## Scope
+- `planningops/scripts/core/loop/runner.py`
+- `planningops/scripts/core/loop/selection.py`
+- `planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh`
+- workbench hub link for this loop-intake packet
+
+## Acceptance
+- `test_issue_loop_runner_multi_repo_intake.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/core/loop/runner.py
+++ b/planningops/scripts/core/loop/runner.py
@@ -46,6 +46,7 @@ from core.loop.selection import (
     parse_selector_hints,
 )
 from federation.adapter_registry import invoke_adapter_hook, resolve_execution_adapter
+from planning_context import parse_depends_on_plan_item_keys, parse_execution_order
 from sync_project_fields_after_issue_create import (
     DEFAULT_CONFIG as PROJECT_SYNC_DEFAULT_CONFIG,
     build_project_item_issue_index as build_project_sync_issue_index,
@@ -64,6 +65,7 @@ WATCHDOG_DIR = Path("planningops/artifacts/loop-runner/watchdog")
 ESCALATION_HISTORY_PATH = Path("planningops/artifacts/loop-runner/escalation-history.json")
 PROJECT_ITEMS_SNAPSHOT_PATH = Path("planningops/artifacts/loop-runner/project-items-snapshot.json")
 PROGRAM_MANIFEST_PATH = Path("planningops/artifacts/program/program-manifest.json")
+ACTIVE_GOAL_REGISTRY_PATH = Path("planningops/config/active-goal-registry.json")
 LAST_RUN_PATH = Path("planningops/artifacts/loop-runner/last-run.json")
 DEFAULT_ATTEMPT_BUDGET = {
     "max_attempts": 3,
@@ -420,13 +422,118 @@ def is_rate_limit_error(text: str):
     return "rate limit exceeded" in str(text or "").lower()
 
 
+def synthesize_project_items_from_issue_snapshot_rows(rows):
+    parsed_rows = []
+    plan_item_issue_index = {}
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        issue_repo = str(row.get("repo") or row.get("repository") or "").strip()
+        issue_number = row.get("number")
+        if not issue_repo or not isinstance(issue_number, int):
+            continue
+        issue_body = str(row.get("body") or "")
+        metadata = parse_project_sync_metadata(issue_body)
+        plan_item_id = str(metadata.get("plan_item_id") or "").strip()
+        parsed = {
+            "row": row,
+            "issue_repo": issue_repo,
+            "issue_number": issue_number,
+            "issue_body": issue_body,
+            "metadata": metadata,
+            "plan_item_id": plan_item_id,
+        }
+        parsed_rows.append(parsed)
+        if plan_item_id:
+            plan_item_issue_index[plan_item_id] = {"issue_repo": issue_repo, "issue_number": issue_number}
+
+    synthesized = []
+    for parsed in parsed_rows:
+        row = parsed["row"]
+        issue_repo = parsed["issue_repo"]
+        issue_number = parsed["issue_number"]
+        issue_body = parsed["issue_body"]
+        metadata = parsed["metadata"]
+        workflow_state = str(metadata.get("workflow_state") or "").strip().lower().replace("_", "-")
+        workflow_state = workflow_state or "backlog"
+        lifecycle_key = workflow_state.replace("-", "_")
+        status_token = WORKFLOW_TO_STATUS.get(lifecycle_key, "todo")
+        status = {
+            "todo": "Todo",
+            "in_progress": "In Progress",
+            "blocked": "Blocked",
+            "done": "Done",
+        }.get(status_token, "Todo")
+        execution_order = parse_execution_order(metadata.get("execution_order")) or 0
+        execution_kind = parse_execution_kind(issue_body)
+        depends_on_refs = []
+        for dep_plan_item in parse_depends_on_plan_item_keys(metadata.get("depends_on")):
+            dep_info = plan_item_issue_index.get(dep_plan_item)
+            if not dep_info:
+                continue
+            if dep_info.get("issue_repo") != issue_repo:
+                continue
+            depends_on_refs.append(f"#{dep_info.get('issue_number')}")
+        normalized_issue_body = issue_body
+        if depends_on_refs:
+            normalized_issue_body = f"{issue_body.rstrip()}\ndepends_on: {', '.join(depends_on_refs)}\n"
+        issue_state = str(row.get("state") or "OPEN").upper()
+        ISSUE_DOC_CACHE[f"{issue_repo}#{issue_number}"] = {
+            "body": normalized_issue_body,
+            "state": issue_state,
+        }
+
+        synthesized.append(
+            {
+                "status": status,
+                "workflow_state": workflow_state,
+                "target_repo": metadata.get("target_repo") or issue_repo,
+                "execution_order": execution_order,
+                "component": metadata.get("component"),
+                "loop_profile": metadata.get("loop_profile"),
+                "initiative": metadata.get("initiative"),
+                "execution_kind": execution_kind,
+                "content": {
+                    "type": "Issue",
+                    "number": issue_number,
+                    "repository": issue_repo,
+                },
+            }
+        )
+
+    return synthesized
+
+
 def load_project_items_snapshot(snapshot_path: Path):
     if not snapshot_path.exists():
         raise RuntimeError(f"project item snapshot missing: {snapshot_path}")
     doc = json.loads(snapshot_path.read_text(encoding="utf-8"))
-    items = doc.get("items")
+
+    if isinstance(doc, list):
+        if doc and isinstance(doc[0], dict) and "repo" in doc[0] and "number" in doc[0]:
+            items = synthesize_project_items_from_issue_snapshot_rows(doc)
+        else:
+            items = doc
+    elif isinstance(doc, dict):
+        items = doc.get("items")
+    else:
+        items = None
+
     if not isinstance(items, list):
         raise RuntimeError(f"invalid project item snapshot: {snapshot_path}")
+    # Allow manifest-style snapshots as a fallback source for selector intake.
+    if items:
+        first_item = items[0]
+        if isinstance(first_item, dict) and "content" not in first_item and "issue_number" in first_item:
+            synthesized_items = synthesize_project_items_from_manifest(snapshot_path)
+            return {
+                "items": synthesized_items,
+                "source": "snapshot",
+                "snapshot_path": str(snapshot_path),
+                "rate_limit_fallback_used": True,
+                "rate_limit_error": None,
+            }
     return {
         "items": items,
         "source": "snapshot",
@@ -458,8 +565,56 @@ def load_program_manifest_items(manifest_path: Path | None = None):
     return items
 
 
+def active_goal_registry_allows_manifest_source_plan(manifest_doc: dict, active_goal_registry_path: Path | None = None):
+    if not isinstance(manifest_doc, dict):
+        return True
+
+    source_plan = str(manifest_doc.get("source_plan") or "").strip()
+    if not source_plan:
+        return True
+
+    registry_path = Path(active_goal_registry_path) if active_goal_registry_path else ACTIVE_GOAL_REGISTRY_PATH
+    registry_doc = load_json(registry_path, {})
+    if not isinstance(registry_doc, dict):
+        return True
+
+    active_goal_key = str(registry_doc.get("active_goal_key") or "").strip()
+    if active_goal_key:
+        return True
+
+    goals = registry_doc.get("goals")
+    if not isinstance(goals, list):
+        return True
+
+    for goal in goals:
+        if not isinstance(goal, dict):
+            continue
+        if str(goal.get("status") or "").strip().lower() != "achieved":
+            continue
+        execution_contract_file = str(goal.get("execution_contract_file") or "").strip()
+        if not execution_contract_file:
+            continue
+        contract_doc = load_json(Path(execution_contract_file), {})
+        execution_contract = contract_doc.get("execution_contract") if isinstance(contract_doc, dict) else None
+        if not isinstance(execution_contract, dict):
+            continue
+        contract_source_plan = str(execution_contract.get("source_of_truth") or "").strip()
+        if contract_source_plan and contract_source_plan == source_plan:
+            return False
+
+    return True
+
+
 def synthesize_project_items_from_manifest(manifest_path: Path | None = None):
-    manifest_items = load_program_manifest_items(manifest_path)
+    path = Path(manifest_path) if manifest_path else PROGRAM_MANIFEST_PATH
+    manifest_doc = load_json(path, {})
+    manifest_items = manifest_doc.get("items") if isinstance(manifest_doc, dict) else None
+    if not isinstance(manifest_items, list):
+        raise RuntimeError(f"invalid program manifest items: {path}")
+
+    if not active_goal_registry_allows_manifest_source_plan(manifest_doc, ACTIVE_GOAL_REGISTRY_PATH):
+        return []
+
     synthesized = []
     for row in manifest_items:
         if not isinstance(row, dict):
@@ -494,8 +649,6 @@ def synthesize_project_items_from_manifest(manifest_path: Path | None = None):
                 },
             }
         )
-    if not synthesized:
-        raise RuntimeError("program manifest fallback has no issue items")
     return synthesized
 
 
@@ -537,6 +690,10 @@ def build_manifest_issue_doc_cache(manifest_path: Path | None = None):
             f"execution_order: {row.get('execution_order') or 0}",
             f"depends_on: {', '.join(depends_tokens)}" if depends_tokens else "depends_on:",
             f"execution_kind: {row.get('execution_kind') or EXECUTION_KIND_EXECUTABLE}",
+            f"interface_contract_refs: {row.get('interface_contract_refs') or ''}",
+            f"package_topology_ref: {row.get('package_topology_ref') or ''}",
+            f"dependency_manifest_ref: {row.get('dependency_manifest_ref') or ''}",
+            f"file_plan_ref: {row.get('file_plan_ref') or ''}",
         ]
         body = "\n".join(line for line in body_lines if line != "")
         issue_state = str(row.get("issue_state") or "").strip().lower()

--- a/planningops/scripts/core/loop/selection.py
+++ b/planningops/scripts/core/loop/selection.py
@@ -30,6 +30,10 @@ EXECUTION_KIND_ALIASES = {
 }
 
 
+def normalize_workflow_state(raw: str | None):
+    return str(raw or "").strip().lower().replace("_", "-")
+
+
 def parse_depends_on(issue_body: str):
     deps = set()
     for line in issue_body.splitlines():
@@ -130,7 +134,8 @@ def parse_blueprint_refs(issue_body: str):
 
 
 def normalize_candidates(items, allowed_workflow_states, high_value_ready_states=None):
-    ready_states = high_value_ready_states or HIGH_VALUE_READY_STATES
+    ready_states = {normalize_workflow_state(state) for state in (high_value_ready_states or HIGH_VALUE_READY_STATES)}
+    allowed_states = {normalize_workflow_state(state) for state in allowed_workflow_states}
     candidates = []
     for it in items:
         content = it.get("content", {})
@@ -139,8 +144,8 @@ def normalize_candidates(items, allowed_workflow_states, high_value_ready_states
         if it.get("status") != "Todo":
             continue
 
-        workflow_state = it.get("workflow_state")
-        if workflow_state not in allowed_workflow_states:
+        workflow_state = normalize_workflow_state(it.get("workflow_state"))
+        if workflow_state not in allowed_states:
             continue
 
         issue_repo = content.get("repository")
@@ -180,7 +185,8 @@ def normalize_candidates(items, allowed_workflow_states, high_value_ready_states
 
 
 def build_selection_trace(candidates, selected, attempts, allowed_workflow_states, high_value_ready_states=None, default_attempt_budget=None):
-    ready_states = high_value_ready_states or HIGH_VALUE_READY_STATES
+    ready_states = {normalize_workflow_state(state) for state in (high_value_ready_states or HIGH_VALUE_READY_STATES)}
+    allowed_states = {normalize_workflow_state(state) for state in allowed_workflow_states}
     selected_ref = None
     if selected is not None:
         selected_ref = {
@@ -209,7 +215,7 @@ def build_selection_trace(candidates, selected, attempts, allowed_workflow_state
             "ready_workflow_states": sorted(ready_states),
             "tie_breaker": ["execution_order_asc", "issue_number_asc"],
         },
-        "allowed_workflow_states": sorted(allowed_workflow_states),
+        "allowed_workflow_states": sorted(allowed_states),
         "candidate_count": len(candidates),
         "candidates": [
             {

--- a/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
+++ b/planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
@@ -36,6 +36,13 @@ items = [
         "content": {"type": "Issue", "number": 42, "repository": "rather-not-work-on/monday"},
     },
     {
+        "status": "Todo",
+        "workflow_state": "ready_contract",
+        "execution_order": 15,
+        "target_repo": "rather-not-work-on/platform-provider-gateway",
+        "content": {"type": "Issue", "number": 55, "repository": "rather-not-work-on/platform-provider-gateway"},
+    },
+    {
         "status": "In Progress",
         "workflow_state": "in-progress",
         "execution_order": 30,
@@ -52,24 +59,26 @@ items = [
 allowed = {"ready-contract", "ready-implementation"}
 candidates = mod.normalize_candidates(items, allowed)
 
-assert [c["number"] for c in candidates] == [42, 77], candidates
+assert [c["number"] for c in candidates] == [42, 55, 77], candidates
 assert candidates[0]["issue_repo"] == "rather-not-work-on/monday", candidates[0]
-assert candidates[1]["issue_repo"] == "rather-not-work-on/platform-planningops", candidates[1]
+assert candidates[1]["issue_repo"] == "rather-not-work-on/platform-provider-gateway", candidates[1]
+assert candidates[2]["issue_repo"] == "rather-not-work-on/platform-planningops", candidates[2]
 
 # High-value ready-first rule must prioritize ready-* over backlog even when backlog has lower execution_order.
 allowed_with_backlog = {"backlog", "ready-contract", "ready-implementation"}
 candidates_with_backlog = mod.normalize_candidates(items, allowed_with_backlog)
-assert [c["number"] for c in candidates_with_backlog] == [42, 77, 101], candidates_with_backlog
+assert [c["number"] for c in candidates_with_backlog] == [42, 55, 77, 101], candidates_with_backlog
 
-selected = dict(candidates[1])
+selected = dict(candidates[2])
 selected["deps"] = [41]
 attempts = [
     {"number": 42, "issue_repo": "rather-not-work-on/monday", "result": "dependency_blocked"},
+    {"number": 55, "issue_repo": "rather-not-work-on/platform-provider-gateway", "result": "dependency_blocked"},
     {"number": 77, "issue_repo": "rather-not-work-on/platform-planningops", "result": "selected"},
 ]
 trace = mod.build_selection_trace(candidates, selected, attempts, allowed)
 
-assert trace["candidate_count"] == 2, trace
+assert trace["candidate_count"] == 3, trace
 assert trace["selected"]["number"] == 77, trace
 assert trace["selected"]["target_repo"] == "rather-not-work-on/platform-planningops", trace
 assert trace["selected"]["execution_kind"] == "executable", trace
@@ -477,6 +486,32 @@ with tempfile.TemporaryDirectory() as td:
     except RuntimeError as exc:
         assert "rate limit" in str(exc).lower(), exc
 
+with tempfile.TemporaryDirectory() as td:
+    list_snapshot_path = Path(td) / "projected-issues.json"
+    list_snapshot_path.write_text(
+        json.dumps(
+            [
+                {
+                    "repo": "rather-not-work-on/platform-planningops",
+                    "number": 10,
+                    "state": "open",
+                    "title": "plan: [10] sample",
+                    "body": "workflow_state: `ready_implementation`\nexecution_order: `10`\ntarget_repo: `rather-not-work-on/platform-planningops`",
+                }
+            ],
+            ensure_ascii=True,
+        ),
+        encoding="utf-8",
+    )
+    list_snapshot_items = mod.load_project_items_snapshot(list_snapshot_path)
+    assert list_snapshot_items["source"] == "snapshot", list_snapshot_items
+    assert len(list_snapshot_items["items"]) == 1, list_snapshot_items
+    list_snapshot_candidate = list_snapshot_items["items"][0]
+    assert list_snapshot_candidate["status"] == "Todo", list_snapshot_candidate
+    assert list_snapshot_candidate["workflow_state"] == "ready-implementation", list_snapshot_candidate
+    assert list_snapshot_candidate["content"]["repository"] == "rather-not-work-on/platform-planningops"
+    assert list_snapshot_candidate["content"]["number"] == 10
+
 guidance_live_blocked = mod.build_rate_limit_guidance(
     run_mode="apply",
     snapshot_path="planningops/artifacts/loop-runner/project-items-snapshot.json",
@@ -611,6 +646,47 @@ with tempfile.TemporaryDirectory() as td:
         assert key in row, key
     assert row["selection_trace"]["selected"]["number"] == 77, row
     assert row["loop_profile"] == "L1 Contract-Clarification", row
+
+with tempfile.TemporaryDirectory() as td:
+    manifest_snapshot_path = Path(td) / "manifest-snapshot.json"
+    active_goal_registry_path = Path(td) / "active-goal-registry.json"
+    active_goal_registry_path.write_text(
+        json.dumps(
+            {
+                "active_goal_key": "wave22-active",
+                "goals": [],
+            },
+            ensure_ascii=True,
+        ),
+        encoding="utf-8",
+    )
+    mod.ACTIVE_GOAL_REGISTRY_PATH = active_goal_registry_path
+    manifest_snapshot_path.write_text(
+        json.dumps(
+            {
+                "source_plan": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
+                "items": [
+                    {
+                        "plan_item_id": "AN10",
+                        "execution_order": 10,
+                        "target_repo": "rather-not-work-on/platform-planningops",
+                        "issue_repo": "rather-not-work-on/platform-planningops",
+                        "issue_number": 10,
+                        "workflow_state": "ready_implementation",
+                        "loop_profile": "l3_implementation_tdd",
+                        "track": "control_plane",
+                    }
+                ],
+            },
+            ensure_ascii=True,
+        ),
+        encoding="utf-8",
+    )
+    snapshot_payload = mod.load_project_items_snapshot(manifest_snapshot_path)
+    manifest_candidates = mod.normalize_candidates(snapshot_payload["items"], {"ready-contract", "ready-implementation"})
+    assert len(manifest_candidates) == 1, manifest_candidates
+    assert manifest_candidates[0]["number"] == 10, manifest_candidates
+    assert manifest_candidates[0]["workflow_state"] == "ready-implementation", manifest_candidates
 
 print("issue_loop_runner multi-repo intake trace ok")
 PY


### PR DESCRIPTION
## Summary
- normalize workflow-state variants before loop-runner candidate selection
- synthesize selector-ready project items from issue snapshots and manifest-style snapshots
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all