### PR TITLE
test(artifact-sink): backfill e2e lane

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -152,6 +152,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)
 - [External Only Commit Guard Artifact Lanes Packet](./plans/2026-03-28-external-only-commit-guard-artifact-lanes-packet.md)
 - [External Only Artifact Migration Lanes Packet](./plans/2026-03-28-external-only-artifact-migration-lanes-packet.md)
+- [Artifact Sink E2E Lane Packet](./plans/2026-03-28-artifact-sink-e2e-lane-packet.md)
 - [Governance Validation Artifact Lanes Packet](./plans/2026-03-28-governance-validation-artifact-lanes-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-artifact-sink-e2e-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-artifact-sink-e2e-lane-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Artifact Sink E2E Lane Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes a normalized artifact-sink end-to-end snapshot into a committed verification lane.
+related_docs:
+  - ./2026-03-28-external-only-commit-guard-artifact-lanes-packet.md
+  - ./2026-03-28-external-only-artifact-migration-lanes-packet.md
+---
+
+# plan: Artifact Sink E2E Lane Packet
+
+## Summary
+- Regenerate a normalized artifact sink end-to-end summary from the local and s3 mock backends.
+- Keep dynamic path and timestamp fields normalized inside the committed lane artifact.
+- Add one regression that compares the normalized summary against the committed baseline.
+
+## Scope
+- `planningops/artifacts/validation/artifact-sink-e2e.test.json`
+- `planningops/scripts/test_artifact_sink_e2e_artifact_lane.sh`
+- `planningops/contracts/artifact-sink-contract.md`
+
+## Acceptance
+- `test_artifact_sink_e2e.sh` passes
+- `test_artifact_sink_e2e_artifact_lane.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -23,6 +23,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`
   - canonical external-only guard lanes also include `external-only-commit-guard-allowed.test.json`, `external-only-commit-guard-blocked.test.json`, and `external-only-commit-guard-tracked.test.json`
   - canonical external-only migration lanes also include `artifact-migration-tracked-dry-run.test.json` and `artifact-migration-tracked-apply.test.json`
+  - canonical artifact sink verification lane also includes `artifact-sink-e2e.test.json`
   - canonical repository-governance validator lanes also include `branch-protection-audit-valid.test.json` and `branch-protection-audit-invalid.test.json`
   - canonical repository-governance apply lanes also include `branch-protection-apply-valid.test.json` and `branch-protection-apply-invalid.test.json`
 - `adapter-hooks/`, `verification/`, `drift/`, `transition-log/`, `pilot/`, `idempotency/`: supporting evidence

--- a/planningops/artifacts/validation/artifact-sink-e2e.test.json
+++ b/planningops/artifacts/validation/artifact-sink-e2e.test.json
@@ -1,0 +1,34 @@
+{
+  "summary_version": 1,
+  "local_pointer": {
+    "generated_at_utc": "__GENERATED_AT__",
+    "policy_path": "__POLICY_PATH__",
+    "policy_version": 1,
+    "tier": "external_only",
+    "logical_path": "planningops/artifacts/loops/demo/run.json",
+    "backend": "local",
+    "uri": "__URI__",
+    "backend_target_path": "__BACKEND_TARGET_PATH__",
+    "bytes": 39,
+    "sha256": "4946e7ce842ec28d36782440090e7092a4c09e4f0a127d33806eb7168cdf6de6",
+    "local_cache_external": false
+  },
+  "s3_pointer": {
+    "generated_at_utc": "__GENERATED_AT__",
+    "policy_path": "__POLICY_PATH__",
+    "policy_version": 1,
+    "tier": "external_only",
+    "logical_path": "planningops/artifacts/loops/demo/replay.ndjson",
+    "backend": "s3",
+    "uri": "s3://demo-bucket/planningops/loops/demo/replay.ndjson",
+    "backend_target_path": "__BACKEND_TARGET_PATH__",
+    "bytes": 14,
+    "sha256": "25a8bbba90ca6e018c37d36f8639a9b428a20b1f4a461eb893a0c1fe6ca71e90",
+    "local_cache_external": false
+  },
+  "rehydrated_local": {
+    "verdict": "pass",
+    "attempt": 1
+  },
+  "rehydrated_s3": "{\"event\":\"a\"}\n"
+}

--- a/planningops/contracts/artifact-sink-contract.md
+++ b/planningops/contracts/artifact-sink-contract.md
@@ -29,6 +29,7 @@ Provide a deterministic write/read/rehydrate abstraction for artifact storage ba
 
 ## Verification
 - E2E sink test: `bash planningops/scripts/test_artifact_sink_e2e.sh`
+- E2E snapshot lane: `bash planningops/scripts/test_artifact_sink_e2e_artifact_lane.sh`
 - Commit guard test: `bash planningops/scripts/test_validate_external_only_commit_guard.sh`
 - Migration test: `bash planningops/scripts/test_migrate_external_only_artifacts_contract.sh`
 - Workflow helper: `bash planningops/scripts/run_external_artifact_residency_ci_check.sh --base-ref <base> --head-ref <head> --python-bin python3`

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -941,6 +941,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_external_only_commit_guard.sh`
   - `test_migrate_external_only_artifact_lanes.sh`
   - `test_migrate_external_only_artifacts_contract.sh`
+  - `test_artifact_sink_e2e_artifact_lane.sh`
   - `test_branch_protection_audit_artifact_lanes.sh`
   - `test_audit_branch_protection_contract.sh`
   - `test_branch_protection_apply_artifact_lanes.sh`

--- a/planningops/scripts/test_artifact_sink_e2e_artifact_lane.sh
+++ b/planningops/scripts/test_artifact_sink_e2e_artifact_lane.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+policy_path="$tmp_dir/policy.json"
+cat > "$policy_path" <<JSON
+{
+  "policy_version": 1,
+  "default_external_backend": "local",
+  "pointer_manifest_root": "$tmp_dir/pointers",
+  "tiers": {
+    "git_canonical": ["planningops/artifacts/validation/**"],
+    "git_optional": [],
+    "external_only": ["planningops/artifacts/loops/**"]
+  },
+  "backends": {
+    "local": {"kind": "local", "base_path": "$tmp_dir/external-local"},
+    "s3": {"kind": "s3_mock", "bucket": "demo-bucket", "prefix": "planningops", "mock_base_path": "$tmp_dir/external-s3"},
+    "oci": {"kind": "oci_mock", "namespace": "demo-ns", "bucket": "demo-bucket", "prefix": "planningops", "mock_base_path": "$tmp_dir/external-oci"}
+  }
+}
+JSON
+
+actual_summary="$tmp_dir/artifact-sink-e2e.test.json"
+
+python3 - <<'PY' "$policy_path" "$tmp_dir" "$actual_summary"
+import json
+import sys
+from pathlib import Path
+
+repo_root = Path.cwd()
+sys.path.insert(0, str(repo_root / "planningops/scripts"))
+from artifact_sink import ArtifactSink  # noqa: E402
+
+policy = Path(sys.argv[1])
+tmp = Path(sys.argv[2])
+summary_path = Path(sys.argv[3])
+
+local_sink = ArtifactSink(policy_path=policy, backend_override="local", local_cache_external=False)
+local_sink.write_json("planningops/artifacts/loops/demo/run.json", {"verdict": "pass", "attempt": 1})
+local_pointer = tmp / "pointers/loops/demo/run.json.pointer.json"
+rehydrated_local = tmp / "rehydrated-local.json"
+local_sink.rehydrate_from_pointer(local_pointer, rehydrated_local)
+
+s3_sink = ArtifactSink(policy_path=policy, backend_override="s3", local_cache_external=False)
+s3_sink.write_text("planningops/artifacts/loops/demo/replay.ndjson", '{"event":"a"}\n', append=False)
+s3_pointer = tmp / "pointers/loops/demo/replay.ndjson.pointer.json"
+rehydrated_s3 = tmp / "rehydrated-s3.ndjson"
+s3_sink.rehydrate_from_pointer(s3_pointer, rehydrated_s3)
+
+
+def normalize_pointer(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    normalized["policy_path"] = "__POLICY_PATH__"
+    normalized["backend_target_path"] = "__BACKEND_TARGET_PATH__"
+    if normalized.get("backend") == "local":
+        normalized["uri"] = "__URI__"
+    return normalized
+
+
+summary = {
+    "summary_version": 1,
+    "local_pointer": normalize_pointer(json.loads(local_pointer.read_text(encoding="utf-8"))),
+    "s3_pointer": normalize_pointer(json.loads(s3_pointer.read_text(encoding="utf-8"))),
+    "rehydrated_local": json.loads(rehydrated_local.read_text(encoding="utf-8")),
+    "rehydrated_s3": rehydrated_s3.read_text(encoding="utf-8"),
+}
+
+summary_path.write_text(json.dumps(summary, ensure_ascii=True, indent=2), encoding="utf-8")
+PY
+
+python3 - <<'PY' "$actual_summary" "planningops/artifacts/validation/artifact-sink-e2e.test.json"
+import json
+import sys
+from pathlib import Path
+
+actual = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+expected = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+assert actual == expected, (actual, expected)
+print("artifact sink e2e artifact lane ok")
+PY


### PR DESCRIPTION
## Summary
- track a normalized artifact-sink end-to-end summary as a committed verification lane
- compare regenerated local and s3 mock pointer summaries against the committed baseline
- document the new artifact-sink snapshot lane in artifacts, scripts, contracts, and workbench docs

## Validation
- bash planningops/scripts/test_artifact_sink_e2e.sh
- bash planningops/scripts/test_artifact_sink_e2e_artifact_lane.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all