### PR TITLE
docs(label-taxonomy): sync issue-quality helper surface

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -138,6 +138,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Local Delivery Queue Admission Boundary Packet](./plans/2026-03-28-local-delivery-queue-admission-boundary-packet.md)
 - [Runtime Operations Cross-Repo Doc Sync Packet](./plans/2026-03-28-runtime-operations-cross-repo-doc-sync-packet.md)
 - [Contract Helper Surface Sync Packet](./plans/2026-03-28-contract-helper-surface-sync-packet.md)
+- [Federated Label Taxonomy Helper Sync Packet](./plans/2026-03-28-federated-label-taxonomy-helper-sync-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-federated-label-taxonomy-helper-sync-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-federated-label-taxonomy-helper-sync-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Federated Label Taxonomy Helper Sync Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Syncs the federated label taxonomy contract with the already-promoted issue-quality helper surface so docs and workflow guardrails point at the same entrypoint.
+related_docs:
+  - ./2026-03-26-issue-quality-helper-family-backfill-packet.md
+---
+
+# plan: Federated Label Taxonomy Helper Sync Packet
+
+## Summary
+- Align the federated label taxonomy contract with the promoted issue-quality helper wrapper.
+- Keep this unit docs-only: no runtime or workflow logic changes.
+- Preserve workbench traceability for the helper-surface sync.
+
+## Scope
+- `planningops/contracts/federated-label-taxonomy-contract.md`
+- workbench hub link for this packet
+
+## Acceptance
+- `test_validate_federated_issue_quality_contract.sh` passes
+- `test_run_issue_quality_ci_check_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/contracts/federated-label-taxonomy-contract.md
+++ b/planningops/contracts/federated-label-taxonomy-contract.md
@@ -29,6 +29,7 @@ Each in-scope planning issue (`plan_item_id:` marker in body) must include:
 - Label sync: `planningops/scripts/ensure_label_taxonomy.py`
 - Issue quality validator: `planningops/scripts/validate_federated_issue_quality.py`
 - Contract test: `planningops/scripts/test_validate_federated_issue_quality_contract.sh`
+- Workflow guardrail companion: `planningops/scripts/run_issue_quality_ci_check.sh`
 
 ## Operational Notes
 - `ensure_label_taxonomy.py --apply` creates/updates missing taxonomy labels per repo.


### PR DESCRIPTION
## Summary
- add the issue-quality helper as the workflow guardrail companion in the federated label taxonomy contract
- add a workbench packet and hub link for the docs-only sync

## Validation
- bash planningops/scripts/test_validate_federated_issue_quality_contract.sh
- bash planningops/scripts/test_run_issue_quality_ci_check_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all