### PR TITLE
test(backlog-materialize): add sample report smoke

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -151,6 +151,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Meta Plan Execution Artifact Refresh Packet](./plans/2026-03-28-meta-plan-execution-artifact-refresh-packet.md)
 - [Backlog Materialize Sample Fixture Packet](./plans/2026-03-28-backlog-materialize-sample-fixture-packet.md)
 - [Backlog Materialize Sample Fixture Smoke Packet](./plans/2026-03-28-backlog-materialize-sample-fixture-smoke-packet.md)
+- [Backlog Materialize Sample Report Smoke Packet](./plans/2026-03-28-backlog-materialize-sample-report-smoke-packet.md)
 - [Backlog Materialize Snapshot Regression Packet](./plans/2026-03-28-backlog-materialize-snapshot-regression-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-sample-report-smoke-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-sample-report-smoke-packet.md
@@ -1,0 +1,33 @@
+---
+title: plan: Backlog Materialize Sample Report Smoke Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Adds a real `core/backlog/materialize.py` dry-run smoke that drives the offline sample execution contract through compile, label, manifest, and issue-quality outputs.
+related_docs:
+  - ./2026-03-28-backlog-materialize-sample-fixture-packet.md
+  - ./2026-03-28-backlog-materialize-sample-fixture-smoke-packet.md
+  - ./2026-03-28-backlog-materialize-snapshot-regression-packet.md
+---
+
+# plan: Backlog Materialize Sample Report Smoke Packet
+
+## Summary
+- Extract the sample execution contract into a reusable fixture.
+- Run `core/backlog/materialize.py` in dry-run mode against that fixture.
+- Assert the combined compile, label, manifest, and issue-quality reports stay deterministic.
+
+## Scope
+- `planningops/fixtures/backlog-materialization-sample-contract.json`
+- `planningops/scripts/test_backlog_materialization_contract.sh`
+- `planningops/scripts/test_backlog_materialize_sample_report_smoke.sh`
+- `planningops/scripts/README.md`
+
+## Acceptance
+- `test_backlog_materialization_contract.sh` passes
+- `test_backlog_materialize_sample_report_smoke.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -7,6 +7,7 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `contracts/`: valid schema fixture payloads (C1~C5)
 - `plan-items/`: valid/invalid planning item sample sets
 - `plan-execution-contract-sample.json`: minimal valid PEC v1 sample
+- `backlog-materialization-sample-contract.json`: ready-implementation PEC sample for offline backlog materialization tests
 - `plan-projection-snapshot-sample.json`: sample project snapshot matching PEC sample
 - `meta-plan-graph-sample.json`: minimal valid MPG v1 graph sample
 - `worker-task-pack-sample.json`: minimal valid worker task pack sample

--- a/planningops/fixtures/backlog-materialization-sample-contract.json
+++ b/planningops/fixtures/backlog-materialization-sample-contract.json
@@ -1,0 +1,21 @@
+{
+  "execution_contract": {
+    "plan_id": "uap-backlog-wave26",
+    "plan_revision": 1,
+    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md",
+    "items": [
+      {
+        "plan_item_id": "A60",
+        "execution_order": 60,
+        "title": "Add recurring backlog materialization runner",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "workflow_state": "ready_implementation",
+        "loop_profile": "l4_integration_reconcile",
+        "plan_lane": "m3_guardrails",
+        "depends_on": [],
+        "primary_output": "planningops/scripts/core/backlog/materialize.py"
+      }
+    ]
+  }
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -557,6 +557,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_backfill_issue_labels_contract.sh`
   - `test_backlog_materialization_contract.sh`
   - `test_backlog_materialize_sample_fixture_smoke.sh`
+  - `test_backlog_materialize_sample_report_smoke.sh`
   - `test_backlog_materialize_sample_snapshot_contract.sh`
   - `test_build_program_manifest_contract.sh`
   - `test_compile_plan_to_backlog_contract.sh`

--- a/planningops/scripts/test_backlog_materialization_contract.sh
+++ b/planningops/scripts/test_backlog_materialization_contract.sh
@@ -15,35 +15,7 @@ spec.loader.exec_module(mod)
 
 with tempfile.TemporaryDirectory() as td:
     td_path = Path(td)
-    contract_path = td_path / "execution-contract.json"
-    contract_path.write_text(
-        json.dumps(
-            {
-                "execution_contract": {
-                    "plan_id": "uap-backlog-wave26",
-                    "plan_revision": 1,
-                    "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md",
-                    "items": [
-                        {
-                            "plan_item_id": "A60",
-                            "execution_order": 60,
-                            "title": "Add recurring backlog materialization runner",
-                            "target_repo": "rather-not-work-on/platform-planningops",
-                            "component": "planningops",
-                            "workflow_state": "ready_implementation",
-                            "loop_profile": "l4_integration_reconcile",
-                            "plan_lane": "m3_guardrails",
-                            "depends_on": [],
-                            "primary_output": "planningops/scripts/core/backlog/materialize.py",
-                        }
-                    ],
-                }
-            },
-            ensure_ascii=True,
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+    contract_path = Path("planningops/fixtures/backlog-materialization-sample-contract.json")
 
     execution_contract = mod.load_execution_contract(contract_path)
     assert execution_contract["plan_id"] == "uap-backlog-wave26", execution_contract

--- a/planningops/scripts/test_backlog_materialize_sample_report_smoke.sh
+++ b/planningops/scripts/test_backlog_materialize_sample_report_smoke.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+contract_file="planningops/fixtures/backlog-materialization-sample-contract.json"
+compile_output="$tmpdir/plan-compile-report.json"
+label_output="$tmpdir/issue-label-backfill-report.json"
+manifest_output="$tmpdir/program-manifest.json"
+manifest_report="$tmpdir/program-manifest-report.json"
+quality_output="$tmpdir/issue-quality-report.json"
+projected_issues_output="$tmpdir/projected-issues.json"
+materialize_output="$tmpdir/materialize-report.json"
+
+python3 planningops/scripts/core/backlog/materialize.py \
+  --contract-file "$contract_file" \
+  --repo rather-not-work-on/platform-planningops \
+  --initiative unified-personal-agent-platform \
+  --compile-output "$compile_output" \
+  --label-output "$label_output" \
+  --manifest-output "$manifest_output" \
+  --manifest-report "$manifest_report" \
+  --quality-output "$quality_output" \
+  --projected-issues-output "$projected_issues_output" \
+  --output "$materialize_output"
+
+python3 - <<'PY' \
+  "$materialize_output" \
+  "$compile_output" \
+  "$label_output" \
+  "$manifest_output" \
+  "$manifest_report" \
+  "$quality_output" \
+  "$projected_issues_output"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+materialize_report = load(sys.argv[1])
+compile_report = load(sys.argv[2])
+label_report = load(sys.argv[3])
+manifest = load(sys.argv[4])
+manifest_report = load(sys.argv[5])
+quality_report = load(sys.argv[6])
+projected_issues = load(sys.argv[7])
+
+assert materialize_report["verdict"] == "pass", materialize_report
+assert materialize_report["mode"] == "dry-run", materialize_report
+assert materialize_report["plan_id"] == "uap-backlog-wave26", materialize_report
+assert materialize_report["projected_issue_count"] == 1, materialize_report
+assert materialize_report["projected_issues_output"] == sys.argv[7], materialize_report
+assert materialize_report["step_count"] == 4, materialize_report
+assert [step["name"] for step in materialize_report["steps"]] == [
+    "compile_plan_to_backlog",
+    "backfill_issue_labels",
+    "build_program_manifest",
+    "validate_issue_quality",
+], materialize_report["steps"]
+assert all(step["verdict"] == "pass" for step in materialize_report["steps"]), materialize_report["steps"]
+
+assert compile_report["verdict"] == "pass", compile_report
+assert compile_report["mode"] == "dry-run", compile_report
+assert compile_report["items_total"] == 1, compile_report
+assert compile_report["issues_source"] == f"file:{sys.argv[7]}", compile_report
+assert len(compile_report["results"]) == 1, compile_report
+assert compile_report["results"][0]["plan_item_id"] == "A60", compile_report["results"][0]
+assert compile_report["results"][0]["issue_number"] == 60, compile_report["results"][0]
+
+assert len(projected_issues) == 1, projected_issues
+assert projected_issues[0]["number"] == 60, projected_issues[0]
+assert sorted(label["name"] for label in projected_issues[0]["labels"]) == [
+    "area/planningops",
+    "p2",
+    "task",
+    "type/hardening",
+], projected_issues[0]
+
+assert label_report["mode"] == "apply", label_report
+assert label_report["issues_in_scope"] == 1, label_report
+assert label_report["issues_applied"] == 1, label_report
+
+assert manifest["item_count"] == 1, manifest
+assert [row["plan_item_id"] for row in manifest["items"]] == ["A60"], manifest
+assert manifest_report["verdict"] == "pass", manifest_report
+assert manifest_report["item_count"] == 1, manifest_report
+
+assert quality_report["verdict"] == "pass", quality_report
+assert quality_report["issues_in_scope"] == 1, quality_report
+assert quality_report["violation_count"] == 0, quality_report
+
+print("backlog materialize sample report smoke ok")
+PY


### PR DESCRIPTION
## Summary
- extract the backlog materialization sample execution contract into a reusable fixture
- add a real dry-run smoke for planningops/scripts/core/backlog/materialize.py against the offline fixture lane
- link the new regression in scripts docs and the workbench hub

## Validation
- bash planningops/scripts/test_backlog_materialization_contract.sh
- bash planningops/scripts/test_backlog_materialize_sample_report_smoke.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all