### PR TITLE
feat(local-runtime-smoke): harden bootstrap and launcher flow

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -133,6 +133,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Compile Backlog Offline Issues Intake Packet](./plans/2026-03-28-compile-backlog-offline-issues-intake-packet.md)
 - [Backlog Stock Snapshot Normalization Packet](./plans/2026-03-28-backlog-stock-snapshot-normalization-packet.md)
 - [Wave14 Rehearsal Default Task Packet](./plans/2026-03-28-wave14-rehearsal-default-task-packet.md)
+- [Local Runtime Smoke Bootstrap Hygiene Packet](./plans/2026-03-28-local-runtime-smoke-bootstrap-hygiene-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-local-runtime-smoke-bootstrap-hygiene-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-local-runtime-smoke-bootstrap-hygiene-packet.md
@@ -1,0 +1,33 @@
+---
+title: plan: Local Runtime Smoke Bootstrap Hygiene Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Hardens federated Python bootstrap and local runtime smoke orchestration so launcher startup, retry evidence, and stale run-root cleanup stay deterministic.
+related_docs:
+  - ./2026-03-28-wave14-rehearsal-default-task-packet.md
+---
+
+# plan: Local Runtime Smoke Bootstrap Hygiene Packet
+
+## Summary
+- Prune AppleDouble files and reject unhealthy managed Python interpreters in federated bootstrap.
+- Rebuild conformance run roots before reuse and add launcher/retry evidence to local runtime smoke reports.
+- Keep the unit limited to bootstrap/conformance/smoke plumbing plus their regressions.
+
+## Scope
+- `planningops/scripts/federation/federated_python_env.py`
+- `planningops/scripts/federation/cross_repo_conformance_check.py`
+- `planningops/scripts/federation/run_local_runtime_stack_smoke.py`
+- `planningops/scripts/test_local_runtime_stack_smoke_contract.sh`
+- workbench hub link for this bootstrap-hygiene packet
+
+## Acceptance
+- `test_federated_python_env_contract.sh` passes
+- `test_cross_repo_conformance_run_root_reuse_contract.sh` passes
+- `test_local_runtime_stack_smoke_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/federation/cross_repo_conformance_check.py
+++ b/planningops/scripts/federation/cross_repo_conformance_check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -232,6 +233,8 @@ def main():
     )
     if not run_root.is_absolute():
         run_root = planningops_repo / run_root
+    if run_root.exists():
+        shutil.rmtree(run_root)
     run_root.mkdir(parents=True, exist_ok=True)
 
     contract_repo = workspace_root / "platform-contracts"

--- a/planningops/scripts/federation/federated_python_env.py
+++ b/planningops/scripts/federation/federated_python_env.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from typing import Any
 
 
@@ -85,6 +86,40 @@ def managed_python_path(venv_dir: Path) -> Path:
     return venv_dir / "bin" / "python"
 
 
+def prune_appledouble_files(root: Path) -> int:
+    if not root.exists():
+        return 0
+    removed = 0
+    for path in root.rglob("._*"):
+        if path.is_file():
+            try:
+                path.unlink()
+                removed += 1
+            except FileNotFoundError:
+                continue
+    return removed
+
+
+def managed_python_is_healthy(managed_python: str) -> bool:
+    path = Path(managed_python)
+    if not path.exists():
+        return False
+    try:
+        probe = subprocess.run(
+            [str(path), "-c", "import site"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        return False
+    return probe.returncode == 0
+
+
+def run_bootstrap_command(command: list[str]) -> None:
+    subprocess.run(command, check=True, stdout=sys.stderr, stderr=sys.stderr)
+
+
 def build_bootstrap_plan(planningops_repo: Path, workspace_root: Path, bootstrap_root: Path) -> dict[str, Any]:
     requirement_files = [workspace_root / rel for rel in REQUIREMENTS_RELATIVE_PATHS]
     requirement_entries: list[dict[str, Any]] = []
@@ -156,6 +191,7 @@ def manifest_is_current(plan: dict[str, Any], manifest: dict[str, Any] | None) -
         and manifest.get("python_version") == plan["python_version"]
         and manifest.get("managed_python") == plan["managed_python"]
         and Path(plan["managed_python"]).exists()
+        and managed_python_is_healthy(plan["managed_python"])
     )
 
 
@@ -179,20 +215,28 @@ def create_managed_venv(plan: dict[str, Any]) -> tuple[bool, list[dict[str, Any]
     if venv_dir.exists():
         shutil.rmtree(venv_dir)
     bootstrap_root.mkdir(parents=True, exist_ok=True)
+    prune_appledouble_files(bootstrap_root)
 
     create_cmd = [sys.executable, "-m", "venv", str(venv_dir)]
     commands.append({"command": create_cmd})
-    subprocess.run(create_cmd, check=True)
+    run_bootstrap_command(create_cmd)
+    prune_appledouble_files(venv_dir)
+    if not managed_python_is_healthy(str(managed_python)):
+        raise RuntimeError(f"managed python is unhealthy after venv creation: {managed_python}")
 
     upgrade_pip_cmd = [str(managed_python), "-m", "pip", "install", "--upgrade", "pip"]
     commands.append({"command": upgrade_pip_cmd})
-    subprocess.run(upgrade_pip_cmd, check=True)
+    run_bootstrap_command(upgrade_pip_cmd)
+    prune_appledouble_files(venv_dir)
 
     install_cmd = [str(managed_python), "-m", "pip", "install"]
     for entry in plan["requirements"]:
         install_cmd.extend(["-r", entry["absolute_path"]])
     commands.append({"command": install_cmd})
-    subprocess.run(install_cmd, check=True)
+    run_bootstrap_command(install_cmd)
+    prune_appledouble_files(venv_dir)
+    if not managed_python_is_healthy(str(managed_python)):
+        raise RuntimeError(f"managed python is unhealthy after dependency install: {managed_python}")
 
     write_json(
         manifest_path,
@@ -208,6 +252,7 @@ def create_managed_venv(plan: dict[str, Any]) -> tuple[bool, list[dict[str, Any]
 
 
 def ensure_bootstrap_environment(plan: dict[str, Any], mode: str) -> dict[str, Any]:
+    prune_appledouble_files(Path(plan["bootstrap_root"]))
     manifest = load_manifest(plan)
     missing_modules_current = detect_missing_modules(plan["import_names"])
     current_python = str(Path(sys.executable).absolute())
@@ -255,6 +300,45 @@ def ensure_bootstrap_environment(plan: dict[str, Any], mode: str) -> dict[str, A
     return result
 
 
+def test_only_create_invalid_python_probe(root: Path) -> Path:
+    script_path = root / "fake-python.sh"
+    script_path.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    script_path.chmod(0o755)
+    return script_path
+
+
+def run_test_mode() -> int:
+    tmp_root = Path(tempfile.mkdtemp(prefix="federated-python-env-test-"))
+    try:
+        apple_root = tmp_root / "appledouble"
+        apple_root.mkdir(parents=True, exist_ok=True)
+        nested = apple_root / "site-packages"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "._distutils-precedence.pth").write_bytes(b"\x00\x01broken")
+        removed = prune_appledouble_files(apple_root)
+        assert removed == 1, removed
+        assert not (nested / "._distutils-precedence.pth").exists()
+
+        invalid_python = test_only_create_invalid_python_probe(tmp_root)
+        assert managed_python_is_healthy(str(invalid_python)) is False
+        plan = {
+            "requirements_hash": "abc",
+            "python_version": "3.9",
+            "managed_python": str(invalid_python),
+        }
+        manifest = {
+            "manifest_version": MANIFEST_VERSION,
+            "requirements_hash": "abc",
+            "python_version": "3.9",
+            "managed_python": str(invalid_python),
+        }
+        assert manifest_is_current(plan, manifest) is False
+        print("federated_python_env contract ok")
+        return 0
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+
+
 def build_managed_env(result: dict[str, Any]) -> dict[str, str]:
     env = dict(os.environ)
     managed_python = Path(result["managed_python"]).absolute()
@@ -273,7 +357,11 @@ def main() -> int:
     parser.add_argument("--plan-only", action="store_true")
     parser.add_argument("--print-python-path", action="store_true")
     parser.add_argument("--output", default=None)
+    parser.add_argument("--test-mode", action="store_true")
     args = parser.parse_args()
+
+    if args.test_mode:
+        return run_test_mode()
 
     planningops_repo = resolve_repo_root()
     workspace_root = resolve_workspace_root(planningops_repo, args.workspace_root)

--- a/planningops/scripts/federation/run_local_runtime_stack_smoke.py
+++ b/planningops/scripts/federation/run_local_runtime_stack_smoke.py
@@ -52,6 +52,31 @@ def run_cmd(cmd: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, s
     return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
 
 
+def execute_with_retries(
+    cmd: list[str],
+    cwd: Path,
+    env: dict[str, str],
+    retries: int,
+) -> tuple[int, str, str, list[dict[str, object]]]:
+    attempts: list[dict[str, object]] = []
+    rc = 1
+    out = ""
+    err = ""
+    for attempt_number in range(1, retries + 2):
+        rc, out, err = run_cmd(cmd, cwd, env)
+        attempts.append(
+            {
+                "attempt": attempt_number,
+                "exit_code": rc,
+                "stdout_tail": out[-1000:],
+                "stderr_tail": err[-1000:],
+            }
+        )
+        if rc == 0:
+            break
+    return rc, out, err, attempts
+
+
 def build_component_report(
     component: str,
     repo: str,
@@ -60,8 +85,9 @@ def build_component_report(
     env: dict[str, str],
     report_path: Path,
     summary_keys: list[str],
+    retries: int,
 ) -> dict:
-    rc, out, err = run_cmd(command, cwd, env)
+    rc, out, err, attempts = execute_with_retries(command, cwd, env, retries)
     return {
         "component": component,
         "repo": repo,
@@ -73,6 +99,31 @@ def build_component_report(
         "report_path": str(report_path),
         "report_exists": report_path.exists(),
         "report_summary": summarize_report(report_path, summary_keys),
+        "attempt_count": len(attempts),
+        "attempts": attempts,
+        "recovered_after_retry": rc == 0 and len(attempts) > 1,
+        "verdict": "pass" if rc == 0 else "fail",
+    }
+
+
+def build_launcher_report(
+    name: str,
+    cwd: Path,
+    command: list[str],
+    env: dict[str, str],
+    retries: int = 0,
+) -> dict:
+    rc, out, err, attempts = execute_with_retries(command, cwd, env, retries)
+    return {
+        "name": name,
+        "cwd": str(cwd),
+        "command": command,
+        "exit_code": rc,
+        "stdout_tail": out[-1000:],
+        "stderr_tail": err[-1000:],
+        "attempt_count": len(attempts),
+        "attempts": attempts,
+        "recovered_after_retry": rc == 0 and len(attempts) > 1,
         "verdict": "pass" if rc == 0 else "fail",
     }
 
@@ -101,6 +152,18 @@ def main() -> int:
         default="planningops/runtime-artifacts/tooling/federated-conformance",
         help="Managed virtualenv root used when local bootstrap is required",
     )
+    parser.add_argument(
+        "--component-retries",
+        type=int,
+        default=1,
+        help="Number of retries for each component smoke after the initial attempt",
+    )
+    parser.add_argument(
+        "--simulate-deepagents-task",
+        action="append",
+        default=[],
+        help="Optional deterministic task forwarded to monday local runtime smoke to avoid live planner variability",
+    )
     args = parser.parse_args()
 
     planningops_repo = resolve_repo_root()
@@ -124,63 +187,143 @@ def main() -> int:
     monday_report = monday_repo / "runtime-artifacts" / "smoke" / f"{args.run_id}-monday.json"
     provider_report = provider_repo / "runtime-artifacts" / "live" / f"{args.run_id}-provider.json"
     o11y_report = o11y_repo / "runtime-artifacts" / "live" / f"{args.run_id}-observability.json"
-
-    component_runs = [
-        build_component_report(
-            component="monday",
-            repo="rather-not-work-on/monday",
-            cwd=monday_repo,
-            env=env,
-            command=[
-                python_bin,
-                "scripts/run_local_runtime_smoke.py",
-                "--profile",
-                args.profile,
-                "--run-id",
-                f"{args.run_id}-monday",
-                "--output",
-                str(monday_report),
+    launcher_runs = [
+        build_launcher_report(
+            "provider_gateway",
+            provider_repo,
+            [
+                "bash",
+                "-c",
+                "bash scripts/litellm_stack_launcher.sh "
+                f"--mode start --runtime-profile-file '{workspace_root / 'platform-planningops' / 'planningops' / 'config' / 'runtime-profiles.json'}' "
+                f"--profiles '{args.profile}' --run-id '{args.run_id}-provider-launcher' "
+                "&& npm run gate:litellm-stack-ready",
             ],
-            report_path=monday_report,
-            summary_keys=["verdict", "reason_code", "runtime_run_id"],
+            env,
+            retries=1,
         ),
-        build_component_report(
-            component="provider",
-            repo="rather-not-work-on/platform-provider-gateway",
-            cwd=provider_repo,
-            env=env,
-            command=[
-                python_bin,
-                "scripts/litellm_live_smoke.py",
-                "--profile",
-                args.profile,
+        build_launcher_report(
+            "observability_gateway",
+            o11y_repo,
+            [
+                "bash",
+                "scripts/langfuse_stack_launcher.sh",
+                "--mode",
+                "start",
                 "--run-id",
-                f"{args.run_id}-provider",
-                "--output",
-                str(provider_report),
+                f"{args.run_id}-observability-launcher",
             ],
-            report_path=provider_report,
-            summary_keys=["verdict", "reason_code", "scenario"],
-        ),
-        build_component_report(
-            component="observability",
-            repo="rather-not-work-on/platform-observability-gateway",
-            cwd=o11y_repo,
-            env=env,
-            command=[
-                python_bin,
-                "scripts/langfuse_live_smoke.py",
-                "--run-id",
-                f"{args.run_id}-observability",
-                "--output",
-                str(o11y_report),
-            ],
-            report_path=o11y_report,
-            summary_keys=["verdict", "reason_code", "launcher_mode_requested"],
+            env,
+            retries=1,
         ),
     ]
 
+    try:
+        component_runs = [
+            build_component_report(
+                component="monday",
+                repo="rather-not-work-on/monday",
+                cwd=monday_repo,
+                env=env,
+                command=[
+                    python_bin,
+                    "scripts/run_local_runtime_smoke.py",
+                    "--profile",
+                    args.profile,
+                    "--run-id",
+                    f"{args.run_id}-monday",
+                    "--output",
+                    str(monday_report),
+                    *[
+                        item
+                        for task in args.simulate_deepagents_task
+                        for item in ("--simulate-deepagents-task", task)
+                    ],
+                ],
+                report_path=monday_report,
+                summary_keys=["verdict", "reason_code", "runtime_run_id"],
+                retries=args.component_retries,
+            ),
+            build_component_report(
+                component="provider",
+                repo="rather-not-work-on/platform-provider-gateway",
+                cwd=provider_repo,
+                env=env,
+                command=[
+                    python_bin,
+                    "scripts/litellm_live_smoke.py",
+                    "--profile",
+                    args.profile,
+                    "--launcher-mode",
+                    "dry-run",
+                    "--run-id",
+                    f"{args.run_id}-provider",
+                    "--output",
+                    str(provider_report),
+                ],
+                report_path=provider_report,
+                summary_keys=["verdict", "reason_code", "scenario"],
+                retries=args.component_retries,
+            ),
+            build_component_report(
+                component="observability",
+                repo="rather-not-work-on/platform-observability-gateway",
+                cwd=o11y_repo,
+                env=env,
+                command=[
+                    python_bin,
+                    "scripts/langfuse_live_smoke.py",
+                    "--launcher-mode",
+                    "dry-run",
+                    "--run-id",
+                    f"{args.run_id}-observability",
+                    "--output",
+                    str(o11y_report),
+                ],
+                report_path=o11y_report,
+                summary_keys=["verdict", "reason_code", "launcher_mode_requested"],
+                retries=args.component_retries,
+            ),
+        ]
+    finally:
+        launcher_runs.extend(
+            [
+                build_launcher_report(
+                    "provider_gateway_stop",
+                    provider_repo,
+                    ["bash", "scripts/litellm_stack_launcher.sh", "--mode", "stop"],
+                    env,
+                ),
+                build_launcher_report(
+                    "observability_gateway_stop",
+                    o11y_repo,
+                    ["bash", "scripts/langfuse_stack_launcher.sh", "--mode", "stop"],
+                    env,
+                ),
+            ]
+        )
+
     failures = [row for row in component_runs if row["verdict"] != "pass"]
+    component_verdicts = {row["component"]: row["verdict"] for row in component_runs}
+    tolerated_launcher_failures: list[dict] = []
+    launcher_failures: list[dict] = []
+    for row in launcher_runs:
+        if row["verdict"] == "pass":
+            row["tolerated_failure"] = False
+            continue
+
+        component_name = None
+        if row["name"] == "provider_gateway":
+            component_name = "provider"
+        elif row["name"] == "observability_gateway":
+            component_name = "observability"
+
+        tolerated = component_name is not None and component_verdicts.get(component_name) == "pass"
+        row["tolerated_failure"] = tolerated
+        if tolerated:
+            tolerated_launcher_failures.append(row)
+        else:
+            launcher_failures.append(row)
     report = {
         "generated_at_utc": now_utc(),
         "run_id": args.run_id,
@@ -194,9 +337,11 @@ def main() -> int:
             "reexec_required": bool(bootstrap_info.get("reexec_required")),
             "venv_rebuilt": bool(bootstrap_info.get("venv_rebuilt")),
         },
+        "launcher_runs": launcher_runs,
+        "tolerated_launcher_failures": tolerated_launcher_failures,
         "component_runs": component_runs,
-        "failure_count": len(failures),
-        "verdict": "pass" if not failures else "fail",
+        "failure_count": len(failures) + len(launcher_failures),
+        "verdict": "pass" if not failures and not launcher_failures else "fail",
     }
 
     output_path = (

--- a/planningops/scripts/test_local_runtime_stack_smoke_contract.sh
+++ b/planningops/scripts/test_local_runtime_stack_smoke_contract.sh
@@ -12,6 +12,8 @@ PYTHON_BIN="${PYTHON_BIN:-python3}"
   --workspace-root "${ROOT_DIR}/.." \
   --bootstrap-mode auto \
   --run-id "contract-local-runtime-stack-smoke" \
+  --simulate-deepagents-task "triage the operator request" \
+  --simulate-deepagents-task "summarize the runtime handoff" \
   --output "${REPORT_PATH}"
 
 python3 - <<'PY' "${REPORT_PATH}"
@@ -26,6 +28,18 @@ assert report["failure_count"] == 0, report
 assert report["requested_profile"] == "local", report
 assert report["bootstrap"]["managed_python"], report
 
+launcher_runs = report["launcher_runs"]
+assert len(launcher_runs) == 4, launcher_runs
+launcher_names = [row["name"] for row in launcher_runs]
+assert launcher_names == [
+    "provider_gateway",
+    "observability_gateway",
+    "provider_gateway_stop",
+    "observability_gateway_stop",
+], launcher_runs
+for row in launcher_runs:
+    assert row["exit_code"] == 0, row
+
 component_runs = report["component_runs"]
 assert len(component_runs) == 3, component_runs
 names = {row["component"] for row in component_runs}
@@ -34,6 +48,9 @@ assert names == {"monday", "provider", "observability"}, component_runs
 for row in component_runs:
     assert row["exit_code"] == 0, row
     assert row["report_exists"] is True, row
+    assert row["attempt_count"] >= 1, row
+    assert isinstance(row["recovered_after_retry"], bool), row
+    assert len(row["attempts"]) == row["attempt_count"], row
     verdict = row["report_summary"]["verdict"]
     assert verdict in {"pass", "skip"}, row
     if verdict == "skip":


### PR DESCRIPTION
## Summary
- prune AppleDouble files and reject unhealthy managed Python interpreters in federated bootstrap
- rebuild conformance run roots before reuse and add launcher/retry evidence to local runtime smoke reports
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_federated_python_env_contract.sh
- bash planningops/scripts/test_cross_repo_conformance_run_root_reuse_contract.sh
- bash planningops/scripts/test_local_runtime_stack_smoke_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all