### PR TITLE
test(plan-projection): backfill sample artifact lane

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -147,6 +147,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Issue Quality Artifact Refresh Packet](./plans/2026-03-28-issue-quality-artifact-refresh-packet.md)
 - [Issue Quality Validation Artifact Lanes Packet](./plans/2026-03-28-issue-quality-validation-artifact-lanes-packet.md)
 - [Validation Sample Artifact Lanes Packet](./plans/2026-03-28-validation-sample-artifact-lanes-packet.md)
+- [Plan Projection Sample Artifact Lane Packet](./plans/2026-03-28-plan-projection-sample-artifact-lane-packet.md)
 - [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
 - [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
 - [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-plan-projection-sample-artifact-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-plan-projection-sample-artifact-lane-packet.md
@@ -1,0 +1,33 @@
+---
+title: plan: Plan Projection Sample Artifact Lane Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes a deterministic `.sample.json` artifact lane for `verify_plan_projection.py`, separate from the mutable live latest projection report.
+related_docs:
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+  - ./2026-03-28-plan-projection-artifact-refresh-packet.md
+---
+
+# plan: Plan Projection Sample Artifact Lane Packet
+
+## Summary
+- Publish a committed sample projection report generated from the PEC sample contract and snapshot fixture.
+- Add one regression that replays `verify_plan_projection.py` in snapshot mode and compares the normalized output to the committed `.sample.json` artifact.
+- Keep the sample lane separate from the mutable `plan-projection-report.json` latest artifact.
+
+## Scope
+- `planningops/artifacts/validation/plan-projection-report.sample.json`
+- `planningops/scripts/test_verify_plan_projection_artifact_lane.sh`
+- `planningops/artifacts/README.md`
+- `planningops/fixtures/README.md`
+- `planningops/scripts/README.md`
+
+## Acceptance
+- `test_verify_plan_projection_contract.sh` passes
+- `test_verify_plan_projection_artifact_lane.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -18,7 +18,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - deterministic sample backlog outputs also live here with `.sample.json` suffixes when a fixture-backed artifact lane is promoted
 - `program/`: canonical program-manifest outputs, including fixture-backed `.sample.json` lanes
 - `validation/`: gate/schema reports, including fixture-backed `.sample.json` lanes that stay separate from live latest artifacts
-  - canonical sample validation lanes currently include `plan-compile-report.sample.json` and `issue-quality-*.sample.json`
+  - canonical sample validation lanes currently include `plan-compile-report.sample.json`, `plan-projection-report.sample.json`, and `issue-quality-*.sample.json`
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical federated issue-quality lanes also include `federated-issue-quality-valid.test.json`, `federated-issue-quality-invalid.test.json`, and `federated-issue-quality-auto-fix.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`

--- a/planningops/artifacts/validation/plan-projection-report.sample.json
+++ b/planningops/artifacts/validation/plan-projection-report.sample.json
@@ -1,0 +1,32 @@
+{
+  "generated_at_utc": "2026-03-28T13:57:52.580805+00:00",
+  "contract_file": "planningops/fixtures/plan-execution-contract-sample.json",
+  "snapshot_file": "planningops/fixtures/plan-projection-snapshot-sample.json",
+  "project": {
+    "owner": "rather-not-work-on",
+    "project_number": 2,
+    "initiative": "unified-personal-agent-platform",
+    "limit": 1000
+  },
+  "validation_errors": [],
+  "plan_id": "sample-pec-plan",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-03-plan-auto-executable-plans-contract-and-runner-plan.md",
+  "expected_items_total": 1,
+  "project_items_limit_hit": false,
+  "mode": "snapshot",
+  "project_items_scanned": 1,
+  "actual_items_total": 1,
+  "duplicate_plan_item_id_count": 0,
+  "duplicate_plan_item_ids": [],
+  "relevant_duplicate_plan_item_id_count": 0,
+  "relevant_duplicate_plan_item_ids": [],
+  "missing_count": 0,
+  "mismatch_count": 0,
+  "unexpected_count": 0,
+  "missing": [],
+  "mismatches": [],
+  "unexpected": [],
+  "verdict": "pass",
+  "reasons": []
+}

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -10,7 +10,7 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `plan-compile-sample-issues.json`: deterministic offline issues input for compile sample artifact lanes
 - `backlog-materialization-sample-contract.json`: ready-implementation PEC sample for offline backlog materialization tests
 - `backlog-materialize-*.expected.json`: normalized expected outputs for the offline backlog materialize sample lane
-- `plan-projection-snapshot-sample.json`: sample project snapshot matching PEC sample
+- `plan-projection-snapshot-sample.json`: sample project snapshot matching the PEC sample for plan-projection artifact lanes
 - `meta-plan-graph-sample.json`: minimal valid MPG v1 graph sample
 - `worker-task-pack-sample.json`: minimal valid worker task pack sample
 - `track1-kpi-baseline-ci.json`: strict gate KPI baseline input

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -583,6 +583,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_meta_plan_orchestrator_contract.sh`
   - `test_meta_plan_graph_schema_contract.sh`
   - `test_verify_plan_projection_contract.sh`
+  - `test_verify_plan_projection_artifact_lane.sh`
   - `test_verify_loop_run_hard_gate_contract.sh`
   - `test_backlog_stock_replenishment_contract.sh`
   - `test_autonomous_supervisor_loop_contract.sh`

--- a/planningops/scripts/test_verify_plan_projection_artifact_lane.sh
+++ b/planningops/scripts/test_verify_plan_projection_artifact_lane.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+output="$tmpdir/plan-projection-report.sample.json"
+
+python3 planningops/scripts/verify_plan_projection.py \
+  --contract-file planningops/fixtures/plan-execution-contract-sample.json \
+  --snapshot-file planningops/fixtures/plan-projection-snapshot-sample.json \
+  --strict \
+  --output "$output"
+
+python3 - <<'PY' "$output" "planningops/artifacts/validation/plan-projection-report.sample.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual = normalize(load(sys.argv[1]))
+expected = normalize(load(sys.argv[2]))
+
+assert actual == expected, (actual, expected)
+print("verify plan projection artifact lane ok")
+PY


### PR DESCRIPTION
## Summary
- add a committed `plan-projection-report.sample.json` artifact lane for the PEC sample contract and snapshot fixture
- add `test_verify_plan_projection_artifact_lane.sh` to replay the verifier and compare normalized output to the committed lane
- document the new lane in artifacts/scripts/fixtures README files and the workbench hub

## Validation
- `bash planningops/scripts/test_verify_plan_projection_contract.sh`
- `bash planningops/scripts/test_verify_plan_projection_artifact_lane.sh`
- `bash planningops/scripts/test_module_readme_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change adds a deterministic fixture-backed artifact lane and docs only.