### PR TITLE
test(repository-governance): backfill apply artifact lanes

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -148,6 +148,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Issue Quality Validation Artifact Lanes Packet](./plans/2026-03-28-issue-quality-validation-artifact-lanes-packet.md)
 - [Validation Sample Artifact Lanes Packet](./plans/2026-03-28-validation-sample-artifact-lanes-packet.md)
 - [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
+- [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
 - [Governance Validation Artifact Lanes Packet](./plans/2026-03-28-governance-validation-artifact-lanes-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md
@@ -1,0 +1,34 @@
+---
+title: plan: Branch Protection Apply Artifact Lanes Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes deterministic branch protection apply outputs into tracked validator lanes backed by stable fixtures.
+related_docs:
+  - ./2026-03-28-branch-protection-audit-artifact-lanes-packet.md
+  - ./2026-03-28-governance-validation-artifact-lanes-packet.md
+---
+
+# plan: Branch Protection Apply Artifact Lanes Packet
+
+## Summary
+- Extract stable repository-governance apply fixtures for branch protection dry-run coverage.
+- Promote deterministic valid and invalid branch protection apply outputs into tracked `.test.json` artifact lanes.
+- Add a comparison regression that regenerates both apply lanes from the fixtures and compares them to the committed snapshots.
+
+## Scope
+- `planningops/fixtures/repository-governance-apply-policy.sample.json`
+- `planningops/fixtures/repository-governance-apply-policy-invalid.sample.json`
+- `planningops/fixtures/branch-protection-apply-snapshot.sample.json`
+- `planningops/artifacts/validation/branch-protection-apply-valid.test.json`
+- `planningops/artifacts/validation/branch-protection-apply-invalid.test.json`
+- `planningops/scripts/test_branch_protection_apply_artifact_lanes.sh`
+
+## Acceptance
+- `test_apply_branch_protection_contract.sh` passes
+- `test_branch_protection_apply_artifact_lanes.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -22,6 +22,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, and `artifact-storage-policy-valid.test.json`
   - canonical repository-governance validator lanes also include `branch-protection-audit-valid.test.json` and `branch-protection-audit-invalid.test.json`
+  - canonical repository-governance apply lanes also include `branch-protection-apply-valid.test.json` and `branch-protection-apply-invalid.test.json`
 - `adapter-hooks/`, `verification/`, `drift/`, `transition-log/`, `pilot/`, `idempotency/`: supporting evidence
 
 ## Change Rules

--- a/planningops/artifacts/validation/branch-protection-apply-invalid.test.json
+++ b/planningops/artifacts/validation/branch-protection-apply-invalid.test.json
@@ -1,0 +1,17 @@
+{
+  "generated_at_utc": "2026-03-28T07:09:59.447311+00:00",
+  "mode": "dry-run",
+  "policy_path": "planningops/fixtures/repository-governance-apply-policy-invalid.sample.json",
+  "owner": "rather-not-work-on",
+  "repo_count": 1,
+  "repo_evaluated_count": 0,
+  "error_count": 1,
+  "results": [],
+  "errors": [
+    {
+      "repo": "platform-planningops",
+      "message": "branch protection apply requires 'required_status_checks_all'; 'required_status_checks_any' is audit-only"
+    }
+  ],
+  "verdict": "fail"
+}

--- a/planningops/artifacts/validation/branch-protection-apply-valid.test.json
+++ b/planningops/artifacts/validation/branch-protection-apply-valid.test.json
@@ -1,0 +1,73 @@
+{
+  "generated_at_utc": "2026-03-28T07:09:59.403522+00:00",
+  "mode": "dry-run",
+  "policy_path": "planningops/fixtures/repository-governance-apply-policy.sample.json",
+  "owner": "rather-not-work-on",
+  "repo_count": 2,
+  "repo_evaluated_count": 2,
+  "error_count": 0,
+  "results": [
+    {
+      "repo": "platform-planningops",
+      "branch": "main",
+      "mode": "dry-run",
+      "required_status_checks": [
+        "template-and-link-check",
+        "validate-and-dry-run",
+        "federated-summary"
+      ],
+      "payload": {
+        "enforce_admins": false,
+        "restrictions": null,
+        "allow_force_pushes": false,
+        "allow_deletions": false,
+        "required_conversation_resolution": true,
+        "required_status_checks": {
+          "strict": true,
+          "contexts": [
+            "template-and-link-check",
+            "validate-and-dry-run",
+            "federated-summary"
+          ]
+        },
+        "required_pull_request_reviews": {
+          "dismiss_stale_reviews": false,
+          "require_code_owner_reviews": false,
+          "required_approving_review_count": 1,
+          "require_last_push_approval": false
+        }
+      }
+    },
+    {
+      "repo": "platform-provider-gateway",
+      "branch": "main",
+      "mode": "dry-run",
+      "required_status_checks": [
+        "template-and-link-check",
+        "provider-local-ci"
+      ],
+      "payload": {
+        "enforce_admins": false,
+        "restrictions": null,
+        "allow_force_pushes": false,
+        "allow_deletions": false,
+        "required_conversation_resolution": true,
+        "required_status_checks": {
+          "strict": true,
+          "contexts": [
+            "template-and-link-check",
+            "provider-local-ci"
+          ]
+        },
+        "required_pull_request_reviews": {
+          "dismiss_stale_reviews": false,
+          "require_code_owner_reviews": false,
+          "required_approving_review_count": 1,
+          "require_last_push_approval": false
+        }
+      }
+    }
+  ],
+  "errors": [],
+  "verdict": "pass"
+}

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -19,6 +19,8 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `supervisor-loop-sequence-sample.json`: deterministic loop-result sequence for supervisor contract tests
 - `repository-governance-policy.sample.json`: fixture-backed repository governance policy for branch protection audit tests
 - `branch-protection-snapshot-*.sample.json`: valid and invalid branch protection snapshots for repository governance audit tests
+- `repository-governance-apply-policy*.sample.json`: valid and invalid repository governance policies for branch protection apply tests
+- `branch-protection-apply-snapshot.sample.json`: minimal apply snapshot for branch protection apply tests
 
 ## Change Rules
 - Fixtures must be static and deterministic.

--- a/planningops/fixtures/branch-protection-apply-snapshot.sample.json
+++ b/planningops/fixtures/branch-protection-apply-snapshot.sample.json
@@ -1,0 +1,12 @@
+{
+  "repositories": [
+    {
+      "name": "platform-planningops",
+      "default_branch": "main"
+    },
+    {
+      "name": "platform-provider-gateway",
+      "default_branch": "main"
+    }
+  ]
+}

--- a/planningops/fixtures/repository-governance-apply-policy-invalid.sample.json
+++ b/planningops/fixtures/repository-governance-apply-policy-invalid.sample.json
@@ -1,0 +1,23 @@
+{
+  "owner": "rather-not-work-on",
+  "default_branch": "main",
+  "defaults": {
+    "require_approving_reviews": true,
+    "min_approving_review_count": 1,
+    "require_conversation_resolution": true,
+    "require_status_checks": true,
+    "require_strict_status_checks": true,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "enforce_admins": false
+  },
+  "repos": [
+    {
+      "name": "platform-planningops",
+      "required_status_checks_any": [
+        "template-and-link-check",
+        "federated-summary"
+      ]
+    }
+  ]
+}

--- a/planningops/fixtures/repository-governance-apply-policy.sample.json
+++ b/planningops/fixtures/repository-governance-apply-policy.sample.json
@@ -1,0 +1,31 @@
+{
+  "owner": "rather-not-work-on",
+  "default_branch": "main",
+  "defaults": {
+    "require_approving_reviews": true,
+    "min_approving_review_count": 1,
+    "require_conversation_resolution": true,
+    "require_status_checks": true,
+    "require_strict_status_checks": true,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "enforce_admins": false
+  },
+  "repos": [
+    {
+      "name": "platform-planningops",
+      "required_status_checks_all": [
+        "template-and-link-check",
+        "validate-and-dry-run",
+        "federated-summary"
+      ]
+    },
+    {
+      "name": "platform-provider-gateway",
+      "required_status_checks_all": [
+        "template-and-link-check",
+        "provider-local-ci"
+      ]
+    }
+  ]
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -940,6 +940,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_migrate_external_only_artifacts_contract.sh`
   - `test_branch_protection_audit_artifact_lanes.sh`
   - `test_audit_branch_protection_contract.sh`
+  - `test_branch_protection_apply_artifact_lanes.sh`
   - `test_apply_branch_protection_contract.sh`
   - `test_cross_repo_conformance_bootstrap_contract.sh`
   - `test_cross_repo_conformance_run_root_reuse_contract.sh`

--- a/planningops/scripts/test_apply_branch_protection_contract.sh
+++ b/planningops/scripts/test_apply_branch_protection_contract.sh
@@ -4,52 +4,13 @@ set -euo pipefail
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-cat > "$tmp_dir/policy.json" <<'JSON'
-{
-  "owner": "rather-not-work-on",
-  "default_branch": "main",
-  "defaults": {
-    "require_approving_reviews": true,
-    "min_approving_review_count": 1,
-    "require_conversation_resolution": true,
-    "require_status_checks": true,
-    "require_strict_status_checks": true,
-    "allow_force_pushes": false,
-    "allow_deletions": false,
-    "enforce_admins": false
-  },
-  "repos": [
-    {
-      "name": "platform-planningops",
-      "required_status_checks_all": [
-        "template-and-link-check",
-        "validate-and-dry-run",
-        "federated-summary"
-      ]
-    },
-    {
-      "name": "platform-provider-gateway",
-      "required_status_checks_all": [
-        "template-and-link-check",
-        "provider-local-ci"
-      ]
-    }
-  ]
-}
-JSON
-
-cat > "$tmp_dir/snapshot.json" <<'JSON'
-{
-  "repositories": [
-    {"name": "platform-planningops", "default_branch": "main"},
-    {"name": "platform-provider-gateway", "default_branch": "main"}
-  ]
-}
-JSON
+policy="planningops/fixtures/repository-governance-apply-policy.sample.json"
+policy_invalid="planningops/fixtures/repository-governance-apply-policy-invalid.sample.json"
+snapshot="planningops/fixtures/branch-protection-apply-snapshot.sample.json"
 
 python3 planningops/scripts/apply_branch_protection.py \
-  --policy "$tmp_dir/policy.json" \
-  --snapshot-file "$tmp_dir/snapshot.json" \
+  --policy "$policy" \
+  --snapshot-file "$snapshot" \
   --output "$tmp_dir/branch-protection-apply.test.json" \
   --strict
 
@@ -81,33 +42,10 @@ assert payload["allow_deletions"] is False, payload
 assert payload["required_conversation_resolution"] is True, payload
 PY
 
-cat > "$tmp_dir/policy-invalid.json" <<'JSON'
-{
-  "owner": "rather-not-work-on",
-  "default_branch": "main",
-  "defaults": {
-    "require_approving_reviews": true,
-    "min_approving_review_count": 1,
-    "require_conversation_resolution": true,
-    "require_status_checks": true,
-    "require_strict_status_checks": true,
-    "allow_force_pushes": false,
-    "allow_deletions": false,
-    "enforce_admins": false
-  },
-  "repos": [
-    {
-      "name": "platform-planningops",
-      "required_status_checks_any": ["template-and-link-check", "federated-summary"]
-    }
-  ]
-}
-JSON
-
 set +e
 python3 planningops/scripts/apply_branch_protection.py \
-  --policy "$tmp_dir/policy-invalid.json" \
-  --snapshot-file "$tmp_dir/snapshot.json" \
+  --policy "$policy_invalid" \
+  --snapshot-file "$snapshot" \
   --output "$tmp_dir/branch-protection-apply-invalid.test.json" \
   --strict
 rc=$?

--- a/planningops/scripts/test_branch_protection_apply_artifact_lanes.sh
+++ b/planningops/scripts/test_branch_protection_apply_artifact_lanes.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+policy="planningops/fixtures/repository-governance-apply-policy.sample.json"
+policy_invalid="planningops/fixtures/repository-governance-apply-policy-invalid.sample.json"
+snapshot="planningops/fixtures/branch-protection-apply-snapshot.sample.json"
+
+valid_report="$tmpdir/branch-protection-apply-valid.test.json"
+invalid_report="$tmpdir/branch-protection-apply-invalid.test.json"
+
+python3 planningops/scripts/apply_branch_protection.py \
+  --policy "$policy" \
+  --snapshot-file "$snapshot" \
+  --output "$valid_report" \
+  >/dev/null
+
+set +e
+python3 planningops/scripts/apply_branch_protection.py \
+  --policy "$policy_invalid" \
+  --snapshot-file "$snapshot" \
+  --output "$invalid_report" \
+  --strict \
+  >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure when only required_status_checks_any is configured"
+  exit 1
+fi
+
+python3 - <<'PY' \
+  "$valid_report" \
+  "$invalid_report" \
+  "planningops/artifacts/validation/branch-protection-apply-valid.test.json" \
+  "planningops/artifacts/validation/branch-protection-apply-invalid.test.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual_valid = normalize(load(sys.argv[1]))
+actual_invalid = normalize(load(sys.argv[2]))
+
+expected_valid = normalize(load(sys.argv[3]))
+expected_invalid = normalize(load(sys.argv[4]))
+
+assert actual_valid == expected_valid, (actual_valid, expected_valid)
+assert actual_invalid == expected_invalid, (actual_invalid, expected_invalid)
+
+print("branch protection apply artifact lanes ok")
+PY


### PR DESCRIPTION
## Summary
- extract stable repository-governance apply fixtures for branch protection dry-run coverage
- track deterministic valid and invalid branch-protection apply outputs as committed `.test.json` artifacts
- add a regression that regenerates the apply lanes and compares them against the committed snapshots

## Validation
- bash planningops/scripts/test_apply_branch_protection_contract.sh
- bash planningops/scripts/test_branch_protection_apply_artifact_lanes.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all