### PR TITLE
chore(project-fields): refresh schema validation artifact

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -145,6 +145,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Track1 Gate Artifact Refresh Packet](./plans/2026-03-28-track1-gate-artifact-refresh-packet.md)
 - [Active Goal Registry Artifact Refresh Packet](./plans/2026-03-28-active-goal-registry-artifact-refresh-packet.md)
 - [Issue Quality Artifact Refresh Packet](./plans/2026-03-28-issue-quality-artifact-refresh-packet.md)
+- [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-project-field-schema-artifact-refresh-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-project-field-schema-artifact-refresh-packet.md
@@ -1,0 +1,28 @@
+---
+title: plan: Project Field Schema Artifact Refresh Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Refreshes the committed project-field-schema validation artifact so canonical validation evidence matches the current schema contract.
+related_docs:
+  - ./2026-03-28-track1-gate-artifact-refresh-packet.md
+---
+
+# plan: Project Field Schema Artifact Refresh Packet
+
+## Summary
+- Re-run the project field schema validator against the current PlanningOps project schema.
+- Refresh the committed schema validation report without changing validator behavior.
+- Keep the unit artifact-only: no helper, workflow, or contract logic changes.
+
+## Scope
+- `planningops/artifacts/validation/project-field-schema-report.json`
+- workbench hub link for this packet
+
+## Acceptance
+- `python3 planningops/scripts/validate_project_field_schema.py --fail-on-mismatch` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/validation/project-field-schema-report.json
+++ b/planningops/artifacts/validation/project-field-schema-report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-03-28T06:19:41.336068+00:00",
+  "generated_at_utc": "2026-03-28T06:27:59.490653+00:00",
   "project": {
     "owner": "rather-not-work-on",
     "project_num": 2,


### PR DESCRIPTION
## Summary
- refresh the committed project-field-schema validation artifact
- add a workbench packet and hub link for the artifact-only refresh
- keep validator and workflow logic unchanged

## Validation
- python3 planningops/scripts/validate_project_field_schema.py --fail-on-mismatch
- bash planningops/scripts/test_validate_project_field_schema_matrix.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all