### PR TITLE
docs(contracts): sync helper surfaces

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -136,6 +136,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Local Runtime Smoke Bootstrap Hygiene Packet](./plans/2026-03-28-local-runtime-smoke-bootstrap-hygiene-packet.md)
 - [Local Delivery Queue Admission Boundary Packet](./plans/2026-03-28-local-delivery-queue-admission-boundary-packet.md)
 - [Runtime Operations Cross-Repo Doc Sync Packet](./plans/2026-03-28-runtime-operations-cross-repo-doc-sync-packet.md)
+- [Contract Helper Surface Sync Packet](./plans/2026-03-28-contract-helper-surface-sync-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-contract-helper-surface-sync-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-contract-helper-surface-sync-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Contract Helper Surface Sync Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Syncs small contract/readme surfaces so helper entrypoints and the active-goal terminal-state rule are explicitly documented.
+related_docs:
+  - ./2026-03-28-active-goal-registry-empty-state-packet.md
+---
+
+# plan: Contract Helper Surface Sync Packet
+
+## Summary
+- Add helper-lane references to artifact-retention and memory-tier contracts.
+- Document the no-active-goal terminal state in the goals README.
+- Keep the unit documentation-only with no runtime behavior changes.
+
+## Scope
+- `planningops/contracts/artifact-retention-tier-contract.md`
+- `planningops/contracts/memory-tier-contract.md`
+- `planningops/scripts/core/goals/README.md`
+- workbench hub link for this helper-surface packet
+
+## Acceptance
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/artifact-retention-tier-contract.md
+++ b/planningops/contracts/artifact-retention-tier-contract.md
@@ -47,6 +47,7 @@ Backend selection is controlled by:
 - Validator: `planningops/scripts/validate_artifact_storage_policy.py`
 - Test: `bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh`
 - Commit guard: `planningops/scripts/validate_external_only_commit_guard.py`
+- Workflow helper: `bash planningops/scripts/run_external_artifact_residency_ci_check.sh --base-ref <base> --head-ref <head> --python-bin python3`
 - Diff guard command: `python3 planningops/scripts/validate_external_only_commit_guard.py --base-ref <base> --head-ref <head> --strict`
 - Tracked baseline audit: `python3 planningops/scripts/validate_external_only_commit_guard.py --mode tracked --strict`
 - Migration/rehydrate: `planningops/scripts/migrate_external_only_artifacts.py`, `planningops/scripts/rehydrate_artifact_pointer.py`

--- a/planningops/contracts/memory-tier-contract.md
+++ b/planningops/contracts/memory-tier-contract.md
@@ -103,6 +103,7 @@ Allowed when:
 - Human prose may use relative links, but automation must resolve `repo + path`.
 
 ## Verification
+- Workflow helper: `bash planningops/scripts/run_control_plane_governance_ci_check.sh --python-bin python3`
 - Rules config: `planningops/config/memory-tier-rules.json`
 - Validator: `planningops/scripts/validate_memory_tier_rules.py`
 - Check mode: `python3 planningops/scripts/memory_compactor.py --mode check`

--- a/planningops/scripts/core/goals/README.md
+++ b/planningops/scripts/core/goals/README.md
@@ -16,4 +16,5 @@ Hold recurring goal-resolution logic for the control plane.
 ## Rules
 - Goal resolution must be deterministic and file-backed.
 - The active goal registry is the first source of truth for autonomous execution when no explicit contract path is supplied.
+- A registry without an active goal is a valid terminal state; callers must fail closed or emit a review-required outcome instead of inventing a fallback goal.
 - Goal state transitions must fail closed when the resulting registry would violate the active-goal contract.


### PR DESCRIPTION
## Summary
- add helper-lane references to artifact-retention and memory-tier contracts
- document the no-active-goal terminal state in the goals README
- link the packet from the UAP workbench hub

## Validation
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all