### PR TITLE
test(governance-artifacts): backfill validation lanes

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -146,6 +146,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Active Goal Registry Artifact Refresh Packet](./plans/2026-03-28-active-goal-registry-artifact-refresh-packet.md)
 - [Issue Quality Artifact Refresh Packet](./plans/2026-03-28-issue-quality-artifact-refresh-packet.md)
 - [Validation Sample Artifact Lanes Packet](./plans/2026-03-28-validation-sample-artifact-lanes-packet.md)
+- [Governance Validation Artifact Lanes Packet](./plans/2026-03-28-governance-validation-artifact-lanes-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)
 - [Plan Compile Artifact Refresh Packet](./plans/2026-03-28-plan-compile-artifact-refresh-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-governance-validation-artifact-lanes-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-governance-validation-artifact-lanes-packet.md
@@ -1,0 +1,35 @@
+---
+title: plan: Governance Validation Artifact Lanes Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Backfills deterministic governance validator report artifacts and locks them with a comparison regression.
+related_docs:
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+  - ./2026-03-28-contract-helper-surface-sync-packet.md
+---
+
+# plan: Governance Validation Artifact Lanes Packet
+
+## Summary
+- Promote deterministic `repo-boundary`, `script-role`, and `artifact-storage-policy` validator reports into tracked `.test.json` artifacts.
+- Keep those artifacts distinct from mutable live validation outputs.
+- Add one regression that regenerates the three reports and compares them to the committed artifacts.
+
+## Scope
+- `planningops/artifacts/validation/repo-boundary-report.test.json`
+- `planningops/artifacts/validation/script-role-report.test.json`
+- `planningops/artifacts/validation/artifact-storage-policy-valid.test.json`
+- `planningops/scripts/test_governance_validation_artifact_lanes.sh`
+- `planningops/artifacts/README.md`
+
+## Acceptance
+- `test_governance_validation_artifact_lanes.sh` passes
+- `test_validate_repo_boundaries_contract.sh` passes
+- `test_validate_script_roles_contract.sh` passes
+- `test_validate_artifact_storage_policy_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -19,6 +19,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
 - `program/`: canonical program-manifest outputs, including fixture-backed `.sample.json` lanes
 - `validation/`: gate/schema reports, including fixture-backed `.sample.json` lanes that stay separate from live latest artifacts
   - canonical sample validation lanes currently include `plan-compile-report.sample.json` and `issue-quality-*.sample.json`
+  - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, and `artifact-storage-policy-valid.test.json`
 - `adapter-hooks/`, `verification/`, `drift/`, `transition-log/`, `pilot/`, `idempotency/`: supporting evidence
 
 ## Change Rules

--- a/planningops/artifacts/validation/artifact-storage-policy-valid.test.json
+++ b/planningops/artifacts/validation/artifact-storage-policy-valid.test.json
@@ -1,0 +1,7 @@
+{
+  "generated_at_utc": "2026-03-28T07:02:33.669146+00:00",
+  "policy_path": "planningops/config/artifact-storage-policy.json",
+  "error_count": 0,
+  "errors": [],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/repo-boundary-report.test.json
+++ b/planningops/artifacts/validation/repo-boundary-report.test.json
@@ -1,0 +1,18 @@
+{
+  "generated_at_utc": "2026-03-28T07:02:33.595881+00:00",
+  "config_path": "planningops/config/repository-boundary-map.json",
+  "verdict": "pass",
+  "violation_count": 0,
+  "violations": [],
+  "info_count": 1,
+  "infos": [
+    {
+      "type": "CHECK_SUMMARY",
+      "scripts_root_file_count": 217,
+      "core_entrypoint_count": 3,
+      "federation_entrypoint_count": 13,
+      "root_wrapper_count": 12,
+      "metadata_ignored_count": 444
+    }
+  ]
+}

--- a/planningops/artifacts/validation/script-role-report.test.json
+++ b/planningops/artifacts/validation/script-role-report.test.json
@@ -1,0 +1,17 @@
+{
+  "generated_at_utc": "2026-03-28T07:02:33.632937+00:00",
+  "config_path": "planningops/config/script-role-map.json",
+  "verdict": "pass",
+  "violation_count": 0,
+  "violations": [],
+  "info_count": 1,
+  "infos": [
+    {
+      "type": "CHECK_SUMMARY",
+      "core_dir_count": 3,
+      "oneoff_entrypoint_count": 1,
+      "wrapper_count": 10,
+      "metadata_ignored_count": 133
+    }
+  ]
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -931,6 +931,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_runtime_profiles_contract.sh`
   - `test_validate_repo_boundaries_contract.sh`
   - `test_validate_script_roles_contract.sh`
+  - `test_governance_validation_artifact_lanes.sh`
   - `test_validate_issue_quality_contract.sh`
   - `test_validate_federated_issue_quality_contract.sh`
   - `test_validate_artifact_storage_policy_contract.sh`

--- a/planningops/scripts/test_governance_validation_artifact_lanes.sh
+++ b/planningops/scripts/test_governance_validation_artifact_lanes.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+repo_probe="planningops/scripts/._github_sync_adapter.py"
+role_probe="planningops/scripts/._bootstrap_two_track_backlog.py"
+trap 'rm -rf "$tmpdir"; rm -f "$repo_probe" "$role_probe"' EXIT
+
+repo_report="$tmpdir/repo-boundary-report.test.json"
+role_report="$tmpdir/script-role-report.test.json"
+policy_report="$tmpdir/artifact-storage-policy-valid.test.json"
+
+printf '# metadata probe\n' > "$repo_probe"
+python3 planningops/scripts/validate_repo_boundaries.py --output "$repo_report" >/dev/null
+rm -f "$repo_probe"
+
+printf '# metadata probe\n' > "$role_probe"
+python3 planningops/scripts/validate_script_roles.py --output "$role_report" >/dev/null
+rm -f "$role_probe"
+
+python3 planningops/scripts/validate_artifact_storage_policy.py \
+  --policy planningops/config/artifact-storage-policy.json \
+  --output "$policy_report" \
+  --strict \
+  >/dev/null
+
+python3 - <<'PY' \
+  "$repo_report" \
+  "$role_report" \
+  "$policy_report" \
+  "planningops/artifacts/validation/repo-boundary-report.test.json" \
+  "planningops/artifacts/validation/script-role-report.test.json" \
+  "planningops/artifacts/validation/artifact-storage-policy-valid.test.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual_repo = normalize(load(sys.argv[1]))
+actual_role = normalize(load(sys.argv[2]))
+actual_policy = normalize(load(sys.argv[3]))
+
+expected_repo = normalize(load(sys.argv[4]))
+expected_role = normalize(load(sys.argv[5]))
+expected_policy = normalize(load(sys.argv[6]))
+
+assert actual_repo == expected_repo, (actual_repo, expected_repo)
+assert actual_role == expected_role, (actual_role, expected_role)
+assert actual_policy == expected_policy, (actual_policy, expected_policy)
+
+print("governance validation artifact lanes ok")
+PY


### PR DESCRIPTION
## Summary
- track deterministic repo-boundary, script-role, and artifact-storage-policy validator lanes as committed `.test.json` artifacts
- add a regression that regenerates those lanes and compares them against the committed snapshots
- document the new governance validation artifact lane in scripts, artifacts, and workbench docs

## Validation
- bash planningops/scripts/test_governance_validation_artifact_lanes.sh
- bash planningops/scripts/test_validate_repo_boundaries_contract.sh
- bash planningops/scripts/test_validate_script_roles_contract.sh
- bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all