### PR TITLE
chore(loop-runner): refresh offline latest artifacts

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/README.md
+++ b/docs/workbench/unified-personal-agent-platform/README.md
@@ -132,6 +132,7 @@ python3 planningops/scripts/memory_compactor.py --mode check --root . --rules pl
 - [Reflection Cycle Contract Surface Sync Packet](./plans/2026-03-28-reflection-cycle-contract-surface-sync-packet.md)
 - [Loop Runner Snapshot Intake Normalization Packet](./plans/2026-03-28-loop-runner-snapshot-intake-normalization-packet.md)
 - [Offline Snapshot Gate Hardening Packet](./plans/2026-03-30-offline-snapshot-gate-hardening-packet.md)
+- [Loop Runner Offline Latest Refresh Packet](./plans/2026-03-30-loop-runner-offline-latest-refresh-packet.md)
 - [Ralph Loop Plain-Python Annotation Hygiene Packet](./plans/2026-03-28-ralph-loop-plain-python-annotation-hygiene-packet.md)
 - [Compile Backlog Offline Issues Intake Packet](./plans/2026-03-28-compile-backlog-offline-issues-intake-packet.md)
 - [Backlog Stock Snapshot Normalization Packet](./plans/2026-03-28-backlog-stock-snapshot-normalization-packet.md)

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-30-loop-runner-offline-latest-refresh-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-30-loop-runner-offline-latest-refresh-packet.md
@@ -1,0 +1,32 @@
+---
+title: plan: Loop Runner Offline Latest Refresh Packet
+type: plan
+date: 2026-03-30
+updated: 2026-03-30
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Refreshes the committed loop-runner latest evidence and active-goal registry validation after the offline snapshot-backed supervisor replay selects the canonical U10 contract lane.
+related_docs:
+  - ./2026-03-30-offline-snapshot-gate-hardening-packet.md
+  - ./2026-03-28-active-goal-registry-artifact-refresh-packet.md
+---
+
+# plan: Loop Runner Offline Latest Refresh Packet
+
+## Summary
+- Refresh `planningops/artifacts/loop-runner/last-run.json` to the latest offline snapshot-backed issue-loop-runner replay.
+- Refresh `planningops/artifacts/loop-runner/escalation-history.json` so issue `10` pass history matches the same replay window.
+- Refresh the committed active-goal registry validation report so the empty active-goal state is revalidated alongside the replayed supervisor artifacts.
+
+## Scope
+- `planningops/artifacts/loop-runner/escalation-history.json`
+- `planningops/artifacts/loop-runner/last-run.json`
+- `planningops/artifacts/validation/active-goal-registry-report.json`
+
+## Acceptance
+- `test_autonomous_supervisor_loop_contract.sh` passes
+- `test_escalation_gate.sh` passes
+- `python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --output planningops/artifacts/validation/active-goal-registry-report.json --strict` passes
+- `uap-docs.sh check --profile workbench` passes
+- `uap-docs.sh check --profile all` passes

--- a/planningops/artifacts/loop-runner/escalation-history.json
+++ b/planningops/artifacts/loop-runner/escalation-history.json
@@ -9,102 +9,102 @@
     ],
     "10": [
       {
-        "recorded_at_utc": "2026-03-19T17:01:35.713077+00:00",
+        "recorded_at_utc": "2026-03-29T13:01:10.847982+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-19T18:01:45.610383+00:00",
+        "recorded_at_utc": "2026-03-29T13:02:43.713333+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-19T19:01:25.854001+00:00",
+        "recorded_at_utc": "2026-03-29T13:03:25.728718+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-21T20:01:30.891658+00:00",
+        "recorded_at_utc": "2026-03-29T20:02:13.479982+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-21T20:01:31.420347+00:00",
+        "recorded_at_utc": "2026-03-29T21:01:10.165542+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T08:05:57.503457+00:00",
+        "recorded_at_utc": "2026-03-29T22:01:15.657163+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T08:06:14.673305+00:00",
+        "recorded_at_utc": "2026-03-29T23:01:04.991146+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T08:07:40.217593+00:00",
+        "recorded_at_utc": "2026-03-30T00:01:40.442393+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T08:07:59.548995+00:00",
+        "recorded_at_utc": "2026-03-30T01:01:09.757888+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T09:01:35.186265+00:00",
+        "recorded_at_utc": "2026-03-30T02:01:35.492115+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T09:01:50.177704+00:00",
+        "recorded_at_utc": "2026-03-30T03:01:13.062933+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T10:01:03.942566+00:00",
+        "recorded_at_utc": "2026-03-30T05:01:00.011120+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T10:02:11.739434+00:00",
+        "recorded_at_utc": "2026-03-30T06:01:32.809493+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T10:02:43.994507+00:00",
+        "recorded_at_utc": "2026-03-30T07:01:19.152905+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T11:00:54.076223+00:00",
+        "recorded_at_utc": "2026-03-30T08:01:30.824813+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T11:00:59.775097+00:00",
+        "recorded_at_utc": "2026-03-30T09:01:16.989577+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T12:01:45.323560+00:00",
+        "recorded_at_utc": "2026-03-30T10:01:04.971372+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T13:00:55.878537+00:00",
+        "recorded_at_utc": "2026-03-30T11:01:09.252663+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T14:01:24.538588+00:00",
+        "recorded_at_utc": "2026-03-30T12:01:32.156022+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       },
       {
-        "recorded_at_utc": "2026-03-23T15:01:07.049114+00:00",
+        "recorded_at_utc": "2026-03-30T13:01:20.446262+00:00",
         "verdict": "pass",
         "reason_code": "ok"
       }

--- a/planningops/artifacts/loop-runner/last-run.json
+++ b/planningops/artifacts/loop-runner/last-run.json
@@ -1,214 +1,331 @@
 {
-  "generated_at_utc": "2026-03-25T02:01:59.941377+00:00",
-  "run_id": "overnight-uap-20260325T0100Z",
-  "mode": "dry-run",
-  "max_cycles": 1,
-  "executed_cycles": 1,
-  "convergence_pass_streak": 2,
-  "stop_on_experiment_trigger": true,
-  "report_only_gates": false,
-  "supervisor_verdict": "inconclusive",
-  "stop_reason": "replan_required",
-  "stop_details": {
-    "cycle": 1,
-    "reason_code": "no_candidate_project_items",
-    "backlog_materialization": {
-      "enabled": false,
-      "rc": null,
-      "output_path": null,
-      "projected_issues_output": null,
-      "verdict": null
-    }
+  "selected_issue": 10,
+  "selected_issue_repo": "rather-not-work-on/platform-planningops",
+  "selected_target_repo": "rather-not-work-on/platform-planningops",
+  "selected_workflow_state": "ready-contract",
+  "selected_loop_profile": "L1 Contract-Clarification",
+  "selected_plan_item_id": "U10",
+  "attempt_budget": {
+    "max_attempts": 3,
+    "max_duration_minutes": 30,
+    "max_token_budget": 120000
   },
-  "cycles": [
-    {
-      "cycle": 1,
-      "started_at_utc": "2026-03-25T02:01:59.935783+00:00",
-      "loop_result_rc": 2,
-      "loop_result": {
-        "result": "no_eligible_todo_issue",
-        "reason_code": "no_candidate_project_items",
-        "recommended_action": "retriage_backlog",
-        "last_verdict": "inconclusive",
-        "auto_paused": false,
-        "selection_trace": {
-          "selection_policy": {
-            "name": "high_value_ready_first",
-            "ready_workflow_states": [
-              "ready-contract",
-              "ready-implementation"
-            ],
-            "tie_breaker": [
-              "execution_order_asc",
-              "issue_number_asc"
-            ]
-          },
-          "allowed_workflow_states": [
-            "ready-contract",
-            "ready-implementation"
-          ],
-          "candidate_count": 0,
-          "candidates": [],
-          "attempts": [],
-          "selected": null,
-          "project_item_limit": 1000,
-          "project_item_limit_hit": false,
-          "project_items_source": "manifest",
-          "project_items_snapshot_path": "planningops/artifacts/program/program-manifest.json",
-          "project_items_rate_limit_fallback_used": true,
-          "project_items_rate_limit_error": "unknown owner type",
-          "rate_limit_guidance": {
-            "status": "snapshot_fallback_active",
-            "recommended_wait_minutes": 15,
-            "retry_mode": "retry_live_after_cooldown",
-            "allowed_modes": [
-              "dry-run",
-              "no-feedback"
-            ],
-            "blocked_modes": [
-              "apply"
-            ],
-            "snapshot_path": "planningops/artifacts/program/program-manifest.json",
-            "reason": "GitHub API rate limit forced project item snapshot fallback; use snapshot-backed dry-runs only until live quota recovers.",
-            "raw_error": "unknown owner type"
-          },
-          "closed_issue_reconcile": {
-            "requested_mode": "auto",
-            "effective_mode": "check",
-            "candidate_scope_count": 0,
-            "leading_closed_candidate_count": 0,
-            "status": "skipped",
-            "reason_code": "closed_issue_reconcile_not_needed",
-            "report_path": null,
-            "issues_total": 0,
-            "updated_count": 0,
-            "error_count": 0,
-            "verdict": "pass",
-            "issue_refs": []
-          },
-          "pec_preflight": {
-            "mode": "hybrid",
-            "contract_file": null,
-            "status": "not_evaluated",
-            "reason_code": "selected_issue_missing"
-          }
-        },
-        "candidate_count": 0,
-        "replenishment_candidates_path": null,
-        "replenishment_candidates_count": 0,
-        "generated_at_utc": "2026-03-25T02:01:59.866617+00:00",
-        "no_feedback": true
-      },
-      "last_verdict": "inconclusive",
-      "reason_code": "no_candidate_project_items",
-      "auto_paused": false,
-      "replan_required": true,
-      "replan_decision_path": null,
-      "replenishment_candidates_path": null,
-      "replenishment_candidates_count": 0,
-      "experiment_trigger": {
-        "triggered": false,
-        "reasons": [],
-        "uncertainty_level": null,
-        "simulation_required": false,
-        "loop_profile": null
-      },
-      "experiment_trigger_artifact": null,
-      "experiment_auto_executor": {
-        "enabled": false,
-        "rc": null,
-        "output_path": null,
-        "verdict": null,
-        "selected_option": null
-      },
-      "backlog_materialization": {
-        "enabled": false,
-        "rc": null,
-        "output_path": null,
-        "projected_issues_output": null,
-        "verdict": null
-      },
-      "goal_transition": {
-        "enabled": false,
-        "rc": null,
-        "output_path": null,
-        "verdict": null,
-        "goal_key": null,
-        "next_goal_key": null
-      },
-      "project_items_source": "manifest",
-      "project_items_rate_limit_fallback_used": true,
-      "project_items_rate_limit_error": "unknown owner type",
-      "rate_limit_guidance": {
-        "status": "snapshot_fallback_active",
-        "recommended_wait_minutes": 15,
-        "retry_mode": "retry_live_after_cooldown",
-        "allowed_modes": [
-          "dry-run",
-          "no-feedback"
-        ],
-        "blocked_modes": [
-          "apply"
-        ],
-        "reason": "Supervisor observed snapshot-backed issue intake due to GitHub API pressure.",
-        "raw_error": "unknown owner type"
-      },
-      "backlog_gate": {
-        "rc": 0,
-        "report_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/supervisor/overnight-uap-20260325T0100Z/cycle-01/backlog-stock-report.json",
-        "verdict": "pass",
-        "breach_count": 0,
-        "candidate_violation_count": 0
-      },
-      "ended_at_utc": "2026-03-25T02:01:59.935857+00:00"
-    }
+  "attempt_budget_guard": {
+    "attempt_budget": {
+      "max_attempts": 3,
+      "max_duration_minutes": 30,
+      "max_token_budget": 120000
+    },
+    "max_attempts": 3,
+    "max_retries": 2,
+    "retry_cap_attempts": 3,
+    "enforced_worker_attempts": 3
+  },
+  "checkpoint_resumed": false,
+  "checkpoint_stage_at_start": null,
+  "lock_owner_id": "issue-loop-runner-8437-1774875680",
+  "stale_lock_recovered": false,
+  "watchdog_report": "planningops/artifacts/loop-runner/watchdog/issue-10.json",
+  "final_loop_profile": "L1 Contract-Clarification",
+  "auto_paused": false,
+  "escalation": {
+    "auto_paused": false,
+    "trigger_type": null,
+    "same_reason_consecutive": 0,
+    "inconclusive_consecutive": 0,
+    "history_count": 20
+  },
+  "replan_decision_path": null,
+  "deps": [],
+  "candidate_count": 3,
+  "allowed_workflow_states": [
+    "ready-contract",
+    "ready-implementation"
   ],
-  "contracts": {
-    "autonomous_run_policy": "planningops/contracts/autonomous-run-policy-contract.md",
-    "worktree_experiment_protocol": "planningops/contracts/worktree-comparative-experiment-protocol.md",
-    "backlog_replenishment": "planningops/contracts/backlog-stock-replenishment-contract.md",
-    "backlog_materialization": "planningops/contracts/backlog-materialization-contract.md",
-    "active_goal_registry": "planningops/contracts/active-goal-registry-contract.md",
-    "goal_lifecycle_transition": "planningops/contracts/goal-lifecycle-transition-contract.md",
-    "goal_completion": "planningops/contracts/goal-completion-contract.md",
-    "operator_channel_adapter": "planningops/contracts/operator-channel-adapter-contract.md"
+  "selection_trace": {
+    "selection_policy": {
+      "name": "high_value_ready_first",
+      "ready_workflow_states": [
+        "ready-contract",
+        "ready-implementation"
+      ],
+      "tie_breaker": [
+        "execution_order_asc",
+        "issue_number_asc"
+      ]
+    },
+    "allowed_workflow_states": [
+      "ready-contract",
+      "ready-implementation"
+    ],
+    "candidate_count": 3,
+    "candidates": [
+      {
+        "number": 10,
+        "order": 10,
+        "status": "Todo",
+        "workflow_state": "ready-contract",
+        "issue_repo": "rather-not-work-on/platform-planningops",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "loop_profile": "l1_contract_clarification",
+        "initiative": "control_plane",
+        "plan_item_id": "U10",
+        "execution_kind": "executable",
+        "simulation_required": false,
+        "uncertainty_level": null,
+        "blueprint_refs": {
+          "interface_contract_refs": null,
+          "package_topology_ref": null,
+          "dependency_manifest_ref": null,
+          "file_plan_ref": null
+        },
+        "blueprint_complete": false
+      },
+      {
+        "number": 20,
+        "order": 20,
+        "status": "Todo",
+        "workflow_state": "ready-implementation",
+        "issue_repo": "rather-not-work-on/platform-planningops",
+        "target_repo": "rather-not-work-on/monday",
+        "component": "runtime",
+        "loop_profile": "l3_implementation_tdd",
+        "initiative": "federated_runtime",
+        "plan_item_id": null,
+        "execution_kind": "executable",
+        "simulation_required": false,
+        "uncertainty_level": null,
+        "blueprint_refs": {},
+        "blueprint_complete": true
+      },
+      {
+        "number": 30,
+        "order": 30,
+        "status": "Todo",
+        "workflow_state": "ready-implementation",
+        "issue_repo": "rather-not-work-on/platform-planningops",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "component": "planningops",
+        "loop_profile": "l3_implementation_tdd",
+        "initiative": "control_plane",
+        "plan_item_id": null,
+        "execution_kind": "executable",
+        "simulation_required": false,
+        "uncertainty_level": null,
+        "blueprint_refs": {},
+        "blueprint_complete": true
+      }
+    ],
+    "attempts": [
+      {
+        "number": 10,
+        "issue_repo": "rather-not-work-on/platform-planningops",
+        "result": "selected",
+        "plan_item_id": "U10",
+        "execution_kind": "executable",
+        "depends_on": [],
+        "dep_checks": [],
+        "attempt_budget": {
+          "max_attempts": 3,
+          "max_duration_minutes": 30,
+          "max_token_budget": 120000
+        },
+        "selector_hints": {
+          "simulation_required": false,
+          "uncertainty_level": null
+        },
+        "blueprint_refs": {
+          "interface_contract_refs": null,
+          "package_topology_ref": null,
+          "dependency_manifest_ref": null,
+          "file_plan_ref": null
+        }
+      }
+    ],
+    "selected": {
+      "number": 10,
+      "order": 10,
+      "status": "Todo",
+      "workflow_state": "ready-contract",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "target_repo": "rather-not-work-on/platform-planningops",
+      "component": "planningops",
+      "loop_profile": "l1_contract_clarification",
+      "initiative": "control_plane",
+      "plan_item_id": "U10",
+      "execution_kind": "executable",
+      "depends_on": [],
+      "attempt_budget": {
+        "max_attempts": 3,
+        "max_duration_minutes": 30,
+        "max_token_budget": 120000
+      },
+      "simulation_required": false,
+      "uncertainty_level": null,
+      "blueprint_refs": {
+        "interface_contract_refs": null,
+        "package_topology_ref": null,
+        "dependency_manifest_ref": null,
+        "file_plan_ref": null
+      },
+      "blueprint_complete": false
+    },
+    "project_item_limit": 1000,
+    "project_item_limit_hit": false,
+    "project_items_source": "snapshot",
+    "project_items_snapshot_path": "planningops/artifacts/loop-runner/project-items-snapshot.json",
+    "project_items_rate_limit_fallback_used": true,
+    "project_items_rate_limit_error": null,
+    "rate_limit_guidance": {
+      "status": "snapshot_fallback_active",
+      "recommended_wait_minutes": 15,
+      "retry_mode": "retry_live_after_cooldown",
+      "allowed_modes": [
+        "dry-run",
+        "no-feedback"
+      ],
+      "blocked_modes": [
+        "apply"
+      ],
+      "snapshot_path": "planningops/artifacts/loop-runner/project-items-snapshot.json",
+      "reason": "Live GitHub project intake failed; using snapshot-backed dry-runs until live access recovers.",
+      "raw_error": null,
+      "fallback_cause": "none"
+    },
+    "closed_issue_reconcile": {
+      "requested_mode": "check",
+      "effective_mode": "check",
+      "candidate_scope_count": 3,
+      "leading_closed_candidate_count": 0,
+      "status": "skipped",
+      "reason_code": "closed_issue_reconcile_not_needed",
+      "report_path": null,
+      "issues_total": 0,
+      "updated_count": 0,
+      "error_count": 0,
+      "verdict": "pass",
+      "issue_refs": []
+    },
+    "pec_preflight": {
+      "mode": "hybrid",
+      "contract_file": null,
+      "plan_item_id": "U10",
+      "status": "skipped",
+      "reason_code": "pec_contract_file_missing_hybrid",
+      "validation_errors": [],
+      "mismatches": []
+    },
+    "worker_task_pack_preflight": {
+      "status": "pass",
+      "reason_code": "worker_task_pack_ok",
+      "report_path": "planningops/artifacts/validation/worker-task-pack-issue-10.json",
+      "rc": 0,
+      "stdout": "{\n  \"generated_at_utc\": \"2026-03-30T13:01:20.267209+00:00\",\n  \"runtime_profile_file\": \"planningops/config/runtime-profiles.json\",\n  \"schema_file\": \"planningops/schemas/worker-task-pack.schema.json\",\n  \"task_key\": \"issue-10\",\n  \"issue_number\": 10,\n  \"mode\": \"dry-run\",\n  \"loop_profile\": \"L1 Contract-Clarification\",\n  \"target_repo\": \"rather-not-work-on/platform-planningops\",\n  \"validation_errors\": [],\n  \"worker_task_pack\": {\n    \"version\": \"v1\",\n    \"task_key\": \"issue-10\",\n    \"issue_number\": 10,\n    \"mode\": \"dry-run\",\n    \"loop_profile\": \"L1 Contract-Clarification\",\n    \"runtime_profile\": \"local\",\n    \"worker_policy_kind\": \"parser_diff_dry_run\",\n    \"command\": [\n      \"python3\",\n      \"planningops/scripts/parser_diff_dry_run.py\",\n      \"--run-id\",\n      \"worker-pack-issue-10\",\n      \"--mode\",\n      \"dry-run\"\n    ],\n    \"retry_policy\": {\n      \"max_retries\": 2\n    },\n    \"timeout_ms\": 60000,\n    \"idempotency_key\": \"4b05ce5303926ae5b24d9f8867bb79669f85fba6b6c112326b8fc1bef1ca3380\",\n    \"target_repo\": \"rather-not-work-on/platform-planningops\",\n    \"metadata\": {\n      \"profile_file\": \"planningops/config/runtime-profiles.json\",\n      \"task_key\": \"issue-10\"\n    }\n  },\n  \"verdict\": \"pass\",\n  \"reason\": \"ok\"\n}",
+      "stderr": "",
+      "worker_task_pack": {
+        "version": "v1",
+        "task_key": "issue-10",
+        "issue_number": 10,
+        "mode": "dry-run",
+        "loop_profile": "L1 Contract-Clarification",
+        "runtime_profile": "local",
+        "worker_policy_kind": "parser_diff_dry_run",
+        "command": [
+          "python3",
+          "planningops/scripts/parser_diff_dry_run.py",
+          "--run-id",
+          "worker-pack-issue-10",
+          "--mode",
+          "dry-run"
+        ],
+        "retry_policy": {
+          "max_retries": 2
+        },
+        "timeout_ms": 60000,
+        "idempotency_key": "4b05ce5303926ae5b24d9f8867bb79669f85fba6b6c112326b8fc1bef1ca3380",
+        "target_repo": "rather-not-work-on/platform-planningops",
+        "metadata": {
+          "profile_file": "planningops/config/runtime-profiles.json",
+          "task_key": "issue-10"
+        }
+      },
+      "validation_errors": []
+    },
+    "attempt_budget_guard": {
+      "attempt_budget": {
+        "max_attempts": 3,
+        "max_duration_minutes": 30,
+        "max_token_budget": 120000
+      },
+      "max_attempts": 3,
+      "max_retries": 2,
+      "retry_cap_attempts": 3,
+      "enforced_worker_attempts": 3
+    }
   },
-  "federated_ci_summary": {
-    "summary_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/ci/federated-ci-summary.json",
-    "readiness_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/validation/federated-ci-summary-readiness.json",
-    "validation_report_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/validation/federated-ci-summary-validation.json",
-    "summary_run_id": "federated-ci-20260324T070603Z",
-    "summary_generated_at_utc": "2026-03-24T07:09:30.235035+00:00",
-    "summary_verdict": "pass",
-    "overall_status": "complete",
-    "check_count": 10,
-    "validation_verdict": "pass",
-    "validation_state": "fresh",
-    "readiness_status": "ready",
-    "ready": true,
-    "blocking_reasons": [],
-    "next_step": "none",
-    "remediation_commands": [],
-    "first_action_command": null
+  "pec_preflight": {
+    "mode": "hybrid",
+    "contract_file": null,
+    "plan_item_id": "U10",
+    "status": "skipped",
+    "reason_code": "pec_contract_file_missing_hybrid",
+    "validation_errors": [],
+    "mismatches": []
   },
-  "operator_report_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/supervisor/overnight-uap-20260325T0100Z/operator-report.json",
-  "operator_report_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/loop-runner/last-run-operator-report.json",
-  "operator_summary_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/supervisor/overnight-uap-20260325T0100Z/operator-summary.md",
-  "operator_summary_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/loop-runner/last-run-operator-summary.md",
-  "inbox_payload_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/supervisor/overnight-uap-20260325T0100Z/inbox-payload.json",
-  "inbox_payload_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/loop-runner/last-run-inbox-payload.json",
-  "operator_handoff_validation_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/supervisor/overnight-uap-20260325T0100Z/operator-handoff-validation.json",
-  "operator_handoff_validation_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/loop-runner/last-run-operator-handoff-validation.json",
-  "operator_priority_preview_path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/runtime-artifacts/messaging/operator-priority-previews/overnight-uap-20260325T0100Z-operator-priority-preview.json",
-  "operator_priority_preview_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/runtime-artifacts/messaging/operator-priority-previews/last-run-operator-priority-preview.json",
-  "operator_priority_display_packet_path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/runtime-artifacts/messaging/operator-priority-display-packets/overnight-uap-20260325T0100Z-operator-priority-display-packet.json",
-  "operator_priority_display_packet_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/monday/runtime-artifacts/messaging/operator-priority-display-packets/last-run-operator-priority-display-packet.json",
-  "operator_handoff_bundle_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/supervisor/overnight-uap-20260325T0100Z/operator-handoff-bundle.json",
-  "operator_handoff_bundle_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/loop-runner/last-run-operator-handoff-bundle.json",
-  "operator_handoff_bundle_validation_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/supervisor/overnight-uap-20260325T0100Z/operator-handoff-bundle-validation.json",
-  "operator_handoff_bundle_validation_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/loop-runner/last-run-operator-handoff-bundle-validation.json",
-  "operator_handoff_bundle_readiness_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/supervisor/overnight-uap-20260325T0100Z/operator-handoff-bundle-readiness.json",
-  "operator_handoff_bundle_readiness_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/loop-runner/last-run-operator-handoff-bundle-readiness.json",
-  "operator_handoff_bundle_readiness_validation_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/supervisor/overnight-uap-20260325T0100Z/operator-handoff-bundle-readiness-validation.json",
-  "operator_handoff_bundle_readiness_validation_last_path": "/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/artifacts/loop-runner/last-run-operator-handoff-bundle-readiness-validation.json"
+  "selection_transition_id": "loop-20260330T130120Z-issue-10-intake-selection",
+  "blueprint_refs": {
+    "interface_contract_refs": null,
+    "package_topology_ref": null,
+    "dependency_manifest_ref": null,
+    "file_plan_ref": null
+  },
+  "blueprint_complete": false,
+  "adapter_id": "planningops-adapter",
+  "adapter_pre_hook": {
+    "status": "ok",
+    "phase": "before_loop",
+    "adapter": "planningops-adapter",
+    "target_repo": "rather-not-work-on/platform-planningops",
+    "reason_code": "runtime",
+    "message": "planningops-adapter pre-hook baseline executed",
+    "emitted_artifacts": [],
+    "details": {
+      "component": "planningops",
+      "issue_number": 10,
+      "workflow_state": "ready-contract"
+    }
+  },
+  "adapter_post_hook": {
+    "status": "ok",
+    "phase": "after_loop",
+    "adapter": "planningops-adapter",
+    "target_repo": "rather-not-work-on/platform-planningops",
+    "reason_code": "runtime",
+    "message": "planningops-adapter post-hook baseline executed",
+    "emitted_artifacts": [],
+    "details": {
+      "component": "planningops",
+      "issue_number": 10,
+      "last_verdict": "pass"
+    }
+  },
+  "adapter_pre_artifact": "planningops/artifacts/adapter-hooks/2026-03-30/loop-20260330T130120Z-issue-10-adapter-pre.json",
+  "adapter_post_artifact": "planningops/artifacts/adapter-hooks/2026-03-30/loop-20260330T130120Z-issue-10-adapter-post.json",
+  "replenishment_candidates_path": "planningops/artifacts/backlog/issue-10-replenishment-candidates.json",
+  "replenishment_candidates_count": 0,
+  "last_verdict": "pass",
+  "reason_code": "ok",
+  "loop_rc": 0,
+  "verify_rc": 0,
+  "already_processed": false,
+  "idempotency_key": "eef06e2d61f0bfe1b2828c0fff30a5a911b1d0346e47c7d4f32dab3379dbf963",
+  "loop_stdout": "loop completed: verdict=pass reason=ok loop_id=loop-20260330T130120Z-issue-10\nartifacts root: planningops/artifacts/loops/2026-03-30/loop-20260330T130120Z-issue-10",
+  "verify_stdout": "verification result: planningops/artifacts/verification/issue-10-verification.json\nproject payload: planningops/artifacts/verification/issue-10-project-payload.json\nverdict=pass reason=ok replanning_triggered=False",
+  "loop_stderr": "",
+  "verify_stderr": "",
+  "generated_at_utc": "2026-03-30T13:01:20.454904+00:00",
+  "runtime_profile_file": "planningops/config/runtime-profiles.json",
+  "no_feedback": true,
+  "externalized_artifact_files": 15
 }

--- a/planningops/artifacts/validation/active-goal-registry-report.json
+++ b/planningops/artifacts/validation/active-goal-registry-report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-03-28T06:21:19.331442+00:00",
+  "generated_at_utc": "2026-03-30T13:39:33.373375+00:00",
   "registry": "planningops/config/active-goal-registry.json",
   "verdict": "pass",
   "error_count": 0,


### PR DESCRIPTION
## Summary
- refresh the committed loop-runner latest evidence after the offline snapshot-backed supervisor replay selects the U10 contract lane
- refresh the issue 10 escalation history window for the same replay and revalidate the empty active-goal registry state
- record the artifact-only refresh in a new workbench packet and hub link

Closes #605

## Validation
- bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh
- bash planningops/scripts/test_escalation_gate.sh
- python3 planningops/scripts/validate_active_goal_registry.py --registry planningops/config/active-goal-registry.json --output planningops/artifacts/validation/active-goal-registry-report.json --strict
- python3 inline JSON check for loop-runner latest fields
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Post-Deploy Monitoring & Validation
- Log/artifact query: inspect `planningops/artifacts/loop-runner/last-run.json` after the next offline or snapshot-backed replay and confirm the selected issue remains the smallest ready candidate
- Expected healthy signals: `selected_issue=10`, `selected_plan_item_id=U10`, `selection_trace.project_items_source=snapshot`, and issue `10` pass history continues to append under `planningops/artifacts/loop-runner/escalation-history.json`
- Failure signals: the latest replay reverts `last-run.json` back to a supervisor summary shape, `selection_trace` disappears, or the active-goal registry validator no longer reports an empty active-goal state
- Validation window and owner: next local offline replay or supervisor dry-run, owned by planningops maintainers
- Rollback trigger: revert this PR if committed loop-runner latest evidence no longer represents the issue-loop-runner artifact expected by runtime-handoff and implementation-readiness surfaces
