### PR TITLE
feat(compile-backlog): support offline issues intake

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -130,6 +130,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Active Goal Registry Empty State Packet](./plans/2026-03-28-active-goal-registry-empty-state-packet.md)
 - [Reflection Contract Guardrails Packet](./plans/2026-03-28-reflection-contract-guardrails-packet.md)
 - [Loop Runner Snapshot Intake Normalization Packet](./plans/2026-03-28-loop-runner-snapshot-intake-normalization-packet.md)
+- [Compile Backlog Offline Issues Intake Packet](./plans/2026-03-28-compile-backlog-offline-issues-intake-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-compile-backlog-offline-issues-intake-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-compile-backlog-offline-issues-intake-packet.md
@@ -1,0 +1,33 @@
+---
+title: plan: Compile Backlog Offline Issues Intake Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Hardens compile/materialize and manifest generation so offline issues snapshots and richer plan metadata propagate through the backlog pipeline deterministically.
+related_docs:
+  - ./2026-03-28-loop-runner-snapshot-intake-normalization-packet.md
+---
+
+# plan: Compile Backlog Offline Issues Intake Packet
+
+## Summary
+- Allow `compile_plan_to_backlog.py` to consume offline issues JSON payloads.
+- Pass projected issues through backlog materialization and preserve richer contract/topology metadata in the program manifest.
+- Keep the unit limited to compile/materialize/manifest pipeline hardening plus regression coverage.
+
+## Scope
+- `planningops/scripts/build_program_manifest.py`
+- `planningops/scripts/compile_plan_to_backlog.py`
+- `planningops/scripts/core/backlog/materialize.py`
+- `planningops/scripts/test_compile_plan_to_backlog_contract.sh`
+- workbench hub link for this offline-intake packet
+
+## Acceptance
+- `test_compile_plan_to_backlog_contract.sh` passes
+- `test_build_program_manifest_contract.sh` passes
+- `test_backlog_materialization_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/build_program_manifest.py
+++ b/planningops/scripts/build_program_manifest.py
@@ -193,7 +193,25 @@ def build_manifest(source_rows, args):
     items = []
     filtered_out_count = 0
     for row in source_rows:
-        metadata = parse_metadata(row["body"], keys=["plan_item_id", "target_repo", "component", "workflow_state", "loop_profile", "execution_order", "depends_on", "plan_lane", "plan_doc", "plan_id"])
+        metadata = parse_metadata(
+            row["body"],
+            keys=[
+                "plan_item_id",
+                "target_repo",
+                "component",
+                "workflow_state",
+                "loop_profile",
+                "execution_order",
+                "depends_on",
+                "plan_lane",
+                "plan_doc",
+                "plan_id",
+                "interface_contract_refs",
+                "package_topology_ref",
+                "dependency_manifest_ref",
+                "file_plan_ref",
+            ],
+        )
         plan_doc = normalize_value(metadata.get("plan_doc"))
         if args.scope_source_plan:
             if not plan_doc or plan_doc != args.source_plan:
@@ -220,6 +238,10 @@ def build_manifest(source_rows, args):
             "loop_profile": normalize_value(metadata.get("loop_profile")),
             "plan_lane": normalize_value(metadata.get("plan_lane")),
             "depends_on": parse_depends_on_plan_item_keys(metadata.get("depends_on", "")),
+            "interface_contract_refs": normalize_value(metadata.get("interface_contract_refs")),
+            "package_topology_ref": normalize_value(metadata.get("package_topology_ref")),
+            "dependency_manifest_ref": normalize_value(metadata.get("dependency_manifest_ref")),
+            "file_plan_ref": normalize_value(metadata.get("file_plan_ref")),
         }
         items.append(item)
 

--- a/planningops/scripts/compile_plan_to_backlog.py
+++ b/planningops/scripts/compile_plan_to_backlog.py
@@ -268,6 +268,37 @@ def parse_issue_metadata(body: str):
     return metadata
 
 
+def load_issues_from_file(path: Path):
+    doc = read_json(path)
+    if isinstance(doc, dict):
+        candidates = doc.get("issues")
+    elif isinstance(doc, list):
+        candidates = doc
+    else:
+        raise RuntimeError("issues-file must contain a list or object with an 'issues' list")
+
+    if not isinstance(candidates, list):
+        raise RuntimeError("issues-file payload 'issues' must be a list")
+
+    issues = []
+    for idx, issue in enumerate(candidates):
+        if not isinstance(issue, dict):
+            raise RuntimeError(f"issues-file entry #{idx} must be an object")
+        number = issue.get("number")
+        if not isinstance(number, int) or number <= 0:
+            raise RuntimeError(f"issues-file entry #{idx} has invalid number")
+        issues.append(
+            {
+                "number": number,
+                "title": issue.get("title", ""),
+                "body": issue.get("body") or "",
+                "url": issue.get("url") or issue.get("html_url"),
+                "state": str(issue.get("state") or "open").lower(),
+            }
+        )
+    return issues
+
+
 def list_existing_issues(repo: str, state: str):
     page = 1
     issues = []
@@ -659,6 +690,11 @@ def main():
         action="store_true",
         help="Scan closed issues and report exact matches even when reopen is disabled",
     )
+    parser.add_argument(
+        "--issues-file",
+        default=None,
+        help="Optional local issues JSON file for offline compile (list or object with 'issues')",
+    )
     parser.add_argument("--output", default="planningops/artifacts/validation/plan-compile-report.json", help="Output report path")
     args = parser.parse_args()
 
@@ -682,8 +718,17 @@ def main():
     items = sorted(ec["items"], key=lambda x: x["execution_order"])
     project = load_project_config(Path(args.config))
     blueprint_defaults_doc = load_blueprint_defaults(Path(args.blueprint_defaults_config))
-    open_issues = list_existing_issues(CONTROL_REPO, "open")
-    closed_issues = list_existing_issues(CONTROL_REPO, "closed") if (args.allow_reopen_closed or args.detect_closed_match) else []
+    if args.issues_file:
+        loaded_issues = load_issues_from_file(Path(args.issues_file))
+        open_issues = [issue for issue in loaded_issues if issue.get("state") != "closed"]
+        closed_issues = [issue for issue in loaded_issues if issue.get("state") == "closed"]
+        issues_source = f"file:{args.issues_file}"
+    else:
+        open_issues = list_existing_issues(CONTROL_REPO, "open")
+        closed_issues = (
+            list_existing_issues(CONTROL_REPO, "closed") if (args.allow_reopen_closed or args.detect_closed_match) else []
+        )
+        issues_source = "github_api"
     project_item_issue_index = {}
     execution_order_issue_index = {}
 
@@ -693,6 +738,7 @@ def main():
             "plan_revision": ec["plan_revision"],
             "source_of_truth": ec["source_of_truth"],
             "items_total": len(items),
+            "issues_source": issues_source,
             "open_issues_scanned": len(open_issues),
             "closed_issues_scanned": len(closed_issues),
         }

--- a/planningops/scripts/core/backlog/materialize.py
+++ b/planningops/scripts/core/backlog/materialize.py
@@ -129,6 +129,8 @@ def build_steps(args, execution_contract, projected_issues_file: str | None = No
         "--output",
         args.compile_output,
     ]
+    if projected_issues_file:
+        compile_cmd.extend(["--issues-file", projected_issues_file])
     if args.apply:
         compile_cmd.append("--apply")
     if args.allow_reopen_closed:

--- a/planningops/scripts/test_compile_plan_to_backlog_contract.sh
+++ b/planningops/scripts/test_compile_plan_to_backlog_contract.sh
@@ -243,6 +243,24 @@ legacy_match, legacy_strategy = mod.find_issue_for_item(
 assert legacy_match is None, legacy_match
 assert legacy_strategy == "identity_legacy_ambiguous_ignored", legacy_strategy
 
+# 4-4) Offline issues-file loader should normalize list payloads.
+issues_file = Path(tempfile.gettempdir()) / "compile-plan-issues-file.json"
+issues_file.write_text(
+    json.dumps(
+        [
+            {"number": 901, "title": "open row", "body": "x", "state": "open"},
+            {"number": 902, "title": "closed row", "body": "y", "state": "closed"},
+            {"number": 903, "title": "default state row", "body": "z"},
+        ]
+    ),
+    encoding="utf-8",
+)
+loaded_issues = mod.load_issues_from_file(issues_file)
+assert [issue["number"] for issue in loaded_issues] == [901, 902, 903], loaded_issues
+assert loaded_issues[0]["state"] == "open", loaded_issues[0]
+assert loaded_issues[1]["state"] == "closed", loaded_issues[1]
+assert loaded_issues[2]["state"] == "open", loaded_issues[2]
+
 # 5) Dry-run compile should create deterministic DRY-RUN issue projection when unmatched.
 dry_result = mod.compile_item(
     project={},


### PR DESCRIPTION
## Summary
- allow compile_plan_to_backlog to consume offline issues JSON payloads
- pass projected issues through backlog materialization and preserve richer metadata in the program manifest
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_compile_plan_to_backlog_contract.sh
- bash planningops/scripts/test_build_program_manifest_contract.sh
- bash planningops/scripts/test_backlog_materialization_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all