### PR TITLE
fix(ralph-loop): add plain-python annotation header

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -131,6 +131,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Reflection Contract Guardrails Packet](./plans/2026-03-28-reflection-contract-guardrails-packet.md)
 - [Reflection Cycle Contract Surface Sync Packet](./plans/2026-03-28-reflection-cycle-contract-surface-sync-packet.md)
 - [Loop Runner Snapshot Intake Normalization Packet](./plans/2026-03-28-loop-runner-snapshot-intake-normalization-packet.md)
+- [Ralph Loop Plain-Python Annotation Hygiene Packet](./plans/2026-03-28-ralph-loop-plain-python-annotation-hygiene-packet.md)
 - [Compile Backlog Offline Issues Intake Packet](./plans/2026-03-28-compile-backlog-offline-issues-intake-packet.md)
 - [Backlog Stock Snapshot Normalization Packet](./plans/2026-03-28-backlog-stock-snapshot-normalization-packet.md)
 - [Wave14 Rehearsal Default Task Packet](./plans/2026-03-28-wave14-rehearsal-default-task-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-ralph-loop-plain-python-annotation-hygiene-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-ralph-loop-plain-python-annotation-hygiene-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Ralph Loop Plain-Python Annotation Hygiene Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Aligns `ralph_loop_local.py` with the plain-python annotation contract so the local Ralph Loop entrypoint matches the rest of the tracked cross-repo manifest surface.
+related_docs:
+  - ./2026-03-28-loop-runner-snapshot-intake-normalization-packet.md
+---
+
+# plan: Ralph Loop Plain-Python Annotation Hygiene Packet
+
+## Summary
+- Add the plain-python annotation header to `ralph_loop_local.py`.
+- Keep the unit narrowly scoped to entrypoint hygiene: no runtime behavior changes.
+- Preserve workbench traceability for the compatibility hardening.
+
+## Scope
+- `planningops/scripts/ralph_loop_local.py`
+- workbench hub link for this packet
+
+## Acceptance
+- `test_ralph_loop_local_worker_policy.sh` passes
+- `test_cross_repo_plain_python_annotation_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/ralph_loop_local.py
+++ b/planningops/scripts/ralph_loop_local.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import argparse
 import json
 from pathlib import Path


### PR DESCRIPTION
## Summary
- add the plain-python annotation header to `ralph_loop_local.py`
- add a workbench packet and hub link for the hygiene hardening

## Validation
- bash planningops/scripts/test_ralph_loop_local_worker_policy.sh
- bash planningops/scripts/test_cross_repo_plain_python_annotation_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all