### PR TITLE
chore(plan-projection): refresh validation artifact

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -146,6 +146,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Active Goal Registry Artifact Refresh Packet](./plans/2026-03-28-active-goal-registry-artifact-refresh-packet.md)
 - [Issue Quality Artifact Refresh Packet](./plans/2026-03-28-issue-quality-artifact-refresh-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
+- [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-plan-projection-artifact-refresh-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-plan-projection-artifact-refresh-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Plan Projection Artifact Refresh Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Refreshes the committed plan-projection validation artifact so canonical sample projection evidence matches the current verifier output.
+related_docs:
+  - ./2026-03-28-project-field-schema-artifact-refresh-packet.md
+---
+
+# plan: Plan Projection Artifact Refresh Packet
+
+## Summary
+- Re-run the sample plan projection verifier against the committed sample contract and snapshot fixtures.
+- Refresh the committed projection validation report without changing verifier behavior.
+- Keep the unit artifact-only: no helper, workflow, or contract logic changes.
+
+## Scope
+- `planningops/artifacts/validation/plan-projection-report.json`
+- workbench hub link for this packet
+
+## Acceptance
+- `test_verify_plan_projection_contract.sh` passes
+- `python3 planningops/scripts/verify_plan_projection.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --snapshot-file planningops/fixtures/plan-projection-snapshot-sample.json --strict --output planningops/artifacts/validation/plan-projection-report.json` succeeds
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/validation/plan-projection-report.json
+++ b/planningops/artifacts/validation/plan-projection-report.json
@@ -1,23 +1,26 @@
 {
-  "generated_at_utc": "2026-03-04T00:49:03.323162+00:00",
+  "generated_at_utc": "2026-03-28T06:29:03.124714+00:00",
   "contract_file": "planningops/fixtures/plan-execution-contract-sample.json",
   "snapshot_file": "planningops/fixtures/plan-projection-snapshot-sample.json",
   "project": {
     "owner": "rather-not-work-on",
     "project_number": 2,
     "initiative": "unified-personal-agent-platform",
-    "limit": 200
+    "limit": 1000
   },
   "validation_errors": [],
   "plan_id": "sample-pec-plan",
   "plan_revision": 1,
   "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-03-plan-auto-executable-plans-contract-and-runner-plan.md",
   "expected_items_total": 1,
+  "project_items_limit_hit": false,
   "mode": "snapshot",
   "project_items_scanned": 1,
   "actual_items_total": 1,
   "duplicate_plan_item_id_count": 0,
   "duplicate_plan_item_ids": [],
+  "relevant_duplicate_plan_item_id_count": 0,
+  "relevant_duplicate_plan_item_ids": [],
   "missing_count": 0,
   "mismatch_count": 0,
   "unexpected_count": 0,


### PR DESCRIPTION
## Summary
- refresh the committed sample plan-projection validation artifact
- add a workbench packet and hub link for the artifact-only refresh
- keep verifier and workflow logic unchanged

## Validation
- bash planningops/scripts/test_verify_plan_projection_contract.sh
- python3 planningops/scripts/verify_plan_projection.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --snapshot-file planningops/fixtures/plan-projection-snapshot-sample.json --strict --output planningops/artifacts/validation/plan-projection-report.json
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all