### PR TITLE
feat(wave14-rehearsal): inject default simulated tasks

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -132,6 +132,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Loop Runner Snapshot Intake Normalization Packet](./plans/2026-03-28-loop-runner-snapshot-intake-normalization-packet.md)
 - [Compile Backlog Offline Issues Intake Packet](./plans/2026-03-28-compile-backlog-offline-issues-intake-packet.md)
 - [Backlog Stock Snapshot Normalization Packet](./plans/2026-03-28-backlog-stock-snapshot-normalization-packet.md)
+- [Wave14 Rehearsal Default Task Packet](./plans/2026-03-28-wave14-rehearsal-default-task-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-wave14-rehearsal-default-task-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-wave14-rehearsal-default-task-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Wave14 Rehearsal Default Task Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Hardens the Wave14 oracle rehearsal so deterministic deepagents-style tasks are always injected into local and oracle portability checks.
+related_docs:
+  - ./2026-03-28-loop-runner-snapshot-intake-normalization-packet.md
+---
+
+# plan: Wave14 Rehearsal Default Task Packet
+
+## Summary
+- Add a deterministic default simulated deepagents task for oracle rehearsal runs.
+- Thread the task list through both local and oracle stack-smoke invocations.
+- Lock the new default-task surface with the existing rehearsal contract regression.
+
+## Scope
+- `planningops/scripts/federation/run_wave14_oracle_rehearsal.py`
+- `planningops/scripts/test_wave14_oracle_rehearsal_contract.sh`
+- workbench hub link for this oracle rehearsal packet
+
+## Acceptance
+- `test_wave14_oracle_rehearsal_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/federation/run_wave14_oracle_rehearsal.py
+++ b/planningops/scripts/federation/run_wave14_oracle_rehearsal.py
@@ -9,6 +9,10 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+DEFAULT_REHEARSAL_TASKS = [
+    "Verify local runtime composition through profiled provider and telemetry adapters.",
+]
+
 
 def now_utc() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -33,6 +37,7 @@ def run_stack_smoke(
     run_id: str,
     output_path: Path,
     bootstrap_mode: str,
+    simulated_deepagents_tasks: list[str],
 ) -> tuple[int, dict]:
     command = [
         sys.executable,
@@ -47,6 +52,11 @@ def run_stack_smoke(
         str(output_path),
         "--bootstrap-mode",
         bootstrap_mode,
+        *[
+            item
+            for task in simulated_deepagents_tasks
+            for item in ("--simulate-deepagents-task", task)
+        ],
     ]
     completed = subprocess.run(command, cwd=str(planningops_repo), capture_output=True, text=True)
     report = load_json(output_path) if output_path.exists() else {}
@@ -124,6 +134,12 @@ def main() -> int:
         default="auto",
         help="Managed Python bootstrap mode passed through to the wave13 runner",
     )
+    parser.add_argument(
+        "--simulate-deepagents-task",
+        action="append",
+        default=[],
+        help="Optional deterministic planner task used to keep rehearsal focused on runtime portability",
+    )
     args = parser.parse_args()
 
     planningops_repo = resolve_repo_root()
@@ -131,6 +147,7 @@ def main() -> int:
     base_dir = planningops_repo / "planningops/runtime-artifacts/oracle-rehearsal"
     local_report_path = base_dir / f"{args.run_id}-{args.local_profile}.json"
     oracle_report_path = base_dir / f"{args.run_id}-{args.oracle_profile}.json"
+    simulated_tasks = list(args.simulate_deepagents_task or DEFAULT_REHEARSAL_TASKS)
 
     local_run_rc, local_summary = run_stack_smoke(
         planningops_repo=planningops_repo,
@@ -139,6 +156,7 @@ def main() -> int:
         run_id=f"{args.run_id}-{args.local_profile}",
         output_path=local_report_path,
         bootstrap_mode=args.bootstrap_mode,
+        simulated_deepagents_tasks=simulated_tasks,
     )
     oracle_run_rc, oracle_summary = run_stack_smoke(
         planningops_repo=planningops_repo,
@@ -147,6 +165,7 @@ def main() -> int:
         run_id=f"{args.run_id}-{args.oracle_profile}",
         output_path=oracle_report_path,
         bootstrap_mode=args.bootstrap_mode,
+        simulated_deepagents_tasks=simulated_tasks,
     )
 
     component_comparison = compare_components(local_summary.get("report") or {}, oracle_summary.get("report") or {})
@@ -164,6 +183,7 @@ def main() -> int:
             "local": args.local_profile,
             "oracle": args.oracle_profile,
         },
+        "simulated_deepagents_tasks": simulated_tasks,
         "runs": {
             "local": local_summary,
             "oracle": oracle_summary,

--- a/planningops/scripts/test_wave14_oracle_rehearsal_contract.sh
+++ b/planningops/scripts/test_wave14_oracle_rehearsal_contract.sh
@@ -24,6 +24,9 @@ assert report["default_profile_preserved"] is True, report
 assert report["oracle_rehearsal_only"] is True, report
 assert report["profiles"]["local"] == "local", report
 assert report["profiles"]["oracle"] == "oracle_cloud", report
+assert report["simulated_deepagents_tasks"] == [
+    "Verify local runtime composition through profiled provider and telemetry adapters."
+], report
 assert report["portability_gap_count"] == 0, report
 assert sorted(report["rehearsal_supported_components"]) == ["monday", "provider"], report
 assert report["shared_profile_components"] == ["observability"], report


### PR DESCRIPTION
## Summary
- add a deterministic default simulated deepagents task for wave14 oracle rehearsal runs
- thread the task list through both local and oracle stack-smoke invocations
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_wave14_oracle_rehearsal_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all