### PR TITLE
test(backlog-materialize): snapshot sample report lane

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -152,6 +152,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Backlog Materialize Sample Fixture Packet](./plans/2026-03-28-backlog-materialize-sample-fixture-packet.md)
 - [Backlog Materialize Sample Fixture Smoke Packet](./plans/2026-03-28-backlog-materialize-sample-fixture-smoke-packet.md)
 - [Backlog Materialize Sample Report Smoke Packet](./plans/2026-03-28-backlog-materialize-sample-report-smoke-packet.md)
+- [Backlog Materialize Sample Report Snapshot Packet](./plans/2026-03-28-backlog-materialize-sample-report-snapshot-packet.md)
 - [Backlog Materialize Snapshot Regression Packet](./plans/2026-03-28-backlog-materialize-snapshot-regression-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-sample-report-snapshot-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-sample-report-snapshot-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Backlog Materialize Sample Report Snapshot Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Locks the full offline `core/backlog/materialize.py` dry-run lane with normalized report and projected-issue snapshots.
+related_docs:
+  - ./2026-03-28-backlog-materialize-sample-report-smoke-packet.md
+  - ./2026-03-28-backlog-materialize-snapshot-regression-packet.md
+---
+
+# plan: Backlog Materialize Sample Report Snapshot Packet
+
+## Summary
+- Capture normalized expected outputs for the offline backlog materialize dry-run lane.
+- Snapshot the top-level materialize report, compile report, issue-quality report, and projected issues.
+- Keep the report lane deterministic without reusing live supervisor artifacts.
+
+## Scope
+- `planningops/fixtures/backlog-materialize-*.expected.json`
+- `planningops/scripts/test_backlog_materialize_sample_report_snapshot_contract.sh`
+- `planningops/scripts/README.md`
+
+## Acceptance
+- `test_backlog_materialize_sample_report_snapshot_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -8,6 +8,7 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `plan-items/`: valid/invalid planning item sample sets
 - `plan-execution-contract-sample.json`: minimal valid PEC v1 sample
 - `backlog-materialization-sample-contract.json`: ready-implementation PEC sample for offline backlog materialization tests
+- `backlog-materialize-*.expected.json`: normalized expected outputs for the offline backlog materialize sample lane
 - `plan-projection-snapshot-sample.json`: sample project snapshot matching PEC sample
 - `meta-plan-graph-sample.json`: minimal valid MPG v1 graph sample
 - `worker-task-pack-sample.json`: minimal valid worker task pack sample

--- a/planningops/fixtures/backlog-materialize-issue-quality-report-sample.expected.json
+++ b/planningops/fixtures/backlog-materialize-issue-quality-report-sample.expected.json
@@ -1,0 +1,10 @@
+{
+  "generated_at_utc": "__GENERATED_AT__",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_scanned": 1,
+  "issues_in_scope": 1,
+  "violation_count": 0,
+  "violations": [],
+  "verdict": "pass"
+}

--- a/planningops/fixtures/backlog-materialize-plan-compile-report-sample.expected.json
+++ b/planningops/fixtures/backlog-materialize-plan-compile-report-sample.expected.json
@@ -1,0 +1,40 @@
+{
+  "mode": "dry-run",
+  "contract_file": "planningops/fixtures/backlog-materialization-sample-contract.json",
+  "validation_errors": [],
+  "results": [
+    {
+      "plan_item_id": "A60",
+      "execution_order": 60,
+      "issue_number": 60,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/60",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "closed_match_detected": false,
+      "closed_match_issue_number": null,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(planningops)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l4_integration_reconcile)",
+        "plan_lane(m3_guardrails)"
+      ]
+    }
+  ],
+  "plan_id": "uap-backlog-wave26",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md",
+  "items_total": 1,
+  "issues_source": "file:__PROJECTED_ISSUES_FILE__",
+  "open_issues_scanned": 1,
+  "closed_issues_scanned": 0,
+  "verdict": "pass"
+}

--- a/planningops/fixtures/backlog-materialize-projected-issues-sample.expected.json
+++ b/planningops/fixtures/backlog-materialize-projected-issues-sample.expected.json
@@ -1,0 +1,25 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 60,
+    "state": "open",
+    "updated_at": "__UPDATED_AT__",
+    "title": "plan: [60] Add recurring backlog materialization runner",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/60",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- plan_id: `uap-backlog-wave26`\n- plan_revision: `1`\n- plan_item_id: `A60`\n- execution_order: `60`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `-`\n- primary_output: `planningops/scripts/core/backlog/materialize.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md`\n- `planningops/scripts/core/backlog/materialize.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: planningops/contracts/requirements-contract.md\npackage_topology_ref: planningops/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md\n",
+    "labels": [
+      {
+        "name": "area/planningops"
+      },
+      {
+        "name": "p2"
+      },
+      {
+        "name": "task"
+      },
+      {
+        "name": "type/hardening"
+      }
+    ]
+  }
+]

--- a/planningops/fixtures/backlog-materialize-report-sample.expected.json
+++ b/planningops/fixtures/backlog-materialize-report-sample.expected.json
@@ -1,0 +1,105 @@
+{
+  "generated_at_utc": "__GENERATED_AT__",
+  "mode": "dry-run",
+  "contract_file": "planningops/fixtures/backlog-materialization-sample-contract.json",
+  "repo": "rather-not-work-on/platform-planningops",
+  "initiative": "unified-personal-agent-platform",
+  "steps": [
+    {
+      "name": "compile_plan_to_backlog",
+      "command": [
+        "python3",
+        "planningops/scripts/compile_plan_to_backlog.py",
+        "--contract-file",
+        "planningops/fixtures/backlog-materialization-sample-contract.json",
+        "--config",
+        "planningops/config/project-field-ids.json",
+        "--blueprint-defaults-config",
+        "planningops/config/ready-implementation-blueprint-defaults.json",
+        "--output",
+        "__COMPILE_OUTPUT__",
+        "--issues-file",
+        "__PROJECTED_ISSUES_FILE__"
+      ],
+      "output_path": "__COMPILE_OUTPUT__",
+      "rc": 0,
+      "stdout": "__STDOUT__",
+      "stderr": "",
+      "verdict": "pass"
+    },
+    {
+      "name": "backfill_issue_labels",
+      "command": [
+        "python3",
+        "planningops/scripts/backfill_issue_labels.py",
+        "--output",
+        "__LABEL_OUTPUT__",
+        "--repo",
+        "rather-not-work-on/platform-planningops",
+        "--issues-file",
+        "__PROJECTED_ISSUES_FILE__",
+        "--write-updated-issues-file",
+        "__PROJECTED_ISSUES_FILE__",
+        "--apply"
+      ],
+      "output_path": "__LABEL_OUTPUT__",
+      "rc": 0,
+      "stdout": "__STDOUT__",
+      "stderr": "",
+      "verdict": "pass"
+    },
+    {
+      "name": "build_program_manifest",
+      "command": [
+        "python3",
+        "planningops/scripts/build_program_manifest.py",
+        "--plan-item-regex",
+        "^(?:A60)$",
+        "--initiative",
+        "unified-personal-agent-platform",
+        "--source-plan",
+        "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md",
+        "--scope-source-plan",
+        "--output",
+        "__MANIFEST_OUTPUT__",
+        "--report-output",
+        "__MANIFEST_REPORT__",
+        "--strict",
+        "--issues-file",
+        "__PROJECTED_ISSUES_FILE__"
+      ],
+      "output_path": "__MANIFEST_REPORT__",
+      "rc": 0,
+      "stdout": "__STDOUT__",
+      "stderr": "",
+      "verdict": "pass"
+    },
+    {
+      "name": "validate_issue_quality",
+      "command": [
+        "python3",
+        "planningops/scripts/validate_issue_quality.py",
+        "--output",
+        "__QUALITY_OUTPUT__",
+        "--strict",
+        "--issues-file",
+        "__PROJECTED_ISSUES_FILE__",
+        "--repo",
+        "rather-not-work-on/platform-planningops"
+      ],
+      "output_path": "__QUALITY_OUTPUT__",
+      "rc": 0,
+      "stdout": "__STDOUT__",
+      "stderr": "",
+      "verdict": "pass"
+    }
+  ],
+  "plan_id": "uap-backlog-wave26",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave26-issue-pack.md",
+  "items_total": 1,
+  "projected_issues_output": "__PROJECTED_ISSUES_FILE__",
+  "projected_issue_count": 1,
+  "step_count": 4,
+  "verdict": "pass"
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -558,6 +558,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_backlog_materialization_contract.sh`
   - `test_backlog_materialize_sample_fixture_smoke.sh`
   - `test_backlog_materialize_sample_report_smoke.sh`
+  - `test_backlog_materialize_sample_report_snapshot_contract.sh`
   - `test_backlog_materialize_sample_snapshot_contract.sh`
   - `test_build_program_manifest_contract.sh`
   - `test_compile_plan_to_backlog_contract.sh`

--- a/planningops/scripts/test_backlog_materialize_sample_report_snapshot_contract.sh
+++ b/planningops/scripts/test_backlog_materialize_sample_report_snapshot_contract.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+contract_file="planningops/fixtures/backlog-materialization-sample-contract.json"
+compile_output="$tmpdir/plan-compile-report.json"
+label_output="$tmpdir/issue-label-backfill-report.json"
+manifest_output="$tmpdir/program-manifest.json"
+manifest_report="$tmpdir/program-manifest-report.json"
+quality_output="$tmpdir/issue-quality-report.json"
+projected_issues_output="$tmpdir/projected-issues.json"
+materialize_output="$tmpdir/materialize-report.json"
+
+python3 planningops/scripts/core/backlog/materialize.py \
+  --contract-file "$contract_file" \
+  --repo rather-not-work-on/platform-planningops \
+  --initiative unified-personal-agent-platform \
+  --compile-output "$compile_output" \
+  --label-output "$label_output" \
+  --manifest-output "$manifest_output" \
+  --manifest-report "$manifest_report" \
+  --quality-output "$quality_output" \
+  --projected-issues-output "$projected_issues_output" \
+  --output "$materialize_output" \
+  >/dev/null
+
+python3 - <<'PY' \
+  "$materialize_output" \
+  "$compile_output" \
+  "$quality_output" \
+  "$projected_issues_output" \
+  "planningops/fixtures/backlog-materialize-report-sample.expected.json" \
+  "planningops/fixtures/backlog-materialize-plan-compile-report-sample.expected.json" \
+  "planningops/fixtures/backlog-materialize-issue-quality-report-sample.expected.json" \
+  "planningops/fixtures/backlog-materialize-projected-issues-sample.expected.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def replace_strings(value, mapping):
+    if isinstance(value, dict):
+        return {key: replace_strings(item, mapping) for key, item in value.items()}
+    if isinstance(value, list):
+        return [replace_strings(item, mapping) for item in value]
+    if isinstance(value, str):
+        replaced = value
+        for source, target in mapping.items():
+            replaced = replaced.replace(source, target)
+        return replaced
+    return value
+
+
+def normalize_materialize_report(doc, path_mapping):
+    normalized = replace_strings(json.loads(json.dumps(doc)), path_mapping)
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    for step in normalized["steps"]:
+        step["stdout"] = "__STDOUT__"
+    return normalized
+
+
+def normalize_quality_report(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+def normalize_projected_issues(doc):
+    normalized = json.loads(json.dumps(doc))
+    for issue in normalized:
+        issue["updated_at"] = "__UPDATED_AT__"
+    return normalized
+
+
+path_mapping = {
+    sys.argv[2]: "__COMPILE_OUTPUT__",
+    sys.argv[3]: "__QUALITY_OUTPUT__",
+    sys.argv[4]: "__PROJECTED_ISSUES_FILE__",
+    str(Path(sys.argv[2]).with_name("issue-label-backfill-report.json")): "__LABEL_OUTPUT__",
+    str(Path(sys.argv[2]).with_name("program-manifest.json")): "__MANIFEST_OUTPUT__",
+    str(Path(sys.argv[2]).with_name("program-manifest-report.json")): "__MANIFEST_REPORT__",
+}
+
+actual_materialize_report = normalize_materialize_report(load(sys.argv[1]), path_mapping)
+actual_compile_report = replace_strings(load(sys.argv[2]), path_mapping)
+actual_quality_report = normalize_quality_report(load(sys.argv[3]))
+actual_projected_issues = normalize_projected_issues(load(sys.argv[4]))
+
+expected_materialize_report = load(sys.argv[5])
+expected_compile_report = load(sys.argv[6])
+expected_quality_report = load(sys.argv[7])
+expected_projected_issues = load(sys.argv[8])
+
+assert actual_materialize_report == expected_materialize_report, (
+    actual_materialize_report,
+    expected_materialize_report,
+)
+assert actual_compile_report == expected_compile_report, (actual_compile_report, expected_compile_report)
+assert actual_quality_report == expected_quality_report, (actual_quality_report, expected_quality_report)
+assert actual_projected_issues == expected_projected_issues, (actual_projected_issues, expected_projected_issues)
+
+print("backlog materialize sample report snapshot contract ok")
+PY


### PR DESCRIPTION
## Summary
- add normalized expected fixtures for the offline backlog materialize report lane
- snapshot the real dry-run materialize, compile, issue-quality, and projected-issues outputs
- document the new regression in scripts docs and the workbench hub

## Validation
- bash planningops/scripts/test_backlog_materialize_sample_report_smoke.sh
- bash planningops/scripts/test_backlog_materialize_sample_report_snapshot_contract.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all