### PR TITLE
test(artifact-residency): backfill migration lanes

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -151,6 +151,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
 - [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)
 - [External Only Commit Guard Artifact Lanes Packet](./plans/2026-03-28-external-only-commit-guard-artifact-lanes-packet.md)
+- [External Only Artifact Migration Lanes Packet](./plans/2026-03-28-external-only-artifact-migration-lanes-packet.md)
 - [Governance Validation Artifact Lanes Packet](./plans/2026-03-28-governance-validation-artifact-lanes-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-external-only-artifact-migration-lanes-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-external-only-artifact-migration-lanes-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: External Only Artifact Migration Lanes Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes deterministic tracked migration dry-run and apply outputs into committed artifact lanes.
+related_docs:
+  - ./2026-03-28-external-only-commit-guard-artifact-lanes-packet.md
+  - ./2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md
+---
+
+# plan: External Only Artifact Migration Lanes Packet
+
+## Summary
+- Reuse the tracked-mode external-only policy fixture for artifact migration coverage.
+- Promote deterministic tracked dry-run and apply migration outputs into committed `.test.json` lanes.
+- Add a comparison regression that regenerates both lanes and compares them to the committed snapshots.
+
+## Scope
+- `planningops/artifacts/validation/artifact-migration-tracked-dry-run.test.json`
+- `planningops/artifacts/validation/artifact-migration-tracked-apply.test.json`
+- `planningops/scripts/test_migrate_external_only_artifact_lanes.sh`
+
+## Acceptance
+- `test_migrate_external_only_artifacts_contract.sh` passes
+- `test_migrate_external_only_artifact_lanes.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -22,6 +22,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`
   - canonical external-only guard lanes also include `external-only-commit-guard-allowed.test.json`, `external-only-commit-guard-blocked.test.json`, and `external-only-commit-guard-tracked.test.json`
+  - canonical external-only migration lanes also include `artifact-migration-tracked-dry-run.test.json` and `artifact-migration-tracked-apply.test.json`
   - canonical repository-governance validator lanes also include `branch-protection-audit-valid.test.json` and `branch-protection-audit-invalid.test.json`
   - canonical repository-governance apply lanes also include `branch-protection-apply-valid.test.json` and `branch-protection-apply-invalid.test.json`
 - `adapter-hooks/`, `verification/`, `drift/`, `transition-log/`, `pilot/`, `idempotency/`: supporting evidence

--- a/planningops/artifacts/validation/artifact-migration-tracked-apply.test.json
+++ b/planningops/artifacts/validation/artifact-migration-tracked-apply.test.json
@@ -1,0 +1,18 @@
+{
+  "generated_at_utc": "2026-03-28T13:47:31.331136+00:00",
+  "policy_path": "policy.json",
+  "backend": "local",
+  "mode": "apply",
+  "scope": "tracked",
+  "candidate_count": 1,
+  "migrated_count": 1,
+  "rows": [
+    {
+      "logical_path": "planningops/artifacts/loops/demo/run.json",
+      "externalized": true,
+      "pointer_path": "planningops/artifacts/pointers/loops/demo/run.json.pointer.json",
+      "backend_target_path": "planningops/runtime-artifacts/local/loops/demo/run.json",
+      "reason": null
+    }
+  ]
+}

--- a/planningops/artifacts/validation/artifact-migration-tracked-dry-run.test.json
+++ b/planningops/artifacts/validation/artifact-migration-tracked-dry-run.test.json
@@ -1,0 +1,16 @@
+{
+  "generated_at_utc": "2026-03-28T13:47:31.277290+00:00",
+  "policy_path": "policy.json",
+  "backend": "local",
+  "mode": "dry-run",
+  "scope": "tracked",
+  "candidate_count": 1,
+  "migrated_count": 0,
+  "rows": [
+    {
+      "logical_path": "planningops/artifacts/loops/demo/run.json",
+      "externalized": false,
+      "reason": "dry-run"
+    }
+  ]
+}

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -23,7 +23,7 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `branch-protection-apply-snapshot.sample.json`: minimal apply snapshot for branch protection apply tests
 - `artifact-storage-policy-invalid.sample.json`: invalid artifact storage policy fixture for validator contract and artifact-lane tests
 - `external-only-commit-guard-*.sample.txt`: allowed and blocked file lists for commit guard validator tests
-- `external-only-commit-guard-policy.sample.json`: tracked-mode policy fixture for commit guard validator tests
+- `external-only-commit-guard-policy.sample.json`: tracked-mode policy fixture for commit guard and migration tests
 
 ## Change Rules
 - Fixtures must be static and deterministic.

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -939,6 +939,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_artifact_storage_policy_contract.sh`
   - `test_external_only_commit_guard_artifact_lanes.sh`
   - `test_validate_external_only_commit_guard.sh`
+  - `test_migrate_external_only_artifact_lanes.sh`
   - `test_migrate_external_only_artifacts_contract.sh`
   - `test_branch_protection_audit_artifact_lanes.sh`
   - `test_audit_branch_protection_contract.sh`

--- a/planningops/scripts/test_migrate_external_only_artifact_lanes.sh
+++ b/planningops/scripts/test_migrate_external_only_artifact_lanes.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+policy_fixture="$repo_root/planningops/fixtures/external-only-commit-guard-policy.sample.json"
+
+work_repo="$tmp_dir/work-repo"
+mkdir -p "$work_repo/planningops/artifacts/loops/demo" "$work_repo/planningops/artifacts/validation"
+cd "$work_repo"
+git init -q
+git config user.name "Codex"
+git config user.email "codex@example.com"
+cp "$policy_fixture" policy.json
+
+printf '{"tracked":true}\n' > planningops/artifacts/loops/demo/run.json
+printf '{"untracked":true}\n' > planningops/artifacts/loops/demo/extra.json
+git add policy.json planningops/artifacts/loops/demo/run.json
+
+python3 "$repo_root/planningops/scripts/migrate_external_only_artifacts.py" \
+  --policy policy.json \
+  --scope tracked \
+  --output "$tmp_dir/artifact-migration-tracked-dry-run.test.json" \
+  >/dev/null
+
+python3 "$repo_root/planningops/scripts/migrate_external_only_artifacts.py" \
+  --policy policy.json \
+  --scope tracked \
+  --apply \
+  --output "$tmp_dir/artifact-migration-tracked-apply.test.json" \
+  >/dev/null
+
+cd "$repo_root"
+
+python3 - <<'PY' \
+  "$tmp_dir/artifact-migration-tracked-dry-run.test.json" \
+  "$tmp_dir/artifact-migration-tracked-apply.test.json" \
+  "planningops/artifacts/validation/artifact-migration-tracked-dry-run.test.json" \
+  "planningops/artifacts/validation/artifact-migration-tracked-apply.test.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual_dry = normalize(load(sys.argv[1]))
+actual_apply = normalize(load(sys.argv[2]))
+
+expected_dry = normalize(load(sys.argv[3]))
+expected_apply = normalize(load(sys.argv[4]))
+
+assert actual_dry == expected_dry, (actual_dry, expected_dry)
+assert actual_apply == expected_apply, (actual_apply, expected_apply)
+
+print("migrate external-only artifact lanes ok")
+PY

--- a/planningops/scripts/test_migrate_external_only_artifacts_contract.sh
+++ b/planningops/scripts/test_migrate_external_only_artifacts_contract.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 repo_root="$(pwd)"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
+policy_fixture="$repo_root/planningops/fixtures/external-only-commit-guard-policy.sample.json"
 
 work_repo="$tmp_dir/work-repo"
 mkdir -p "$work_repo/planningops/artifacts/loops/demo" "$work_repo/planningops/artifacts/validation"
@@ -11,32 +12,7 @@ cd "$work_repo"
 git init -q
 git config user.name "Codex"
 git config user.email "codex@example.com"
-
-cat > policy.json <<'JSON'
-{
-  "policy_version": 1,
-  "default_external_backend": "local",
-  "pointer_manifest_root": "planningops/artifacts/pointers",
-  "tiers": {
-    "git_canonical": ["planningops/artifacts/validation/**"],
-    "git_optional": [],
-    "external_only": ["planningops/artifacts/loops/**"]
-  },
-  "backends": {
-    "local": {"kind": "local", "base_path": "planningops/runtime-artifacts/local"},
-    "s3": {"kind": "s3_mock", "bucket": "demo", "prefix": "planningops", "mock_base_path": "planningops/runtime-artifacts/s3"},
-    "oci": {"kind": "oci_mock", "namespace": "demo", "bucket": "demo", "prefix": "planningops", "mock_base_path": "planningops/runtime-artifacts/oci"}
-  },
-  "retention": {
-    "git_canonical_days": 3650,
-    "git_optional_days": 180,
-    "external_only_days": 30
-  },
-  "commit_guard": {
-    "forbidden_external_only_in_git": true
-  }
-}
-JSON
+cp "$policy_fixture" policy.json
 
 printf '{"tracked":true}\n' > planningops/artifacts/loops/demo/run.json
 printf '{"untracked":true}\n' > planningops/artifacts/loops/demo/extra.json


### PR DESCRIPTION
## Summary
- reuse the tracked-mode external-only policy fixture for artifact migration coverage
- track deterministic tracked dry-run and apply migration outputs as committed `.test.json` lanes
- add a regression that regenerates both lanes and compares them against the committed snapshots

## Validation
- bash planningops/scripts/test_migrate_external_only_artifacts_contract.sh
- bash planningops/scripts/test_migrate_external_only_artifact_lanes.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all