### PR TITLE
test(artifact-residency): backfill external-only guard lanes

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -150,6 +150,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
 - [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
 - [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)
+- [External Only Commit Guard Artifact Lanes Packet](./plans/2026-03-28-external-only-commit-guard-artifact-lanes-packet.md)
 - [Governance Validation Artifact Lanes Packet](./plans/2026-03-28-governance-validation-artifact-lanes-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-external-only-commit-guard-artifact-lanes-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-external-only-commit-guard-artifact-lanes-packet.md
@@ -1,0 +1,35 @@
+---
+title: plan: External Only Commit Guard Artifact Lanes Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes deterministic external-only commit guard outputs into tracked validator lanes.
+related_docs:
+  - ./2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md
+  - ./2026-03-28-governance-validation-artifact-lanes-packet.md
+---
+
+# plan: External Only Commit Guard Artifact Lanes Packet
+
+## Summary
+- Extract stable allowed, blocked, and tracked-mode fixtures for external-only commit guard coverage.
+- Promote deterministic allowed, blocked, and tracked validator outputs into tracked `.test.json` lanes.
+- Add a comparison regression that regenerates all three lanes and compares them to the committed snapshots.
+
+## Scope
+- `planningops/fixtures/external-only-commit-guard-allowed-files.sample.txt`
+- `planningops/fixtures/external-only-commit-guard-blocked-files.sample.txt`
+- `planningops/fixtures/external-only-commit-guard-policy.sample.json`
+- `planningops/artifacts/validation/external-only-commit-guard-allowed.test.json`
+- `planningops/artifacts/validation/external-only-commit-guard-blocked.test.json`
+- `planningops/artifacts/validation/external-only-commit-guard-tracked.test.json`
+- `planningops/scripts/test_external_only_commit_guard_artifact_lanes.sh`
+
+## Acceptance
+- `test_validate_external_only_commit_guard.sh` passes
+- `test_external_only_commit_guard_artifact_lanes.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -21,6 +21,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - canonical sample validation lanes currently include `plan-compile-report.sample.json` and `issue-quality-*.sample.json`
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`
+  - canonical external-only guard lanes also include `external-only-commit-guard-allowed.test.json`, `external-only-commit-guard-blocked.test.json`, and `external-only-commit-guard-tracked.test.json`
   - canonical repository-governance validator lanes also include `branch-protection-audit-valid.test.json` and `branch-protection-audit-invalid.test.json`
   - canonical repository-governance apply lanes also include `branch-protection-apply-valid.test.json` and `branch-protection-apply-invalid.test.json`
 - `adapter-hooks/`, `verification/`, `drift/`, `transition-log/`, `pilot/`, `idempotency/`: supporting evidence

--- a/planningops/artifacts/validation/external-only-commit-guard-allowed.test.json
+++ b/planningops/artifacts/validation/external-only-commit-guard-allowed.test.json
@@ -1,0 +1,14 @@
+{
+  "generated_at_utc": "2026-03-28T13:45:01.072634+00:00",
+  "policy_path": "planningops/config/artifact-storage-policy.json",
+  "mode": "diff",
+  "base_ref": null,
+  "head_ref": "HEAD",
+  "changed_file_count": 2,
+  "candidate_file_count": 2,
+  "metadata_file_count": 0,
+  "metadata_files": [],
+  "violation_count": 0,
+  "violations": [],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/external-only-commit-guard-blocked.test.json
+++ b/planningops/artifacts/validation/external-only-commit-guard-blocked.test.json
@@ -1,0 +1,17 @@
+{
+  "generated_at_utc": "2026-03-28T13:45:01.128147+00:00",
+  "policy_path": "planningops/config/artifact-storage-policy.json",
+  "mode": "diff",
+  "base_ref": null,
+  "head_ref": "HEAD",
+  "changed_file_count": 2,
+  "candidate_file_count": 2,
+  "metadata_file_count": 0,
+  "metadata_files": [],
+  "violation_count": 2,
+  "violations": [
+    "planningops/artifacts/loops/2026-03-06/loop-001/verification-report.json",
+    "planningops/artifacts/transition-log/2026-03-06.ndjson"
+  ],
+  "verdict": "fail"
+}

--- a/planningops/artifacts/validation/external-only-commit-guard-tracked.test.json
+++ b/planningops/artifacts/validation/external-only-commit-guard-tracked.test.json
@@ -1,0 +1,18 @@
+{
+  "generated_at_utc": "2026-03-28T13:45:01.251436+00:00",
+  "policy_path": "policy.json",
+  "mode": "tracked",
+  "base_ref": null,
+  "head_ref": "HEAD",
+  "changed_file_count": 4,
+  "candidate_file_count": 3,
+  "metadata_file_count": 1,
+  "metadata_files": [
+    "planningops/artifacts/loops/demo/._run.json"
+  ],
+  "violation_count": 1,
+  "violations": [
+    "planningops/artifacts/loops/demo/run.json"
+  ],
+  "verdict": "fail"
+}

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -22,6 +22,8 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `repository-governance-apply-policy*.sample.json`: valid and invalid repository governance policies for branch protection apply tests
 - `branch-protection-apply-snapshot.sample.json`: minimal apply snapshot for branch protection apply tests
 - `artifact-storage-policy-invalid.sample.json`: invalid artifact storage policy fixture for validator contract and artifact-lane tests
+- `external-only-commit-guard-*.sample.txt`: allowed and blocked file lists for commit guard validator tests
+- `external-only-commit-guard-policy.sample.json`: tracked-mode policy fixture for commit guard validator tests
 
 ## Change Rules
 - Fixtures must be static and deterministic.

--- a/planningops/fixtures/external-only-commit-guard-allowed-files.sample.txt
+++ b/planningops/fixtures/external-only-commit-guard-allowed-files.sample.txt
@@ -1,0 +1,2 @@
+planningops/artifacts/validation/report.json
+planningops/contracts/issue-quality-contract.md

--- a/planningops/fixtures/external-only-commit-guard-blocked-files.sample.txt
+++ b/planningops/fixtures/external-only-commit-guard-blocked-files.sample.txt
@@ -1,0 +1,2 @@
+planningops/artifacts/loops/2026-03-06/loop-001/verification-report.json
+planningops/artifacts/transition-log/2026-03-06.ndjson

--- a/planningops/fixtures/external-only-commit-guard-policy.sample.json
+++ b/planningops/fixtures/external-only-commit-guard-policy.sample.json
@@ -1,0 +1,41 @@
+{
+  "policy_version": 1,
+  "default_external_backend": "local",
+  "pointer_manifest_root": "planningops/artifacts/pointers",
+  "tiers": {
+    "git_canonical": [
+      "planningops/artifacts/validation/**"
+    ],
+    "git_optional": [],
+    "external_only": [
+      "planningops/artifacts/loops/**"
+    ]
+  },
+  "backends": {
+    "local": {
+      "kind": "local",
+      "base_path": "planningops/runtime-artifacts/local"
+    },
+    "s3": {
+      "kind": "s3_mock",
+      "bucket": "demo",
+      "prefix": "planningops",
+      "mock_base_path": "planningops/runtime-artifacts/s3"
+    },
+    "oci": {
+      "kind": "oci_mock",
+      "namespace": "demo",
+      "bucket": "demo",
+      "prefix": "planningops",
+      "mock_base_path": "planningops/runtime-artifacts/oci"
+    }
+  },
+  "retention": {
+    "git_canonical_days": 3650,
+    "git_optional_days": 180,
+    "external_only_days": 30
+  },
+  "commit_guard": {
+    "forbidden_external_only_in_git": true
+  }
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -937,6 +937,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_federated_issue_quality_contract.sh`
   - `test_artifact_storage_policy_validation_artifact_lanes.sh`
   - `test_validate_artifact_storage_policy_contract.sh`
+  - `test_external_only_commit_guard_artifact_lanes.sh`
   - `test_validate_external_only_commit_guard.sh`
   - `test_migrate_external_only_artifacts_contract.sh`
   - `test_branch_protection_audit_artifact_lanes.sh`

--- a/planningops/scripts/test_external_only_commit_guard_artifact_lanes.sh
+++ b/planningops/scripts/test_external_only_commit_guard_artifact_lanes.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+allowed_report="$tmp_dir/external-only-commit-guard-allowed.test.json"
+blocked_report="$tmp_dir/external-only-commit-guard-blocked.test.json"
+tracked_report="$tmp_dir/external-only-commit-guard-tracked.test.json"
+
+python3 planningops/scripts/validate_external_only_commit_guard.py \
+  --policy planningops/config/artifact-storage-policy.json \
+  --files-file planningops/fixtures/external-only-commit-guard-allowed-files.sample.txt \
+  --output "$allowed_report" \
+  --strict \
+  >/dev/null
+
+set +e
+python3 planningops/scripts/validate_external_only_commit_guard.py \
+  --policy planningops/config/artifact-storage-policy.json \
+  --files-file planningops/fixtures/external-only-commit-guard-blocked-files.sample.txt \
+  --output "$blocked_report" \
+  --strict \
+  >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for external-only commit guard sample"
+  exit 1
+fi
+
+tracked_repo="$tmp_dir/tracked-repo"
+mkdir -p "$tracked_repo/planningops/artifacts/loops/demo" "$tracked_repo/planningops/artifacts/validation"
+cd "$tracked_repo"
+git init -q
+git config user.name "Codex"
+git config user.email "codex@example.com"
+cp "$repo_root/planningops/fixtures/external-only-commit-guard-policy.sample.json" policy.json
+printf '{"ok":true}\n' > planningops/artifacts/validation/report.json
+printf '{"bad":true}\n' > planningops/artifacts/loops/demo/run.json
+printf 'metadata\n' > planningops/artifacts/loops/demo/._run.json
+git add policy.json planningops/artifacts/validation/report.json planningops/artifacts/loops/demo/run.json planningops/artifacts/loops/demo/._run.json
+
+set +e
+python3 "$repo_root/planningops/scripts/validate_external_only_commit_guard.py" \
+  --policy policy.json \
+  --mode tracked \
+  --output "$tracked_report" \
+  --strict \
+  >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for tracked external-only baseline"
+  exit 1
+fi
+
+cd "$repo_root"
+
+python3 - <<'PY' \
+  "$allowed_report" \
+  "$blocked_report" \
+  "$tracked_report" \
+  "planningops/artifacts/validation/external-only-commit-guard-allowed.test.json" \
+  "planningops/artifacts/validation/external-only-commit-guard-blocked.test.json" \
+  "planningops/artifacts/validation/external-only-commit-guard-tracked.test.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual_allowed = normalize(load(sys.argv[1]))
+actual_blocked = normalize(load(sys.argv[2]))
+actual_tracked = normalize(load(sys.argv[3]))
+
+expected_allowed = normalize(load(sys.argv[4]))
+expected_blocked = normalize(load(sys.argv[5]))
+expected_tracked = normalize(load(sys.argv[6]))
+
+assert actual_allowed == expected_allowed, (actual_allowed, expected_allowed)
+assert actual_blocked == expected_blocked, (actual_blocked, expected_blocked)
+assert actual_tracked == expected_tracked, (actual_tracked, expected_tracked)
+
+print("external-only commit guard artifact lanes ok")
+PY

--- a/planningops/scripts/test_validate_external_only_commit_guard.sh
+++ b/planningops/scripts/test_validate_external_only_commit_guard.sh
@@ -5,18 +5,9 @@ repo_root="$(pwd)"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-allowed_files="$tmp_dir/allowed.txt"
-blocked_files="$tmp_dir/blocked.txt"
-
-cat > "$allowed_files" <<'EOF'
-planningops/artifacts/validation/report.json
-planningops/contracts/issue-quality-contract.md
-EOF
-
-cat > "$blocked_files" <<'EOF'
-planningops/artifacts/loops/2026-03-06/loop-001/verification-report.json
-planningops/artifacts/transition-log/2026-03-06.ndjson
-EOF
+allowed_files="planningops/fixtures/external-only-commit-guard-allowed-files.sample.txt"
+blocked_files="planningops/fixtures/external-only-commit-guard-blocked-files.sample.txt"
+tracked_policy="planningops/fixtures/external-only-commit-guard-policy.sample.json"
 
 python3 planningops/scripts/validate_external_only_commit_guard.py \
   --policy planningops/config/artifact-storage-policy.json \
@@ -44,31 +35,7 @@ cd "$tracked_repo"
 git init -q
 git config user.name "Codex"
 git config user.email "codex@example.com"
-cat > policy.json <<'JSON'
-{
-  "policy_version": 1,
-  "default_external_backend": "local",
-  "pointer_manifest_root": "planningops/artifacts/pointers",
-  "tiers": {
-    "git_canonical": ["planningops/artifacts/validation/**"],
-    "git_optional": [],
-    "external_only": ["planningops/artifacts/loops/**"]
-  },
-  "backends": {
-    "local": {"kind": "local", "base_path": "planningops/runtime-artifacts/local"},
-    "s3": {"kind": "s3_mock", "bucket": "demo", "prefix": "planningops", "mock_base_path": "planningops/runtime-artifacts/s3"},
-    "oci": {"kind": "oci_mock", "namespace": "demo", "bucket": "demo", "prefix": "planningops", "mock_base_path": "planningops/runtime-artifacts/oci"}
-  },
-  "retention": {
-    "git_canonical_days": 3650,
-    "git_optional_days": 180,
-    "external_only_days": 30
-  },
-  "commit_guard": {
-    "forbidden_external_only_in_git": true
-  }
-}
-JSON
+cp "$repo_root/$tracked_policy" policy.json
 printf '{"ok":true}\n' > planningops/artifacts/validation/report.json
 printf '{"bad":true}\n' > planningops/artifacts/loops/demo/run.json
 printf 'metadata\n' > planningops/artifacts/loops/demo/._run.json


### PR DESCRIPTION
## Summary
- extract stable allowed, blocked, and tracked-mode fixtures for external-only commit guard coverage
- track deterministic allowed, blocked, and tracked validator outputs as committed `.test.json` lanes
- add a regression that regenerates all three lanes and compares them against the committed snapshots

## Validation
- bash planningops/scripts/test_validate_external_only_commit_guard.sh
- bash planningops/scripts/test_external_only_commit_guard_artifact_lanes.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all