### PR TITLE
test(governance): backfill artifact storage policy lanes

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -149,6 +149,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Validation Sample Artifact Lanes Packet](./plans/2026-03-28-validation-sample-artifact-lanes-packet.md)
 - [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
 - [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
+- [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)
 - [Governance Validation Artifact Lanes Packet](./plans/2026-03-28-governance-validation-artifact-lanes-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md
@@ -1,0 +1,32 @@
+---
+title: plan: Artifact Storage Policy Validation Artifact Lanes Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes deterministic valid and invalid artifact storage policy validator outputs into tracked lanes.
+related_docs:
+  - ./2026-03-28-governance-validation-artifact-lanes-packet.md
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+---
+
+# plan: Artifact Storage Policy Validation Artifact Lanes Packet
+
+## Summary
+- Extract a stable invalid artifact storage policy fixture for validator coverage.
+- Promote deterministic valid and invalid artifact storage policy outputs into tracked `.test.json` lanes.
+- Add a comparison regression that regenerates both lanes and compares them to the committed snapshots.
+
+## Scope
+- `planningops/fixtures/artifact-storage-policy-invalid.sample.json`
+- `planningops/artifacts/validation/artifact-storage-policy-valid.test.json`
+- `planningops/artifacts/validation/artifact-storage-policy-invalid.test.json`
+- `planningops/scripts/test_artifact_storage_policy_validation_artifact_lanes.sh`
+
+## Acceptance
+- `test_validate_artifact_storage_policy_contract.sh` passes
+- `test_artifact_storage_policy_validation_artifact_lanes.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -20,7 +20,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
 - `validation/`: gate/schema reports, including fixture-backed `.sample.json` lanes that stay separate from live latest artifacts
   - canonical sample validation lanes currently include `plan-compile-report.sample.json` and `issue-quality-*.sample.json`
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
-  - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, and `artifact-storage-policy-valid.test.json`
+  - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`
   - canonical repository-governance validator lanes also include `branch-protection-audit-valid.test.json` and `branch-protection-audit-invalid.test.json`
   - canonical repository-governance apply lanes also include `branch-protection-apply-valid.test.json` and `branch-protection-apply-invalid.test.json`
 - `adapter-hooks/`, `verification/`, `drift/`, `transition-log/`, `pilot/`, `idempotency/`: supporting evidence

--- a/planningops/artifacts/validation/artifact-storage-policy-invalid.test.json
+++ b/planningops/artifacts/validation/artifact-storage-policy-invalid.test.json
@@ -1,0 +1,33 @@
+{
+  "generated_at_utc": "2026-03-28T13:42:09.235396+00:00",
+  "policy_path": "planningops/fixtures/artifact-storage-policy-invalid.sample.json",
+  "error_count": 25,
+  "errors": [
+    "policy_version must be >= 1",
+    "default_external_backend must be non-empty string",
+    "pointer_manifest_root must start with planningops/artifacts/pointers",
+    "tiers.git_canonical must be non-empty list",
+    "tiers.git_optional must be non-empty list",
+    "tiers.external_only must be non-empty list",
+    "backends.local.base_path must be non-empty string",
+    "backends.s3 must be object",
+    "backends.oci must be object",
+    "default_external_backend must reference existing backends key",
+    "retention.git_canonical_days must be positive integer",
+    "retention.git_optional_days must be positive integer",
+    "retention.external_only_days must be positive integer",
+    "portability_profile.mode must be local_first",
+    "portability_profile.default_backend must match default_external_backend",
+    "portability_profile.approved_migration_backends must be non-empty list",
+    "portability_profile.target_platforms must be non-empty list",
+    "portability_profile.canonical_pointer_strategy must be git_pointer_only",
+    "execution_event_families.broken_family.logical_root must be planningops/artifacts/*/ path",
+    "execution_event_families.broken_family.residency must be external_only",
+    "execution_event_families.broken_family.pointer_visibility must be git_pointer_only",
+    "execution_event_families.broken_family.migration_backends must stay within portability profile",
+    "execution_event_families.broken_family.retention_days exceeds retention.external_only_days",
+    "execution_event_families.broken_family.owner_script missing: planningops/scripts/does-not-exist.py",
+    "commit_guard.forbidden_external_only_in_git must be boolean"
+  ],
+  "verdict": "fail"
+}

--- a/planningops/artifacts/validation/artifact-storage-policy-valid.test.json
+++ b/planningops/artifacts/validation/artifact-storage-policy-valid.test.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-03-28T07:02:33.669146+00:00",
+  "generated_at_utc": "2026-03-28T13:42:09.122875+00:00",
   "policy_path": "planningops/config/artifact-storage-policy.json",
   "error_count": 0,
   "errors": [],

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -21,6 +21,7 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `branch-protection-snapshot-*.sample.json`: valid and invalid branch protection snapshots for repository governance audit tests
 - `repository-governance-apply-policy*.sample.json`: valid and invalid repository governance policies for branch protection apply tests
 - `branch-protection-apply-snapshot.sample.json`: minimal apply snapshot for branch protection apply tests
+- `artifact-storage-policy-invalid.sample.json`: invalid artifact storage policy fixture for validator contract and artifact-lane tests
 
 ## Change Rules
 - Fixtures must be static and deterministic.

--- a/planningops/fixtures/artifact-storage-policy-invalid.sample.json
+++ b/planningops/fixtures/artifact-storage-policy-invalid.sample.json
@@ -1,0 +1,45 @@
+{
+  "policy_version": 0,
+  "default_external_backend": "",
+  "pointer_manifest_root": "planningops/artifacts/invalid-root",
+  "tiers": {
+    "git_canonical": [],
+    "git_optional": [],
+    "external_only": []
+  },
+  "backends": {
+    "local": {
+      "kind": "local"
+    }
+  },
+  "portability_profile": {
+    "mode": "remote_first",
+    "default_backend": "s3",
+    "approved_migration_backends": [],
+    "target_platforms": [],
+    "canonical_pointer_strategy": "inline_git"
+  },
+  "execution_event_families": {
+    "broken_family": {
+      "logical_root": "planningops/artifacts/validation",
+      "residency": "git_canonical",
+      "pointer_visibility": "inline_git",
+      "default_backend": "s3",
+      "migration_backends": [
+        "local"
+      ],
+      "retention_days": 999,
+      "owner_scripts": [
+        "planningops/scripts/does-not-exist.py"
+      ]
+    }
+  },
+  "retention": {
+    "git_canonical_days": 0,
+    "git_optional_days": -1,
+    "external_only_days": 0
+  },
+  "commit_guard": {
+    "forbidden_external_only_in_git": "yes"
+  }
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -935,6 +935,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_issue_quality_validation_artifact_lanes.sh`
   - `test_validate_issue_quality_contract.sh`
   - `test_validate_federated_issue_quality_contract.sh`
+  - `test_artifact_storage_policy_validation_artifact_lanes.sh`
   - `test_validate_artifact_storage_policy_contract.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_migrate_external_only_artifacts_contract.sh`

--- a/planningops/scripts/test_artifact_storage_policy_validation_artifact_lanes.sh
+++ b/planningops/scripts/test_artifact_storage_policy_validation_artifact_lanes.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+valid_report="$tmpdir/artifact-storage-policy-valid.test.json"
+invalid_report="$tmpdir/artifact-storage-policy-invalid.test.json"
+
+python3 planningops/scripts/validate_artifact_storage_policy.py \
+  --policy planningops/config/artifact-storage-policy.json \
+  --output "$valid_report" \
+  --strict \
+  >/dev/null
+
+set +e
+python3 planningops/scripts/validate_artifact_storage_policy.py \
+  --policy planningops/fixtures/artifact-storage-policy-invalid.sample.json \
+  --output "$invalid_report" \
+  --strict \
+  >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for invalid artifact-storage policy fixture"
+  exit 1
+fi
+
+python3 - <<'PY' \
+  "$valid_report" \
+  "$invalid_report" \
+  "planningops/artifacts/validation/artifact-storage-policy-valid.test.json" \
+  "planningops/artifacts/validation/artifact-storage-policy-invalid.test.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual_valid = normalize(load(sys.argv[1]))
+actual_invalid = normalize(load(sys.argv[2]))
+
+expected_valid = normalize(load(sys.argv[3]))
+expected_invalid = normalize(load(sys.argv[4]))
+
+assert actual_valid == expected_valid, (actual_valid, expected_valid)
+assert actual_invalid == expected_invalid, (actual_invalid, expected_invalid)
+
+print("artifact storage policy validation artifact lanes ok")
+PY

--- a/planningops/scripts/test_validate_artifact_storage_policy_contract.sh
+++ b/planningops/scripts/test_validate_artifact_storage_policy_contract.sh
@@ -9,53 +9,9 @@ python3 planningops/scripts/validate_artifact_storage_policy.py \
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-cat > "$tmp_dir/invalid-policy.json" <<'JSON'
-{
-  "policy_version": 0,
-  "default_external_backend": "",
-  "pointer_manifest_root": "planningops/artifacts/invalid-root",
-  "tiers": {
-    "git_canonical": [],
-    "git_optional": [],
-    "external_only": []
-  },
-  "backends": {
-    "local": {
-      "kind": "local"
-    }
-  },
-  "portability_profile": {
-    "mode": "remote_first",
-    "default_backend": "s3",
-    "approved_migration_backends": [],
-    "target_platforms": [],
-    "canonical_pointer_strategy": "inline_git"
-  },
-  "execution_event_families": {
-    "broken_family": {
-      "logical_root": "planningops/artifacts/validation",
-      "residency": "git_canonical",
-      "pointer_visibility": "inline_git",
-      "default_backend": "s3",
-      "migration_backends": ["local"],
-      "retention_days": 999,
-      "owner_scripts": ["planningops/scripts/does-not-exist.py"]
-    }
-  },
-  "retention": {
-    "git_canonical_days": 0,
-    "git_optional_days": -1,
-    "external_only_days": 0
-  },
-  "commit_guard": {
-    "forbidden_external_only_in_git": "yes"
-  }
-}
-JSON
-
 set +e
 python3 planningops/scripts/validate_artifact_storage_policy.py \
-  --policy "$tmp_dir/invalid-policy.json" \
+  --policy planningops/fixtures/artifact-storage-policy-invalid.sample.json \
   --output "$tmp_dir/artifact-storage-policy-invalid.test.json" \
   --strict
 rc=$?


### PR DESCRIPTION
## Summary
- extract a stable invalid artifact storage policy fixture for validator coverage
- track deterministic valid and invalid artifact storage policy outputs as committed `.test.json` lanes
- add a regression that regenerates both lanes and compares them against the committed snapshots

## Validation
- bash planningops/scripts/test_validate_artifact_storage_policy_contract.sh
- bash planningops/scripts/test_artifact_storage_policy_validation_artifact_lanes.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all