### PR TITLE
chore(backlog-materialize): refresh wave22 latest artifacts

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -175,6 +175,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Backlog Materialize Sample Report Smoke Packet](./plans/2026-03-28-backlog-materialize-sample-report-smoke-packet.md)
 - [Backlog Materialize Sample Report Snapshot Packet](./plans/2026-03-28-backlog-materialize-sample-report-snapshot-packet.md)
 - [Backlog Materialize Snapshot Regression Packet](./plans/2026-03-28-backlog-materialize-snapshot-regression-packet.md)
+- [Backlog Materialize Wave22 Latest Refresh Packet](./plans/2026-03-28-backlog-materialize-wave22-latest-refresh-packet.md)
 - [MONDAY Harness Capability Contract Draft](./plans/2026-03-23-monday-harness-capability-contract-draft.md)
 - [MONDAY PlanningOps Evidence Projection Contract Draft](./plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
 - [MONDAY Runtime Artifact Map Draft](./plans/2026-03-23-monday-runtime-artifact-map-draft.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-wave22-latest-refresh-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-28-backlog-materialize-wave22-latest-refresh-packet.md
@@ -1,0 +1,32 @@
+---
+title: plan: Backlog Materialize Wave22 Latest Refresh Packet
+type: plan
+date: 2026-03-28
+updated: 2026-03-28
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Refreshes the canonical backlog materialization outputs from the wave22 execution contract so projected issues, label backfill evidence, and program-manifest evidence share one deterministic source plan.
+related_docs:
+  - ./2026-03-28-backlog-materialize-sample-artifact-lane-packet.md
+  - ./2026-03-28-backlog-materialize-sample-report-snapshot-packet.md
+---
+
+# plan: Backlog Materialize Wave22 Latest Refresh Packet
+
+## Summary
+- Replay `planningops/scripts/core/backlog/materialize.py` against the checked-in wave22 execution contract.
+- Refresh the canonical latest backlog-projected issues, issue-label backfill report, and program-manifest/report outputs from one consistent source plan.
+- Keep auxiliary compile, quality, and materialization reports outside the committed unit by routing them to temporary outputs.
+
+## Scope
+- `planningops/artifacts/backlog/projected-issues.json`
+- `planningops/artifacts/validation/issue-label-backfill-report.json`
+- `planningops/artifacts/program/program-manifest.json`
+- `planningops/artifacts/validation/program-manifest-report.json`
+
+## Acceptance
+- `test_backlog_materialization_contract.sh` passes
+- `python3 planningops/scripts/core/backlog/materialize.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave22.execution-contract.json ...` succeeds with canonical projected-issues, label, and manifest outputs
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/backlog/projected-issues.json
+++ b/planningops/artifacts/backlog/projected-issues.json
@@ -3,10 +3,10 @@
     "repo": "rather-not-work-on/platform-planningops",
     "number": 10,
     "state": "open",
-    "updated_at": "2026-03-15T06:30:22.695272+00:00",
-    "title": "plan: [10] Freeze monday scheduled delivery-cycle handoff contract",
+    "updated_at": "2026-03-28T14:31:27.452835+00:00",
+    "title": "plan: [10] planningops runner rate-limit guidance",
     "url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
-    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md`\n- plan_id: `uap-goal-driven-autonomy-wave20`\n- plan_revision: `1`\n- plan_item_id: `T10`\n- execution_order: `10`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_contract`\n- loop_profile: `l1_contract_clarification`\n- plan_lane: `m1_contract_freeze`\n- depends_on: `-`\n- primary_output: `planningops/contracts/scheduled-delivery-cycle-handoff-contract.md`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md`\n- `planningops/contracts/scheduled-delivery-cycle-handoff-contract.md`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- plan_id: `uap-runtime-mission-wave22`\n- plan_revision: `1`\n- plan_item_id: `AN10`\n- execution_order: `10`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `-`\n- primary_output: `planningops/scripts/core/loop/runner.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- `planningops/scripts/core/loop/runner.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: planningops/contracts/requirements-contract.md\npackage_topology_ref: planningops/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md\n",
     "labels": [
       {
         "name": "area/planningops"
@@ -18,7 +18,7 @@
         "name": "task"
       },
       {
-        "name": "type/governance"
+        "name": "type/hardening"
       }
     ]
   },
@@ -26,13 +26,13 @@
     "repo": "rather-not-work-on/platform-planningops",
     "number": 20,
     "state": "open",
-    "updated_at": "2026-03-15T06:30:22.695272+00:00",
-    "title": "plan: [20] Define monday scheduler delivery-cycle work items",
+    "updated_at": "2026-03-28T14:31:27.452835+00:00",
+    "title": "plan: [20] planningops supervisor rate-limit guidance summary",
     "url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
-    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md`\n- plan_id: `uap-goal-driven-autonomy-wave20`\n- plan_revision: `1`\n- plan_item_id: `T20`\n- execution_order: `20`\n- target_repo: `rather-not-work-on/monday`\n- component: `runtime`\n- workflow_state: `ready_implementation`\n- loop_profile: `l3_implementation_tdd`\n- plan_lane: `m2_sync_core`\n- depends_on: `T10`\n- primary_output: `monday/scripts/scheduler_delivery_cycle_work_items.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/monday`\n- depends_on: `T10`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md`\n- `monday/scripts/scheduler_delivery_cycle_work_items.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: docs/initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md\npackage_topology_ref: docs/initiatives/unified-personal-agent-platform/20-repos/monday/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/2026-02-27-uap-contract-first-foundation.execution-plan.md\n",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- plan_id: `uap-runtime-mission-wave22`\n- plan_revision: `1`\n- plan_item_id: `AN20`\n- execution_order: `20`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `AN10`\n- primary_output: `planningops/scripts/autonomous_supervisor_loop.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `AN10`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- `planningops/scripts/autonomous_supervisor_loop.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: planningops/contracts/requirements-contract.md\npackage_topology_ref: planningops/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md\n",
     "labels": [
       {
-        "name": "area/runtime"
+        "name": "area/planningops"
       },
       {
         "name": "p2"
@@ -49,33 +49,10 @@
     "repo": "rather-not-work-on/platform-planningops",
     "number": 30,
     "state": "open",
-    "updated_at": "2026-03-15T06:30:22.695272+00:00",
-    "title": "plan: [30] Execute scheduled delivery work items through monday queue cycle",
+    "updated_at": "2026-03-28T14:31:27.452835+00:00",
+    "title": "plan: [30] runtime mission wave22 review",
     "url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
-    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md`\n- plan_id: `uap-goal-driven-autonomy-wave20`\n- plan_revision: `1`\n- plan_item_id: `T30`\n- execution_order: `30`\n- target_repo: `rather-not-work-on/monday`\n- component: `runtime`\n- workflow_state: `ready_implementation`\n- loop_profile: `l3_implementation_tdd`\n- plan_lane: `m2_sync_core`\n- depends_on: `T10,T20`\n- primary_output: `monday/scripts/run_scheduled_queue_cycle.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/monday`\n- depends_on: `T10,T20`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md`\n- `monday/scripts/run_scheduled_queue_cycle.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: docs/initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md\npackage_topology_ref: docs/initiatives/unified-personal-agent-platform/20-repos/monday/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/2026-02-27-uap-contract-first-foundation.execution-plan.md\n",
-    "labels": [
-      {
-        "name": "area/runtime"
-      },
-      {
-        "name": "p2"
-      },
-      {
-        "name": "task"
-      },
-      {
-        "name": "type/hardening"
-      }
-    ]
-  },
-  {
-    "repo": "rather-not-work-on/platform-planningops",
-    "number": 40,
-    "state": "open",
-    "updated_at": "2026-03-15T06:30:22.695272+00:00",
-    "title": "plan: [40] Review goal-driven autonomy wave 20 scheduled delivery queue execution",
-    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/40",
-    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md`\n- plan_id: `uap-goal-driven-autonomy-wave20`\n- plan_revision: `1`\n- plan_item_id: `T40`\n- execution_order: `40`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `review_gate`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `T10,T20,T30`\n- primary_output: `planningops/artifacts/validation/goal-driven-autonomy-wave20-review.json`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `T10,T20,T30`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md`\n- `planningops/artifacts/validation/goal-driven-autonomy-wave20-review.json`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- plan_id: `uap-runtime-mission-wave22`\n- plan_revision: `1`\n- plan_item_id: `AN30`\n- execution_order: `30`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `review_gate`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `AN10,AN20`\n- primary_output: `planningops/artifacts/validation/runtime-mission-wave22-review.json`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `AN10,AN20`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- `planningops/artifacts/validation/runtime-mission-wave22-review.json`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
     "labels": [
       {
         "name": "area/planningops"

--- a/planningops/artifacts/program/program-manifest.json
+++ b/planningops/artifacts/program/program-manifest.json
@@ -2,14 +2,14 @@
   "manifest_version": 1,
   "program_id": "uap-po-ct-program",
   "initiative": "unified-personal-agent-platform",
-  "source_plan": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md",
+  "source_plan": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
   "scope_source_plan": true,
-  "generated_at_utc": "2026-03-15T06:30:23.292890+00:00",
+  "generated_at_utc": "2026-03-28T14:31:27.568225+00:00",
   "selection_policy": "dedupe_by_plan_item_id_and_target_repo_open_first_then_latest_update",
-  "item_count": 4,
+  "item_count": 3,
   "items": [
     {
-      "plan_item_id": "T10",
+      "plan_item_id": "AN10",
       "track": "control_plane",
       "execution_order": 10,
       "target_repo": "rather-not-work-on/platform-planningops",
@@ -17,69 +17,61 @@
       "issue_number": 10,
       "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
       "issue_state": "open",
-      "issue_updated_at": "2026-03-15T06:30:22.695272+00:00",
+      "issue_updated_at": "2026-03-28T14:31:27.452835+00:00",
       "component": "planningops",
-      "workflow_state": "ready_contract",
-      "loop_profile": "l1_contract_clarification",
-      "plan_lane": "m1_contract_freeze",
-      "depends_on": []
+      "workflow_state": "ready_implementation",
+      "loop_profile": "l4_integration_reconcile",
+      "plan_lane": "m3_guardrails",
+      "depends_on": [],
+      "interface_contract_refs": "planningops/contracts/requirements-contract.md",
+      "package_topology_ref": "planningops/README.md",
+      "dependency_manifest_ref": "planningops/config/runtime-profiles.json",
+      "file_plan_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md"
     },
     {
-      "plan_item_id": "T20",
-      "track": "federated_runtime",
+      "plan_item_id": "AN20",
+      "track": "control_plane",
       "execution_order": 20,
-      "target_repo": "rather-not-work-on/monday",
+      "target_repo": "rather-not-work-on/platform-planningops",
       "issue_repo": "rather-not-work-on/platform-planningops",
       "issue_number": 20,
       "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
       "issue_state": "open",
-      "issue_updated_at": "2026-03-15T06:30:22.695272+00:00",
-      "component": "runtime",
+      "issue_updated_at": "2026-03-28T14:31:27.452835+00:00",
+      "component": "planningops",
       "workflow_state": "ready_implementation",
-      "loop_profile": "l3_implementation_tdd",
-      "plan_lane": "m2_sync_core",
+      "loop_profile": "l4_integration_reconcile",
+      "plan_lane": "m3_guardrails",
       "depends_on": [
-        "T10"
-      ]
+        "AN10"
+      ],
+      "interface_contract_refs": "planningops/contracts/requirements-contract.md",
+      "package_topology_ref": "planningops/README.md",
+      "dependency_manifest_ref": "planningops/config/runtime-profiles.json",
+      "file_plan_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md"
     },
     {
-      "plan_item_id": "T30",
-      "track": "federated_runtime",
+      "plan_item_id": "AN30",
+      "track": "control_plane",
       "execution_order": 30,
-      "target_repo": "rather-not-work-on/monday",
+      "target_repo": "rather-not-work-on/platform-planningops",
       "issue_repo": "rather-not-work-on/platform-planningops",
       "issue_number": 30,
       "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
       "issue_state": "open",
-      "issue_updated_at": "2026-03-15T06:30:22.695272+00:00",
-      "component": "runtime",
-      "workflow_state": "ready_implementation",
-      "loop_profile": "l3_implementation_tdd",
-      "plan_lane": "m2_sync_core",
-      "depends_on": [
-        "T10",
-        "T20"
-      ]
-    },
-    {
-      "plan_item_id": "T40",
-      "track": "control_plane",
-      "execution_order": 40,
-      "target_repo": "rather-not-work-on/platform-planningops",
-      "issue_repo": "rather-not-work-on/platform-planningops",
-      "issue_number": 40,
-      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/40",
-      "issue_state": "open",
-      "issue_updated_at": "2026-03-15T06:30:22.695272+00:00",
+      "issue_updated_at": "2026-03-28T14:31:27.452835+00:00",
       "component": "planningops",
       "workflow_state": "review_gate",
       "loop_profile": "l4_integration_reconcile",
       "plan_lane": "m3_guardrails",
       "depends_on": [
-        "T10",
-        "T20",
-        "T30"
-      ]
+        "AN10",
+        "AN20"
+      ],
+      "interface_contract_refs": "",
+      "package_topology_ref": "",
+      "dependency_manifest_ref": "",
+      "file_plan_ref": ""
     }
   ]
 }

--- a/planningops/artifacts/validation/issue-label-backfill-report.json
+++ b/planningops/artifacts/validation/issue-label-backfill-report.json
@@ -1,35 +1,35 @@
 {
-  "generated_at_utc": "2026-03-15T06:30:23.251510+00:00",
+  "generated_at_utc": "2026-03-28T14:31:27.527242+00:00",
   "repo": "rather-not-work-on/platform-planningops",
   "rules_path": "planningops/config/issue-quality-rules.json",
   "issues_file": "planningops/artifacts/backlog/projected-issues.json",
   "write_updated_issues_file": "planningops/artifacts/backlog/projected-issues.json",
   "mode": "apply",
-  "issues_in_scope": 4,
-  "issues_with_missing_labels": 4,
-  "issues_applied": 4,
+  "issues_in_scope": 3,
+  "issues_with_missing_labels": 3,
+  "issues_applied": 3,
   "rows": [
     {
       "number": 10,
-      "title": "plan: [10] Freeze monday scheduled delivery-cycle handoff contract",
+      "title": "plan: [10] planningops runner rate-limit guidance",
       "url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
       "existing_labels": [],
       "planned_labels": [
         "area/planningops",
         "p2",
         "task",
-        "type/governance"
+        "type/hardening"
       ],
       "apply_status": "applied_local",
       "error": ""
     },
     {
       "number": 20,
-      "title": "plan: [20] Define monday scheduler delivery-cycle work items",
+      "title": "plan: [20] planningops supervisor rate-limit guidance summary",
       "url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
       "existing_labels": [],
       "planned_labels": [
-        "area/runtime",
+        "area/planningops",
         "p2",
         "task",
         "type/hardening"
@@ -39,22 +39,8 @@
     },
     {
       "number": 30,
-      "title": "plan: [30] Execute scheduled delivery work items through monday queue cycle",
+      "title": "plan: [30] runtime mission wave22 review",
       "url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
-      "existing_labels": [],
-      "planned_labels": [
-        "area/runtime",
-        "p2",
-        "task",
-        "type/hardening"
-      ],
-      "apply_status": "applied_local",
-      "error": ""
-    },
-    {
-      "number": 40,
-      "title": "plan: [40] Review goal-driven autonomy wave 20 scheduled delivery queue execution",
-      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/40",
       "existing_labels": [],
       "planned_labels": [
         "area/planningops",

--- a/planningops/artifacts/validation/program-manifest-report.json
+++ b/planningops/artifacts/validation/program-manifest-report.json
@@ -1,8 +1,8 @@
 {
-  "generated_at_utc": "2026-03-15T06:30:23.292171+00:00",
+  "generated_at_utc": "2026-03-28T14:31:27.567292+00:00",
   "program_id": "uap-po-ct-program",
   "initiative": "unified-personal-agent-platform",
-  "source_plan": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave20-issue-pack.md",
+  "source_plan": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
   "repos": [
     "rather-not-work-on/platform-planningops",
     "rather-not-work-on/platform-contracts",
@@ -13,14 +13,14 @@
   "issues_file": "planningops/artifacts/backlog/projected-issues.json",
   "verdict": "pass",
   "errors": [],
-  "issues_scanned": 4,
+  "issues_scanned": 3,
   "filtered_out_count": 0,
-  "item_count": 4,
+  "item_count": 3,
   "duplicate_group_count": 0,
   "duplicate_groups": [],
   "track_summary": {
-    "control_plane": 2,
-    "federated_runtime": 2,
+    "control_plane": 3,
+    "federated_runtime": 0,
     "reconciliation": 0,
     "unknown": 0
   }


### PR DESCRIPTION
## Summary
- refresh canonical backlog projected issues from the wave22 execution contract
- refresh canonical issue-label backfill and program-manifest outputs from the same wave22 source plan
- register the refresh packet in the workbench hub

## Validation
- bash planningops/scripts/test_backlog_materialization_contract.sh
- python3 planningops/scripts/core/backlog/materialize.py --contract-file docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave22.execution-contract.json --repo rather-not-work-on/platform-planningops --initiative unified-personal-agent-platform --compile-output "$TMPDIR/plan-compile-report.json" --quality-output "$TMPDIR/issue-quality-report.json" --output "$TMPDIR/materialize-report.json"
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all
