### PR TITLE
test(issue-quality): backfill federated artifact lanes

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -153,6 +153,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [External Only Commit Guard Artifact Lanes Packet](./plans/2026-03-28-external-only-commit-guard-artifact-lanes-packet.md)
 - [External Only Artifact Migration Lanes Packet](./plans/2026-03-28-external-only-artifact-migration-lanes-packet.md)
 - [Artifact Sink E2E Lane Packet](./plans/2026-03-28-artifact-sink-e2e-lane-packet.md)
+- [Federated Issue Quality Artifact Lanes Packet](./plans/2026-03-28-federated-issue-quality-artifact-lanes-packet.md)
 - [Governance Validation Artifact Lanes Packet](./plans/2026-03-28-governance-validation-artifact-lanes-packet.md)
 - [Project Field Schema Artifact Refresh Packet](./plans/2026-03-28-project-field-schema-artifact-refresh-packet.md)
 - [Plan Projection Artifact Refresh Packet](./plans/2026-03-28-plan-projection-artifact-refresh-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-federated-issue-quality-artifact-lanes-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-federated-issue-quality-artifact-lanes-packet.md
@@ -1,0 +1,35 @@
+---
+title: plan: Federated Issue Quality Artifact Lanes Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes deterministic federated issue-quality validation outputs into committed artifact lanes.
+related_docs:
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+  - ./2026-03-28-issue-quality-validation-artifact-lanes-packet.md
+---
+
+# plan: Federated Issue Quality Artifact Lanes Packet
+
+## Summary
+- Extract stable config and issue fixtures for federated issue-quality coverage.
+- Promote deterministic valid, invalid, and auto-fix outputs into committed `.test.json` lanes.
+- Add a comparison regression that regenerates all three lanes and compares them to the committed snapshots.
+
+## Scope
+- `planningops/fixtures/federated-issue-quality-config.sample.json`
+- `planningops/fixtures/federated-issue-quality-valid.sample.json`
+- `planningops/fixtures/federated-issue-quality-invalid.sample.json`
+- `planningops/artifacts/validation/federated-issue-quality-valid.test.json`
+- `planningops/artifacts/validation/federated-issue-quality-invalid.test.json`
+- `planningops/artifacts/validation/federated-issue-quality-auto-fix.test.json`
+- `planningops/scripts/test_federated_issue_quality_artifact_lanes.sh`
+
+## Acceptance
+- `test_validate_federated_issue_quality_contract.sh` passes
+- `test_federated_issue_quality_artifact_lanes.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -20,6 +20,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
 - `validation/`: gate/schema reports, including fixture-backed `.sample.json` lanes that stay separate from live latest artifacts
   - canonical sample validation lanes currently include `plan-compile-report.sample.json` and `issue-quality-*.sample.json`
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
+  - canonical federated issue-quality lanes also include `federated-issue-quality-valid.test.json`, `federated-issue-quality-invalid.test.json`, and `federated-issue-quality-auto-fix.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`
   - canonical external-only guard lanes also include `external-only-commit-guard-allowed.test.json`, `external-only-commit-guard-blocked.test.json`, and `external-only-commit-guard-tracked.test.json`
   - canonical external-only migration lanes also include `artifact-migration-tracked-dry-run.test.json` and `artifact-migration-tracked-apply.test.json`

--- a/planningops/artifacts/validation/federated-issue-quality-auto-fix.test.json
+++ b/planningops/artifacts/validation/federated-issue-quality-auto-fix.test.json
@@ -1,0 +1,33 @@
+{
+  "generated_at_utc": "2026-03-28T13:52:42.254846+00:00",
+  "mode": "apply-default-labels",
+  "config_path": "planningops/fixtures/federated-issue-quality-config.sample.json",
+  "issues_in_scope": 1,
+  "applied_label_count": 4,
+  "violation_count": 0,
+  "error_count": 0,
+  "violations": [],
+  "errors": [],
+  "results": [
+    {
+      "repo": "rather-not-work-on/platform-contracts",
+      "issue_number": 2,
+      "issue_title": "invalid sample",
+      "issue_url": "https://example.com/2",
+      "missing_before": [
+        "task",
+        "priority",
+        "area/",
+        "type/"
+      ],
+      "applied_labels": [
+        "area/contracts",
+        "p2",
+        "task",
+        "type/governance"
+      ],
+      "missing_after": []
+    }
+  ],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/federated-issue-quality-invalid.test.json
+++ b/planningops/artifacts/validation/federated-issue-quality-invalid.test.json
@@ -1,0 +1,46 @@
+{
+  "generated_at_utc": "2026-03-28T13:52:42.210348+00:00",
+  "mode": "check",
+  "config_path": "planningops/fixtures/federated-issue-quality-config.sample.json",
+  "issues_in_scope": 1,
+  "applied_label_count": 0,
+  "violation_count": 1,
+  "error_count": 0,
+  "violations": [
+    {
+      "repo": "rather-not-work-on/platform-contracts",
+      "issue_number": 2,
+      "issue_title": "invalid sample",
+      "issue_url": "https://example.com/2",
+      "missing": [
+        "task",
+        "priority",
+        "area/",
+        "type/"
+      ]
+    }
+  ],
+  "errors": [],
+  "results": [
+    {
+      "repo": "rather-not-work-on/platform-contracts",
+      "issue_number": 2,
+      "issue_title": "invalid sample",
+      "issue_url": "https://example.com/2",
+      "missing_before": [
+        "task",
+        "priority",
+        "area/",
+        "type/"
+      ],
+      "applied_labels": [],
+      "missing_after": [
+        "task",
+        "priority",
+        "area/",
+        "type/"
+      ]
+    }
+  ],
+  "verdict": "fail"
+}

--- a/planningops/artifacts/validation/federated-issue-quality-valid.test.json
+++ b/planningops/artifacts/validation/federated-issue-quality-valid.test.json
@@ -1,0 +1,23 @@
+{
+  "generated_at_utc": "2026-03-28T13:52:42.167409+00:00",
+  "mode": "check",
+  "config_path": "planningops/fixtures/federated-issue-quality-config.sample.json",
+  "issues_in_scope": 1,
+  "applied_label_count": 0,
+  "violation_count": 0,
+  "error_count": 0,
+  "violations": [],
+  "errors": [],
+  "results": [
+    {
+      "repo": "rather-not-work-on/platform-contracts",
+      "issue_number": 1,
+      "issue_title": "valid sample",
+      "issue_url": "https://example.com/1",
+      "missing_before": [],
+      "applied_labels": [],
+      "missing_after": []
+    }
+  ],
+  "verdict": "pass"
+}

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -24,6 +24,7 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `artifact-storage-policy-invalid.sample.json`: invalid artifact storage policy fixture for validator contract and artifact-lane tests
 - `external-only-commit-guard-*.sample.txt`: allowed and blocked file lists for commit guard validator tests
 - `external-only-commit-guard-policy.sample.json`: tracked-mode policy fixture for commit guard and migration tests
+- `federated-issue-quality-*.sample.json`: config, valid issue set, and invalid issue set for federated label-quality tests
 
 ## Change Rules
 - Fixtures must be static and deterministic.

--- a/planningops/fixtures/federated-issue-quality-config.sample.json
+++ b/planningops/fixtures/federated-issue-quality-config.sample.json
@@ -1,0 +1,24 @@
+{
+  "default_priority_label": "p2",
+  "required": {
+    "required_labels_all": [
+      "task"
+    ],
+    "required_priority_labels_any": [
+      "p1",
+      "p2",
+      "p3"
+    ],
+    "required_label_prefixes": [
+      "area/",
+      "type/"
+    ]
+  },
+  "repos": [
+    {
+      "repo": "rather-not-work-on/platform-contracts",
+      "default_area_label": "area/contracts",
+      "default_type_label": "type/governance"
+    }
+  ]
+}

--- a/planningops/fixtures/federated-issue-quality-invalid.sample.json
+++ b/planningops/fixtures/federated-issue-quality-invalid.sample.json
@@ -1,0 +1,10 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-contracts",
+    "number": 2,
+    "title": "invalid sample",
+    "url": "https://example.com/2",
+    "body": "## Planning Context\n- plan_item_id: `B11`",
+    "labels": []
+  }
+]

--- a/planningops/fixtures/federated-issue-quality-valid.sample.json
+++ b/planningops/fixtures/federated-issue-quality-valid.sample.json
@@ -1,0 +1,23 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-contracts",
+    "number": 1,
+    "title": "valid sample",
+    "url": "https://example.com/1",
+    "body": "## Planning Context\n- plan_item_id: `B10`",
+    "labels": [
+      {
+        "name": "task"
+      },
+      {
+        "name": "p2"
+      },
+      {
+        "name": "area/contracts"
+      },
+      {
+        "name": "type/governance"
+      }
+    ]
+  }
+]

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -934,6 +934,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_governance_validation_artifact_lanes.sh`
   - `test_issue_quality_validation_artifact_lanes.sh`
   - `test_validate_issue_quality_contract.sh`
+  - `test_federated_issue_quality_artifact_lanes.sh`
   - `test_validate_federated_issue_quality_contract.sh`
   - `test_artifact_storage_policy_validation_artifact_lanes.sh`
   - `test_validate_artifact_storage_policy_contract.sh`

--- a/planningops/scripts/test_federated_issue_quality_artifact_lanes.sh
+++ b/planningops/scripts/test_federated_issue_quality_artifact_lanes.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+config_fixture="planningops/fixtures/federated-issue-quality-config.sample.json"
+valid_fixture="planningops/fixtures/federated-issue-quality-valid.sample.json"
+invalid_fixture="planningops/fixtures/federated-issue-quality-invalid.sample.json"
+
+valid_report="$tmp_dir/federated-issue-quality-valid.test.json"
+invalid_report="$tmp_dir/federated-issue-quality-invalid.test.json"
+auto_fix_report="$tmp_dir/federated-issue-quality-auto-fix.test.json"
+
+python3 planningops/scripts/validate_federated_issue_quality.py \
+  --config "$config_fixture" \
+  --issues-file "$valid_fixture" \
+  --output "$valid_report" \
+  --strict \
+  >/dev/null
+
+set +e
+python3 planningops/scripts/validate_federated_issue_quality.py \
+  --config "$config_fixture" \
+  --issues-file "$invalid_fixture" \
+  --output "$invalid_report" \
+  --strict \
+  >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected strict failure for invalid federated issue quality sample"
+  exit 1
+fi
+
+python3 planningops/scripts/validate_federated_issue_quality.py \
+  --config "$config_fixture" \
+  --issues-file "$invalid_fixture" \
+  --output "$auto_fix_report" \
+  --apply-default-labels \
+  --strict \
+  >/dev/null
+
+python3 - <<'PY' \
+  "$valid_report" \
+  "$invalid_report" \
+  "$auto_fix_report" \
+  "planningops/artifacts/validation/federated-issue-quality-valid.test.json" \
+  "planningops/artifacts/validation/federated-issue-quality-invalid.test.json" \
+  "planningops/artifacts/validation/federated-issue-quality-auto-fix.test.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual_valid = normalize(load(sys.argv[1]))
+actual_invalid = normalize(load(sys.argv[2]))
+actual_auto_fix = normalize(load(sys.argv[3]))
+
+expected_valid = normalize(load(sys.argv[4]))
+expected_invalid = normalize(load(sys.argv[5]))
+expected_auto_fix = normalize(load(sys.argv[6]))
+
+assert actual_valid == expected_valid, (actual_valid, expected_valid)
+assert actual_invalid == expected_invalid, (actual_invalid, expected_invalid)
+assert actual_auto_fix == expected_auto_fix, (actual_auto_fix, expected_auto_fix)
+
+print("federated issue quality artifact lanes ok")
+PY

--- a/planningops/scripts/test_validate_federated_issue_quality_contract.sh
+++ b/planningops/scripts/test_validate_federated_issue_quality_contract.sh
@@ -4,65 +4,20 @@ set -euo pipefail
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-cat > "$tmp_dir/config.json" <<'JSON'
-{
-  "default_priority_label": "p2",
-  "required": {
-    "required_labels_all": ["task"],
-    "required_priority_labels_any": ["p1", "p2", "p3"],
-    "required_label_prefixes": ["area/", "type/"]
-  },
-  "repos": [
-    {
-      "repo": "rather-not-work-on/platform-contracts",
-      "default_area_label": "area/contracts",
-      "default_type_label": "type/governance"
-    }
-  ]
-}
-JSON
-
-cat > "$tmp_dir/issues-valid.json" <<'JSON'
-[
-  {
-    "repo": "rather-not-work-on/platform-contracts",
-    "number": 1,
-    "title": "valid sample",
-    "url": "https://example.com/1",
-    "body": "## Planning Context\n- plan_item_id: `B10`",
-    "labels": [
-      {"name": "task"},
-      {"name": "p2"},
-      {"name": "area/contracts"},
-      {"name": "type/governance"}
-    ]
-  }
-]
-JSON
+config_fixture="planningops/fixtures/federated-issue-quality-config.sample.json"
+valid_fixture="planningops/fixtures/federated-issue-quality-valid.sample.json"
+invalid_fixture="planningops/fixtures/federated-issue-quality-invalid.sample.json"
 
 python3 planningops/scripts/validate_federated_issue_quality.py \
-  --config "$tmp_dir/config.json" \
-  --issues-file "$tmp_dir/issues-valid.json" \
+  --config "$config_fixture" \
+  --issues-file "$valid_fixture" \
   --output "$tmp_dir/federated-issue-quality-valid.test.json" \
   --strict
 
-cat > "$tmp_dir/issues-invalid.json" <<'JSON'
-[
-  {
-    "repo": "rather-not-work-on/platform-contracts",
-    "number": 2,
-    "title": "invalid sample",
-    "url": "https://example.com/2",
-    "body": "## Planning Context\n- plan_item_id: `B11`",
-    "labels": []
-  }
-]
-JSON
-
 set +e
 python3 planningops/scripts/validate_federated_issue_quality.py \
-  --config "$tmp_dir/config.json" \
-  --issues-file "$tmp_dir/issues-invalid.json" \
+  --config "$config_fixture" \
+  --issues-file "$invalid_fixture" \
   --output "$tmp_dir/federated-issue-quality-invalid.test.json" \
   --strict
 rc=$?
@@ -74,8 +29,8 @@ if [[ "$rc" -eq 0 ]]; then
 fi
 
 python3 planningops/scripts/validate_federated_issue_quality.py \
-  --config "$tmp_dir/config.json" \
-  --issues-file "$tmp_dir/issues-invalid.json" \
+  --config "$config_fixture" \
+  --issues-file "$invalid_fixture" \
   --output "$tmp_dir/federated-issue-quality-auto-fix.test.json" \
   --apply-default-labels \
   --strict


### PR DESCRIPTION
## Summary
- extract stable config and issue fixtures for federated issue-quality coverage
- track deterministic valid, invalid, and auto-fix outputs as committed `.test.json` lanes
- add a regression that regenerates all three lanes and compares them against the committed snapshots

## Validation
- bash planningops/scripts/test_validate_federated_issue_quality_contract.sh
- bash planningops/scripts/test_federated_issue_quality_artifact_lanes.sh
- bash planningops/scripts/test_module_readme_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all