### PR TITLE
test(blueprint-pack): backfill sample artifact lane

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -151,6 +151,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Project Field Schema Sample Artifact Lane Packet](./plans/2026-03-28-project-field-schema-sample-artifact-lane-packet.md)
 - [Worker Task Pack Sample Artifact Lane Packet](./plans/2026-03-28-worker-task-pack-sample-artifact-lane-packet.md)
 - [Runtime Profiles Sample Artifact Lane Packet](./plans/2026-03-28-runtime-profiles-sample-artifact-lane-packet.md)
+- [Blueprint Pack Sample Artifact Lane Packet](./plans/2026-03-28-blueprint-pack-sample-artifact-lane-packet.md)
 - [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
 - [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
 - [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-blueprint-pack-sample-artifact-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-blueprint-pack-sample-artifact-lane-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Blueprint Pack Sample Artifact Lane Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes a deterministic `.sample.json` lane for `validate_blueprint_pack.py`, backed by a committed markdown fixture.
+related_docs:
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+---
+
+# plan: Blueprint Pack Sample Artifact Lane Packet
+
+## Summary
+- Add a committed valid blueprint-pack markdown fixture with all required sections.
+- Publish a committed sample report generated from that fixture.
+- Add one regression that replays `validate_blueprint_pack.py` and compares the output to the committed `.sample.json` artifact.
+
+## Scope
+- `planningops/fixtures/blueprint-pack-valid.sample.md`
+- `planningops/artifacts/validation/blueprint-pack-report.sample.json`
+- `planningops/scripts/test_validate_blueprint_pack_artifact_lane.sh`
+
+## Acceptance
+- `test_validate_blueprint_pack_contract.sh` passes
+- `test_validate_blueprint_pack_artifact_lane.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -18,7 +18,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - deterministic sample backlog outputs also live here with `.sample.json` suffixes when a fixture-backed artifact lane is promoted
 - `program/`: canonical program-manifest outputs, including fixture-backed `.sample.json` lanes
 - `validation/`: gate/schema reports, including fixture-backed `.sample.json` lanes that stay separate from live latest artifacts
-  - canonical sample validation lanes currently include `plan-compile-report.sample.json`, `plan-projection-report.sample.json`, `project-field-schema-report.sample.json`, `runtime-profiles-report.sample.json`, `worker-task-pack-report.sample.json`, and `issue-quality-*.sample.json`
+  - canonical sample validation lanes currently include `blueprint-pack-report.sample.json`, `plan-compile-report.sample.json`, `plan-projection-report.sample.json`, `project-field-schema-report.sample.json`, `runtime-profiles-report.sample.json`, `worker-task-pack-report.sample.json`, and `issue-quality-*.sample.json`
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical federated issue-quality lanes also include `federated-issue-quality-valid.test.json`, `federated-issue-quality-invalid.test.json`, and `federated-issue-quality-auto-fix.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`

--- a/planningops/artifacts/validation/blueprint-pack-report.sample.json
+++ b/planningops/artifacts/validation/blueprint-pack-report.sample.json
@@ -1,0 +1,21 @@
+{
+  "docs_checked": 1,
+  "violation_count": 0,
+  "required_sections": [
+    "Interface Contract Refs",
+    "Target Package Topology",
+    "Dependency Manifest",
+    "File Plan",
+    "Verification Plan",
+    "Module README Deltas"
+  ],
+  "rows": [
+    {
+      "path": "planningops/fixtures/blueprint-pack-valid.sample.md",
+      "exists": true,
+      "missing_sections": [],
+      "verdict": "pass"
+    }
+  ],
+  "verdict": "pass"
+}

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -11,6 +11,7 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `backlog-materialization-sample-contract.json`: ready-implementation PEC sample for offline backlog materialization tests
 - `backlog-materialize-*.expected.json`: normalized expected outputs for the offline backlog materialize sample lane
 - `plan-projection-snapshot-sample.json`: sample project snapshot matching the PEC sample for plan-projection artifact lanes
+- `blueprint-pack-valid.sample.md`: fixture-backed ready-implementation blueprint pack doc with all required sections
 - `project-field-schema-*.sample.json`: fixture-backed `gh project` field-list and item-list payloads for offline project field schema validation lanes
 - `meta-plan-graph-sample.json`: minimal valid MPG v1 graph sample
 - `worker-task-pack-sample.json`: minimal valid worker task pack sample

--- a/planningops/fixtures/blueprint-pack-valid.sample.md
+++ b/planningops/fixtures/blueprint-pack-valid.sample.md
@@ -1,0 +1,17 @@
+## Interface Contract Refs
+ok
+
+## Target Package Topology
+ok
+
+## Dependency Manifest
+ok
+
+## File Plan
+ok
+
+## Verification Plan
+ok
+
+## Module README Deltas
+ok

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -587,6 +587,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_project_field_schema_artifact_lane.sh`
   - `test_validate_runtime_profiles_artifact_lane.sh`
   - `test_validate_worker_task_pack_artifact_lane.sh`
+  - `test_validate_blueprint_pack_artifact_lane.sh`
   - `test_verify_loop_run_hard_gate_contract.sh`
   - `test_backlog_stock_replenishment_contract.sh`
   - `test_autonomous_supervisor_loop_contract.sh`

--- a/planningops/scripts/test_validate_blueprint_pack_artifact_lane.sh
+++ b/planningops/scripts/test_validate_blueprint_pack_artifact_lane.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+output="$tmpdir/blueprint-pack-report.sample.json"
+
+python3 planningops/scripts/validate_blueprint_pack.py \
+  --doc planningops/fixtures/blueprint-pack-valid.sample.md \
+  --output "$output"
+
+python3 - <<'PY' "$output" "planningops/artifacts/validation/blueprint-pack-report.sample.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+actual = load(sys.argv[1])
+expected = load(sys.argv[2])
+
+assert actual == expected, (actual, expected)
+print("validate blueprint pack artifact lane ok")
+PY


### PR DESCRIPTION
## Summary
- add a committed valid blueprint-pack markdown fixture and matching `blueprint-pack-report.sample.json` artifact lane
- add `test_validate_blueprint_pack_artifact_lane.sh` to replay the validator and compare output to the committed sample
- document the new lane in artifacts/scripts/fixtures README files and the workbench hub

## Validation
- `bash planningops/scripts/test_validate_blueprint_pack_contract.sh`
- `bash planningops/scripts/test_validate_blueprint_pack_artifact_lane.sh`
- `bash planningops/scripts/test_module_readme_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change adds a deterministic sample artifact lane and docs only.