### PR TITLE
test(backlog-materialize): extract sample issue fixtures

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -149,6 +149,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)
 - [Plan Compile Artifact Refresh Packet](./plans/2026-03-28-plan-compile-artifact-refresh-packet.md)
 - [Meta Plan Execution Artifact Refresh Packet](./plans/2026-03-28-meta-plan-execution-artifact-refresh-packet.md)
+- [Backlog Materialize Sample Fixture Packet](./plans/2026-03-28-backlog-materialize-sample-fixture-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-sample-fixture-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-sample-fixture-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Backlog Materialize Sample Fixture Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Extracts deterministic sample issue fixtures for program-manifest and issue-label backfill contract coverage.
+related_docs:
+  - ./2026-03-28-meta-plan-execution-artifact-refresh-packet.md
+---
+
+# plan: Backlog Materialize Sample Fixture Packet
+
+## Summary
+- Add reusable sample issues fixtures for program manifest and label backfill contract tests.
+- Remove large inline JSON payloads from the shell tests.
+- Keep the unit test-only so later live artifact refreshes can target deterministic fixture-backed evidence.
+
+## Scope
+- `planningops/fixtures/program-manifest-sample-issues.json`
+- `planningops/fixtures/issue-label-backfill-sample-issues.json`
+- `planningops/scripts/test_build_program_manifest_contract.sh`
+- `planningops/scripts/test_backfill_issue_labels_contract.sh`
+
+## Acceptance
+- `test_build_program_manifest_contract.sh` passes
+- `test_backfill_issue_labels_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/fixtures/issue-label-backfill-sample-issues.json
+++ b/planningops/fixtures/issue-label-backfill-sample-issues.json
@@ -1,0 +1,12 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 60,
+    "state": "open",
+    "updated_at": "2026-03-12T00:00:00+00:00",
+    "title": "plan: [60] Add recurring backlog materialization runner",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/60",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- plan_id: `uap-backlog-wave26`\n- plan_revision: `1`\n- plan_item_id: `A60`\n- execution_order: `60`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `-`\n- primary_output: `planningops/scripts/core/backlog/materialize.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- `planningops/scripts/core/backlog/materialize.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
+    "labels": []
+  }
+]

--- a/planningops/fixtures/program-manifest-sample-issues.json
+++ b/planningops/fixtures/program-manifest-sample-issues.json
@@ -1,0 +1,29 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 94,
+    "state": "open",
+    "updated_at": "2026-03-10T12:00:00Z",
+    "title": "[PO-CT][A00]",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/94",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- plan_item_id: `A00`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `orchestrator`\n- workflow_state: `ready-contract`\n- loop_profile: `l1_contract_clarification`\n- execution_order: `1000`\n- depends_on: `none`\n- plan_lane: `M0 Bootstrap`"
+  },
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 95,
+    "state": "open",
+    "updated_at": "2026-03-10T13:00:00Z",
+    "title": "[PO-CT][A10]",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/95",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- plan_item_id: `A10`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready-contract`\n- loop_profile: `l1_contract_clarification`\n- execution_order: `1010`\n- depends_on: `A00 (rather-not-work-on/platform-planningops#94)`\n- plan_lane: `M0 Bootstrap`"
+  },
+  {
+    "repo": "rather-not-work-on/platform-contracts",
+    "number": 2,
+    "state": "open",
+    "updated_at": "2026-03-10T14:00:00Z",
+    "title": "[PO-CT][B10]",
+    "url": "https://github.com/rather-not-work-on/platform-contracts/issues/2",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- plan_item_id: `B10`\n- target_repo: `rather-not-work-on/platform-contracts`\n- component: `contracts`\n- workflow_state: `ready-contract`\n- loop_profile: `l1_contract_clarification`\n- execution_order: `2100`\n- depends_on: `A10 (rather-not-work-on/platform-planningops#95)`\n- plan_lane: `M1 Contract Freeze`"
+  }
+]

--- a/planningops/scripts/test_backfill_issue_labels_contract.sh
+++ b/planningops/scripts/test_backfill_issue_labels_contract.sh
@@ -7,20 +7,7 @@ trap 'rm -rf "$tmpdir"' EXIT
 issues_file="$tmpdir/issues.json"
 report_file="$tmpdir/report.json"
 
-cat >"$issues_file" <<'JSON'
-[
-  {
-    "repo": "rather-not-work-on/platform-planningops",
-    "number": 60,
-    "state": "open",
-    "updated_at": "2026-03-12T00:00:00+00:00",
-    "title": "plan: [60] Add recurring backlog materialization runner",
-    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/60",
-    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- plan_id: `uap-backlog-wave26`\n- plan_revision: `1`\n- plan_item_id: `A60`\n- execution_order: `60`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `-`\n- primary_output: `planningops/scripts/core/backlog/materialize.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- `planningops/scripts/core/backlog/materialize.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
-    "labels": []
-  }
-]
-JSON
+cp planningops/fixtures/issue-label-backfill-sample-issues.json "$issues_file"
 
 python3 planningops/scripts/backfill_issue_labels.py \
   --repo rather-not-work-on/platform-planningops \

--- a/planningops/scripts/test_build_program_manifest_contract.sh
+++ b/planningops/scripts/test_build_program_manifest_contract.sh
@@ -19,74 +19,9 @@ with tempfile.TemporaryDirectory() as td:
     output_path = td_path / "program-manifest.json"
     report_path = td_path / "program-manifest-report.json"
 
-    base_issues = [
-        {
-            "repo": "rather-not-work-on/platform-planningops",
-            "number": 94,
-            "state": "open",
-            "updated_at": "2026-03-10T12:00:00Z",
-            "title": "[PO-CT][A00]",
-            "url": "https://github.com/rather-not-work-on/platform-planningops/issues/94",
-            "body": "\n".join(
-                [
-                    "## Planning Context",
-                    "- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`",
-                    "- plan_item_id: `A00`",
-                    "- target_repo: `rather-not-work-on/platform-planningops`",
-                    "- component: `orchestrator`",
-                    "- workflow_state: `ready-contract`",
-                    "- loop_profile: `l1_contract_clarification`",
-                    "- execution_order: `1000`",
-                    "- depends_on: `none`",
-                    "- plan_lane: `M0 Bootstrap`",
-                ]
-            ),
-        },
-        {
-            "repo": "rather-not-work-on/platform-planningops",
-            "number": 95,
-            "state": "open",
-            "updated_at": "2026-03-10T13:00:00Z",
-            "title": "[PO-CT][A10]",
-            "url": "https://github.com/rather-not-work-on/platform-planningops/issues/95",
-            "body": "\n".join(
-                [
-                    "## Planning Context",
-                    "- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`",
-                    "- plan_item_id: `A10`",
-                    "- target_repo: `rather-not-work-on/platform-planningops`",
-                    "- component: `planningops`",
-                    "- workflow_state: `ready-contract`",
-                    "- loop_profile: `l1_contract_clarification`",
-                    "- execution_order: `1010`",
-                    "- depends_on: `A00 (rather-not-work-on/platform-planningops#94)`",
-                    "- plan_lane: `M0 Bootstrap`",
-                ]
-            ),
-        },
-        {
-            "repo": "rather-not-work-on/platform-contracts",
-            "number": 2,
-            "state": "open",
-            "updated_at": "2026-03-10T14:00:00Z",
-            "title": "[PO-CT][B10]",
-            "url": "https://github.com/rather-not-work-on/platform-contracts/issues/2",
-            "body": "\n".join(
-                [
-                    "## Planning Context",
-                    "- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`",
-                    "- plan_item_id: `B10`",
-                    "- target_repo: `rather-not-work-on/platform-contracts`",
-                    "- component: `contracts`",
-                    "- workflow_state: `ready-contract`",
-                    "- loop_profile: `l1_contract_clarification`",
-                    "- execution_order: `2100`",
-                    "- depends_on: `A10 (rather-not-work-on/platform-planningops#95)`",
-                    "- plan_lane: `M1 Contract Freeze`",
-                ]
-            ),
-        },
-    ]
+    base_issues = json.loads(
+        Path("planningops/fixtures/program-manifest-sample-issues.json").read_text(encoding="utf-8")
+    )
 
     issues_path.write_text(json.dumps(base_issues, ensure_ascii=True, indent=2), encoding="utf-8")
     rc, out, err = run(


### PR DESCRIPTION
## Summary
- add reusable sample issue fixtures for program-manifest and issue-label backfill contract tests
- remove large inline JSON payloads from the shell regressions
- document the fixture extraction in the workbench hub

## Validation
- bash planningops/scripts/test_build_program_manifest_contract.sh
- bash planningops/scripts/test_backfill_issue_labels_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all