### PR TITLE
test(issue-quality): backfill validation artifact lanes

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -145,6 +145,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Track1 Gate Artifact Refresh Packet](./plans/2026-03-28-track1-gate-artifact-refresh-packet.md)
 - [Active Goal Registry Artifact Refresh Packet](./plans/2026-03-28-active-goal-registry-artifact-refresh-packet.md)
 - [Issue Quality Artifact Refresh Packet](./plans/2026-03-28-issue-quality-artifact-refresh-packet.md)
+- [Issue Quality Validation Artifact Lanes Packet](./plans/2026-03-28-issue-quality-validation-artifact-lanes-packet.md)
 - [Validation Sample Artifact Lanes Packet](./plans/2026-03-28-validation-sample-artifact-lanes-packet.md)
 - [Governance Validation Artifact Lanes Packet](./plans/2026-03-28-governance-validation-artifact-lanes-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-issue-quality-validation-artifact-lanes-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-issue-quality-validation-artifact-lanes-packet.md
@@ -1,0 +1,32 @@
+---
+title: plan: Issue Quality Validation Artifact Lanes Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes deterministic issue-quality valid and invalid validator reports into tracked test lanes.
+related_docs:
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+  - ./2026-03-28-governance-validation-artifact-lanes-packet.md
+---
+
+# plan: Issue Quality Validation Artifact Lanes Packet
+
+## Summary
+- Promote deterministic `issue-quality-valid.test.json` and `issue-quality-invalid.test.json` outputs into tracked validation artifacts.
+- Keep the `.test.json` issue-quality lanes distinct from the fixture-backed `.sample.json` validation outputs.
+- Add one regression that regenerates both lanes and compares them to the committed snapshots.
+
+## Scope
+- `planningops/artifacts/validation/issue-quality-valid.test.json`
+- `planningops/artifacts/validation/issue-quality-invalid.test.json`
+- `planningops/scripts/test_issue_quality_validation_artifact_lanes.sh`
+- `planningops/artifacts/README.md`
+
+## Acceptance
+- `test_issue_quality_validation_artifact_lanes.sh` passes
+- `test_validate_issue_quality_contract.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -19,6 +19,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
 - `program/`: canonical program-manifest outputs, including fixture-backed `.sample.json` lanes
 - `validation/`: gate/schema reports, including fixture-backed `.sample.json` lanes that stay separate from live latest artifacts
   - canonical sample validation lanes currently include `plan-compile-report.sample.json` and `issue-quality-*.sample.json`
+  - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, and `artifact-storage-policy-valid.test.json`
 - `adapter-hooks/`, `verification/`, `drift/`, `transition-log/`, `pilot/`, `idempotency/`: supporting evidence
 

--- a/planningops/artifacts/validation/issue-quality-invalid.test.json
+++ b/planningops/artifacts/validation/issue-quality-invalid.test.json
@@ -1,0 +1,35 @@
+{
+  "generated_at_utc": "2026-03-28T07:04:11.035293+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_scanned": 1,
+  "issues_in_scope": 1,
+  "violation_count": 1,
+  "violations": [
+    {
+      "number": 1002,
+      "title": "Invalid quality issue",
+      "url": "https://example.local/1002",
+      "labels": [],
+      "violation_count": 15,
+      "violations": [
+        "missing section: Problem Statement",
+        "missing section: Interfaces & Dependencies",
+        "missing section: Definition of Done",
+        "missing metadata key: target_repo",
+        "missing metadata key: component",
+        "missing metadata key: workflow_state",
+        "missing metadata key: loop_profile",
+        "missing metadata key: execution_order",
+        "missing metadata key: depends_on",
+        "acceptance checklist items < 2 (actual=1)",
+        "forbidden evidence marker present: - (none)",
+        "missing required label: task",
+        "missing priority label; require one of ['p1', 'p2', 'p3']",
+        "missing required label prefix: area/*",
+        "missing required label prefix: type/*"
+      ]
+    }
+  ],
+  "verdict": "fail"
+}

--- a/planningops/artifacts/validation/issue-quality-valid.test.json
+++ b/planningops/artifacts/validation/issue-quality-valid.test.json
@@ -1,0 +1,10 @@
+{
+  "generated_at_utc": "2026-03-28T07:04:10.995147+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_scanned": 1,
+  "issues_in_scope": 1,
+  "violation_count": 0,
+  "violations": [],
+  "verdict": "pass"
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -932,6 +932,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_repo_boundaries_contract.sh`
   - `test_validate_script_roles_contract.sh`
   - `test_governance_validation_artifact_lanes.sh`
+  - `test_issue_quality_validation_artifact_lanes.sh`
   - `test_validate_issue_quality_contract.sh`
   - `test_validate_federated_issue_quality_contract.sh`
   - `test_validate_artifact_storage_policy_contract.sh`

--- a/planningops/scripts/test_issue_quality_validation_artifact_lanes.sh
+++ b/planningops/scripts/test_issue_quality_validation_artifact_lanes.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+valid_report="$tmpdir/issue-quality-valid.test.json"
+invalid_report="$tmpdir/issue-quality-invalid.test.json"
+
+python3 planningops/scripts/validate_issue_quality.py \
+  --issues-file planningops/fixtures/issue-quality/issue-quality-sample-valid.json \
+  --output "$valid_report" \
+  --strict \
+  >/dev/null
+
+set +e
+python3 planningops/scripts/validate_issue_quality.py \
+  --issues-file planningops/fixtures/issue-quality/issue-quality-sample-invalid.json \
+  --output "$invalid_report" \
+  --strict \
+  >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for invalid issue-quality fixture"
+  exit 1
+fi
+
+python3 - <<'PY' \
+  "$valid_report" \
+  "$invalid_report" \
+  "planningops/artifacts/validation/issue-quality-valid.test.json" \
+  "planningops/artifacts/validation/issue-quality-invalid.test.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual_valid = normalize(load(sys.argv[1]))
+actual_invalid = normalize(load(sys.argv[2]))
+
+expected_valid = normalize(load(sys.argv[3]))
+expected_invalid = normalize(load(sys.argv[4]))
+
+assert actual_valid == expected_valid, (actual_valid, expected_valid)
+assert actual_invalid == expected_invalid, (actual_invalid, expected_invalid)
+
+print("issue quality validation artifact lanes ok")
+PY


### PR DESCRIPTION
## Summary
- track deterministic issue-quality valid and invalid validator outputs as committed `.test.json` artifacts
- add a regression that regenerates both lanes and compares them with the committed snapshots
- document the new issue-quality validation artifact lane in artifacts, scripts, and workbench docs

## Validation
- bash planningops/scripts/test_validate_issue_quality_contract.sh
- bash planningops/scripts/test_issue_quality_validation_artifact_lanes.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all