### PR TITLE
chore(plan-compile): refresh validation artifact

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -147,6 +147,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Issue Quality Artifact Refresh Packet](./plans/2026-03-28-issue-quality-artifact-refresh-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)
+- [Plan Compile Artifact Refresh Packet](./plans/2026-03-28-plan-compile-artifact-refresh-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-plan-compile-artifact-refresh-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-plan-compile-artifact-refresh-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Plan Compile Artifact Refresh Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Refreshes the committed plan-compile validation artifact so canonical sample backlog compilation evidence matches the current compiler output.
+related_docs:
+  - ./2026-03-28-plan-projection-artifact-refresh-packet.md
+---
+
+# plan: Plan Compile Artifact Refresh Packet
+
+## Summary
+- Re-run the sample backlog compiler against the committed sample execution contract.
+- Refresh the committed compile validation report without changing compiler behavior.
+- Keep the unit artifact-only: no helper, workflow, or contract logic changes.
+
+## Scope
+- `planningops/artifacts/validation/plan-compile-report.json`
+- workbench hub link for this packet
+
+## Acceptance
+- `test_compile_plan_to_backlog_contract.sh` passes
+- `python3 planningops/scripts/compile_plan_to_backlog.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --output planningops/artifacts/validation/plan-compile-report.json` succeeds
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/validation/plan-compile-report.json
+++ b/planningops/artifacts/validation/plan-compile-report.json
@@ -1,13 +1,13 @@
 {
   "mode": "dry-run",
-  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20.execution-contract.json",
+  "contract_file": "planningops/fixtures/plan-execution-contract-sample.json",
   "validation_errors": [],
   "results": [
     {
-      "plan_item_id": "T10",
-      "execution_order": 10,
+      "plan_item_id": "sample-001",
+      "execution_order": 1,
       "issue_number": null,
-      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-10",
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-1",
       "created_issue": true,
       "dedup_match_state": null,
       "dedup_strategy": null,
@@ -27,88 +27,14 @@
         "loop_profile(l1_contract_clarification)",
         "plan_lane(m1_contract_freeze)"
       ]
-    },
-    {
-      "plan_item_id": "T20",
-      "execution_order": 20,
-      "issue_number": null,
-      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-20",
-      "created_issue": true,
-      "dedup_match_state": null,
-      "dedup_strategy": null,
-      "reused_closed_issue": false,
-      "reopened_closed_issue": false,
-      "closed_match_detected": false,
-      "closed_match_issue_number": null,
-      "metadata_sync_required": false,
-      "metadata_sync_action": "none",
-      "field_updates": [
-        "initiative(text)",
-        "target_repo(text)",
-        "execution_order(number)",
-        "status(todo)",
-        "component(runtime)",
-        "workflow_state(ready_implementation)",
-        "loop_profile(l3_implementation_tdd)",
-        "plan_lane(m2_sync_core)"
-      ]
-    },
-    {
-      "plan_item_id": "T30",
-      "execution_order": 30,
-      "issue_number": null,
-      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-30",
-      "created_issue": true,
-      "dedup_match_state": null,
-      "dedup_strategy": null,
-      "reused_closed_issue": false,
-      "reopened_closed_issue": false,
-      "closed_match_detected": false,
-      "closed_match_issue_number": null,
-      "metadata_sync_required": false,
-      "metadata_sync_action": "none",
-      "field_updates": [
-        "initiative(text)",
-        "target_repo(text)",
-        "execution_order(number)",
-        "status(todo)",
-        "component(runtime)",
-        "workflow_state(ready_implementation)",
-        "loop_profile(l3_implementation_tdd)",
-        "plan_lane(m2_sync_core)"
-      ]
-    },
-    {
-      "plan_item_id": "T40",
-      "execution_order": 40,
-      "issue_number": null,
-      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/DRY-RUN-40",
-      "created_issue": true,
-      "dedup_match_state": null,
-      "dedup_strategy": null,
-      "reused_closed_issue": false,
-      "reopened_closed_issue": false,
-      "closed_match_detected": false,
-      "closed_match_issue_number": null,
-      "metadata_sync_required": false,
-      "metadata_sync_action": "none",
-      "field_updates": [
-        "initiative(text)",
-        "target_repo(text)",
-        "execution_order(number)",
-        "status(in_progress)",
-        "component(planningops)",
-        "workflow_state(review_gate)",
-        "loop_profile(l4_integration_reconcile)",
-        "plan_lane(m3_guardrails)"
-      ]
     }
   ],
-  "plan_id": "uap-goal-driven-autonomy-wave20",
+  "plan_id": "sample-pec-plan",
   "plan_revision": 1,
-  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md",
-  "items_total": 4,
-  "open_issues_scanned": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-03-plan-auto-executable-plans-contract-and-runner-plan.md",
+  "items_total": 1,
+  "issues_source": "github_api",
+  "open_issues_scanned": 3,
   "closed_issues_scanned": 0,
   "verdict": "pass"
 }


### PR DESCRIPTION
## Summary
- refresh the committed sample plan-compile validation artifact
- add a workbench packet and hub link for the artifact-only refresh
- keep compiler and workflow logic unchanged

## Validation
- bash planningops/scripts/test_compile_plan_to_backlog_contract.sh
- python3 planningops/scripts/compile_plan_to_backlog.py --contract-file planningops/fixtures/plan-execution-contract-sample.json --output planningops/artifacts/validation/plan-compile-report.json
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all