### PR TITLE
test(backlog-materialize): add sample fixture smoke

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -150,6 +150,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Plan Compile Artifact Refresh Packet](./plans/2026-03-28-plan-compile-artifact-refresh-packet.md)
 - [Meta Plan Execution Artifact Refresh Packet](./plans/2026-03-28-meta-plan-execution-artifact-refresh-packet.md)
 - [Backlog Materialize Sample Fixture Packet](./plans/2026-03-28-backlog-materialize-sample-fixture-packet.md)
+- [Backlog Materialize Sample Fixture Smoke Packet](./plans/2026-03-28-backlog-materialize-sample-fixture-smoke-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-sample-fixture-smoke-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-sample-fixture-smoke-packet.md
@@ -1,0 +1,28 @@
+---
+title: plan: Backlog Materialize Sample Fixture Smoke Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Adds a smoke regression that drives the new offline manifest and label fixtures through the real backlog materialization CLIs.
+related_docs:
+  - ./2026-03-28-backlog-materialize-sample-fixture-packet.md
+---
+
+# plan: Backlog Materialize Sample Fixture Smoke Packet
+
+## Summary
+- Run the sample manifest fixture through `build_program_manifest.py`.
+- Run the sample label fixture through `backfill_issue_labels.py`.
+- Assert the combined offline materialization flow stays deterministic.
+
+## Scope
+- `planningops/scripts/test_backlog_materialize_sample_fixture_smoke.sh`
+- `planningops/scripts/README.md`
+
+## Acceptance
+- `test_backlog_materialize_sample_fixture_smoke.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -556,6 +556,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_active_goal_registry_contract.sh`
   - `test_backfill_issue_labels_contract.sh`
   - `test_backlog_materialization_contract.sh`
+  - `test_backlog_materialize_sample_fixture_smoke.sh`
   - `test_build_program_manifest_contract.sh`
   - `test_compile_plan_to_backlog_contract.sh`
   - `test_sync_project_fields_after_issue_create_contract.sh`

--- a/planningops/scripts/test_backlog_materialize_sample_fixture_smoke.sh
+++ b/planningops/scripts/test_backlog_materialize_sample_fixture_smoke.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+manifest_issues="$tmpdir/program-manifest-issues.json"
+label_issues="$tmpdir/issue-label-issues.json"
+manifest_output="$tmpdir/program-manifest.json"
+manifest_report="$tmpdir/program-manifest-report.json"
+label_report="$tmpdir/issue-label-backfill-report.json"
+
+cp planningops/fixtures/program-manifest-sample-issues.json "$manifest_issues"
+cp planningops/fixtures/issue-label-backfill-sample-issues.json "$label_issues"
+
+python3 planningops/scripts/build_program_manifest.py \
+  --issues-file "$manifest_issues" \
+  --output "$manifest_output" \
+  --report-output "$manifest_report" \
+  --strict
+
+python3 planningops/scripts/backfill_issue_labels.py \
+  --repo rather-not-work-on/platform-planningops \
+  --issues-file "$label_issues" \
+  --write-updated-issues-file "$label_issues" \
+  --output "$label_report" \
+  --apply
+
+python3 - <<'PY' "$manifest_output" "$manifest_report" "$label_issues" "$label_report"
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+manifest_report = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+label_issues = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+label_report = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
+
+assert manifest["item_count"] == 3, manifest
+assert [row["plan_item_id"] for row in manifest["items"]] == ["A00", "A10", "B10"], manifest
+assert manifest_report["verdict"] == "pass", manifest_report
+assert manifest_report["duplicate_group_count"] == 0, manifest_report
+
+assert len(label_issues) == 1, label_issues
+labels = sorted(label["name"] for label in label_issues[0]["labels"])
+assert labels == ["area/planningops", "p2", "task", "type/hardening"], labels
+assert label_report["mode"] == "apply", label_report
+assert label_report["issues_applied"] == 1, label_report
+
+print("backlog materialize sample fixture smoke ok")
+PY


### PR DESCRIPTION
## Summary
- add a smoke regression that drives the new offline manifest and label fixtures through the real CLIs
- document the smoke coverage in the scripts inventory and workbench hub
- keep the unit test-only with no live artifact rewrites

## Validation
- bash planningops/scripts/test_backlog_materialize_sample_fixture_smoke.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all