### PR TITLE
test(worker-task-pack): backfill sample artifact lane

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -149,6 +149,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Validation Sample Artifact Lanes Packet](./plans/2026-03-28-validation-sample-artifact-lanes-packet.md)
 - [Plan Projection Sample Artifact Lane Packet](./plans/2026-03-28-plan-projection-sample-artifact-lane-packet.md)
 - [Project Field Schema Sample Artifact Lane Packet](./plans/2026-03-28-project-field-schema-sample-artifact-lane-packet.md)
+- [Worker Task Pack Sample Artifact Lane Packet](./plans/2026-03-28-worker-task-pack-sample-artifact-lane-packet.md)
 - [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
 - [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
 - [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-worker-task-pack-sample-artifact-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-worker-task-pack-sample-artifact-lane-packet.md
@@ -1,0 +1,32 @@
+---
+title: plan: Worker Task Pack Sample Artifact Lane Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes a deterministic `.sample.json` artifact lane for `validate_worker_task_pack.py`, separate from mutable live task-pack reports.
+related_docs:
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+  - ./2026-03-26-runtime-profiles-validator-family-backfill-packet.md
+---
+
+# plan: Worker Task Pack Sample Artifact Lane Packet
+
+## Summary
+- Publish a committed sample worker-task-pack report generated from the current runtime profile catalog and a fixed `reflection_action` replay input.
+- Add one regression that replays `validate_worker_task_pack.py` and compares the normalized output to the committed `.sample.json` artifact.
+- Keep the sample lane separate from mutable live `worker-task-pack-report.json` outputs.
+
+## Scope
+- `planningops/artifacts/validation/worker-task-pack-report.sample.json`
+- `planningops/scripts/test_validate_worker_task_pack_artifact_lane.sh`
+- `planningops/artifacts/README.md`
+- `planningops/scripts/README.md`
+
+## Acceptance
+- `test_validate_worker_task_pack_contract.sh` passes
+- `test_validate_worker_task_pack_artifact_lane.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -18,7 +18,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - deterministic sample backlog outputs also live here with `.sample.json` suffixes when a fixture-backed artifact lane is promoted
 - `program/`: canonical program-manifest outputs, including fixture-backed `.sample.json` lanes
 - `validation/`: gate/schema reports, including fixture-backed `.sample.json` lanes that stay separate from live latest artifacts
-  - canonical sample validation lanes currently include `plan-compile-report.sample.json`, `plan-projection-report.sample.json`, `project-field-schema-report.sample.json`, and `issue-quality-*.sample.json`
+  - canonical sample validation lanes currently include `plan-compile-report.sample.json`, `plan-projection-report.sample.json`, `project-field-schema-report.sample.json`, `worker-task-pack-report.sample.json`, and `issue-quality-*.sample.json`
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical federated issue-quality lanes also include `federated-issue-quality-valid.test.json`, `federated-issue-quality-invalid.test.json`, and `federated-issue-quality-auto-fix.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`

--- a/planningops/artifacts/validation/worker-task-pack-report.sample.json
+++ b/planningops/artifacts/validation/worker-task-pack-report.sample.json
@@ -1,0 +1,40 @@
+{
+  "generated_at_utc": "2026-03-28T14:03:05.464400+00:00",
+  "runtime_profile_file": "planningops/config/runtime-profiles.json",
+  "schema_file": "planningops/schemas/worker-task-pack.schema.json",
+  "task_key": "reflection_action",
+  "issue_number": 95,
+  "mode": "dry-run",
+  "loop_profile": "L3 Implementation-TDD",
+  "target_repo": "rather-not-work-on/platform-planningops",
+  "validation_errors": [],
+  "worker_task_pack": {
+    "version": "v1",
+    "task_key": "reflection_action",
+    "issue_number": 95,
+    "mode": "dry-run",
+    "loop_profile": "L3 Implementation-TDD",
+    "runtime_profile": "local",
+    "worker_policy_kind": "parser_diff_dry_run",
+    "command": [
+      "python3",
+      "planningops/scripts/parser_diff_dry_run.py",
+      "--run-id",
+      "worker-pack-issue-95",
+      "--mode",
+      "dry-run"
+    ],
+    "retry_policy": {
+      "max_retries": 2
+    },
+    "timeout_ms": 60000,
+    "idempotency_key": "71877e41370622d41daa75d49a251a91a1d709c33b3066212edf723c9d2cb0df",
+    "target_repo": "rather-not-work-on/platform-planningops",
+    "metadata": {
+      "profile_file": "planningops/config/runtime-profiles.json",
+      "task_key": "reflection_action"
+    }
+  },
+  "verdict": "pass",
+  "reason": "ok"
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -585,6 +585,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_verify_plan_projection_contract.sh`
   - `test_verify_plan_projection_artifact_lane.sh`
   - `test_validate_project_field_schema_artifact_lane.sh`
+  - `test_validate_worker_task_pack_artifact_lane.sh`
   - `test_verify_loop_run_hard_gate_contract.sh`
   - `test_backlog_stock_replenishment_contract.sh`
   - `test_autonomous_supervisor_loop_contract.sh`

--- a/planningops/scripts/test_validate_worker_task_pack_artifact_lane.sh
+++ b/planningops/scripts/test_validate_worker_task_pack_artifact_lane.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+output="$tmpdir/worker-task-pack-report.sample.json"
+
+python3 planningops/scripts/validate_worker_task_pack.py \
+  --runtime-profile-file planningops/config/runtime-profiles.json \
+  --task-key reflection_action \
+  --issue-number 95 \
+  --mode dry-run \
+  --loop-profile "L3 Implementation-TDD" \
+  --target-repo rather-not-work-on/platform-planningops \
+  --output "$output" \
+  --strict
+
+python3 - <<'PY' "$output" "planningops/artifacts/validation/worker-task-pack-report.sample.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual = normalize(load(sys.argv[1]))
+expected = normalize(load(sys.argv[2]))
+
+assert actual == expected, (actual, expected)
+print("validate worker task pack artifact lane ok")
+PY


### PR DESCRIPTION
## Summary
- add a committed `worker-task-pack-report.sample.json` artifact lane for a fixed `reflection_action` replay input
- add `test_validate_worker_task_pack_artifact_lane.sh` to replay the validator and compare normalized output to the committed sample
- document the new lane in artifacts/scripts README files and the workbench hub

## Validation
- `bash planningops/scripts/test_validate_worker_task_pack_contract.sh`
- `bash planningops/scripts/test_validate_worker_task_pack_artifact_lane.sh`
- `bash planningops/scripts/test_module_readme_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change adds a deterministic sample artifact lane and docs only.