### PR TITLE
chore(issue-quality): refresh validation artifact

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -144,6 +144,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Supervisor Handoff Sidecar Surface Packet](./plans/2026-03-28-supervisor-handoff-sidecar-surface-packet.md)
 - [Track1 Gate Artifact Refresh Packet](./plans/2026-03-28-track1-gate-artifact-refresh-packet.md)
 - [Active Goal Registry Artifact Refresh Packet](./plans/2026-03-28-active-goal-registry-artifact-refresh-packet.md)
+- [Issue Quality Artifact Refresh Packet](./plans/2026-03-28-issue-quality-artifact-refresh-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-issue-quality-artifact-refresh-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-issue-quality-artifact-refresh-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Issue Quality Artifact Refresh Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Refreshes the committed issue-quality validation artifact so canonical evidence matches the current in-scope planning issue set.
+related_docs:
+  - ./2026-03-26-issue-quality-helper-family-backfill-packet.md
+  - ./2026-03-28-federated-label-taxonomy-helper-sync-packet.md
+---
+
+# plan: Issue Quality Artifact Refresh Packet
+
+## Summary
+- Re-run the issue-quality validator against the current in-scope planning issues.
+- Refresh the committed validation report without touching label backfill side effects.
+- Keep the unit artifact-only: no helper, contract, or workflow logic changes.
+
+## Scope
+- `planningops/artifacts/validation/issue-quality-report.json`
+- workbench hub link for this packet
+
+## Acceptance
+- `test_validate_issue_quality_contract.sh` passes
+- `python3 planningops/scripts/validate_issue_quality.py --strict` succeeds
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/validation/issue-quality-report.json
+++ b/planningops/artifacts/validation/issue-quality-report.json
@@ -1,9 +1,9 @@
 {
-  "generated_at_utc": "2026-03-15T06:30:23.329835+00:00",
+  "generated_at_utc": "2026-03-28T06:24:32.777158+00:00",
   "repo": "rather-not-work-on/platform-planningops",
   "rules_path": "planningops/config/issue-quality-rules.json",
-  "issues_scanned": 4,
-  "issues_in_scope": 4,
+  "issues_scanned": 3,
+  "issues_in_scope": 3,
   "violation_count": 0,
   "violations": [],
   "verdict": "pass"


### PR DESCRIPTION
## Summary
- refresh the committed issue-quality validation artifact for the current in-scope planning issues
- add a workbench packet and hub link for the artifact-only refresh
- keep label-backfill side effects out of scope for this unit

## Validation
- bash planningops/scripts/test_validate_issue_quality_contract.sh
- python3 planningops/scripts/validate_issue_quality.py --output planningops/artifacts/validation/issue-quality-report.json --strict
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all