### PR TITLE
test(repository-governance): backfill audit artifact lanes

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -147,6 +147,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Issue Quality Artifact Refresh Packet](./plans/2026-03-28-issue-quality-artifact-refresh-packet.md)
 - [Issue Quality Validation Artifact Lanes Packet](./plans/2026-03-28-issue-quality-validation-artifact-lanes-packet.md)
 - [Validation Sample Artifact Lanes Packet](./plans/2026-03-28-validation-sample-artifact-lanes-packet.md)
+- [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
 - [Governance Validation Artifact Lanes Packet](./plans/2026-03-28-governance-validation-artifact-lanes-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md
@@ -1,0 +1,34 @@
+---
+title: plan: Branch Protection Audit Artifact Lanes Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes deterministic branch protection audit outputs into tracked validator lanes backed by stable fixtures.
+related_docs:
+  - ./2026-03-28-governance-validation-artifact-lanes-packet.md
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+---
+
+# plan: Branch Protection Audit Artifact Lanes Packet
+
+## Summary
+- Extract stable repository-governance fixtures for branch protection audit coverage.
+- Promote deterministic valid and invalid branch protection audit outputs into tracked `.test.json` artifact lanes.
+- Add a comparison regression that regenerates both audit lanes from the fixtures and compares them to the committed snapshots.
+
+## Scope
+- `planningops/fixtures/repository-governance-policy.sample.json`
+- `planningops/fixtures/branch-protection-snapshot-valid.sample.json`
+- `planningops/fixtures/branch-protection-snapshot-invalid.sample.json`
+- `planningops/artifacts/validation/branch-protection-audit-valid.test.json`
+- `planningops/artifacts/validation/branch-protection-audit-invalid.test.json`
+- `planningops/scripts/test_branch_protection_audit_artifact_lanes.sh`
+
+## Acceptance
+- `test_audit_branch_protection_contract.sh` passes
+- `test_branch_protection_audit_artifact_lanes.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -21,6 +21,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - canonical sample validation lanes currently include `plan-compile-report.sample.json` and `issue-quality-*.sample.json`
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, and `artifact-storage-policy-valid.test.json`
+  - canonical repository-governance validator lanes also include `branch-protection-audit-valid.test.json` and `branch-protection-audit-invalid.test.json`
 - `adapter-hooks/`, `verification/`, `drift/`, `transition-log/`, `pilot/`, `idempotency/`: supporting evidence
 
 ## Change Rules

--- a/planningops/artifacts/validation/branch-protection-audit-invalid.test.json
+++ b/planningops/artifacts/validation/branch-protection-audit-invalid.test.json
@@ -1,0 +1,143 @@
+{
+  "generated_at_utc": "2026-03-28T07:07:38.941101+00:00",
+  "mode": "snapshot",
+  "policy_path": "planningops/fixtures/repository-governance-policy.sample.json",
+  "owner": "rather-not-work-on",
+  "repo_count": 2,
+  "repo_evaluated_count": 2,
+  "fetch_error_count": 0,
+  "fetch_errors": [],
+  "violation_count": 9,
+  "violations": [
+    {
+      "repo": "platform-planningops",
+      "code": "required_status_checks_all_missing",
+      "message": "missing required status checks (all): federated-summary",
+      "field": "requiredStatusCheckContexts"
+    },
+    {
+      "repo": "monday",
+      "code": "approving_reviews_mismatch",
+      "message": "requiresApprovingReviews expected=True actual=False",
+      "field": "requiresApprovingReviews"
+    },
+    {
+      "repo": "monday",
+      "code": "insufficient_approving_review_count",
+      "message": "requiredApprovingReviewCount expected>=1 actual=0",
+      "field": "requiredApprovingReviewCount"
+    },
+    {
+      "repo": "monday",
+      "code": "status_checks_requirement_mismatch",
+      "message": "requiresStatusChecks expected=True actual=False",
+      "field": "requiresStatusChecks"
+    },
+    {
+      "repo": "monday",
+      "code": "required_status_checks_all_missing",
+      "message": "missing required status checks (all): monday-local-ci, template-and-link-check",
+      "field": "requiredStatusCheckContexts"
+    },
+    {
+      "repo": "monday",
+      "code": "strict_status_checks_mismatch",
+      "message": "requiresStrictStatusChecks expected=True actual=False",
+      "field": "requiresStrictStatusChecks"
+    },
+    {
+      "repo": "monday",
+      "code": "conversation_resolution_mismatch",
+      "message": "requiresConversationResolution expected=True actual=False",
+      "field": "requiresConversationResolution"
+    },
+    {
+      "repo": "monday",
+      "code": "force_push_policy_mismatch",
+      "message": "allowsForcePushes expected=False actual=True",
+      "field": "allowsForcePushes"
+    },
+    {
+      "repo": "monday",
+      "code": "deletion_policy_mismatch",
+      "message": "allowsDeletions expected=False actual=True",
+      "field": "allowsDeletions"
+    }
+  ],
+  "results": [
+    {
+      "repo": "platform-planningops",
+      "default_branch": "main",
+      "selected_pattern": "main",
+      "available_status_checks": [
+        "template-and-link-check",
+        "validate-and-dry-run"
+      ],
+      "violations": [
+        {
+          "repo": "platform-planningops",
+          "code": "required_status_checks_all_missing",
+          "message": "missing required status checks (all): federated-summary",
+          "field": "requiredStatusCheckContexts"
+        }
+      ]
+    },
+    {
+      "repo": "monday",
+      "default_branch": "main",
+      "selected_pattern": "main",
+      "available_status_checks": [],
+      "violations": [
+        {
+          "repo": "monday",
+          "code": "approving_reviews_mismatch",
+          "message": "requiresApprovingReviews expected=True actual=False",
+          "field": "requiresApprovingReviews"
+        },
+        {
+          "repo": "monday",
+          "code": "insufficient_approving_review_count",
+          "message": "requiredApprovingReviewCount expected>=1 actual=0",
+          "field": "requiredApprovingReviewCount"
+        },
+        {
+          "repo": "monday",
+          "code": "status_checks_requirement_mismatch",
+          "message": "requiresStatusChecks expected=True actual=False",
+          "field": "requiresStatusChecks"
+        },
+        {
+          "repo": "monday",
+          "code": "required_status_checks_all_missing",
+          "message": "missing required status checks (all): monday-local-ci, template-and-link-check",
+          "field": "requiredStatusCheckContexts"
+        },
+        {
+          "repo": "monday",
+          "code": "strict_status_checks_mismatch",
+          "message": "requiresStrictStatusChecks expected=True actual=False",
+          "field": "requiresStrictStatusChecks"
+        },
+        {
+          "repo": "monday",
+          "code": "conversation_resolution_mismatch",
+          "message": "requiresConversationResolution expected=True actual=False",
+          "field": "requiresConversationResolution"
+        },
+        {
+          "repo": "monday",
+          "code": "force_push_policy_mismatch",
+          "message": "allowsForcePushes expected=False actual=True",
+          "field": "allowsForcePushes"
+        },
+        {
+          "repo": "monday",
+          "code": "deletion_policy_mismatch",
+          "message": "allowsDeletions expected=False actual=True",
+          "field": "allowsDeletions"
+        }
+      ]
+    }
+  ],
+  "verdict": "fail"
+}

--- a/planningops/artifacts/validation/branch-protection-audit-valid.test.json
+++ b/planningops/artifacts/validation/branch-protection-audit-valid.test.json
@@ -1,0 +1,36 @@
+{
+  "generated_at_utc": "2026-03-28T07:07:38.895395+00:00",
+  "mode": "snapshot",
+  "policy_path": "planningops/fixtures/repository-governance-policy.sample.json",
+  "owner": "rather-not-work-on",
+  "repo_count": 2,
+  "repo_evaluated_count": 2,
+  "fetch_error_count": 0,
+  "fetch_errors": [],
+  "violation_count": 0,
+  "violations": [],
+  "results": [
+    {
+      "repo": "platform-planningops",
+      "default_branch": "main",
+      "selected_pattern": "main",
+      "available_status_checks": [
+        "federated-summary",
+        "template-and-link-check",
+        "validate-and-dry-run"
+      ],
+      "violations": []
+    },
+    {
+      "repo": "monday",
+      "default_branch": "main",
+      "selected_pattern": "main",
+      "available_status_checks": [
+        "monday-local-ci",
+        "template-and-link-check"
+      ],
+      "violations": []
+    }
+  ],
+  "verdict": "pass"
+}

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -17,6 +17,8 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `backlog-stock-items-sample.json`: normalized project-item sample for stock gate checks
 - `backlog-replenishment-candidates-sample.json`: evidence-backed replenishment candidate sample
 - `supervisor-loop-sequence-sample.json`: deterministic loop-result sequence for supervisor contract tests
+- `repository-governance-policy.sample.json`: fixture-backed repository governance policy for branch protection audit tests
+- `branch-protection-snapshot-*.sample.json`: valid and invalid branch protection snapshots for repository governance audit tests
 
 ## Change Rules
 - Fixtures must be static and deterministic.

--- a/planningops/fixtures/branch-protection-snapshot-invalid.sample.json
+++ b/planningops/fixtures/branch-protection-snapshot-invalid.sample.json
@@ -1,0 +1,43 @@
+{
+  "repositories": [
+    {
+      "name": "platform-planningops",
+      "default_branch": "main",
+      "rules": [
+        {
+          "pattern": "main",
+          "requiresApprovingReviews": true,
+          "requiredApprovingReviewCount": 1,
+          "requiresStatusChecks": true,
+          "requiredStatusCheckContexts": [
+            "template-and-link-check",
+            "validate-and-dry-run"
+          ],
+          "requiresStrictStatusChecks": true,
+          "requiresConversationResolution": true,
+          "allowsForcePushes": false,
+          "allowsDeletions": false,
+          "isAdminEnforced": false
+        }
+      ]
+    },
+    {
+      "name": "monday",
+      "default_branch": "main",
+      "rules": [
+        {
+          "pattern": "main",
+          "requiresApprovingReviews": false,
+          "requiredApprovingReviewCount": 0,
+          "requiresStatusChecks": false,
+          "requiredStatusCheckContexts": [],
+          "requiresStrictStatusChecks": false,
+          "requiresConversationResolution": false,
+          "allowsForcePushes": true,
+          "allowsDeletions": true,
+          "isAdminEnforced": false
+        }
+      ]
+    }
+  ]
+}

--- a/planningops/fixtures/branch-protection-snapshot-valid.sample.json
+++ b/planningops/fixtures/branch-protection-snapshot-valid.sample.json
@@ -1,0 +1,47 @@
+{
+  "repositories": [
+    {
+      "name": "platform-planningops",
+      "default_branch": "main",
+      "rules": [
+        {
+          "pattern": "main",
+          "requiresApprovingReviews": true,
+          "requiredApprovingReviewCount": 1,
+          "requiresStatusChecks": true,
+          "requiredStatusCheckContexts": [
+            "template-and-link-check",
+            "validate-and-dry-run",
+            "federated-summary"
+          ],
+          "requiresStrictStatusChecks": true,
+          "requiresConversationResolution": true,
+          "allowsForcePushes": false,
+          "allowsDeletions": false,
+          "isAdminEnforced": false
+        }
+      ]
+    },
+    {
+      "name": "monday",
+      "default_branch": "main",
+      "rules": [
+        {
+          "pattern": "main",
+          "requiresApprovingReviews": true,
+          "requiredApprovingReviewCount": 1,
+          "requiresStatusChecks": true,
+          "requiredStatusCheckContexts": [
+            "template-and-link-check",
+            "monday-local-ci"
+          ],
+          "requiresStrictStatusChecks": true,
+          "requiresConversationResolution": true,
+          "allowsForcePushes": false,
+          "allowsDeletions": false,
+          "isAdminEnforced": false
+        }
+      ]
+    }
+  ]
+}

--- a/planningops/fixtures/repository-governance-policy.sample.json
+++ b/planningops/fixtures/repository-governance-policy.sample.json
@@ -1,0 +1,31 @@
+{
+  "owner": "rather-not-work-on",
+  "default_branch": "main",
+  "defaults": {
+    "require_approving_reviews": true,
+    "min_approving_review_count": 1,
+    "require_conversation_resolution": true,
+    "require_status_checks": true,
+    "require_strict_status_checks": true,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "enforce_admins": false
+  },
+  "repos": [
+    {
+      "name": "platform-planningops",
+      "required_status_checks_all": [
+        "template-and-link-check",
+        "validate-and-dry-run",
+        "federated-summary"
+      ]
+    },
+    {
+      "name": "monday",
+      "required_status_checks_all": [
+        "template-and-link-check",
+        "monday-local-ci"
+      ]
+    }
+  ]
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -938,6 +938,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_artifact_storage_policy_contract.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_migrate_external_only_artifacts_contract.sh`
+  - `test_branch_protection_audit_artifact_lanes.sh`
   - `test_audit_branch_protection_contract.sh`
   - `test_apply_branch_protection_contract.sh`
   - `test_cross_repo_conformance_bootstrap_contract.sh`

--- a/planningops/scripts/test_audit_branch_protection_contract.sh
+++ b/planningops/scripts/test_audit_branch_protection_contract.sh
@@ -4,136 +4,20 @@ set -euo pipefail
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-cat > "$tmp_dir/policy.json" <<'JSON'
-{
-  "owner": "rather-not-work-on",
-  "default_branch": "main",
-  "defaults": {
-    "require_approving_reviews": true,
-    "min_approving_review_count": 1,
-    "require_conversation_resolution": true,
-    "require_status_checks": true,
-    "require_strict_status_checks": true,
-    "allow_force_pushes": false,
-    "allow_deletions": false,
-    "enforce_admins": false
-  },
-  "repos": [
-    {
-      "name": "platform-planningops",
-      "required_status_checks_all": ["template-and-link-check", "validate-and-dry-run", "federated-summary"]
-    },
-    {
-      "name": "monday",
-      "required_status_checks_all": ["template-and-link-check", "monday-local-ci"]
-    }
-  ]
-}
-JSON
-
-cat > "$tmp_dir/snapshot-valid.json" <<'JSON'
-{
-  "repositories": [
-    {
-      "name": "platform-planningops",
-      "default_branch": "main",
-      "rules": [
-        {
-          "pattern": "main",
-          "requiresApprovingReviews": true,
-          "requiredApprovingReviewCount": 1,
-          "requiresStatusChecks": true,
-          "requiredStatusCheckContexts": [
-            "template-and-link-check",
-            "validate-and-dry-run",
-            "federated-summary"
-          ],
-          "requiresStrictStatusChecks": true,
-          "requiresConversationResolution": true,
-          "allowsForcePushes": false,
-          "allowsDeletions": false,
-          "isAdminEnforced": false
-        }
-      ]
-    },
-    {
-      "name": "monday",
-      "default_branch": "main",
-      "rules": [
-        {
-          "pattern": "main",
-          "requiresApprovingReviews": true,
-          "requiredApprovingReviewCount": 1,
-          "requiresStatusChecks": true,
-          "requiredStatusCheckContexts": ["template-and-link-check", "monday-local-ci"],
-          "requiresStrictStatusChecks": true,
-          "requiresConversationResolution": true,
-          "allowsForcePushes": false,
-          "allowsDeletions": false,
-          "isAdminEnforced": false
-        }
-      ]
-    }
-  ]
-}
-JSON
+policy="planningops/fixtures/repository-governance-policy.sample.json"
+snapshot_valid="planningops/fixtures/branch-protection-snapshot-valid.sample.json"
+snapshot_invalid="planningops/fixtures/branch-protection-snapshot-invalid.sample.json"
 
 python3 planningops/scripts/audit_branch_protection.py \
-  --policy "$tmp_dir/policy.json" \
-  --snapshot-file "$tmp_dir/snapshot-valid.json" \
+  --policy "$policy" \
+  --snapshot-file "$snapshot_valid" \
   --output "$tmp_dir/branch-protection-valid.test.json" \
   --strict
 
-cat > "$tmp_dir/snapshot-invalid.json" <<'JSON'
-{
-  "repositories": [
-    {
-      "name": "platform-planningops",
-      "default_branch": "main",
-      "rules": [
-        {
-          "pattern": "main",
-          "requiresApprovingReviews": true,
-          "requiredApprovingReviewCount": 1,
-          "requiresStatusChecks": true,
-          "requiredStatusCheckContexts": [
-            "template-and-link-check",
-            "validate-and-dry-run"
-          ],
-          "requiresStrictStatusChecks": true,
-          "requiresConversationResolution": true,
-          "allowsForcePushes": false,
-          "allowsDeletions": false,
-          "isAdminEnforced": false
-        }
-      ]
-    },
-    {
-      "name": "monday",
-      "default_branch": "main",
-      "rules": [
-        {
-          "pattern": "main",
-          "requiresApprovingReviews": false,
-          "requiredApprovingReviewCount": 0,
-          "requiresStatusChecks": false,
-          "requiredStatusCheckContexts": [],
-          "requiresStrictStatusChecks": false,
-          "requiresConversationResolution": false,
-          "allowsForcePushes": true,
-          "allowsDeletions": true,
-          "isAdminEnforced": false
-        }
-      ]
-    }
-  ]
-}
-JSON
-
 set +e
 python3 planningops/scripts/audit_branch_protection.py \
-  --policy "$tmp_dir/policy.json" \
-  --snapshot-file "$tmp_dir/snapshot-invalid.json" \
+  --policy "$policy" \
+  --snapshot-file "$snapshot_invalid" \
   --output "$tmp_dir/branch-protection-invalid.test.json" \
   --strict
 rc=$?

--- a/planningops/scripts/test_branch_protection_audit_artifact_lanes.sh
+++ b/planningops/scripts/test_branch_protection_audit_artifact_lanes.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+policy="planningops/fixtures/repository-governance-policy.sample.json"
+snapshot_valid="planningops/fixtures/branch-protection-snapshot-valid.sample.json"
+snapshot_invalid="planningops/fixtures/branch-protection-snapshot-invalid.sample.json"
+
+valid_report="$tmpdir/branch-protection-audit-valid.test.json"
+invalid_report="$tmpdir/branch-protection-audit-invalid.test.json"
+
+python3 planningops/scripts/audit_branch_protection.py \
+  --policy "$policy" \
+  --snapshot-file "$snapshot_valid" \
+  --output "$valid_report" \
+  >/dev/null
+
+set +e
+python3 planningops/scripts/audit_branch_protection.py \
+  --policy "$policy" \
+  --snapshot-file "$snapshot_invalid" \
+  --output "$invalid_report" \
+  --strict \
+  >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for invalid branch protection snapshot"
+  exit 1
+fi
+
+python3 - <<'PY' \
+  "$valid_report" \
+  "$invalid_report" \
+  "planningops/artifacts/validation/branch-protection-audit-valid.test.json" \
+  "planningops/artifacts/validation/branch-protection-audit-invalid.test.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual_valid = normalize(load(sys.argv[1]))
+actual_invalid = normalize(load(sys.argv[2]))
+
+expected_valid = normalize(load(sys.argv[3]))
+expected_invalid = normalize(load(sys.argv[4]))
+
+assert actual_valid == expected_valid, (actual_valid, expected_valid)
+assert actual_invalid == expected_invalid, (actual_invalid, expected_invalid)
+
+print("branch protection audit artifact lanes ok")
+PY


### PR DESCRIPTION
## Summary
- extract stable repository-governance fixtures for branch protection audit coverage
- track deterministic valid and invalid branch-protection audit outputs as committed `.test.json` artifacts
- add a regression that regenerates the audit lanes and compares them against the committed snapshots

## Validation
- bash planningops/scripts/test_audit_branch_protection_contract.sh
- bash planningops/scripts/test_branch_protection_audit_artifact_lanes.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all