### PR TITLE
chore(validation-artifacts): refresh project schema and blueprint normalize latest

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -155,6 +155,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Ready-Implementation Blueprint Normalize Sample Artifact Lane Packet](./plans/2026-03-28-ready-implementation-blueprint-normalize-sample-artifact-lane-packet.md)
 - [Federated Artifact Policy Rollout Sample Artifact Lane Packet](./plans/2026-03-28-federated-artifact-policy-rollout-sample-artifact-lane-packet.md)
 - [Track2 Contract Pack Sample Artifact Lane Packet](./plans/2026-03-28-track2-contract-pack-sample-artifact-lane-packet.md)
+- [Project Field And Blueprint Latest Refresh Packet](./plans/2026-03-28-project-field-and-blueprint-latest-refresh-packet.md)
 - [Branch Protection Audit Artifact Lanes Packet](./plans/2026-03-28-branch-protection-audit-artifact-lanes-packet.md)
 - [Branch Protection Apply Artifact Lanes Packet](./plans/2026-03-28-branch-protection-apply-artifact-lanes-packet.md)
 - [Artifact Storage Policy Validation Artifact Lanes Packet](./plans/2026-03-28-artifact-storage-policy-validation-artifact-lanes-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-project-field-and-blueprint-latest-refresh-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-project-field-and-blueprint-latest-refresh-packet.md
@@ -1,0 +1,30 @@
+---
+title: plan: Project Field And Blueprint Latest Refresh Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Refreshes the canonical latest project-field schema and ready-implementation blueprint normalization reports after the corresponding sample lanes were promoted.
+related_docs:
+  - ./2026-03-28-project-field-schema-sample-artifact-lane-packet.md
+  - ./2026-03-28-ready-implementation-blueprint-normalize-sample-artifact-lane-packet.md
+---
+
+# plan: Project Field And Blueprint Latest Refresh Packet
+
+## Summary
+- Re-run the live project-field schema validator and publish an updated latest report.
+- Re-run the live ready-implementation blueprint normalizer in dry-run mode and publish an updated latest report.
+- Keep these mutable latest artifacts separate from the committed fixture-backed `.sample.json` lanes.
+
+## Scope
+- `planningops/artifacts/validation/project-field-schema-report.json`
+- `planningops/artifacts/validation/ready-implementation-blueprint-normalize-report.json`
+
+## Acceptance
+- `python3 planningops/scripts/validate_project_field_schema.py --fail-on-mismatch --output planningops/artifacts/validation/project-field-schema-report.json` passes
+- `python3 planningops/scripts/normalize_ready_implementation_blueprint_refs.py --fail-on-missing --output planningops/artifacts/validation/ready-implementation-blueprint-normalize-report.json` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/validation/project-field-schema-report.json
+++ b/planningops/artifacts/validation/project-field-schema-report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-03-28T06:27:59.490653+00:00",
+  "generated_at_utc": "2026-03-28T14:20:08.991537+00:00",
   "project": {
     "owner": "rather-not-work-on",
     "project_num": 2,

--- a/planningops/artifacts/validation/ready-implementation-blueprint-normalize-report.json
+++ b/planningops/artifacts/validation/ready-implementation-blueprint-normalize-report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-03-03T06:46:08.923305+00:00",
+  "generated_at_utc": "2026-03-28T14:20:45.410477+00:00",
   "mode": "dry-run",
   "owner": "rather-not-work-on",
   "project_num": 2,
@@ -8,10 +8,59 @@
     "ready-implementation",
     "ready_implementation"
   ],
-  "candidates_count": 0,
+  "candidates_count": 56,
   "changed_count": 0,
   "applied_count": 0,
   "missing_count": 0,
-  "rows": [],
+  "rows": [
+    {
+      "issue_number": 499,
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "target_repo": "rather-not-work-on/monday",
+      "workflow_state": "ready-implementation",
+      "status": "Todo",
+      "changed": false,
+      "applied": false,
+      "apply_error": null,
+      "missing_keys": [],
+      "source": {
+        "interface_contract_refs": "existing",
+        "package_topology_ref": "existing",
+        "dependency_manifest_ref": "existing",
+        "file_plan_ref": "existing"
+      },
+      "resolved_refs": {
+        "interface_contract_refs": "docs/initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md",
+        "package_topology_ref": "docs/initiatives/unified-personal-agent-platform/20-repos/monday/README.md",
+        "dependency_manifest_ref": "planningops/config/runtime-profiles.json",
+        "file_plan_ref": "docs/initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/2026-02-27-uap-contract-first-foundation.execution-plan.md"
+      },
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/499"
+    },
+    {
+      "issue_number": 500,
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "target_repo": "rather-not-work-on/platform-planningops",
+      "workflow_state": "ready-implementation",
+      "status": "Todo",
+      "changed": false,
+      "applied": false,
+      "apply_error": null,
+      "missing_keys": [],
+      "source": {
+        "interface_contract_refs": "existing",
+        "package_topology_ref": "existing",
+        "dependency_manifest_ref": "existing",
+        "file_plan_ref": "existing"
+      },
+      "resolved_refs": {
+        "interface_contract_refs": "planningops/contracts/requirements-contract.md",
+        "package_topology_ref": "planningops/README.md",
+        "dependency_manifest_ref": "planningops/config/runtime-profiles.json",
+        "file_plan_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md"
+      },
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/500"
+    }
+  ],
   "verdict": "pass"
 }


### PR DESCRIPTION
## Summary
- refresh the canonical latest project-field schema validation report
- refresh the canonical latest ready-implementation blueprint normalization report
- record the refresh in the workbench hub and packet index

## Validation
- python3 planningops/scripts/validate_project_field_schema.py --fail-on-mismatch --output planningops/artifacts/validation/project-field-schema-report.json
- python3 planningops/scripts/normalize_ready_implementation_blueprint_refs.py --fail-on-missing --output planningops/artifacts/validation/ready-implementation-blueprint-normalize-report.json
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all
