### PR TITLE
test(backlog-materialize): add snapshot regression

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -151,6 +151,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Meta Plan Execution Artifact Refresh Packet](./plans/2026-03-28-meta-plan-execution-artifact-refresh-packet.md)
 - [Backlog Materialize Sample Fixture Packet](./plans/2026-03-28-backlog-materialize-sample-fixture-packet.md)
 - [Backlog Materialize Sample Fixture Smoke Packet](./plans/2026-03-28-backlog-materialize-sample-fixture-smoke-packet.md)
+- [Backlog Materialize Snapshot Regression Packet](./plans/2026-03-28-backlog-materialize-snapshot-regression-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-snapshot-regression-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-snapshot-regression-packet.md
@@ -1,0 +1,32 @@
+---
+title: plan: Backlog Materialize Snapshot Regression Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Adds canonical expected-output fixtures and a regression that compares offline backlog materialization CLI outputs to normalized sample snapshots.
+related_docs:
+  - ./2026-03-28-backlog-materialize-sample-fixture-smoke-packet.md
+---
+
+# plan: Backlog Materialize Snapshot Regression Packet
+
+## Summary
+- Store canonical expected outputs for the sample program manifest and label backfill flows.
+- Normalize timestamp and temp-path noise before comparison.
+- Lock the offline materialization path to exact sample snapshots.
+
+## Scope
+- `planningops/fixtures/program-manifest-sample.expected.json`
+- `planningops/fixtures/program-manifest-report-sample.expected.json`
+- `planningops/fixtures/issue-label-backfill-sample-updated-issues.expected.json`
+- `planningops/fixtures/issue-label-backfill-report-sample.expected.json`
+- `planningops/scripts/test_backlog_materialize_sample_snapshot_contract.sh`
+
+## Acceptance
+- `test_backlog_materialize_sample_snapshot_contract.sh` passes
+- `test_module_readme_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/fixtures/issue-label-backfill-report-sample.expected.json
+++ b/planningops/fixtures/issue-label-backfill-report-sample.expected.json
@@ -1,0 +1,27 @@
+{
+  "generated_at_utc": "__GENERATED_AT__",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_file": "__ISSUES_FILE__",
+  "write_updated_issues_file": "__UPDATED_ISSUES_FILE__",
+  "mode": "apply",
+  "issues_in_scope": 1,
+  "issues_with_missing_labels": 1,
+  "issues_applied": 1,
+  "rows": [
+    {
+      "number": 60,
+      "title": "plan: [60] Add recurring backlog materialization runner",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/60",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied_local",
+      "error": ""
+    }
+  ]
+}

--- a/planningops/fixtures/issue-label-backfill-sample-updated-issues.expected.json
+++ b/planningops/fixtures/issue-label-backfill-sample-updated-issues.expected.json
@@ -1,0 +1,25 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 60,
+    "state": "open",
+    "updated_at": "2026-03-12T00:00:00+00:00",
+    "title": "plan: [60] Add recurring backlog materialization runner",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/60",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- plan_id: `uap-backlog-wave26`\n- plan_revision: `1`\n- plan_item_id: `A60`\n- execution_order: `60`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `-`\n- primary_output: `planningops/scripts/core/backlog/materialize.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- `planningops/scripts/core/backlog/materialize.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
+    "labels": [
+      {
+        "name": "area/planningops"
+      },
+      {
+        "name": "p2"
+      },
+      {
+        "name": "task"
+      },
+      {
+        "name": "type/hardening"
+      }
+    ]
+  }
+]

--- a/planningops/fixtures/program-manifest-report-sample.expected.json
+++ b/planningops/fixtures/program-manifest-report-sample.expected.json
@@ -1,0 +1,27 @@
+{
+  "generated_at_utc": "__GENERATED_AT__",
+  "program_id": "uap-po-ct-program",
+  "initiative": "unified-personal-agent-platform",
+  "source_plan": "docs/workbench/unified-personal-agent-platform/plans/2026-03-05-plan-meta-backlog-atomic-decomposition-and-federated-delivery-plan.md",
+  "repos": [
+    "rather-not-work-on/platform-planningops",
+    "rather-not-work-on/platform-contracts",
+    "rather-not-work-on/platform-provider-gateway",
+    "rather-not-work-on/platform-observability-gateway",
+    "rather-not-work-on/monday"
+  ],
+  "issues_file": "__ISSUES_FILE__",
+  "verdict": "pass",
+  "errors": [],
+  "issues_scanned": 3,
+  "filtered_out_count": 0,
+  "item_count": 3,
+  "duplicate_group_count": 0,
+  "duplicate_groups": [],
+  "track_summary": {
+    "control_plane": 2,
+    "federated_runtime": 1,
+    "reconciliation": 0,
+    "unknown": 0
+  }
+}

--- a/planningops/fixtures/program-manifest-sample.expected.json
+++ b/planningops/fixtures/program-manifest-sample.expected.json
@@ -1,0 +1,76 @@
+{
+  "manifest_version": 1,
+  "program_id": "uap-po-ct-program",
+  "initiative": "unified-personal-agent-platform",
+  "source_plan": "docs/workbench/unified-personal-agent-platform/plans/2026-03-05-plan-meta-backlog-atomic-decomposition-and-federated-delivery-plan.md",
+  "scope_source_plan": false,
+  "generated_at_utc": "__GENERATED_AT__",
+  "selection_policy": "dedupe_by_plan_item_id_and_target_repo_open_first_then_latest_update",
+  "item_count": 3,
+  "items": [
+    {
+      "plan_item_id": "A00",
+      "track": "control_plane",
+      "execution_order": 1000,
+      "target_repo": "rather-not-work-on/platform-planningops",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 94,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/94",
+      "issue_state": "open",
+      "issue_updated_at": "2026-03-10T12:00:00Z",
+      "component": "orchestrator",
+      "workflow_state": "ready-contract",
+      "loop_profile": "l1_contract_clarification",
+      "plan_lane": "M0 Bootstrap",
+      "depends_on": [],
+      "interface_contract_refs": "",
+      "package_topology_ref": "",
+      "dependency_manifest_ref": "",
+      "file_plan_ref": ""
+    },
+    {
+      "plan_item_id": "A10",
+      "track": "control_plane",
+      "execution_order": 1010,
+      "target_repo": "rather-not-work-on/platform-planningops",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 95,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/95",
+      "issue_state": "open",
+      "issue_updated_at": "2026-03-10T13:00:00Z",
+      "component": "planningops",
+      "workflow_state": "ready-contract",
+      "loop_profile": "l1_contract_clarification",
+      "plan_lane": "M0 Bootstrap",
+      "depends_on": [
+        "A00"
+      ],
+      "interface_contract_refs": "",
+      "package_topology_ref": "",
+      "dependency_manifest_ref": "",
+      "file_plan_ref": ""
+    },
+    {
+      "plan_item_id": "B10",
+      "track": "federated_runtime",
+      "execution_order": 2100,
+      "target_repo": "rather-not-work-on/platform-contracts",
+      "issue_repo": "rather-not-work-on/platform-contracts",
+      "issue_number": 2,
+      "issue_url": "https://github.com/rather-not-work-on/platform-contracts/issues/2",
+      "issue_state": "open",
+      "issue_updated_at": "2026-03-10T14:00:00Z",
+      "component": "contracts",
+      "workflow_state": "ready-contract",
+      "loop_profile": "l1_contract_clarification",
+      "plan_lane": "M1 Contract Freeze",
+      "depends_on": [
+        "A10"
+      ],
+      "interface_contract_refs": "",
+      "package_topology_ref": "",
+      "dependency_manifest_ref": "",
+      "file_plan_ref": ""
+    }
+  ]
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -557,6 +557,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_backfill_issue_labels_contract.sh`
   - `test_backlog_materialization_contract.sh`
   - `test_backlog_materialize_sample_fixture_smoke.sh`
+  - `test_backlog_materialize_sample_snapshot_contract.sh`
   - `test_build_program_manifest_contract.sh`
   - `test_compile_plan_to_backlog_contract.sh`
   - `test_sync_project_fields_after_issue_create_contract.sh`

--- a/planningops/scripts/test_backlog_materialize_sample_snapshot_contract.sh
+++ b/planningops/scripts/test_backlog_materialize_sample_snapshot_contract.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+manifest_issues="$tmpdir/program-manifest-issues.json"
+label_issues="$tmpdir/issue-label-issues.json"
+manifest_output="$tmpdir/program-manifest.json"
+manifest_report="$tmpdir/program-manifest-report.json"
+label_report="$tmpdir/issue-label-backfill-report.json"
+
+cp planningops/fixtures/program-manifest-sample-issues.json "$manifest_issues"
+cp planningops/fixtures/issue-label-backfill-sample-issues.json "$label_issues"
+
+python3 planningops/scripts/build_program_manifest.py \
+  --issues-file "$manifest_issues" \
+  --output "$manifest_output" \
+  --report-output "$manifest_report" \
+  --strict
+
+python3 planningops/scripts/backfill_issue_labels.py \
+  --repo rather-not-work-on/platform-planningops \
+  --issues-file "$label_issues" \
+  --write-updated-issues-file "$label_issues" \
+  --output "$label_report" \
+  --apply
+
+python3 - <<'PY' \
+  "$manifest_output" \
+  "$manifest_report" \
+  "$label_issues" \
+  "$label_report" \
+  "planningops/fixtures/program-manifest-sample.expected.json" \
+  "planningops/fixtures/program-manifest-report-sample.expected.json" \
+  "planningops/fixtures/issue-label-backfill-sample-updated-issues.expected.json" \
+  "planningops/fixtures/issue-label-backfill-report-sample.expected.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize_manifest(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+def normalize_manifest_report(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    normalized["issues_file"] = "__ISSUES_FILE__"
+    return normalized
+
+
+def normalize_label_report(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    normalized["issues_file"] = "__ISSUES_FILE__"
+    normalized["write_updated_issues_file"] = "__UPDATED_ISSUES_FILE__"
+    return normalized
+
+
+actual_manifest = normalize_manifest(load(sys.argv[1]))
+actual_manifest_report = normalize_manifest_report(load(sys.argv[2]))
+actual_label_issues = load(sys.argv[3])
+actual_label_report = normalize_label_report(load(sys.argv[4]))
+
+expected_manifest = load(sys.argv[5])
+expected_manifest_report = load(sys.argv[6])
+expected_label_issues = load(sys.argv[7])
+expected_label_report = load(sys.argv[8])
+
+assert actual_manifest == expected_manifest, (actual_manifest, expected_manifest)
+assert actual_manifest_report == expected_manifest_report, (actual_manifest_report, expected_manifest_report)
+assert actual_label_issues == expected_label_issues, (actual_label_issues, expected_label_issues)
+assert actual_label_report == expected_label_report, (actual_label_report, expected_label_report)
+
+print("backlog materialize sample snapshot contract ok")
+PY


### PR DESCRIPTION
## Summary
- add canonical expected-output fixtures for the sample manifest and label backfill flows
- normalize timestamp and temp path noise before comparing actual CLI outputs to the expected snapshots
- document the new snapshot regression in the scripts inventory and workbench hub

## Validation
- bash planningops/scripts/test_backlog_materialize_sample_snapshot_contract.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all