### PR TITLE
docs(local-delivery): align queue admission boundary

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -134,6 +134,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Backlog Stock Snapshot Normalization Packet](./plans/2026-03-28-backlog-stock-snapshot-normalization-packet.md)
 - [Wave14 Rehearsal Default Task Packet](./plans/2026-03-28-wave14-rehearsal-default-task-packet.md)
 - [Local Runtime Smoke Bootstrap Hygiene Packet](./plans/2026-03-28-local-runtime-smoke-bootstrap-hygiene-packet.md)
+- [Local Delivery Queue Admission Boundary Packet](./plans/2026-03-28-local-delivery-queue-admission-boundary-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-local-delivery-queue-admission-boundary-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-local-delivery-queue-admission-boundary-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Local Delivery Queue Admission Boundary Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Realigns the local delivery orchestration contract around monday-owned scheduled delivery queue admission instead of direct local delivery-cycle invocation.
+related_docs:
+  - ./2026-03-28-reflection-delivery-queue-admission-packet.md
+---
+
+# plan: Local Delivery Queue Admission Boundary Packet
+
+## Summary
+- Update the local delivery orchestration contract to reflect monday-owned queue admission as the primary boundary.
+- Align the contract regression with the promoted queue-admission markers and canonical path list.
+- Keep the unit contract-only with no runtime logic changes.
+
+## Scope
+- `planningops/contracts/local-delivery-cycle-orchestration-contract.md`
+- `planningops/scripts/test_local_delivery_cycle_orchestration_contract.sh`
+- workbench hub link for this local-delivery packet
+
+## Acceptance
+- `test_local_delivery_cycle_orchestration_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/local-delivery-cycle-orchestration-contract.md
+++ b/planningops/contracts/local-delivery-cycle-orchestration-contract.md
@@ -1,30 +1,34 @@
 # Local Delivery Cycle Orchestration Contract
 
 ## Purpose
-Define the deterministic control-plane boundary where `planningops` delegates operator and goal-completion delivery through monday-owned local delivery-cycle entrypoints instead of stitching lower-level delivery and dispatch steps itself.
+Define the deterministic control-plane boundary where `planningops` delegates reflection-triggered and supervisor-triggered delivery through monday-owned queue admission instead of stitching local delivery and dispatch steps itself.
 
 This contract exists so:
-- `planningops` can stay transport-agnostic while still orchestrating delivery outcomes
-- `monday` remains the only runtime owner of local delivery, dispatch export, acknowledgement, and receipt mutation
-- future Slack skill and terminal notifier adapters can evolve behind monday entrypoints without changing planningops control-plane flow
+- `planningops` can stay transport-agnostic while still orchestrating delivery intent
+- `monday` remains the only runtime owner of queue admission, local delivery-cycle selection, delivery execution, dispatch export, acknowledgement, and receipt mutation
+- future Slack skill and terminal notifier adapters can evolve behind monday-owned entrypoints without changing planningops control-plane flow
 
 ## Canonical Boundary
 - reflection delivery runner: `planningops/scripts/federation/run_reflection_delivery_cycle.py`
 - supervisor loop: `planningops/scripts/autonomous_supervisor_loop.py`
+- monday queue admission entrypoint: `monday/scripts/enqueue_scheduled_delivery_work_item.py`
 - monday operator delivery cycle entrypoint: `monday/scripts/run_operator_message_delivery_cycle.py`
 - monday goal completion delivery cycle entrypoint: `monday/scripts/run_goal_completion_delivery_cycle.py`
 - monday entrypoint contract: `planningops/contracts/local-delivery-cycle-entrypoint-contract.md`
+- scheduled delivery queue admission contract: `planningops/contracts/scheduled-delivery-queue-admission-contract.md`
 - operator channel adapter contract: `planningops/contracts/operator-channel-adapter-contract.md`
 - goal completion contract: `planningops/contracts/goal-completion-contract.md`
 
 ## Primary Local Path
 The primary local autonomous path is:
-- `planningops reflection action -> monday run_operator_message_delivery_cycle.py -> monday runtime artifacts -> planningops aggregate evidence`
-- `planningops goal completion decision -> monday run_goal_completion_delivery_cycle.py -> monday runtime artifacts -> planningops aggregate evidence`
+- `planningops reflection action -> monday/scripts/enqueue_scheduled_delivery_work_item.py -> monday scheduler-owned delivery entrypoint -> monday runtime artifacts -> planningops aggregate evidence`
+- `planningops goal completion decision -> monday/scripts/enqueue_scheduled_delivery_work_item.py -> monday scheduler-owned delivery entrypoint -> monday runtime artifacts -> planningops aggregate evidence`
 
-`planningops` must invoke only monday-owned local delivery-cycle entrypoints on the primary local path.
+`planningops` must invoke only monday-owned queue-admission entrypoints on the primary local path.
 
-`planningops` must not invoke these lower-level monday scripts directly on the primary local path:
+`planningops` must not invoke these monday scripts directly on the primary local path:
+- `monday/scripts/run_operator_message_delivery_cycle.py`
+- `monday/scripts/run_goal_completion_delivery_cycle.py`
 - `monday/scripts/send_operator_message.py`
 - `monday/scripts/send_goal_completion_notification.py`
 - `monday/scripts/export_local_outbox_dispatch_packet.py`
@@ -32,12 +36,15 @@ The primary local autonomous path is:
 
 ## Ownership Boundary
 ### PlanningOps owns
-- orchestration of the delivery-cycle stage
+- orchestration of the queue-admission stage
 - aggregate control-plane evidence that links to monday runtime artifacts
-- validation that the correct monday entrypoint was invoked for the correct action kind
+- validation that the correct downstream monday entrypoint was selected for the correct action kind
 
 ### Monday owns
 - payload translation
+- queue admission
+- scheduled delivery work-item creation
+- local delivery-cycle entrypoint selection
 - local target resolution
 - outbox write behavior
 - dispatch packet export
@@ -48,21 +55,25 @@ The primary local autonomous path is:
 ### PlanningOps must not own
 - concrete Slack or email delivery execution
 - monday runtime-artifact mutation
+- monday queue insertion or retry mutation
 - construction of monday dispatch packets or dispatch receipts
 - fallback recreation of lower-level delivery-plus-dispatch logic
 
 ## Required Inputs
 Reflection-delivery orchestration must accept:
 - a reflection action artifact governed by `planningops/contracts/reflection-action-handoff-contract.md`
+- a `schedule-key`
 - optional local profile hints or mode flags
 
 Supervisor goal-completion orchestration must accept:
 - a supervisor/operator report path
 - a summary path or completion evidence path
+- a `schedule-key`
 - optional local profile hints or mode flags
 
 Input rules:
 - `planningops` may forward monday profile/config hints for deterministic local execution
+- `planningops` may forward a monday queue-db override only for deterministic testing
 - `planningops` must not resolve concrete Slack channels or email recipients itself
 - `planningops` must not require caller-supplied dispatch packet or receipt paths on the primary local path
 
@@ -71,31 +82,35 @@ Every planningops orchestration report for this stage must include:
 - `monday_delivery_entrypoint`
 - `monday_delivery_report_ref`
 - `delivery_verdict`
-- `delivery_target_resolution_mode`
-- `delivery_target_profile_ref`
-- `delivery_transport_kind`
-- `delivery_outbox_message_ref`
+- `queue_admission_verdict`
+- `selected_delivery_entrypoint`
+- `scheduled_delivery_work_item_ref`
+- `scheduled_queue_item_ref`
+- `scheduled_queue_item_id`
+- `delivery_idempotency_key`
 
 Output rules:
-- `monday_delivery_entrypoint` must be one of the two monday local delivery-cycle entrypoints
+- `monday_delivery_entrypoint` must be `monday/scripts/enqueue_scheduled_delivery_work_item.py`
+- `selected_delivery_entrypoint` must be one of the two monday local delivery-cycle entrypoints
 - `monday_delivery_report_ref` must point at a monday-owned runtime artifact
-- planningops may summarize monday delivery evidence, but must not copy concrete recipient data into control-plane-owned fields
+- planningops may summarize monday queue-admission evidence, but must not copy concrete recipient data into control-plane-owned fields
 
 ## Deterministic Rules
-- reflection actions requiring operator delivery must flow through `monday/scripts/run_operator_message_delivery_cycle.py`
-- goal completion delivery must flow through `monday/scripts/run_goal_completion_delivery_cycle.py`
-- identical dry-run inputs must preserve the same selected monday entrypoint and the same verdict shape apart from timestamps
-- planningops must fail closed if monday entrypoint evidence is missing or references lower-level direct delivery instead of the canonical entrypoint
+- reflection actions requiring operator delivery must flow through `monday/scripts/enqueue_scheduled_delivery_work_item.py`
+- goal completion delivery must flow through `monday/scripts/enqueue_scheduled_delivery_work_item.py`
+- identical dry-run inputs must preserve the same selected downstream monday entrypoint and the same verdict shape apart from timestamps
+- planningops must fail closed if monday queue-admission evidence is missing or references lower-level direct delivery instead of the canonical entrypoint
 
 ## Failure Rules
 - planningops must fail if reflection delivery or goal completion delivery calls a lower-level monday delivery CLI directly on the primary local path
-- planningops must fail if monday delivery-cycle evidence points outside the monday repo `runtime-artifacts/` boundary
-- planningops must fail if a goal-completion path emits an operator-message entrypoint or vice versa
+- planningops must fail if monday queue-admission evidence points outside the monday repo `runtime-artifacts/` boundary
+- planningops must fail if a goal-completion path emits an operator-message downstream entrypoint or vice versa
 
 ## Validation
 - `planningops/scripts/test_local_delivery_cycle_orchestration_contract.sh`
 - `planningops/contracts/local-delivery-cycle-entrypoint-contract.md`
 - `planningops/scripts/federation/run_reflection_delivery_cycle.py`
 - `planningops/scripts/autonomous_supervisor_loop.py`
+- `monday/scripts/enqueue_scheduled_delivery_work_item.py`
 - `monday/scripts/run_operator_message_delivery_cycle.py`
 - `monday/scripts/run_goal_completion_delivery_cycle.py`

--- a/planningops/scripts/test_local_delivery_cycle_orchestration_contract.sh
+++ b/planningops/scripts/test_local_delivery_cycle_orchestration_contract.sh
@@ -13,15 +13,16 @@ text = contract.read_text(encoding="utf-8")
 required_paths = [
     "planningops/scripts/federation/run_reflection_delivery_cycle.py",
     "planningops/scripts/autonomous_supervisor_loop.py",
+    "monday/scripts/enqueue_scheduled_delivery_work_item.py",
     "monday/scripts/run_operator_message_delivery_cycle.py",
     "monday/scripts/run_goal_completion_delivery_cycle.py",
 ]
 
 required_markers = [
-    "must invoke only monday-owned local delivery-cycle entrypoints on the primary local path",
-    "must not invoke these lower-level monday scripts directly on the primary local path",
-    "reflection actions requiring operator delivery must flow through `monday/scripts/run_operator_message_delivery_cycle.py`",
-    "goal completion delivery must flow through `monday/scripts/run_goal_completion_delivery_cycle.py`",
+    "must invoke only monday-owned queue-admission entrypoints on the primary local path",
+    "must not invoke these monday scripts directly on the primary local path",
+    "reflection actions requiring operator delivery must flow through `monday/scripts/enqueue_scheduled_delivery_work_item.py`",
+    "goal completion delivery must flow through `monday/scripts/enqueue_scheduled_delivery_work_item.py`",
 ]
 
 for path in required_paths:


### PR DESCRIPTION
## Summary
- realign the local delivery orchestration contract around monday-owned scheduled delivery queue admission
- update the contract regression to assert the promoted queue-admission boundary markers
- link the packet from the UAP workbench hub

## Validation
- bash planningops/scripts/test_local_delivery_cycle_orchestration_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all