### PR TITLE
chore(meta-plan): refresh execution artifact

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -148,6 +148,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)
 - [Plan Compile Artifact Refresh Packet](./plans/2026-03-28-plan-compile-artifact-refresh-packet.md)
+- [Meta Plan Execution Artifact Refresh Packet](./plans/2026-03-28-meta-plan-execution-artifact-refresh-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-meta-plan-execution-artifact-refresh-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-meta-plan-execution-artifact-refresh-packet.md
@@ -1,0 +1,29 @@
+---
+title: plan: Meta Plan Execution Artifact Refresh Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Refreshes the committed meta-plan execution report so canonical sample orchestration evidence matches the current dry-run orchestrator output.
+related_docs:
+  - ./2026-03-28-plan-compile-artifact-refresh-packet.md
+---
+
+# plan: Meta Plan Execution Artifact Refresh Packet
+
+## Summary
+- Re-run the sample meta-plan orchestrator in dry-run mode against the committed meta-graph contract.
+- Refresh the committed execution report without changing orchestrator behavior.
+- Keep the unit artifact-only: no helper, workflow, or contract logic changes.
+
+## Scope
+- `planningops/artifacts/meta-plan/meta-execution-report.json`
+- workbench hub link for this packet
+
+## Acceptance
+- `test_meta_plan_orchestrator_contract.sh` passes
+- `python3 planningops/scripts/meta_plan_orchestrator.py --meta-graph-contract planningops/fixtures/meta-plan-graph-sample.json --schema-file planningops/schemas/meta-plan-graph.schema.json --meta-graph-output planningops/artifacts/meta-plan/meta-graph.json --output planningops/artifacts/meta-plan/meta-execution-report.json --mode dry-run --strict` succeeds
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/meta-plan/meta-execution-report.json
+++ b/planningops/artifacts/meta-plan/meta-execution-report.json
@@ -1,7 +1,8 @@
 {
-  "generated_at_utc": "2026-03-04T01:04:06.631055+00:00",
+  "generated_at_utc": "2026-03-28T06:32:19.439557+00:00",
   "mode": "dry-run",
   "meta_graph_contract": "planningops/fixtures/meta-plan-graph-sample.json",
+  "schema_file": "planningops/schemas/meta-plan-graph.schema.json",
   "meta_graph_output": "planningops/artifacts/meta-plan/meta-graph.json",
   "validation_errors": [],
   "meta_plan_id": "uap-meta-20260303",


### PR DESCRIPTION
## Summary
- refresh the committed sample meta-plan execution artifact
- add a workbench packet and hub link for the artifact-only refresh
- keep orchestrator and workflow logic unchanged

## Validation
- bash planningops/scripts/test_meta_plan_orchestrator_contract.sh
- python3 planningops/scripts/meta_plan_orchestrator.py --meta-graph-contract planningops/fixtures/meta-plan-graph-sample.json --schema-file planningops/schemas/meta-plan-graph.schema.json --meta-graph-output planningops/artifacts/meta-plan/meta-graph.json --output planningops/artifacts/meta-plan/meta-execution-report.json --mode dry-run --strict
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all