### PR TITLE
docs(wave21): record closeout status

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-goal-brief.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-goal-brief.md
@@ -2,7 +2,7 @@
 title: plan: Goal-Driven Autonomy Wave 21 Goal Brief
 type: plan
 date: 2026-03-15
-updated: 2026-03-15
+updated: 2026-03-17
 initiative: unified-personal-agent-platform
 lifecycle: workbench
 status: active
@@ -57,3 +57,11 @@ Move the primary recurring delivery handoff up to monday queue admission:
 ## Execution Contract
 
 - `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json`
+
+## Current Status
+
+- implementation and review scope for wave21 is complete
+- review evidence is green at `planningops/artifacts/validation/goal-driven-autonomy-wave21-review.json`
+- active-goal lifecycle transition is green in `dry-run` at `planningops/artifacts/validation/wave21-goal-transition-dry-run.json`
+- live registry mutation is applied at `planningops/artifacts/validation/wave21-goal-transition-apply.json`
+- `planningops/config/active-goal-registry.json` now records no active goal and marks `uap-goal-driven-autonomy-wave21` as `achieved`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md
@@ -2,7 +2,7 @@
 title: plan: Goal-Driven Autonomy Wave 21 Issue Pack
 type: plan
 date: 2026-03-15
-updated: 2026-03-15
+updated: 2026-03-17
 initiative: unified-personal-agent-platform
 lifecycle: workbench
 status: active
@@ -55,3 +55,12 @@ Move recurring delivery from direct monday delivery-cycle invocation into monday
 - no SMTP or third-party email provider integration
 - no distributed scheduler backend
 - no planningops-owned queue persistence
+
+## Current Status
+
+- `U10`, `U20`, `U30`, and `U40` now have implementation/review evidence
+- queue-admission delegation is validated through reflection, supervisor, and scheduled orchestration regressions
+- review gate output is `planningops/artifacts/validation/goal-driven-autonomy-wave21-review.json`
+- active-goal transition feasibility is recorded in `planningops/artifacts/validation/wave21-goal-transition-dry-run.json`
+- live terminal closeout is recorded in `planningops/artifacts/validation/wave21-goal-transition-apply.json`
+- `planningops/config/active-goal-registry.json` now has `active_goal_key = ""` and `uap-goal-driven-autonomy-wave21.status = "achieved"`


### PR DESCRIPTION
## Summary
- update the wave21 goal brief with closeout status and achieved-goal evidence
- update the wave21 issue pack with implementation and transition evidence

## Validation
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all