### PR TITLE
test(project-field-schema): backfill sample artifact lane

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -148,6 +148,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Issue Quality Validation Artifact Lanes Packet](./plans/2026-03-28-issue-quality-validation-artifact-lanes-packet.md)
 - [Validation Sample Artifact Lanes Packet](./plans/2026-03-28-validation-sample-artifact-lanes-packet.md)
 - [Plan Projection Sample Artifact Lane Packet](./plans/2026-03-28-plan-projection-sample-artifact-lane-packet.md)
+- [Project Field Schema Sample Artifact Lane Packet](./plans/2026-03-28-project-field-schema-sample-artifact-lane-packet.md)
 - [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
 - [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
 - [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-project-field-schema-sample-artifact-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-project-field-schema-sample-artifact-lane-packet.md
@@ -1,0 +1,32 @@
+---
+title: plan: Project Field Schema Sample Artifact Lane Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes a fixture-backed `.sample.json` lane for `validate_project_field_schema.py` so project-schema validation can be replayed deterministically without live GitHub fetches.
+related_docs:
+  - ./2026-03-28-project-field-schema-artifact-refresh-packet.md
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+---
+
+# plan: Project Field Schema Sample Artifact Lane Packet
+
+## Summary
+- Add fixture-backed `gh project field-list` and `gh project item-list` payloads for the project field schema validator.
+- Publish a committed sample validation report generated from those fixtures.
+- Add one regression that replays the validator through a mocked `gh` binary and compares the normalized output to the committed `.sample.json` lane.
+
+## Scope
+- `planningops/fixtures/project-field-schema-field-list.sample.json`
+- `planningops/fixtures/project-field-schema-item-list.sample.json`
+- `planningops/artifacts/validation/project-field-schema-report.sample.json`
+- `planningops/scripts/test_validate_project_field_schema_artifact_lane.sh`
+
+## Acceptance
+- `test_validate_project_field_schema_matrix.sh` passes
+- `test_validate_project_field_schema_artifact_lane.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -18,7 +18,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - deterministic sample backlog outputs also live here with `.sample.json` suffixes when a fixture-backed artifact lane is promoted
 - `program/`: canonical program-manifest outputs, including fixture-backed `.sample.json` lanes
 - `validation/`: gate/schema reports, including fixture-backed `.sample.json` lanes that stay separate from live latest artifacts
-  - canonical sample validation lanes currently include `plan-compile-report.sample.json`, `plan-projection-report.sample.json`, and `issue-quality-*.sample.json`
+  - canonical sample validation lanes currently include `plan-compile-report.sample.json`, `plan-projection-report.sample.json`, `project-field-schema-report.sample.json`, and `issue-quality-*.sample.json`
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical federated issue-quality lanes also include `federated-issue-quality-valid.test.json`, `federated-issue-quality-invalid.test.json`, and `federated-issue-quality-auto-fix.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`

--- a/planningops/artifacts/validation/project-field-schema-report.sample.json
+++ b/planningops/artifacts/validation/project-field-schema-report.sample.json
@@ -1,0 +1,74 @@
+{
+  "generated_at_utc": "2026-03-28T14:00:12.000000+00:00",
+  "project": {
+    "owner": "rather-not-work-on",
+    "project_num": 2,
+    "initiative": "unified-personal-agent-platform"
+  },
+  "required_field_checks": [
+    {
+      "field_key": "status",
+      "expected_id": "PVTSSF_lADOD8NujM4BQYNEzg-hBm0",
+      "exists": true,
+      "actual_name": "Status",
+      "missing_option_ids": [],
+      "options_ok": true
+    },
+    {
+      "field_key": "initiative",
+      "expected_id": "PVTF_lADOD8NujM4BQYNEzg-hBrQ",
+      "exists": true,
+      "actual_name": "Initiative"
+    },
+    {
+      "field_key": "target_repo",
+      "expected_id": "PVTF_lADOD8NujM4BQYNEzg-hBrM",
+      "exists": true,
+      "actual_name": "Target Repo"
+    },
+    {
+      "field_key": "component",
+      "expected_id": "PVTSSF_lADOD8NujM4BQYNEzg-hBsE",
+      "exists": true,
+      "actual_name": "Component",
+      "missing_option_ids": [],
+      "options_ok": true
+    },
+    {
+      "field_key": "execution_order",
+      "expected_id": "PVTF_lADOD8NujM4BQYNEzg-hM3Y",
+      "exists": true,
+      "actual_name": "Execution Order"
+    },
+    {
+      "field_key": "plan_lane",
+      "expected_id": "PVTSSF_lADOD8NujM4BQYNEzg-hM3c",
+      "exists": true,
+      "actual_name": "Plan Lane",
+      "missing_option_ids": [],
+      "options_ok": true
+    },
+    {
+      "field_key": "workflow_state",
+      "expected_id": "PVTSSF_lADOD8NujM4BQYNEzg-hxGo",
+      "exists": true,
+      "actual_name": "Workflow State",
+      "missing_option_ids": [],
+      "options_ok": true
+    },
+    {
+      "field_key": "loop_profile",
+      "expected_id": "PVTSSF_lADOD8NujM4BQYNEzg-kZMI",
+      "exists": true,
+      "actual_name": "Loop Profile",
+      "missing_option_ids": [],
+      "options_ok": true
+    }
+  ],
+  "evaluated_items": 1,
+  "violation_count": 0,
+  "violations": [],
+  "info_count": 0,
+  "infos": [],
+  "verdict": "pass"
+}

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -11,6 +11,7 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `backlog-materialization-sample-contract.json`: ready-implementation PEC sample for offline backlog materialization tests
 - `backlog-materialize-*.expected.json`: normalized expected outputs for the offline backlog materialize sample lane
 - `plan-projection-snapshot-sample.json`: sample project snapshot matching the PEC sample for plan-projection artifact lanes
+- `project-field-schema-*.sample.json`: fixture-backed `gh project` field-list and item-list payloads for offline project field schema validation lanes
 - `meta-plan-graph-sample.json`: minimal valid MPG v1 graph sample
 - `worker-task-pack-sample.json`: minimal valid worker task pack sample
 - `track1-kpi-baseline-ci.json`: strict gate KPI baseline input

--- a/planningops/fixtures/project-field-schema-field-list.sample.json
+++ b/planningops/fixtures/project-field-schema-field-list.sample.json
@@ -1,0 +1,72 @@
+{
+  "fields": [
+    {
+      "id": "PVTSSF_lADOD8NujM4BQYNEzg-hBm0",
+      "name": "Status",
+      "options": [
+        {"id": "e225d619", "name": "Todo"},
+        {"id": "18f5944b", "name": "In Progress"},
+        {"id": "1184a4e7", "name": "Blocked"},
+        {"id": "cffcdc7d", "name": "Done"}
+      ]
+    },
+    {
+      "id": "PVTF_lADOD8NujM4BQYNEzg-hBrQ",
+      "name": "Initiative"
+    },
+    {
+      "id": "PVTF_lADOD8NujM4BQYNEzg-hBrM",
+      "name": "Target Repo"
+    },
+    {
+      "id": "PVTSSF_lADOD8NujM4BQYNEzg-hBsE",
+      "name": "Component",
+      "options": [
+        {"id": "1a47f1d9", "name": "planningops"},
+        {"id": "ac884f5a", "name": "contracts"},
+        {"id": "f6ceeede", "name": "provider_gateway"},
+        {"id": "2a19b378", "name": "observability_gateway"},
+        {"id": "d55bc97a", "name": "runtime"},
+        {"id": "9233c6ef", "name": "orchestrator"}
+      ]
+    },
+    {
+      "id": "PVTF_lADOD8NujM4BQYNEzg-hM3Y",
+      "name": "Execution Order"
+    },
+    {
+      "id": "PVTSSF_lADOD8NujM4BQYNEzg-hM3c",
+      "name": "Plan Lane",
+      "options": [
+        {"id": "c12b812b", "name": "m0_bootstrap"},
+        {"id": "0f566f80", "name": "m1_contract_freeze"},
+        {"id": "196964ba", "name": "m2_sync_core"},
+        {"id": "6b2c1c64", "name": "m3_guardrails"}
+      ]
+    },
+    {
+      "id": "PVTSSF_lADOD8NujM4BQYNEzg-hxGo",
+      "name": "Workflow State",
+      "options": [
+        {"id": "5635cc18", "name": "backlog"},
+        {"id": "1da67253", "name": "ready_contract"},
+        {"id": "c8b7cc9f", "name": "in_progress"},
+        {"id": "18a75432", "name": "review_gate"},
+        {"id": "c8b07c0f", "name": "ready_implementation"},
+        {"id": "41f8c85f", "name": "blocked"},
+        {"id": "c8db8ee1", "name": "done"}
+      ]
+    },
+    {
+      "id": "PVTSSF_lADOD8NujM4BQYNEzg-kZMI",
+      "name": "Loop Profile",
+      "options": [
+        {"id": "0aa7a66a", "name": "l1_contract_clarification"},
+        {"id": "60de8d1a", "name": "l2_simulation"},
+        {"id": "e18297a8", "name": "l3_implementation_tdd"},
+        {"id": "1e144499", "name": "l4_integration_reconcile"},
+        {"id": "9f6cfe0a", "name": "l5_recovery_replan"}
+      ]
+    }
+  ]
+}

--- a/planningops/fixtures/project-field-schema-item-list.sample.json
+++ b/planningops/fixtures/project-field-schema-item-list.sample.json
@@ -1,0 +1,22 @@
+{
+  "items": [
+    {
+      "id": "PVTI_project_field_schema_sample",
+      "status": "Todo",
+      "initiative": "unified-personal-agent-platform",
+      "target_repo": "rather-not-work-on/platform-planningops",
+      "component": "planningops",
+      "workflow_state": "ready-contract",
+      "loop_profile": "L1 Contract-Clarification",
+      "execution_order": 1,
+      "plan_lane": "m1-contract-freeze",
+      "content": {
+        "type": "Issue",
+        "number": 4001,
+        "url": "https://github.com/rather-not-work-on/platform-planningops/issues/4001",
+        "repository": "rather-not-work-on/platform-planningops",
+        "body": "fixture-backed project field schema sample"
+      }
+    }
+  ]
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -584,6 +584,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_meta_plan_graph_schema_contract.sh`
   - `test_verify_plan_projection_contract.sh`
   - `test_verify_plan_projection_artifact_lane.sh`
+  - `test_validate_project_field_schema_artifact_lane.sh`
   - `test_verify_loop_run_hard_gate_contract.sh`
   - `test_backlog_stock_replenishment_contract.sh`
   - `test_autonomous_supervisor_loop_contract.sh`

--- a/planningops/scripts/test_validate_project_field_schema_artifact_lane.sh
+++ b/planningops/scripts/test_validate_project_field_schema_artifact_lane.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+mock_bin="$tmpdir/bin"
+mkdir -p "$mock_bin"
+
+cat > "$mock_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${PROJECT_FIELD_SCHEMA_REPO_ROOT:?}"
+
+if [[ "${1:-}" == "project" && "${2:-}" == "field-list" ]]; then
+  cat "$repo_root/planningops/fixtures/project-field-schema-field-list.sample.json"
+  exit 0
+fi
+
+if [[ "${1:-}" == "project" && "${2:-}" == "item-list" ]]; then
+  cat "$repo_root/planningops/fixtures/project-field-schema-item-list.sample.json"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$mock_bin/gh"
+
+output="$tmpdir/project-field-schema-report.sample.json"
+
+PROJECT_FIELD_SCHEMA_REPO_ROOT="$repo_root" \
+PATH="$mock_bin:$PATH" \
+python3 planningops/scripts/validate_project_field_schema.py \
+  --config planningops/config/project-field-ids.json \
+  --output "$output" \
+  --fail-on-mismatch
+
+python3 - <<'PY' "$output" "planningops/artifacts/validation/project-field-schema-report.sample.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual = normalize(load(sys.argv[1]))
+expected = normalize(load(sys.argv[2]))
+
+assert actual == expected, (actual, expected)
+print("validate project field schema artifact lane ok")
+PY


### PR DESCRIPTION
## Summary
- add fixture-backed `gh project field-list` and `gh project item-list` payloads for deterministic project field schema validation
- add a committed `project-field-schema-report.sample.json` artifact lane and a replay regression that compares normalized output to the committed sample
- document the new sample lane in artifacts/scripts/fixtures README files and the workbench hub

## Validation
- `bash planningops/scripts/test_validate_project_field_schema_matrix.sh`
- `bash planningops/scripts/test_validate_project_field_schema_artifact_lane.sh`
- `bash planningops/scripts/test_module_readme_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change adds deterministic fixtures, a sample artifact lane, and docs only.