### PR TITLE
test(blueprint-normalize): backfill sample artifact lane

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -152,6 +152,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Worker Task Pack Sample Artifact Lane Packet](./plans/2026-03-28-worker-task-pack-sample-artifact-lane-packet.md)
 - [Runtime Profiles Sample Artifact Lane Packet](./plans/2026-03-28-runtime-profiles-sample-artifact-lane-packet.md)
 - [Blueprint Pack Sample Artifact Lane Packet](./plans/2026-03-28-blueprint-pack-sample-artifact-lane-packet.md)
+- [Ready-Implementation Blueprint Normalize Sample Artifact Lane Packet](./plans/2026-03-28-ready-implementation-blueprint-normalize-sample-artifact-lane-packet.md)
 - [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
 - [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
 - [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-ready-implementation-blueprint-normalize-sample-artifact-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-ready-implementation-blueprint-normalize-sample-artifact-lane-packet.md
@@ -1,0 +1,31 @@
+---
+title: plan: Ready-Implementation Blueprint Normalize Sample Artifact Lane Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes a deterministic `.sample.json` lane for `normalize_ready_implementation_blueprint_refs.py` using fixture-backed `gh` responses.
+related_docs:
+  - ./2026-03-28-validation-sample-artifact-lanes-packet.md
+---
+
+# plan: Ready-Implementation Blueprint Normalize Sample Artifact Lane Packet
+
+## Summary
+- Add fixture-backed project item-list and issue-view payloads for the ready-implementation blueprint normalizer.
+- Publish a committed dry-run normalization report generated from those fixtures.
+- Add one regression that replays the normalizer through a mocked `gh` binary and compares the normalized output to the committed `.sample.json` artifact.
+
+## Scope
+- `planningops/fixtures/ready-implementation-blueprint-project-items.sample.json`
+- `planningops/fixtures/ready-implementation-blueprint-issue-view.sample.json`
+- `planningops/artifacts/validation/ready-implementation-blueprint-normalize-report.sample.json`
+- `planningops/scripts/test_normalize_ready_implementation_blueprint_refs_artifact_lane.sh`
+
+## Acceptance
+- `test_normalize_ready_implementation_blueprint_refs.sh` passes
+- `test_normalize_ready_implementation_blueprint_refs_artifact_lane.sh` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/README.md
+++ b/planningops/artifacts/README.md
@@ -18,7 +18,7 @@ Persist loop execution outputs, validation reports, and CI evidence bundles.
   - deterministic sample backlog outputs also live here with `.sample.json` suffixes when a fixture-backed artifact lane is promoted
 - `program/`: canonical program-manifest outputs, including fixture-backed `.sample.json` lanes
 - `validation/`: gate/schema reports, including fixture-backed `.sample.json` lanes that stay separate from live latest artifacts
-  - canonical sample validation lanes currently include `blueprint-pack-report.sample.json`, `plan-compile-report.sample.json`, `plan-projection-report.sample.json`, `project-field-schema-report.sample.json`, `runtime-profiles-report.sample.json`, `worker-task-pack-report.sample.json`, and `issue-quality-*.sample.json`
+  - canonical sample validation lanes currently include `blueprint-pack-report.sample.json`, `plan-compile-report.sample.json`, `plan-projection-report.sample.json`, `project-field-schema-report.sample.json`, `ready-implementation-blueprint-normalize-report.sample.json`, `runtime-profiles-report.sample.json`, `worker-task-pack-report.sample.json`, and `issue-quality-*.sample.json`
   - canonical issue-quality validator lanes also include `issue-quality-valid.test.json` and `issue-quality-invalid.test.json`
   - canonical federated issue-quality lanes also include `federated-issue-quality-valid.test.json`, `federated-issue-quality-invalid.test.json`, and `federated-issue-quality-auto-fix.test.json`
   - canonical governance validator lanes also include `repo-boundary-report.test.json`, `script-role-report.test.json`, `artifact-storage-policy-valid.test.json`, and `artifact-storage-policy-invalid.test.json`

--- a/planningops/artifacts/validation/ready-implementation-blueprint-normalize-report.sample.json
+++ b/planningops/artifacts/validation/ready-implementation-blueprint-normalize-report.sample.json
@@ -1,0 +1,42 @@
+{
+  "generated_at_utc": "2026-03-28T14:09:02.311891+00:00",
+  "mode": "dry-run",
+  "owner": "rather-not-work-on",
+  "project_num": 2,
+  "initiative": "unified-personal-agent-platform",
+  "workflow_states": [
+    "ready-implementation",
+    "ready_implementation"
+  ],
+  "candidates_count": 1,
+  "changed_count": 1,
+  "applied_count": 0,
+  "missing_count": 0,
+  "rows": [
+    {
+      "issue_number": 321,
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "target_repo": "rather-not-work-on/monday",
+      "workflow_state": "ready-implementation",
+      "status": "Todo",
+      "changed": true,
+      "applied": false,
+      "apply_error": null,
+      "missing_keys": [],
+      "source": {
+        "interface_contract_refs": "default",
+        "package_topology_ref": "default",
+        "dependency_manifest_ref": "default",
+        "file_plan_ref": "default"
+      },
+      "resolved_refs": {
+        "interface_contract_refs": "docs/initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md",
+        "package_topology_ref": "docs/initiatives/unified-personal-agent-platform/20-repos/monday/README.md",
+        "dependency_manifest_ref": "planningops/config/runtime-profiles.json",
+        "file_plan_ref": "docs/initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/2026-02-27-uap-contract-first-foundation.execution-plan.md"
+      },
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/321"
+    }
+  ],
+  "verdict": "pass"
+}

--- a/planningops/fixtures/README.md
+++ b/planningops/fixtures/README.md
@@ -12,6 +12,7 @@ Provide deterministic sample inputs for contract and loop verification tests.
 - `backlog-materialize-*.expected.json`: normalized expected outputs for the offline backlog materialize sample lane
 - `plan-projection-snapshot-sample.json`: sample project snapshot matching the PEC sample for plan-projection artifact lanes
 - `blueprint-pack-valid.sample.md`: fixture-backed ready-implementation blueprint pack doc with all required sections
+- `ready-implementation-blueprint-*.sample.json`: fixture-backed project item-list and issue-view payloads for offline blueprint normalization lanes
 - `project-field-schema-*.sample.json`: fixture-backed `gh project` field-list and item-list payloads for offline project field schema validation lanes
 - `meta-plan-graph-sample.json`: minimal valid MPG v1 graph sample
 - `worker-task-pack-sample.json`: minimal valid worker task pack sample

--- a/planningops/fixtures/ready-implementation-blueprint-issue-view.sample.json
+++ b/planningops/fixtures/ready-implementation-blueprint-issue-view.sample.json
@@ -1,0 +1,7 @@
+{
+  "number": 321,
+  "title": "sample",
+  "body": "## Context\nplan_item_id: `sample-321`\n",
+  "state": "OPEN",
+  "url": "https://github.com/rather-not-work-on/platform-planningops/issues/321"
+}

--- a/planningops/fixtures/ready-implementation-blueprint-project-items.sample.json
+++ b/planningops/fixtures/ready-implementation-blueprint-project-items.sample.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "id": "PVTI_sample_ready_impl",
+      "initiative": "unified-personal-agent-platform",
+      "target_repo": "rather-not-work-on/monday",
+      "workflow_state": "ready-implementation",
+      "status": "Todo",
+      "content": {
+        "type": "Issue",
+        "number": 321,
+        "repository": "rather-not-work-on/platform-planningops"
+      }
+    }
+  ]
+}

--- a/planningops/scripts/README.md
+++ b/planningops/scripts/README.md
@@ -588,6 +588,7 @@ Host executable runners, validators, and contract tests for planningops loops.
   - `test_validate_runtime_profiles_artifact_lane.sh`
   - `test_validate_worker_task_pack_artifact_lane.sh`
   - `test_validate_blueprint_pack_artifact_lane.sh`
+  - `test_normalize_ready_implementation_blueprint_refs_artifact_lane.sh`
   - `test_verify_loop_run_hard_gate_contract.sh`
   - `test_backlog_stock_replenishment_contract.sh`
   - `test_autonomous_supervisor_loop_contract.sh`

--- a/planningops/scripts/test_normalize_ready_implementation_blueprint_refs_artifact_lane.sh
+++ b/planningops/scripts/test_normalize_ready_implementation_blueprint_refs_artifact_lane.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+mock_bin="$tmpdir/bin"
+mkdir -p "$mock_bin"
+
+cat > "$mock_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${MOCK_REPO_ROOT:?}"
+
+if [[ "${1:-}" == "project" && "${2:-}" == "item-list" ]]; then
+  cat "$repo_root/planningops/fixtures/ready-implementation-blueprint-project-items.sample.json"
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+  cat "$repo_root/planningops/fixtures/ready-implementation-blueprint-issue-view.sample.json"
+  exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$mock_bin/gh"
+
+output="$tmpdir/ready-implementation-blueprint-normalize-report.sample.json"
+
+MOCK_REPO_ROOT="$repo_root" \
+PATH="$mock_bin:$PATH" \
+python3 planningops/scripts/normalize_ready_implementation_blueprint_refs.py \
+  --config planningops/config/ready-implementation-blueprint-defaults.json \
+  --output "$output"
+
+python3 - <<'PY' "$output" "planningops/artifacts/validation/ready-implementation-blueprint-normalize-report.sample.json"
+import json
+import sys
+from pathlib import Path
+
+
+def load(path_arg: str):
+    return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+
+
+def normalize(doc):
+    normalized = json.loads(json.dumps(doc))
+    normalized["generated_at_utc"] = "__GENERATED_AT__"
+    return normalized
+
+
+actual = normalize(load(sys.argv[1]))
+expected = normalize(load(sys.argv[2]))
+
+assert actual == expected, (actual, expected)
+print("normalize ready implementation blueprint refs artifact lane ok")
+PY


### PR DESCRIPTION
## Summary
- add fixture-backed project item-list and issue-view payloads for deterministic ready-implementation blueprint normalization
- add a committed `ready-implementation-blueprint-normalize-report.sample.json` artifact lane and a mock-`gh` replay regression
- document the new lane in artifacts/scripts/fixtures README files and the workbench hub

## Validation
- `bash planningops/scripts/test_normalize_ready_implementation_blueprint_refs.sh`
- `bash planningops/scripts/test_normalize_ready_implementation_blueprint_refs_artifact_lane.sh`
- `bash planningops/scripts/test_module_readme_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This change adds deterministic fixtures, a sample artifact lane, and docs only.