### PR TITLE
feat(federated-ci): sync matrix helper wiring

### DIFF
--- a/.github/workflows/federated-ci-matrix.yml
+++ b/.github/workflows/federated-ci-matrix.yml
@@ -22,14 +22,10 @@ jobs:
           repository: rather-not-work-on/platform-contracts
           path: platform-contracts
 
-      - name: Validate contracts and semver
+      - name: Run platform contracts helper
         run: |
           set -euo pipefail
-          cd platform-contracts
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-dev.txt
-          python3 scripts/validate_contracts.py --root .
-          python3 scripts/classify_schema_change.py --enforce-expected
+          bash planningops/scripts/run_platform_contracts_ci_check.sh --contracts-root platform-contracts --python-bin python3
 
   provider-profile:
     runs-on: ubuntu-latest
@@ -46,12 +42,7 @@ jobs:
       - name: Run provider launcher/profile drill
         run: |
           set -euo pipefail
-          cd platform-provider-gateway
-          bash scripts/litellm_stack_launcher.sh \
-            --mode dry-run \
-            --runtime-profile-file ../planningops/config/runtime-profiles.json \
-            --profiles local,oracle_cloud \
-            --run-id ci-provider-${{ github.run_id }}
+          bash planningops/scripts/run_provider_profile_ci_check.sh --run-id ci-provider-${{ github.run_id }} --provider-root platform-provider-gateway --runtime-profile-file planningops/config/runtime-profiles.json --profiles local,oracle_cloud
 
   o11y-replay:
     runs-on: ubuntu-latest
@@ -68,8 +59,7 @@ jobs:
       - name: Run o11y replay/backfill drill
         run: |
           set -euo pipefail
-          cd platform-observability-gateway
-          bash scripts/langfuse_stack_launcher.sh --mode dry-run --run-id ci-o11y-${{ github.run_id }}
+          bash planningops/scripts/run_o11y_replay_ci_check.sh --run-id ci-o11y-${{ github.run_id }} --o11y-root platform-observability-gateway
 
   runtime-handoff:
     runs-on: ubuntu-latest
@@ -86,13 +76,24 @@ jobs:
       - name: Run handoff/scheduler integration
         run: |
           set -euo pipefail
-          cd monday
-          python3 scripts/integrate_planningops_handoff.py \
-            --planningops-last-run ../planningops/artifacts/loop-runner/last-run.json \
-            --run-id ci-runtime-${{ github.run_id }} \
-            --idempotency artifacts/integration/ci-runtime-${{ github.run_id }}-idempotency.json \
-            --transition-log artifacts/integration/ci-runtime-${{ github.run_id }}-scheduler.ndjson
+          bash planningops/scripts/run_runtime_handoff_ci_check.sh --run-id ci-runtime-${{ github.run_id }} --monday-root monday --planningops-last-run planningops/artifacts/loop-runner/last-run.json
 
+  monday-harness-projection:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout planningops
+        uses: actions/checkout@v4
+
+      - name: Checkout monday runtime
+        uses: actions/checkout@v4
+        with:
+          repository: rather-not-work-on/monday
+          path: monday
+
+      - name: Run monday projection bridge gate
+        run: |
+          set -euo pipefail
+          bash planningops/scripts/run_monday_agent_harness_projection_ci_check.sh --summary-run-id ci-${{ github.run_id }} --monday-root monday --mission-id monday-harness-projection
   federated-conformance:
     runs-on: ubuntu-latest
     steps:
@@ -128,26 +129,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install federated evidence dependencies
-        run: |
-          set -euo pipefail
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r platform-contracts/requirements-dev.txt
-          python3 -m pip install -r platform-provider-gateway/requirements-dev.txt
-          python3 -m pip install -r platform-observability-gateway/requirements-dev.txt
-          python3 -m pip install -r monday/requirements-dev.txt
-
       - name: Run federated conformance
         run: |
           set -euo pipefail
-          python3 planningops/scripts/rollout_external_artifact_policy.py \
-            --workspace-root . \
-            --strict \
-            --output planningops/artifacts/validation/federated-artifact-policy-rollout-report.json
-          python3 planningops/scripts/federation/cross_repo_conformance_check.py \
-            --workspace-root . \
-            --run-id ci-federated-${{ github.run_id }} \
-            --output planningops/artifacts/conformance/ci-federated-${{ github.run_id }}.json
+          bash planningops/scripts/run_federated_conformance_ci_check.sh --run-id ci-federated-${{ github.run_id }} --workspace-root . --python-bin python3 --policy-output planningops/artifacts/validation/federated-artifact-policy-rollout-report.json --bootstrap-mode require --output planningops/artifacts/conformance/ci-federated-${{ github.run_id }}.json
 
   loop-guardrails:
     runs-on: ubuntu-latest
@@ -160,6 +145,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Checkout observability gateway
+        uses: actions/checkout@v4
+        with:
+          repository: rather-not-work-on/platform-observability-gateway
+          path: platform-observability-gateway
+
+      - name: Checkout monday runtime
+        uses: actions/checkout@v4
+        with:
+          repository: rather-not-work-on/monday
+          path: monday
 
       - name: Run guardrail checks
         env:
@@ -200,64 +197,120 @@ jobs:
           bash planningops/scripts/test_validate_repo_boundaries_contract.sh
           bash planningops/scripts/test_validate_script_roles_contract.sh
           bash planningops/scripts/test_cross_repo_conformance_bootstrap_contract.sh
+          bash planningops/scripts/test_cross_repo_conformance_run_root_reuse_contract.sh
           bash planningops/scripts/test_validate_wrapper_deprecation_contract.sh
-          bash planningops/scripts/test_validate_issue_quality_contract.sh
-          bash planningops/scripts/test_validate_federated_issue_quality_contract.sh
+          bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
+          bash planningops/scripts/test_federated_ci_local_matrix_mode_contract.sh
+          bash planningops/scripts/test_reconcile_federated_ci_summary_tmp.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
+          bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle.sh
+          bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_validation_contract.sh
+          bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_validation_contract.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle.sh
+          bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_validation_contract.sh
+          bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_validation_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_validation_contract.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh
+          bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile.sh
+          bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile.sh
+          bash planningops/scripts/test_validate_federated_ci_summary_contract.sh
+          bash planningops/scripts/test_federated_ci_summary_contract_doc.sh
+          bash planningops/scripts/test_plain_python_compat_manifest_contract_doc.sh
+          bash planningops/scripts/test_uap_automation_operations_summary_contract.sh
+          bash planningops/scripts/test_run_platform_contracts_ci_check_contract.sh
+          bash planningops/scripts/test_platform_contracts_helper_wiring.sh
+          bash planningops/scripts/test_run_contract_conformance_ci_check_contract.sh
+          bash planningops/scripts/test_contract_conformance_helper_wiring.sh
+          bash planningops/scripts/test_run_federated_conformance_ci_check_contract.sh
+          bash planningops/scripts/test_federated_conformance_helper_wiring.sh
+          bash planningops/scripts/test_run_federated_summary_ci_check_contract.sh
+          bash planningops/scripts/test_federated_summary_helper_wiring.sh
+          bash planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
+          bash planningops/scripts/test_run_provider_profile_ci_check_contract.sh
+          bash planningops/scripts/test_provider_profile_helper_wiring.sh
+          bash planningops/scripts/test_run_provider_gateway_ready_ci_check_contract.sh
+          bash planningops/scripts/test_provider_gateway_ready_helper_wiring.sh
+          bash planningops/scripts/test_run_o11y_replay_ci_check_contract.sh
+          bash planningops/scripts/test_o11y_replay_helper_wiring.sh
+          bash planningops/scripts/test_run_runtime_operations_ready_ci_check_contract.sh
+          bash planningops/scripts/test_runtime_operations_ready_helper_wiring.sh
+          bash planningops/scripts/test_assess_federated_ci_summary_readiness.sh
+          bash planningops/scripts/test_doctor_federated_ci_summary.sh
+          bash planningops/scripts/test_gate_federated_ci_summary.sh
+          bash planningops/scripts/test_run_plain_python_compat_workflow_chain_contract.sh
+          bash planningops/scripts/run_plain_python_compat_workflow_chain.sh
+          bash planningops/scripts/test_run_issue_quality_ci_check_contract.sh
+          bash planningops/scripts/test_issue_quality_helper_wiring.sh
+          bash planningops/scripts/run_issue_quality_ci_check.sh --python-bin python3
           python3 planningops/scripts/validate_wrapper_deprecation.py \
             --mode warn \
             --output planningops/artifacts/deprecation/wrapper-deprecation-warn-report.json
           python3 planningops/scripts/validate_wrapper_deprecation.py \
             --mode fail \
             --output planningops/artifacts/deprecation/wrapper-deprecation-fail-report.json
-          python3 planningops/scripts/validate_issue_quality.py --strict
-          bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh
-          python3 planningops/scripts/validate_artifact_storage_policy.py --strict
-          bash planningops/scripts/test_control_tower_ontology_contract.sh
-          bash planningops/scripts/test_ontology_entity_map_contract.sh
-          bash planningops/scripts/test_memory_tier_contract.sh
-          bash planningops/scripts/test_memory_compactor_contract.sh
-          bash planningops/scripts/test_memory_archive_contract.sh
-          bash planningops/scripts/test_memory_rehydrate_contract.sh
-          bash planningops/scripts/test_inventory_issue_lifecycle_contract.sh
-          bash planningops/scripts/test_autonomous_scheduler_queue_control_plane_contract.sh
-          python3 planningops/scripts/memory_compactor.py \
-            --mode check \
-            --root . \
-            --rules planningops/config/memory-tier-rules.json \
-            --output planningops/artifacts/validation/memory-gate-report.json \
-            --strict
-          python3 planningops/scripts/inventory_issue_lifecycle.py \
-            audit \
-            --repo rather-not-work-on/platform-planningops \
-            --strict \
-            --output planningops/artifacts/validation/inventory-issue-lifecycle-report.json
+          bash planningops/scripts/test_run_control_plane_governance_ci_check_contract.sh
+          bash planningops/scripts/test_control_plane_governance_helper_wiring.sh
+          bash planningops/scripts/run_control_plane_governance_ci_check.sh --python-bin python3
           bash planningops/scripts/test_audit_branch_protection_contract.sh
           bash planningops/scripts/test_apply_branch_protection_contract.sh
           python3 planningops/scripts/audit_branch_protection.py \
             --policy planningops/config/repository-governance-policy.json \
             --output planningops/artifacts/validation/branch-protection-audit-report.json \
             --allow-fetch-failure
-          bash planningops/scripts/test_validate_external_only_commit_guard.sh
-          bash planningops/scripts/test_migrate_external_only_artifacts_contract.sh
-          bash planningops/scripts/test_artifact_sink_e2e.sh
-          BASE_REF="${{ github.event.pull_request.base.sha }}"
-          if [[ -z "$BASE_REF" || "$BASE_REF" == "null" ]]; then
-            BASE_REF="origin/main"
-          fi
-          python3 planningops/scripts/validate_external_only_commit_guard.py \
-            --base-ref "$BASE_REF" \
-            --head-ref "${{ github.sha }}" \
-            --strict
-          python3 planningops/scripts/validate_external_only_commit_guard.py \
-            --mode tracked \
-            --strict
+          bash planningops/scripts/test_run_external_artifact_residency_ci_check_contract.sh
+          bash planningops/scripts/test_external_artifact_residency_helper_wiring.sh
+          bash planningops/scripts/run_external_artifact_residency_ci_check.sh --base-ref "${{ github.event.pull_request.base.sha }}" --head-ref "${{ github.sha }}" --python-bin python3
           bash planningops/scripts/test_normalize_ready_implementation_blueprint_refs.sh
           bash planningops/scripts/test_planning_context_contract.sh
           bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh
           bash planningops/scripts/test_issue_loop_runner_wrapper_compat.sh
           bash planningops/scripts/test_repo_execution_adapters_wrapper_compat.sh
           bash planningops/scripts/test_ralph_loop_local_worker_policy.sh
+          python3 planningops/scripts/validate_runtime_profiles.py --strict
           bash planningops/scripts/test_validate_worker_task_pack_contract.sh
+          bash planningops/scripts/test_validate_runtime_profiles_contract.sh
           bash planningops/scripts/test_issue_driven_mission_smoke_contract.sh
           bash planningops/scripts/test_issue_driven_runtime_stack_smoke_contract.sh
           bash planningops/scripts/test_loop_checkpoint_resume.sh
@@ -266,6 +319,14 @@ jobs:
           bash planningops/scripts/test_backlog_stock_replenishment_contract.sh
           bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh
           bash planningops/scripts/test_supervisor_operator_handoff_contract.sh
+          bash planningops/scripts/test_validate_supervisor_operator_handoff_contract.sh
+          bash planningops/scripts/test_resolve_supervisor_operator_handoff_validation.sh
+          bash planningops/scripts/test_resolve_supervisor_operator_handoff_bundle.sh
+          bash planningops/scripts/test_validate_supervisor_operator_handoff_bundle.sh
+          bash planningops/scripts/test_assess_supervisor_operator_handoff_bundle_readiness.sh
+          bash planningops/scripts/test_validate_supervisor_operator_handoff_bundle_readiness.sh
+          bash planningops/scripts/test_doctor_supervisor_operator_handoff_bundle.sh
+          bash planningops/scripts/test_gate_supervisor_operator_handoff_bundle.sh
           bash planningops/scripts/test_supervisor_experiment_auto_executor_contract.sh
 
   federated-summary:
@@ -275,6 +336,7 @@ jobs:
       - provider-profile
       - o11y-replay
       - runtime-handoff
+      - monday-harness-projection
       - federated-conformance
       - loop-guardrails
     if: always()
@@ -285,60 +347,19 @@ jobs:
       - name: Build federated summary
         run: |
           set -euo pipefail
-          mkdir -p planningops/artifacts/ci
-          python3 - <<'PY'
-          import json
-          from datetime import datetime, timezone
-          from pathlib import Path
-
-          needs = {
-            "contract-conformance": "${{ needs.contract-conformance.result }}",
-            "runtime-handoff": "${{ needs.runtime-handoff.result }}",
-            "o11y-replay": "${{ needs.o11y-replay.result }}",
-            "provider-profile": "${{ needs.provider-profile.result }}",
-            "federated-conformance": "${{ needs.federated-conformance.result }}",
-            "loop-guardrails": "${{ needs.loop-guardrails.result }}",
-          }
-
-          domain_map = {
-            "contract-conformance": "contract",
-            "runtime-handoff": "runtime",
-            "o11y-replay": "infra",
-            "provider-profile": "infra",
-            "federated-conformance": "federation",
-            "loop-guardrails": "policy",
-          }
-
-          checks = []
-          for name, result in needs.items():
-            verdict = "pass" if result == "success" else "fail"
-            checks.append({"name": name, "result": result, "verdict": verdict, "domain": domain_map[name]})
-
-          failures = [c for c in checks if c["verdict"] == "fail"]
-          doc = {
-            "generated_at_utc": datetime.now(timezone.utc).isoformat(),
-            "run_id": "ci-${{ github.run_id }}",
-            "required_checks": list(needs.keys()),
-            "checks": checks,
-            "failure_classification": {
-              "count": len(failures),
-              "domains": sorted({f["domain"] for f in failures}),
-              "deterministic_rule": "contract-conformance->contract, provider-profile/o11y-replay->infra, runtime-handoff->runtime, federated-conformance->federation, loop-guardrails->policy",
-            },
-            "verdict": "pass" if not failures else "fail",
-          }
-
-          Path("planningops/artifacts/ci/federated-ci-summary.json").write_text(
-            json.dumps(doc, ensure_ascii=True, indent=2), encoding="utf-8"
-          )
-          print("summary written: planningops/artifacts/ci/federated-ci-summary.json")
-          print(f"verdict={doc['verdict']} failures={len(failures)}")
-          if failures:
-              raise SystemExit(1)
-          PY
+          bash planningops/scripts/run_federated_summary_ci_check.sh --run-id ci-${{ github.run_id }} --contract-conformance-result ${{ needs.contract-conformance.result }} --runtime-handoff-result ${{ needs.runtime-handoff.result }} --monday-harness-projection-result ${{ needs.monday-harness-projection.result }} --o11y-replay-result ${{ needs.o11y-replay.result }} --provider-profile-result ${{ needs.provider-profile.result }} --federated-conformance-result ${{ needs.federated-conformance.result }} --loop-guardrails-result ${{ needs.loop-guardrails.result }}
 
       - name: Upload federated summary artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: federated-ci-summary
-          path: planningops/artifacts/ci/federated-ci-summary.json
+          path: |
+            planningops/artifacts/ci/federated-ci-summary.json
+            planningops/artifacts/ci/ci-${{ github.run_id }}.json
+            planningops/artifacts/validation/federated-ci-summary-validation.json
+            planningops/artifacts/validation/ci-${{ github.run_id }}-summary-validation.json
+            planningops/artifacts/validation/federated-ci-summary-readiness.json
+            planningops/artifacts/validation/ci-${{ github.run_id }}-summary-readiness.json
+            planningops/artifacts/validation/federated-ci-summary-readiness-validation.json
+            planningops/artifacts/validation/ci-${{ github.run_id }}-summary-readiness-validation.json

--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -140,6 +140,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Runtime Operations Cross-Repo Doc Sync Packet](./plans/2026-03-28-runtime-operations-cross-repo-doc-sync-packet.md)
 - [Contract Helper Surface Sync Packet](./plans/2026-03-28-contract-helper-surface-sync-packet.md)
 - [Federated Label Taxonomy Helper Sync Packet](./plans/2026-03-28-federated-label-taxonomy-helper-sync-packet.md)
+- [Federated CI Matrix Helper Wiring Sync Packet](./plans/2026-03-28-federated-ci-matrix-helper-wiring-sync-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-federated-ci-matrix-helper-wiring-sync-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-federated-ci-matrix-helper-wiring-sync-packet.md
@@ -1,0 +1,33 @@
+---
+title: plan: Federated CI Matrix Helper Wiring Sync Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes the GitHub and local federated CI matrix surfaces onto the helper entrypoints that were already backfilled, so workflow and local execution share the same canonical lanes and summary sidecars.
+related_docs:
+  - ./2026-03-26-federated-conformance-helper-family-backfill-packet.md
+  - ./2026-03-26-federated-summary-helper-family-backfill-packet.md
+  - ./2026-03-26-platform-contracts-helper-family-backfill-packet.md
+---
+
+# plan: Federated CI Matrix Helper Wiring Sync Packet
+
+## Summary
+- Rewire the GitHub federated CI workflow to call canonical helper entrypoints instead of inlining lane-specific command blocks.
+- Align the local federated matrix runner with the same helper surfaces and expanded summary sidecar chain.
+- Keep the unit focused on workflow and local-matrix wiring plus workbench traceability.
+
+## Scope
+- `.github/workflows/federated-ci-matrix.yml`
+- `planningops/scripts/federation/federated_ci_matrix_local.sh`
+- workbench hub link for this packet
+
+## Acceptance
+- `test_federated_ci_workflow_summary_contract.sh` passes
+- `test_federated_ci_local_matrix_mode_contract.sh` passes
+- helper wiring regressions for promoted lanes pass
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/federation/federated_ci_matrix_local.sh
+++ b/planningops/scripts/federation/federated_ci_matrix_local.sh
@@ -4,15 +4,443 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 WORKSPACE_DIR="$(cd "${ROOT_DIR}/.." && pwd)"
 RUN_ID="${1:-federated-ci-$(date -u +%Y%m%dT%H%M%SZ)}"
+SYSTEM_PYTHON_BIN="$(command -v python3)"
 PYTHON_BIN="$(python3 "${ROOT_DIR}/planningops/scripts/federation/federated_python_env.py" --workspace-root "${WORKSPACE_DIR}" --mode auto --print-python-path)"
 PYTHON_BIN_DIR="$(cd "$(dirname "${PYTHON_BIN}")" && pwd)"
 export PYTHON_BIN
 export PATH="${PYTHON_BIN_DIR}:${PATH}"
+SUMMARY_RECONCILE_HELPER="${ROOT_DIR}/planningops/scripts/federation/reconcile_federated_ci_summary_tmp.py"
 
 OUT_DIR="${ROOT_DIR}/planningops/artifacts/ci"
 mkdir -p "${OUT_DIR}"
+VALIDATION_DIR="${ROOT_DIR}/planningops/artifacts/validation"
+mkdir -p "${VALIDATION_DIR}"
 LATEST_PATH="${OUT_DIR}/federated-ci-summary.json"
 STAMPED_PATH="${OUT_DIR}/${RUN_ID}.json"
+SUMMARY_TMP_PATH="${OUT_DIR}/${RUN_ID}.tmp.json"
+SUMMARY_CHECKPOINT_PATH="${OUT_DIR}/${RUN_ID}.checkpoint.json"
+LATEST_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-validation.json"
+STAMPED_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-validation.json"
+LATEST_READINESS_PATH="${VALIDATION_DIR}/federated-ci-summary-readiness.json"
+STAMPED_READINESS_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-readiness.json"
+LATEST_READINESS_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-readiness-validation.json"
+STAMPED_READINESS_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-readiness-validation.json"
+LATEST_RECONCILE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile.json"
+STAMPED_RECONCILE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile.json"
+LATEST_RECONCILE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-validation.json"
+STAMPED_RECONCILE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-validation.json"
+LATEST_RECONCILE_BUNDLE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle.json"
+STAMPED_RECONCILE_BUNDLE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle.json"
+LATEST_RECONCILE_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-validation.json"
+STAMPED_RECONCILE_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status.json"
+LATEST_RECONCILE_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-validation.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle.json"
+LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/federated-ci-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH="${VALIDATION_DIR}/${RUN_ID}-summary-tmp-reconcile-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-validation.json"
+SUMMARY_FINALIZED=0
+LOCAL_RUNTIME_PROFILE="local"
+
+REQUIRED_CHECKS=(
+  "contract-conformance"
+  "provider-gateway-ready"
+  "runtime-handoff"
+  "runtime-operations-ready"
+  "monday-harness-projection"
+  "o11y-replay"
+  "provider-profile"
+  "loop-guardrails"
+)
+
+INIT_ARGS=(
+  --summary "${SUMMARY_TMP_PATH}"
+  --run-id "${RUN_ID}"
+)
+for required_check in "${REQUIRED_CHECKS[@]}"; do
+  INIT_ARGS+=(--required-check "${required_check}")
+done
+
+python3 "${ROOT_DIR}/planningops/scripts/federation/federated_ci_summary.py" init "${INIT_ARGS[@]}"
+cp "${SUMMARY_TMP_PATH}" "${SUMMARY_CHECKPOINT_PATH}"
+
+restore_summary_from_checkpoint_if_needed() {
+  local check_name="$1"
+  python3 "${SUMMARY_RECONCILE_HELPER}" \
+    --summary "${SUMMARY_TMP_PATH}" \
+    --checkpoint "${SUMMARY_CHECKPOINT_PATH}" \
+    --output "${STAMPED_RECONCILE_PATH}" \
+    --previous-report "${STAMPED_RECONCILE_PATH}" \
+    --check-name "${check_name}" \
+    --restore-in-place >/dev/null
+  cp "${STAMPED_RECONCILE_PATH}" "${LATEST_RECONCILE_PATH}"
+  python3 - <<'PY' "${LATEST_RECONCILE_PATH}"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["output_path"] = str(path)
+path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile.py" \
+    --report-file "${STAMPED_RECONCILE_PATH}" \
+    --output "${STAMPED_RECONCILE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile.py" \
+    --report-file "${LATEST_RECONCILE_PATH}" \
+    --output "${LATEST_RECONCILE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile.py" \
+    --artifact-file "${STAMPED_RECONCILE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile.py" \
+    --artifact-file "${LATEST_RECONCILE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_PATH}" \
+    --validation-report "${STAMPED_RECONCILE_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${STAMPED_RECONCILE_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_PATH}" \
+    --validation-report "${LATEST_RECONCILE_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${LATEST_RECONCILE_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --bundle-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --bundle-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --status-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --status-validation-output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_VALIDATION_PATH}" \
+    --require-pass >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.py" \
+    --artifact-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${STAMPED_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+  python3 "${ROOT_DIR}/planningops/scripts/validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.py" \
+    --bundle-file "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_PATH}" \
+    --output "${LATEST_RECONCILE_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_STATUS_BUNDLE_VALIDATION_PATH}" \
+    --strict >/dev/null
+}
+
+finalize_summary() {
+  local status="$1"
+  local shell_exit_code="$2"
+  local readiness_rc=0
+  local restore_errexit=0
+  case "$-" in
+    *e*) restore_errexit=1 ;;
+  esac
+  set +e
+  python3 "${ROOT_DIR}/planningops/scripts/federation/federated_ci_summary.py" finalize \
+    --summary "${SUMMARY_TMP_PATH}" \
+    --stamped-path "${STAMPED_PATH}" \
+    --latest-path "${LATEST_PATH}" \
+    --status "${status}" \
+    --stamped-validation-output "${STAMPED_VALIDATION_PATH}" \
+    --latest-validation-output "${LATEST_VALIDATION_PATH}" \
+    --shell-exit-code "${shell_exit_code}"
+  local summary_rc=$?
+
+  if [[ -f "${STAMPED_PATH}" && -f "${STAMPED_VALIDATION_PATH}" ]]; then
+    python3 "${ROOT_DIR}/planningops/scripts/assess_federated_ci_summary_readiness.py" \
+      --summary "${STAMPED_PATH}" \
+      --validation-report "${STAMPED_VALIDATION_PATH}" \
+      --output "${STAMPED_READINESS_PATH}" \
+      --validation-output "${STAMPED_READINESS_VALIDATION_PATH}"
+    local stamped_readiness_rc=$?
+    if [[ "${stamped_readiness_rc}" -ne 0 ]]; then
+      readiness_rc="${stamped_readiness_rc}"
+    fi
+  fi
+  if [[ -f "${LATEST_PATH}" && -f "${LATEST_VALIDATION_PATH}" ]]; then
+    python3 "${ROOT_DIR}/planningops/scripts/assess_federated_ci_summary_readiness.py" \
+      --summary "${LATEST_PATH}" \
+      --validation-report "${LATEST_VALIDATION_PATH}" \
+      --output "${LATEST_READINESS_PATH}" \
+      --validation-output "${LATEST_READINESS_VALIDATION_PATH}"
+    local latest_readiness_rc=$?
+    if [[ "${latest_readiness_rc}" -ne 0 && "${readiness_rc}" -eq 0 ]]; then
+      readiness_rc="${latest_readiness_rc}"
+    fi
+  fi
+  if [[ "${restore_errexit}" -eq 1 ]]; then
+    set -e
+  else
+    set +e
+  fi
+  if [[ "${summary_rc}" -ne 0 ]]; then
+    return "${summary_rc}"
+  fi
+  return "${readiness_rc}"
+}
+
+trap 'shell_rc=$?; if [ "${SUMMARY_FINALIZED}" -eq 0 ]; then finalize_summary interrupted "${shell_rc}" >/dev/null 2>&1 || true; fi' EXIT
 
 run_check() {
   local check_name="$1"
@@ -22,75 +450,60 @@ run_check() {
   local stdout_file="${OUT_DIR}/${RUN_ID}-${check_name}.stdout.log"
   local stderr_file="${OUT_DIR}/${RUN_ID}-${check_name}.stderr.log"
 
+  cp "${SUMMARY_TMP_PATH}" "${SUMMARY_CHECKPOINT_PATH}"
+
   set +e
   "${cmd[@]}" >"${stdout_file}" 2>"${stderr_file}"
   local rc=$?
   set -e
 
-  python3 - <<PY
-import json
-from pathlib import Path
-summary_path = Path("${OUT_DIR}/${RUN_ID}.tmp.json")
-doc = {"checks": []}
-if summary_path.exists():
-    doc = json.loads(summary_path.read_text(encoding="utf-8"))
-doc["checks"].append({
-    "name": "${check_name}",
-    "domain": "${domain}",
-    "exit_code": ${rc},
-    "verdict": "pass" if ${rc} == 0 else "fail",
-    "stdout_log": "${stdout_file}",
-    "stderr_log": "${stderr_file}",
-})
-summary_path.write_text(json.dumps(doc, ensure_ascii=True, indent=2), encoding="utf-8")
-PY
+  restore_summary_from_checkpoint_if_needed "${check_name}"
+
+  python3 "${ROOT_DIR}/planningops/scripts/federation/federated_ci_summary.py" append-check \
+    --summary "${SUMMARY_TMP_PATH}" \
+    --name "${check_name}" \
+    --domain "${domain}" \
+    --exit-code "${rc}" \
+    --stdout-log "${stdout_file}" \
+    --stderr-log "${stderr_file}"
 }
 
 run_check "contract-conformance" "contract" \
-  "${PYTHON_BIN}" "${ROOT_DIR}/planningops/scripts/federation/cross_repo_conformance_check.py" --workspace-root "${WORKSPACE_DIR}" --bootstrap-mode auto --run-id "${RUN_ID}-contract"
+  bash -c "cd '${ROOT_DIR}' && bash planningops/scripts/run_contract_conformance_ci_check.sh --run-id ${RUN_ID}-contract --workspace-root .. --bootstrap-mode auto --python-bin \"${PYTHON_BIN}\""
 
 run_check "provider-profile" "infra" \
-  bash -c "cd '${WORKSPACE_DIR}/platform-provider-gateway' && bash scripts/litellm_stack_launcher.sh --mode dry-run --profiles local,oracle_cloud --run-id '${RUN_ID}-provider'"
+  bash -c "cd '${ROOT_DIR}' && bash planningops/scripts/run_provider_profile_ci_check.sh --run-id ${RUN_ID}-provider --provider-root ../platform-provider-gateway --runtime-profile-file planningops/config/runtime-profiles.json --profiles local,oracle_cloud"
+
+run_check "provider-gateway-ready" "infra" \
+  bash -c "cd '${ROOT_DIR}' && bash planningops/scripts/run_provider_gateway_ready_ci_check.sh --run-id ${RUN_ID}-provider-gateway-ready --provider-root ../platform-provider-gateway"
 
 run_check "o11y-replay" "infra" \
-  bash -c "cd '${WORKSPACE_DIR}/platform-observability-gateway' && bash scripts/langfuse_stack_launcher.sh --mode dry-run --run-id '${RUN_ID}-o11y'"
+  bash -c "cd '${ROOT_DIR}' && bash planningops/scripts/run_o11y_replay_ci_check.sh --run-id ${RUN_ID}-o11y --o11y-root ../platform-observability-gateway"
 
 run_check "runtime-handoff" "runtime" \
-  bash -c "cd '${WORKSPACE_DIR}/monday' && \"${PYTHON_BIN}\" scripts/integrate_planningops_handoff.py --run-id '${RUN_ID}-runtime' --idempotency artifacts/integration/${RUN_ID}-idempotency.json --transition-log artifacts/integration/${RUN_ID}-scheduler.ndjson"
+  bash -c "cd '${ROOT_DIR}' && bash planningops/scripts/run_runtime_handoff_ci_check.sh --run-id ${RUN_ID}-runtime --monday-root ../monday --python-bin \"${PYTHON_BIN}\""
 
+run_check "runtime-operations-ready" "runtime" \
+  bash -c "cd '${ROOT_DIR}' && bash planningops/scripts/run_runtime_operations_ready_ci_check.sh --run-id ${RUN_ID}-runtime-operations-ready --provider-root ../platform-provider-gateway --monday-root ../monday --runtime-profile ${LOCAL_RUNTIME_PROFILE}"
+
+run_check "monday-harness-projection" "runtime" \
+  bash -c "
+    set -euo pipefail
+    cd '${ROOT_DIR}'
+    bash planningops/scripts/run_monday_agent_harness_projection_ci_check.sh --summary-run-id ${RUN_ID} --monday-root ../monday --mission-id monday-harness-projection
+  "
 run_check "loop-guardrails" "policy" \
-  bash -c "cd '${ROOT_DIR}' && \"${PYTHON_BIN}\" planningops/scripts/run_track1_gate_dryrun.py --kpi-path planningops/fixtures/track1-kpi-baseline-ci.json --strict && bash planningops/scripts/test_track1_gate_dryrun_contract.sh && bash planningops/scripts/test_bootstrap_two_track_backlog_contract.sh && bash planningops/scripts/test_compile_plan_to_backlog_contract.sh && bash planningops/scripts/test_verify_plan_projection_contract.sh && bash planningops/scripts/test_planning_context_contract.sh && bash planningops/scripts/test_inventory_issue_lifecycle_contract.sh && \"${PYTHON_BIN}\" planningops/scripts/inventory_issue_lifecycle.py audit --repo rather-not-work-on/platform-planningops --strict --output planningops/artifacts/validation/inventory-issue-lifecycle-report.json && \"${PYTHON_BIN}\" planningops/scripts/compile_plan_to_backlog.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --output planningops/artifacts/validation/plan-compile-report.json && \"${PYTHON_BIN}\" planningops/scripts/verify_plan_projection.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --snapshot-file planningops/fixtures/plan-projection-snapshot-sample.json --strict --output planningops/artifacts/validation/plan-projection-report.json && bash planningops/scripts/test_meta_plan_graph_schema_contract.sh && bash planningops/scripts/test_build_meta_plan_graph_contract.sh && bash planningops/scripts/test_meta_plan_orchestrator_contract.sh && \"${PYTHON_BIN}\" planningops/scripts/build_meta_plan_graph.py --contract-file planningops/fixtures/meta-plan-graph-sample.json --strict --output planningops/artifacts/meta-plan/meta-graph.json && \"${PYTHON_BIN}\" planningops/scripts/meta_plan_orchestrator.py --meta-graph-contract planningops/fixtures/meta-plan-graph-sample.json --mode dry-run --strict --meta-graph-output planningops/artifacts/meta-plan/meta-graph.json --output planningops/artifacts/meta-plan/meta-execution-report.json && bash planningops/scripts/test_validate_project_field_schema_matrix.sh && bash planningops/scripts/test_module_readme_contract.sh && bash planningops/scripts/test_validate_repo_boundaries_contract.sh && bash planningops/scripts/test_validate_script_roles_contract.sh && bash planningops/scripts/test_validate_issue_quality_contract.sh && \"${PYTHON_BIN}\" planningops/scripts/validate_issue_quality.py --strict && bash planningops/scripts/test_normalize_ready_implementation_blueprint_refs.sh && bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh && bash planningops/scripts/test_ralph_loop_local_worker_policy.sh && bash planningops/scripts/test_validate_worker_task_pack_contract.sh && bash planningops/scripts/test_issue_driven_mission_smoke_contract.sh && bash planningops/scripts/test_issue_driven_runtime_stack_smoke_contract.sh && bash planningops/scripts/test_local_runtime_stack_smoke_contract.sh && bash planningops/scripts/test_wave14_oracle_rehearsal_contract.sh && bash planningops/scripts/test_loop_checkpoint_resume.sh && bash planningops/scripts/test_lease_lock_watchdog.sh && bash planningops/scripts/test_escalation_gate.sh"
+  bash -c "cd '${ROOT_DIR}' && bash planningops/scripts/test_federated_python_env_contract.sh && bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh && bash planningops/scripts/test_federated_ci_local_matrix_mode_contract.sh && bash planningops/scripts/test_reconcile_federated_ci_summary_tmp.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh && bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle.sh && bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle.sh && bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_validation_contract.sh && bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle.sh && bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_doctor_federated_ci_summary_tmp_reconcile.sh && bash planningops/scripts/test_gate_federated_ci_summary_tmp_reconcile.sh && bash planningops/scripts/test_validate_federated_ci_summary_contract.sh && bash planningops/scripts/test_federated_ci_summary_contract_doc.sh && bash planningops/scripts/test_plain_python_compat_manifest_contract_doc.sh && bash planningops/scripts/test_uap_automation_operations_summary_contract.sh && bash planningops/scripts/test_validate_supervisor_operator_handoff_contract.sh && bash planningops/scripts/test_resolve_supervisor_operator_handoff_validation.sh && bash planningops/scripts/test_resolve_supervisor_operator_handoff_bundle.sh && bash planningops/scripts/test_validate_supervisor_operator_handoff_bundle.sh && bash planningops/scripts/test_assess_supervisor_operator_handoff_bundle_readiness.sh && bash planningops/scripts/test_validate_supervisor_operator_handoff_bundle_readiness.sh && bash planningops/scripts/test_doctor_supervisor_operator_handoff_bundle.sh && bash planningops/scripts/test_gate_supervisor_operator_handoff_bundle.sh && bash planningops/scripts/test_supervisor_handoff_bridge_wiring.sh && bash planningops/scripts/test_assess_federated_ci_summary_readiness.sh && bash planningops/scripts/test_validate_federated_ci_summary_readiness_contract.sh && bash planningops/scripts/test_doctor_federated_ci_summary.sh && bash planningops/scripts/test_gate_federated_ci_summary.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_validation_contract.sh && bash planningops/scripts/test_doctor_plain_python_compat_manifest.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_contract.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_validation_contract.sh && bash planningops/scripts/test_gate_plain_python_compat_manifest.sh && bash planningops/scripts/gate_plain_python_compat_manifest.sh && bash planningops/scripts/test_resolve_plain_python_compat_manifest_status.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_validation_contract.sh && bash planningops/scripts/test_doctor_plain_python_compat_manifest_status_bundle.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_resolve_plain_python_compat_manifest_status_bundle_status.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_doctor_plain_python_compat_manifest_status_bundle_status_bundle.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_resolve_plain_python_compat_manifest_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_doctor_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_resolve_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_doctor_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_resolve_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_doctor_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_resolve_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_doctor_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_contract.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_validation_contract.sh && bash planningops/scripts/test_resolve_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh && bash planningops/scripts/test_validate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh && bash planningops/scripts/test_gate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/gate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh --artifact-file planningops/artifacts/validation/plain-python-compat-manifest-status-bundle-status-bundle-status-bundle-status-bundle-status-bundle-status.json && bash planningops/scripts/test_gate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/gate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle.sh --artifact-file planningops/artifacts/validation/plain-python-compat-manifest-status-bundle-status-bundle-status-bundle-status-bundle-status.json && bash planningops/scripts/test_gate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/gate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle_status_bundle.sh --artifact-file planningops/artifacts/validation/plain-python-compat-manifest-status-bundle-status-bundle-status-bundle-status.json && bash planningops/scripts/test_gate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle.sh && bash planningops/scripts/gate_plain_python_compat_manifest_status_bundle_status_bundle_status_bundle.sh --artifact-file planningops/artifacts/validation/plain-python-compat-manifest-status-bundle-status-bundle-status.json && bash planningops/scripts/test_gate_plain_python_compat_manifest_status_bundle.sh && bash planningops/scripts/gate_plain_python_compat_manifest_status_bundle.sh --artifact-file planningops/artifacts/validation/plain-python-compat-manifest-status.json && bash planningops/scripts/test_gate_plain_python_compat_manifest_status_bundle_status_bundle.sh && bash planningops/scripts/gate_plain_python_compat_manifest_status_bundle_status_bundle.sh --artifact-file planningops/artifacts/validation/plain-python-compat-manifest-status-bundle-status.json && bash planningops/scripts/test_resolve_plain_python_compat_manifest.sh && bash planningops/scripts/test_cross_repo_plain_python_annotation_contract.sh && bash planningops/scripts/test_plain_python_compat_manifest_wiring.sh && bash planningops/scripts/test_plain_python_compat_manifest_surface_inventory.sh && PLAIN_PYTHON_BIN='${SYSTEM_PYTHON_BIN}' bash planningops/scripts/test_cross_repo_plain_python_compat.sh && PLAIN_PYTHON_BIN='${SYSTEM_PYTHON_BIN}' bash planningops/scripts/test_runtime_stack_smoke_sequence_contract.sh && PLANNINGOPS_ALLOW_SCHEMA_FETCH_FAILURE=1 \"${PYTHON_BIN}\" planningops/scripts/run_track1_gate_dryrun.py --kpi-path planningops/fixtures/track1-kpi-baseline-ci.json --strict && bash planningops/scripts/test_track1_gate_dryrun_contract.sh && bash planningops/scripts/test_bootstrap_two_track_backlog_contract.sh && bash planningops/scripts/test_compile_plan_to_backlog_contract.sh && bash planningops/scripts/test_verify_plan_projection_contract.sh && bash planningops/scripts/test_planning_context_contract.sh && bash planningops/scripts/test_inventory_issue_lifecycle_contract.sh && bash planningops/scripts/test_inventory_issue_lifecycle_audit_snapshot.sh && \"${PYTHON_BIN}\" planningops/scripts/compile_plan_to_backlog.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --output planningops/artifacts/validation/plan-compile-report.json && \"${PYTHON_BIN}\" planningops/scripts/verify_plan_projection.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --snapshot-file planningops/fixtures/plan-projection-snapshot-sample.json --strict --output planningops/artifacts/validation/plan-projection-report.json && \"${PYTHON_BIN}\" planningops/scripts/validate_runtime_profiles.py --strict && bash planningops/scripts/test_meta_plan_graph_schema_contract.sh && bash planningops/scripts/test_build_meta_plan_graph_contract.sh && bash planningops/scripts/test_meta_plan_orchestrator_contract.sh && \"${PYTHON_BIN}\" planningops/scripts/build_meta_plan_graph.py --contract-file planningops/fixtures/meta-plan-graph-sample.json --strict --output planningops/artifacts/meta-plan/meta-graph.json && \"${PYTHON_BIN}\" planningops/scripts/meta_plan_orchestrator.py --meta-graph-contract planningops/fixtures/meta-plan-graph-sample.json --mode dry-run --strict --meta-graph-output planningops/artifacts/meta-plan/meta-graph.json --output planningops/artifacts/meta-plan/meta-execution-report.json && bash planningops/scripts/test_validate_project_field_schema_matrix.sh && bash planningops/scripts/test_module_readme_contract.sh && bash planningops/scripts/test_validate_repo_boundaries_contract.sh && bash planningops/scripts/test_validate_script_roles_contract.sh && bash planningops/scripts/test_cross_repo_conformance_run_root_reuse_contract.sh && bash planningops/scripts/test_validate_issue_quality_contract.sh && \"${PYTHON_BIN}\" planningops/scripts/validate_issue_quality.py --strict && bash planningops/scripts/test_normalize_ready_implementation_blueprint_refs.sh && bash planningops/scripts/test_issue_loop_runner_multi_repo_intake.sh && bash planningops/scripts/test_ralph_loop_local_worker_policy.sh && bash planningops/scripts/test_validate_worker_task_pack_contract.sh && bash planningops/scripts/test_validate_runtime_profiles_contract.sh && bash planningops/scripts/test_issue_driven_mission_smoke_contract.sh && bash planningops/scripts/test_issue_driven_runtime_stack_smoke_contract.sh && bash planningops/scripts/test_local_runtime_stack_smoke_contract.sh && bash planningops/scripts/test_wave14_oracle_rehearsal_contract.sh && bash planningops/scripts/test_loop_checkpoint_resume.sh && bash planningops/scripts/test_lease_lock_watchdog.sh && bash planningops/scripts/test_escalation_gate.sh"
 
-python3 - <<PY
-import json
-from datetime import datetime, timezone
-from pathlib import Path
+run_check "loop-guardrails-outer-status-resolve" "policy" \
+  bash -c "cd '${ROOT_DIR}' && bash planningops/scripts/test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status.sh"
 
-tmp_path = Path("${OUT_DIR}/${RUN_ID}.tmp.json")
-doc = json.loads(tmp_path.read_text(encoding="utf-8"))
-checks = doc.get("checks", [])
-failures = [c for c in checks if c.get("verdict") == "fail"]
-doc["generated_at_utc"] = datetime.now(timezone.utc).isoformat()
-doc["run_id"] = "${RUN_ID}"
-doc["required_checks"] = [
-    "contract-conformance",
-    "runtime-handoff",
-    "o11y-replay",
-    "provider-profile",
-    "loop-guardrails",
-]
-doc["failure_classification"] = {
-    "count": len(failures),
-    "domains": sorted({f.get("domain") for f in failures}),
-    "deterministic_rule": "contract-conformance->contract, provider-profile/o11y-replay->infra, runtime-handoff->runtime, loop-guardrails->policy",
-}
-doc["verdict"] = "pass" if not failures else "fail"
+run_check "loop-guardrails-outer-status-bundle-validation" "policy" \
+  bash -c "cd '${ROOT_DIR}' && bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh"
 
-for out in ["${LATEST_PATH}", "${STAMPED_PATH}"]:
-    Path(out).write_text(json.dumps(doc, ensure_ascii=True, indent=2), encoding="utf-8")
-tmp_path.unlink(missing_ok=True)
-
-print(f"federated summary written: ${STAMPED_PATH}")
-print(f"federated summary written: ${LATEST_PATH}")
-print(f"verdict={doc['verdict']} failure_count={len(failures)}")
-PY
+set +e
+finalize_summary complete 0
+finalize_rc=$?
+set -e
+SUMMARY_FINALIZED=1
+exit "${finalize_rc}"


### PR DESCRIPTION
## Summary
- rewire the GitHub federated CI workflow onto canonical helper entrypoints
- align the local federated matrix runner with the expanded helper and summary sidecar surfaces
- add a workbench packet and hub link for the matrix wiring sync

## Validation
- bash -n planningops/scripts/federation/federated_ci_matrix_local.sh
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_federated_ci_local_matrix_mode_contract.sh
- bash planningops/scripts/test_platform_contracts_helper_wiring.sh
- bash planningops/scripts/test_provider_profile_helper_wiring.sh
- bash planningops/scripts/test_o11y_replay_helper_wiring.sh
- bash planningops/scripts/test_monday_agent_harness_projection_helper_wiring.sh
- bash planningops/scripts/test_federated_conformance_helper_wiring.sh
- bash planningops/scripts/test_federated_summary_helper_wiring.sh
- bash planningops/scripts/test_issue_quality_helper_wiring.sh
- bash planningops/scripts/test_control_plane_governance_helper_wiring.sh
- bash planningops/scripts/test_external_artifact_residency_helper_wiring.sh
- bash planningops/scripts/test_provider_gateway_ready_helper_wiring.sh
- bash planningops/scripts/test_runtime_operations_ready_helper_wiring.sh
- bash planningops/scripts/test_contract_conformance_helper_wiring.sh
- bash planningops/scripts/test_plain_python_compat_manifest_wiring.sh
- bash planningops/scripts/test_supervisor_handoff_bridge_wiring.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all