### PR TITLE
chore(active-goal): refresh registry validation artifact

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -143,6 +143,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Federated CI Matrix Helper Wiring Sync Packet](./plans/2026-03-28-federated-ci-matrix-helper-wiring-sync-packet.md)
 - [Supervisor Handoff Sidecar Surface Packet](./plans/2026-03-28-supervisor-handoff-sidecar-surface-packet.md)
 - [Track1 Gate Artifact Refresh Packet](./plans/2026-03-28-track1-gate-artifact-refresh-packet.md)
+- [Active Goal Registry Artifact Refresh Packet](./plans/2026-03-28-active-goal-registry-artifact-refresh-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-active-goal-registry-artifact-refresh-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-active-goal-registry-artifact-refresh-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Active Goal Registry Artifact Refresh Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Refreshes the committed active-goal registry validation artifact so canonical evidence matches the achieved no-active-goal registry state.
+related_docs:
+  - ./2026-03-28-active-goal-registry-empty-state-packet.md
+  - ./2026-03-15-goal-driven-autonomy-wave21-goal-brief.md
+---
+
+# plan: Active Goal Registry Artifact Refresh Packet
+
+## Summary
+- Re-run the active-goal registry validator against the current achieved-goal registry.
+- Refresh the committed validation artifact to reflect the empty `active_goal_key` state.
+- Keep the unit artifact-only: no contract or runtime logic changes.
+
+## Scope
+- `planningops/artifacts/validation/active-goal-registry-report.json`
+- workbench hub link for this packet
+
+## Acceptance
+- `test_active_goal_registry_contract.sh` passes
+- `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --output planningops/artifacts/validation/active-goal-registry-report.json --strict` succeeds
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/validation/active-goal-registry-report.json
+++ b/planningops/artifacts/validation/active-goal-registry-report.json
@@ -1,44 +1,9 @@
 {
-  "generated_at_utc": "2026-03-15T06:30:22.111215+00:00",
+  "generated_at_utc": "2026-03-28T06:21:19.331442+00:00",
   "registry": "planningops/config/active-goal-registry.json",
   "verdict": "pass",
   "error_count": 0,
   "errors": [],
-  "active_goal_key": "uap-goal-driven-autonomy-wave19",
-  "resolved_goal": {
-    "goal_key": "uap-goal-driven-autonomy-wave19",
-    "title": "Wave 19 - PlanningOps Delivery Cycle Delegation",
-    "status": "active",
-    "owner_repo": "rather-not-work-on/platform-planningops",
-    "goal_brief_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19-goal-brief.md",
-    "execution_contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave19.execution-contract.json",
-    "completion_contract_refs": [
-      "planningops/contracts/operator-channel-adapter-contract.md",
-      "planningops/contracts/goal-completion-contract.md",
-      "planningops/contracts/local-delivery-cycle-entrypoint-contract.md"
-    ],
-    "operator_channels": {
-      "primary_operator_channel": {
-        "kind": "slack_skill_cli",
-        "execution_repo": "rather-not-work-on/monday",
-        "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
-      },
-      "terminal_notification_channel": {
-        "kind": "email_cli",
-        "execution_repo": "rather-not-work-on/monday",
-        "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
-      }
-    },
-    "primary_operator_channel": {
-      "kind": "slack_skill_cli",
-      "execution_repo": "rather-not-work-on/monday",
-      "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
-    },
-    "terminal_notification_channel": {
-      "kind": "email_cli",
-      "execution_repo": "rather-not-work-on/monday",
-      "adapter_contract_ref": "planningops/contracts/operator-channel-adapter-contract.md"
-    },
-    "next_goal_key": "uap-goal-driven-autonomy-wave20"
-  }
+  "active_goal_key": "",
+  "resolved_goal": null
 }


### PR DESCRIPTION
## Summary
- refresh the committed active-goal registry validation artifact against the achieved no-active-goal registry state
- add a workbench packet and hub link for the artifact refresh

## Validation
- bash planningops/scripts/test_active_goal_registry_contract.sh
- python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --output planningops/artifacts/validation/active-goal-registry-report.json --strict
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all