### PR TITLE
docs(monday-harness): track reference workbench closure

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/audits/2026-03-23-monday-agent-harness-reference-gap-analysis.md
+++ b/docs/workbench/unified-personal-agent-platform/audits/2026-03-23-monday-agent-harness-reference-gap-analysis.md
@@ -1,0 +1,299 @@
+---
+title: audit: MONDAY Agent Harness Reference Gap Analysis
+type: audit
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Compares MONDAY's current runtime direction against oh-my-claudecode, oh-my-openagent, and oh-my-codex, then classifies which harness patterns should be adopted, adapted, deferred, or rejected.
+related_docs:
+  - ../plans/2026-03-23-monday-agent-harness-reference-assimilation-plan.md
+  - ../plans/2026-03-16-plan-deepagents-core-skillctl-and-sandbox-rollout-plan.md
+  - ../../../initiatives/unified-personal-agent-platform/00-governance/uap-monday-identity.meta.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/runtime-skeleton-ready-implementation-pack.md
+  - ../../../../planningops/adr/adr-0001-ralph-loop-harness-topology.md
+---
+
+# audit: MONDAY Agent Harness Reference Gap Analysis
+
+## Objective
+
+Evaluate three external agent-harness references against the current `monday` direction and produce one adoption matrix that preserves the existing boundary:
+
+- `platform-planningops` remains the development orchestration and governance layer
+- `monday` becomes the execution harness owner
+
+This audit is not asking whether upstream harnesses are impressive. It is asking which pieces fit `M.O.N.D.A.Y.` as an execution repo and which pieces should remain outside the system.
+
+## Inputs
+
+### Internal inputs
+
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-reference-assimilation-plan.md`
+- `docs/workbench/unified-personal-agent-platform/plans/2026-03-16-plan-deepagents-core-skillctl-and-sandbox-rollout-plan.md`
+- `docs/initiatives/unified-personal-agent-platform/00-governance/uap-monday-identity.meta.md`
+- `docs/initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/runtime-skeleton-ready-implementation-pack.md`
+- `planningops/adr/adr-0001-ralph-loop-harness-topology.md`
+
+### External references
+
+- `oh-my-claudecode`
+- `oh-my-openagent`
+- `oh-my-codex`
+
+Reference snapshot date: **2026-03-23**
+
+## Current MONDAY Baseline
+
+The current internal direction already implies several constraints:
+
+- `monday` is the correct execution-repo owner for harness evolution
+- `platform-planningops` must not become a runtime host
+- `deepagents` and `skillctl` work already move MONDAY toward a repo-owned planner/runtime surface
+- existing monday runtime planning freezes package boundaries such as:
+  - `agent-kernel`
+  - `orchestrator`
+  - `executor-ralph-loop`
+  - `messaging-adapter`
+  - gateway-facing adapters
+
+That means the question is not “should we add a harness somewhere?”  
+The real question is “which reference-harness patterns should MONDAY absorb into its own architecture?”
+
+## Fit Classification
+
+Classification meanings:
+
+- `adopt`: build into MONDAY with minimal conceptual change
+- `adapt`: keep the idea, redesign the implementation to match MONDAY boundaries
+- `defer`: useful, but not first-wave critical
+- `reject`: conflicts with MONDAY or planningops ownership boundaries
+
+## Capability Matrix
+
+| capability | current MONDAY state | strongest reference | decision | why |
+|---|---|---|---|---|
+| explicit staged team lifecycle | partial | `oh-my-claudecode` | adopt | MONDAY needs a first-class execution phase model, not just implicit planner/executor hops |
+| worker role taxonomy | partial | `oh-my-openagent` | adopt | role-based delegation is more stable than model-specific delegation |
+| session state artifacts | weak | `oh-my-openagent` | adopt | long-running autonomy needs durable run/session state |
+| replay logs | weak | `oh-my-openagent` | adopt | post-run diagnosis and resumability need replayable logs |
+| clarification / interview mode | absent | `oh-my-claudecode` | adapt | MONDAY should clarify vague goals before planning, but with MONDAY-specific UX and contracts |
+| advisor workers | absent | `oh-my-claudecode` | adapt | architecture/review/docs advisors fit MONDAY, but must not bypass executor boundaries |
+| persistent repair loop | partial | `oh-my-openagent` | adopt | MONDAY needs verify-repair completion, not single-pass execution |
+| skill auto-load / precedence | partial | `oh-my-claudecode` | adapt | integrate with `skillctl`, not plugin conventions |
+| lightweight Codex-native wrapper | weak | `oh-my-codex` | defer | useful for ergonomics, but not the core architecture priority |
+| tmux worker runtime | absent | `oh-my-claudecode`, `oh-my-openagent` | adapt | good for real local worker concurrency, but must be optional and bounded |
+| background agent fanout | weak | `oh-my-openagent` | adapt | useful once session state and worker controls exist |
+| hash-anchored edit discipline | absent | `oh-my-openagent` | defer | valuable for high-trust edits, but not the first correctness bottleneck in MONDAY |
+| model auto-routing | partial | all three | adapt | MONDAY should route by role/policy, not copy upstream model maps |
+| HUD/live observability | weak | `oh-my-claudecode` | defer | useful later; evidence artifacts matter before live HUD polish |
+| slash/magic keyword UX | absent | all three | reject | upstream command vocabulary is not a stable MONDAY surface |
+| full upstream harness vendoring | absent | all three | reject | direct import would collapse ownership boundaries and create dependency drag |
+
+## Reference-by-Reference Assessment
+
+## A. `oh-my-openagent`
+
+### Best fit areas
+
+- worker specialization
+- persistent execution model
+- session and replay artifacts
+- strong runtime/tool surface
+- background agent orientation
+
+### MONDAY interpretation
+
+This is the best source for **runtime architecture patterns**.
+
+MONDAY should learn from its:
+
+- worker categorization
+- durable execution semantics
+- operational tooling
+- session-oriented design
+
+MONDAY should not inherit:
+
+- branding
+- upstream command model
+- upstream provider/runtime assumptions
+
+### Final classification
+
+- architecture patterns: `adopt/adapt`
+- runtime implementation: `reject as dependency`
+
+## B. `oh-my-claudecode`
+
+### Best fit areas
+
+- phase-based team orchestration
+- clarification mode
+- advisor surface
+- skill lifecycle model
+
+### MONDAY interpretation
+
+This is the best source for **execution lifecycle design**.
+
+The single most important pattern is the explicit team pipeline. MONDAY should convert that into a contractable phase model such as:
+
+`clarify -> plan -> design -> execute -> verify -> repair -> publish-evidence`
+
+MONDAY should not inherit:
+
+- plugin-specific assumptions
+- Claude-specific slash surface
+- direct command vocabulary as the public MONDAY interface
+
+### Final classification
+
+- phase model: `adopt`
+- command surface: `reject`
+
+## C. `oh-my-codex`
+
+### Best fit areas
+
+- thin Codex-native wrapper thinking
+- simple orchestration ergonomics
+- lightweight configuration patterns
+
+### MONDAY interpretation
+
+This is useful as a **local ergonomics reference**, not as the primary architecture source.
+
+It helps answer:
+
+- how should a Codex-friendly MONDAY surface feel?
+- what should stay thin and local instead of becoming framework-heavy?
+
+It does not answer:
+
+- how to build the full harness runtime
+- how to manage long-running multi-agent execution
+
+### Final classification
+
+- ergonomics ideas: `defer/adapt`
+- architecture dependency: `reject`
+
+## MONDAY Gap Summary
+
+## Highest-priority missing capabilities
+
+1. explicit team-phase execution contract
+2. durable session state
+3. replay log format
+4. worker role taxonomy
+5. verify/repair completion loop
+6. clarification mode before planning
+
+## Medium-priority missing capabilities
+
+1. advisor workers
+2. tmux or subprocess worker pool
+3. skill auto-resolution and precedence UX
+4. runtime operator status surface
+
+## Low-priority missing capabilities
+
+1. HUD polish
+2. Codex-specific wrapper ergonomics
+3. anchored editing discipline
+
+## Recommended Assimilation Order
+
+## Wave A: Runtime skeleton closure
+
+Deliver first:
+
+- worker role taxonomy
+- team-phase contract
+- session state schema
+- replay log schema
+
+Rationale:
+
+Without these four, MONDAY cannot safely absorb the more impressive external harness behaviors.
+
+## Wave B: Completion semantics
+
+Deliver next:
+
+- verify/repair loop
+- bounded retry policy
+- evidence publishing at phase boundaries
+
+Rationale:
+
+This is the minimum needed for “persistent autonomy” without hiding failure.
+
+## Wave C: Interaction improvements
+
+Deliver after Wave B:
+
+- clarification/interview mode
+- advisor workers
+- tool-router policy
+- optional tmux worker runtime
+
+Rationale:
+
+These improve quality and throughput, but they should sit on top of stable session and evidence primitives.
+
+## Wave D: Ergonomics and polish
+
+Deliver last:
+
+- Codex-thin wrapper UX
+- operator HUD
+- richer local worker controls
+
+Rationale:
+
+These matter, but only after the harness semantics are trustworthy.
+
+## Boundary Audit Result
+
+## What planningops should do
+
+- keep the boundary explicit
+- define harness capability contracts
+- define evidence and readiness expectations
+- validate MONDAY outputs
+- avoid runtime ownership creep
+
+## What planningops should not do
+
+- host worker runtime code
+- embed external harness runtimes
+- become the place where agent execution loops live
+- mirror upstream command surfaces
+
+## What monday should do
+
+- absorb the reusable architecture patterns
+- implement the actual runtime
+- own worker/session/tool/runtime behavior
+- remain the single execution-plane repo
+
+## Verdict
+
+- `oh-my-openagent`: best architecture reference for runtime composition
+- `oh-my-claudecode`: best lifecycle reference for staged team execution
+- `oh-my-codex`: best lightweight reference for Codex-facing ergonomics
+
+### Final decision
+
+MONDAY should use all three as **reference inputs**, but it should build one repo-owned harness architecture instead of composing upstream systems.
+
+The strongest next design move is:
+
+- build a MONDAY capability contract around staged phases, session state, replay logs, and worker taxonomy
+
+The strongest anti-goal is:
+
+- never let `platform-planningops` turn into the harness just because it already owns the plans

--- a/docs/workbench/unified-personal-agent-platform/audits/2026-03-23-monday-agent-harness-reference-traceability-map.md
+++ b/docs/workbench/unified-personal-agent-platform/audits/2026-03-23-monday-agent-harness-reference-traceability-map.md
@@ -1,0 +1,130 @@
+---
+title: audit: MONDAY Agent Harness Reference Traceability Map
+type: audit
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Maps the external oh-my-* reference projects to concrete MONDAY wave1 sub-issues so research findings can be applied without importing foreign runtime ownership into planningops.
+related_docs:
+  - ../plans/2026-03-23-monday-agent-harness-reference-assimilation-plan.md
+  - ./2026-03-23-monday-agent-harness-reference-gap-analysis.md
+  - ../plans/2026-03-23-monday-agent-harness-wave1-implementation-issue-pack.md
+  - ../plans/2026-03-23-monday-agent-harness-wave1-sub-issue-decomposition.md
+  - ../plans/2026-03-23-monday-harness-capability-contract-draft.md
+---
+
+# audit: MONDAY Agent Harness Reference Traceability Map
+
+## Purpose
+
+Turn the external reference study into implementation guidance.
+
+This map answers one question only:
+
+Which concrete MONDAY sub-issues should absorb which ideas from:
+
+- `oh-my-openagent`
+- `oh-my-claudecode`
+- `oh-my-codex`
+
+## Boundary Reminder
+
+The references are pattern sources, not import targets.
+
+Use them to shape:
+
+- monday runtime behavior
+- monday artifact discipline
+- monday operator ergonomics
+
+Do not use them to:
+
+- move runtime ownership into planningops
+- justify vendoring a foreign harness whole
+- bypass monday-native contracts
+
+## Traceability Table
+
+| Reference Pattern | Best Source | MONDAY Sub-Issue Targets | Adoption Mode | Notes |
+| --- | --- | --- | --- | --- |
+| explicit staged execution lifecycle | `oh-my-claudecode` | `MH10A`,`MH10C`,`MH40A`,`MH40B` | adapt | keep the phase model, not the repo/plugin structure |
+| mission clarification before execution | `oh-my-claudecode` | `MH10B` | adapt | preserve user-gated boundaries and ambiguity handling |
+| team worker role separation | `oh-my-openagent` + `oh-my-claudecode` | `MH30A`,`MH30C` | adapt | monday should keep repo-native role names |
+| background worker orchestration runtime | `oh-my-openagent` | `MH30A`,`MH30C` | adapt | runtime composition idea is useful; exact worker engine is not |
+| tool-call lineage and auditable mutation path | `oh-my-openagent` | `MH30B`,`MH40C` | adopt/adapt | strong fit for replay-backed evidence |
+| session persistence and resumability | `oh-my-openagent` | `MH20A`,`MH20B`,`MH20C` | adapt | monday needs equivalent artifact discipline |
+| replay-first diagnosis | `oh-my-openagent` | `MH20B`,`MH40C`,`MH50A` | adopt | best direct architecture match |
+| evidence-first completion | mixed | `MH40A`,`MH40C`,`MH50A`,`MH50B`,`MH50C` | adopt | this should become a monday invariant |
+| advisor / operator surface | `oh-my-claudecode` | `MH50D`,`MH60B` | adapt | operator guidance is useful; plugin-specific shape is not |
+| lightweight codex-native ergonomics | `oh-my-codex` | `MH10B`,`MH30B` | defer/selective adapt | use only for thin wrapper ergonomics, not architecture |
+| skill and command modularity | `oh-my-claudecode` + `oh-my-openagent` | later than wave1 | defer | useful, but not required to land wave1 runtime core |
+| multi-model routing and provider strategy | `oh-my-openagent` | later than wave1 | defer | belongs after runtime core and evidence surfaces stabilize |
+
+## What to Copy Closely
+
+These are the closest architectural fits and should influence implementation strongly:
+
+- replay-backed evidence publication
+- resumable session state
+- explicit team-phase lifecycle
+- auditable tool lineage
+
+These patterns align with monday's execution-plane role and PlanningOps' control-plane boundary.
+
+## What to Redesign Heavily
+
+These ideas are useful but should be reimplemented in monday-native form:
+
+- worker role naming
+- operator/advisor shell
+- task queue shapes
+- CLI entrypoints
+- skill package layout
+
+The foreign repos solve similar problems, but inside different assumptions.
+
+## What to Reject
+
+Reject these moves even if they look convenient:
+
+- vendoring the full harness into planningops
+- treating plugin metadata as canonical runtime contracts
+- copying upstream directory layout as if it were an interface
+- using prompt-only completion with no replay/evidence lineage
+
+## Wave 1 Priority Lens
+
+For wave1, the reference priorities should be:
+
+1. `oh-my-openagent` for session, replay, lineage, and execution discipline
+2. `oh-my-claudecode` for staged team lifecycle and operator-facing stop/handoff logic
+3. `oh-my-codex` for thin ergonomics only
+
+That means:
+
+- most of `MH20`, `MH30`, and `MH40` should lean on `oh-my-openagent` patterns
+- most of `MH10` and `MH50D` should lean on `oh-my-claudecode` patterns
+- almost none of wave1 should depend materially on `oh-my-codex`
+
+## Hand-Off Guidance for monday
+
+If this map is handed to the monday repo, the implementation guidance should be:
+
+1. start with `MH10A`, `MH20B`, and `MH20A`
+2. implement replay and session rules before operator sugar
+3. land sealed evidence before any control-plane projection
+4. keep planningops consumption out of scope until `MH50*`
+
+## Promotion Note
+
+If a future canonical monday document is written, this audit should not be promoted verbatim.
+
+Instead, promote:
+
+- the capability contract
+- the artifact map
+- the issue pack or sub-issue breakdown
+
+This traceability map should remain supporting analysis.

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-16-plan-deepagents-core-skillctl-and-sandbox-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-16-plan-deepagents-core-skillctl-and-sandbox-rollout-plan.md
@@ -1,0 +1,545 @@
+---
+title: plan: DeepAgents Core, Skillctl, and Sandboxed Apply-Mode Rollout
+type: plan
+date: 2026-03-16
+updated: 2026-03-19
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: reference
+summary: Replaces NanoClaw-first planning assumptions with a vendor-neutral planner-engine strategy that adopts DeepAgents first, adds an OpenClaw-inspired skill manager, and adopts NanoClaw-style sandboxing for apply-mode execution.
+---
+
+# plan: DeepAgents Core, Skillctl, and Sandboxed Apply-Mode Rollout
+
+## Overview
+This plan defines one operating model for the next planner/runtime wave:
+
+1. bounded context C moves from a NanoClaw-first description to a vendor-neutral `planner engine` abstraction, with `deepagents` as the first preferred implementation candidate inside `monday`.
+2. `skillctl` becomes the repo-owned skill supply-chain tool that imports, pins, syncs, and audits repo-local skills.
+3. `OpenClaw` is used as a reference for skill registry and precedence design, not as a replacement runtime.
+4. `NanoClaw` is used as a reference for isolation and anti-bloat discipline, not as the default planner runtime.
+5. existing `nanoclaw` assumptions in canonical docs/config move through an explicit compatibility migration instead of ad hoc replacement.
+
+## Implementation Reality Update (2026-03-19)
+
+- `monday` has now promoted `local` to the gateway-first `deepagents` default planner profile.
+- the active live path is:
+  - `local runtime profile`
+  - `deepagents` planner engine
+  - local LiteLLM-compatible endpoint
+  - intended routing priority `Gemini free-tier -> Ollama local fallback`
+- `legacy_local` is retained as the rollback profile.
+- runtime readiness and gate evidence are passing.
+- `monday` runtime-operations readiness now aggregates the sibling `platform-provider-gateway` LiteLLM stack as an explicit external surface instead of assuming planner evidence alone is sufficient.
+- this plan therefore moves from “future default-promotion design” into “post-promotion governance catch-up” status.
+- the governance/documentation gap is now closed:
+  - canonical docs describe bounded context C as a vendor-neutral planner engine
+  - `planningops/config/runtime-profiles.json` no longer carries `nanoclaw_endpoint`
+  - `monday` consumes shared runtime planner hints through `planner_policy` only
+- this plan should now be treated as implementation history and reference material.
+
+## Research Consolidation
+### Current State (2026-03-16)
+- canonical monday architecture still names bounded context C as `Planning & Delegation (nanoclaw core)`.
+- canonical foundation planning still assumes `nanoclaw + orchestrator + ralph-loop + codex2message` as the core composition.
+- `planningops/config/runtime-profiles.json` still carries `nanoclaw_endpoint` in both `local` and `oracle_cloud` profiles.
+- `monday` already has the correct seam for engine replacement:
+  - `MissionPlannerPort`
+  - `MissionOrchestrator` dependency injection
+  - `SubtaskDelegator` / handoff plan scaffolding
+- operator-channel delivery is already contract-pinned to `monday`-owned CLI/MCP adapters and must remain a thin wrapper over `packages/messaging-adapter`.
+- no checked-in `.mcp.json` exists in the current repo set, so initial deepagents adoption should not depend on MCP-first wiring.
+- internal workbench evidence currently includes only a NanoClaw fit assessment, so this migration must preserve explicit compatibility notes until a canonical planner-engine update is approved.
+
+### Existing Internal Inputs
+- `docs/workbench/unified-personal-agent-platform/audits/nanoclaw-fit-assessment.md`
+- `docs/initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md`
+- `docs/initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/2026-02-27-uap-contract-first-foundation.execution-plan.md`
+- `planningops/contracts/operator-channel-adapter-contract.md`
+- `planningops/contracts/control-plane-boundary-contract.md`
+- `planningops/config/runtime-profiles.json`
+
+### External Inputs
+- DeepAgents official docs and repo
+- OpenClaw gateway and skills docs
+- NanoClaw official repo
+
+## Problem Statement
+The platform has three mismatches that now need a single corrective plan:
+
+1. `nanoclaw` is still embedded in core architecture language even though the current direction requires a vendor-neutral planner seam with `deepagents` as the leading implementation candidate.
+2. the system has no approved skill supply-chain model for importing curated external skills such as `pm-skills` into repo-local deepagents/Codex surfaces.
+3. apply-mode execution is transport-gated, but tool execution and external skill ingestion are not yet isolated under a dedicated sandbox contract.
+
+If these remain unresolved:
+- canonical docs will diverge from the intended runtime direction,
+- `monday` planner evolution will stay stuck on a stub seam,
+- external skills will enter by copy/paste instead of an auditable pipeline,
+- apply-mode will accumulate unsafe exceptions around tools and imported skills.
+
+## Goals
+1. Replace `nanoclaw`-first planning assumptions with a vendor-neutral planner-engine design whose first implementation target is `deepagents`.
+2. Keep `platform-planningops` as a thin control plane while `monday` remains the only execution/runtime owner.
+3. Introduce a repo-owned `skillctl` workflow with source pinning, namespacing, precedence, and lock evidence.
+4. Add a sandbox contract for risky apply-mode tool execution and imported skills.
+5. Roll out the migration in waves that preserve documentation, runtime, and contract integrity.
+
+## Non-Goals
+- adopting the full OpenClaw gateway/runtime stack
+- adopting NanoClaw as the default planner runtime
+- replacing `monday` queue, messaging, or delivery-cycle ownership
+- building a public skill marketplace in the first rollout wave
+- redesigning Slack/email transport semantics in this plan
+
+## Decision Summary
+### Chosen Operating Model
+- `deepagents` is the first embedded planner-engine implementation inside `monday/packages/agent-kernel`.
+- `skillctl` is the repo-owned skill manager for deepagents/Codex-facing skill roots.
+- `OpenClaw` contributes skill precedence, registry metadata, and bundle ideas only.
+- `NanoClaw` contributes isolation, anti-bloat, and capability discipline only.
+
+### Explicit Rejections
+- no OpenClaw gateway process inside `monday`
+- no NanoClaw-first planner assumption in new docs
+- no direct planner-level Slack/email/provider calls outside existing CLI/MCP and gateway boundaries
+
+## Detailed Architecture
+## A. Ownership Model
+### `platform-planningops` owns
+- canonical planner/runtime contracts
+- approved external skill source policy
+- compatibility migration plan (`nanoclaw` terminology -> `deepagents` terminology)
+- rollout gates and verification commands
+
+### `monday` owns
+- embedded `deepagents` planner implementation
+- repo-local skill resolution and execution
+- `skillctl` implementation and lockfile generation
+- apply-mode sandbox enforcement
+- CLI/MCP operator channel adapters and transport evidence
+
+### Boundary Rule
+`platform-planningops` must not become a runtime host for deepagents, skills, or sandboxes. It governs the contracts; `monday` executes them.
+
+## B. `monday` DeepAgents Core Design
+### Package Additions
+- `packages/agent-kernel/src/deepagents_planner.ts`
+- `packages/agent-kernel/src/planner_engine_selector.ts`
+- `packages/agent-kernel/src/skill_manifest_loader.ts`
+- `packages/orchestrator/src/planner_run_metadata.ts`
+
+### Planner Port Strategy
+Keep the existing planner seam stable:
+- `MissionPlannerPort` remains the only planning contract exposed to orchestrator.
+- `DeepAgentsPlanner` implements `MissionPlannerPort`.
+- legacy `SubtaskDelegator` remains available behind a feature flag for fallback and regression comparison.
+- canonical docs should describe bounded context C as `planner engine` first, and list DeepAgents/NanoClaw only as implementation candidates or historical compatibility notes.
+
+### Runtime Selection
+Introduce planner engine selection in `monday`:
+
+```text
+planner_engine = legacy | deepagents
+rollout_default = legacy
+target_default_after_gate = deepagents
+```
+
+Selection inputs:
+- `monday` repo-local planner config
+- abstract planner hint from `planningops` runtime profile
+- explicit CLI override for local smoke
+
+### DeepAgents Planner Responsibilities
+- interpret `MissionInput`
+- select approved repo-local skills
+- build `TaskPlan`
+- emit planner metadata artifact for diagnostics
+- never perform operator delivery directly
+- never bypass executor or messaging boundaries
+
+### DeepAgents Planner Non-Responsibilities
+- queue mutation
+- Slack/email delivery
+- provider gateway ownership
+- run state creation outside orchestrator/executor contracts
+
+## C. Orchestrator and Handoff Evolution
+### Current Gap
+`MissionOrchestrator` only executes the first generated handoff. That is acceptable for the current stub, but under-utilizes a richer planner.
+
+### Required Change
+Extend orchestrator semantics in one controlled step:
+- preserve `createRun(mission): RunRef`
+- add internal support for ordered handoff candidate metadata
+- emit planner diagnostics without changing external run semantics
+- keep `ExecutorPort` as the single execution entrypoint
+- keep one primary executor invocation per `createRun` until a separate run-lifecycle contract change explicitly allows multi-handoff execution semantics
+
+### Guardrail
+Do not let planner richness leak into new cross-package coupling. `orchestrator` still consumes plans and handoffs through typed ports only.
+
+## D. `skillctl` Design
+### Goal
+Create one deterministic skill supply-chain tool for:
+- internal repo-owned skills
+- imported external skills such as `pm-skills`
+- synchronized deepagents/Codex skill views
+
+### Implementation Reality (2026-03-19)
+- phase-1 `skillctl` is now Python-first, not package-first
+- landed files in `monday`:
+  - `config/skill-registry.json`
+  - `config/skill-registry.schema.json`
+  - `config/skill-lock.json`
+  - `config/skill-lock.schema.json`
+  - `scripts/import_pm_skills.py`
+  - `scripts/validate_skill_registry.py`
+  - `scripts/validate_skill_lock.py`
+  - `scripts/test_skill_registry_suite.sh`
+  - `vendor/skills/pm-skills/...`
+- current baseline imports the full `phuryn/pm-skills` skill tree while ignoring Claude-only slash commands
+- future TypeScript/package ergonomics remain optional follow-up work, not a prerequisite for claiming `U40`
+
+### Proposed Files
+- `monday/config/skill-registry.json`
+- `monday/config/skill-lock.json`
+- `monday/config/planner-runtime.json`
+- `monday/config/apply-sandbox-policy.json`
+- `monday/scripts/skill_registry_contract.py`
+- `monday/scripts/validate_skill_registry.py`
+- `monday/scripts/import_pm_skills.py`
+- `monday/scripts/validate_skill_lock.py`
+- `monday/vendor/skills/`
+- optional later ergonomics:
+  - `monday/packages/skill-registry/README.md`
+  - `monday/packages/skill-registry/src/cli.ts`
+
+### Source Classes
+1. `bundled`
+   - future repo-owned skills committed under a dedicated repo-local skill root
+2. `vendor`
+   - imported external skills mirrored under `monday/vendor/skills/`
+3. `user`
+   - local developer-only overlays outside the repo
+
+### Precedence Rules
+1. `bundled` is the default CI/apply baseline.
+2. `vendor` must not silently override `bundled`; any same-capability replacement must use an explicit namespace and activation profile.
+3. `user` is allowed for local interactive exploration only.
+4. CI and apply-mode must reject `user` skills.
+5. name resolution must fail closed on namespace collisions or ambiguous activation.
+
+### Lockfile Contract
+Each locked skill entry must record:
+- `source_type`
+- `source_repo`
+- `source_ref`
+- `source_path`
+- `license`
+- `content_hash`
+- `namespace`
+- `enabled`
+- `sync_targets`
+
+### `pm-skills` Import Strategy
+- recursively discover `*/skills/*/SKILL.md`
+- ignore Claude-only `commands/` in v1
+- namespace imported skills by plugin and skill slug
+- record source repo/ref/path/license/hash in the lockfile
+
+### Sync Targets
+`skillctl sync` writes deterministic outputs to:
+- `monday/vendor/skills/`
+- optional local Codex target for operator/dev workflows only
+
+Local Codex sync rules:
+- never executed by CI
+- never required for apply-mode
+- never used as the source of truth for lock verification
+
+## E. Sandboxed Apply-Mode Design
+### Goal
+Adopt NanoClaw-style isolation without importing NanoClaw runtime ownership.
+
+### Implementation Reality (2026-03-19)
+- phase-1 sandboxing is now implemented in `monday` with:
+  - `config/apply-sandbox-policy.json`
+  - `config/apply-sandbox-policy.schema.json`
+  - `contracts/runtime-apply-sandbox-decision.schema.json`
+  - `scripts/validate_apply_sandbox_policy.py`
+  - `scripts/assess_skill_apply_sandbox.py`
+  - `scripts/run_skill_apply_mode.py`
+  - `scripts/validate_skill_apply_sandbox_decision.py`
+  - `scripts/test_apply_sandbox_suite.sh`
+- current enforcement is intentionally process-level, not container-level:
+  - source-class policy is fail-closed
+  - imported vendor skills are limited to `observe/read_repo`
+  - user skills are blocked in `ci` and `apply`
+  - subprocess execution strips provider credentials unless `credential_access` is explicitly allowed
+- future containerization was not required for the first `U50` claim, and `monday` now includes optional container-required hardening hooks without changing the default subprocess-first posture
+- reviewed container runtime profiles are now separated into `monday/config/apply-sandbox-container-profiles.json`, so sandbox policy selection and runtime implementation details no longer drift together
+
+### Policy Levels
+1. `observe`
+   - read-only inspection, no filesystem mutation
+2. `dry-run`
+   - patch proposal/evidence only
+3. `apply-sandboxed`
+   - isolated process or container with explicit capability allowlist
+4. `apply-reviewed`
+   - reviewed adapters only, used for approved channel/delivery or higher-risk mutations
+
+### Capability Classes
+- `read_repo`
+- `write_workspace`
+- `run_tests`
+- `network_fetch`
+- `provider_call`
+- `credential_access`
+- `channel_delivery`
+
+### Sandbox Rules
+- imported external skills default to `observe` until approved
+- `credential_access` and `channel_delivery` are never granted to vendor/user skills
+- apply-mode writes must remain inside repo-owned boundaries
+- planner-level tools cannot directly invoke Slack/email/provider gateways outside approved adapters
+
+### Initial Isolation Mechanism
+Start with isolated subprocess profiles and workspace allowlists. Containerization is a phase-2 hardening step only for high-risk capability classes.
+
+## F. Config and Contract Migration
+### Runtime Profile Migration
+Current:
+- `nanoclaw_endpoint`
+
+Target:
+
+```json
+{
+  "planner_policy": {
+    "engine_hint": "deepagents",
+    "execution_mode": "embedded",
+    "capability_profile": "repo_local_skills"
+  }
+}
+```
+
+Concrete repo-local planner settings move to `monday/config/planner-runtime.json`:
+
+```json
+{
+  "engine": "deepagents",
+  "skills_root": ".deepagents/skills",
+  "sandbox_policy_ref": "config/apply-sandbox-policy.json",
+  "mcp_config": null
+}
+```
+
+### Compatibility Window
+1. add `planner_policy` while keeping `nanoclaw_endpoint`
+2. migrate all planningops readers to `planner_policy`
+3. add `monday/config/planner-runtime.json` for repo-local paths and sandbox refs
+4. migrate monday readers to repo-local planner config
+5. freeze new `nanoclaw_*` additions
+6. remove `nanoclaw_endpoint` after contract and config consumers are updated
+
+### Canonical Doc Migration Targets
+- `20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md`
+- `20-repos/monday/30-execution-plan/2026-02-27-uap-contract-first-foundation.execution-plan.md`
+- any remaining workbench/canonical references that position NanoClaw as the default planner core
+
+## File Plan
+## PlanningOps / Docs
+- add workbench plan (this document)
+- add a canonical follow-up architecture or execution-plan update once approved
+- update planner terminology in canonical monday docs
+- update quality/gate docs if migration introduces new contract evidence
+
+## Monday / Runtime
+- add planner engine selector and deepagents adapter
+- add skill registry package and `skillctl`
+- add `packages/skill-registry/README.md` and monday topology/readme updates alongside the new package
+- add sandbox policy config
+- add repo-local planner config
+- add repo-local deepagents skills root
+- add optional `.mcp.json` only after CLI-first rollout is green
+
+## Implementation Phases
+## Phase 0: Decision Lock and Migration Scope (P0)
+### Deliverables
+- this workbench plan
+- migration scope inventory for `nanoclaw` references
+- approval decision on `planner_policy` and repo-local planner config schemas
+
+### Validation
+- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
+- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
+
+## Phase 1: DeepAgents Adapter Skeleton (P1)
+### Deliverables
+- `DeepAgentsPlanner` skeleton in `monday/packages/agent-kernel`
+- planner engine feature flag / selector
+- planner diagnostics artifact format
+- legacy planner fallback preserved
+- `legacy` remains the rollout default in local and CI paths
+
+### Validation
+- `pnpm typecheck` in `monday`
+- planner unit tests for `legacy` and `deepagents`
+- no contract or messaging boundary regressions
+
+## Phase 2: Orchestrator Multi-Handoff Readiness (P1)
+### Deliverables
+- orchestrator support for ordered handoff candidate metadata and deterministic primary-selection tracing
+- planner metadata surfaced in local runtime evidence
+- regression tests proving `createRun` semantics remain stable
+
+### Validation
+- `bash scripts/test_runtime_guardrails.sh` in `monday`
+- scheduler/queue smoke unchanged
+- planner richer output does not change operator delivery path
+
+## Phase 3: `skillctl` and Skill Supply Chain (P1)
+### Deliverables
+- `monday/config/planner-runtime.json`
+- `skill-registry.json`
+- `skill-lock.json`
+- `skillctl` phase-1 baseline via Python importer/validator/report flow
+- `pm-skills` recursive importer
+- namespace policy for bundled/vendor/user skills
+
+### Validation
+- lockfile reproducibility test
+- imported skill hash drift test
+- full `pm-skills` skill tree imported successfully without commands
+- collision test proves vendor skills cannot shadow bundled skills without explicit activation
+
+## Phase 4: Sandboxed Apply-Mode (P1)
+### Deliverables
+- `apply-sandbox-policy.json`
+- isolated subprocess runner
+- capability allowlist enforcement
+- CI rejection of unapproved vendor/user skills in apply-mode
+
+### Validation
+- sandbox policy contract tests
+- apply-mode failure-closed tests
+- operator-channel delivery tests still route through reviewed adapters only
+
+Status (2026-03-19):
+- all phase-4 deliverables are implemented in `monday`
+- validation is covered by `scripts/test_apply_sandbox_suite.sh`
+
+## Phase 5: DeepAgents Default Promotion (P2)
+### Deliverables
+- promote `deepagents` from gated option to default planner engine in approved runtime paths
+- preserve explicit `legacy` fallback path for rollback
+- document rollout verdict and rollback trigger
+
+### Validation
+- dual-engine comparison corpus passes
+- no planner/evidence schema drift between `legacy` and `deepagents` on approved missions
+- rollback switch verified in local smoke
+
+## Phase 6: Canonical Migration and Nanoclaw Terminology Retirement (P2)
+### Deliverables
+- canonical architecture doc update
+- canonical execution-plan update
+- planningops runtime profile migration off `nanoclaw_endpoint`
+- deprecation note in workbench audit and config consumers
+
+### Validation
+- `rg -n "nanoclaw core|nanoclaw_endpoint" docs/initiatives docs/workbench planningops/config`
+- no unresolved default-planner references remain
+- config readers pass against new schema
+
+## Backlog Issue Split
+1. `UAP-DA-001` (`platform-planningops`)
+- inventory and migrate canonical `nanoclaw` planner references
+- depends_on: none
+
+2. `MON-DA-002` (`monday`)
+- add `DeepAgentsPlanner` and planner engine selector
+- depends_on: `UAP-DA-001`
+
+3. `MON-DA-003` (`monday`)
+- extend orchestrator for multi-handoff readiness without changing external run semantics
+- depends_on: `MON-DA-002`
+
+4. `MON-DA-004` (`monday`)
+- add `skillctl`, registry, lockfile, and sync pipeline
+- depends_on: `MON-DA-002`
+
+5. `MON-DA-005` (`monday`)
+- import first curated `pm-skills` bundle with namespace + hash pinning
+- depends_on: `MON-DA-004`
+
+6. `MON-DA-006` (`monday`)
+- add sandbox policy and apply-mode isolation runner
+- depends_on: `MON-DA-004`
+
+7. `MON-DA-007` (`monday`)
+- promote `deepagents` to default behind rollout gate and preserve rollback switch
+- depends_on: `MON-DA-003`, `MON-DA-005`, `MON-DA-006`
+
+8. `PO-DA-008` (`platform-planningops`)
+- migrate `runtime-profiles.json` to `planner_policy`
+- depends_on: `MON-DA-002`, `MON-DA-006`
+
+## Acceptance Criteria
+- [ ] canonical monday architecture no longer presents NanoClaw as the default planner core and instead describes bounded context C in vendor-neutral terms
+- [ ] `monday` can select `legacy` or `deepagents` through the same planner port
+- [ ] `skillctl` can import at least one curated external skill bundle and emit a reproducible lockfile
+- [ ] imported skills are namespaced and hash-pinned
+- [ ] vendor skills cannot shadow bundled skills without explicit activation
+- [ ] apply-mode rejects unapproved vendor/user skills and capability overreach
+- [ ] operator-channel delivery still flows only through `monday`-owned CLI/MCP adapters
+- [ ] documentation and contract validation remain green through the migration
+
+## Success Metrics
+- `default_planner_reference_nanoclaw_count = 0` outside compatibility notes
+- `skill_lock_reproducibility_failures = 0`
+- `vendor_skill_shadow_collision_count = 0`
+- `apply_mode_unapproved_skill_executions = 0`
+- `planner_port_dual_engine_regressions = 0`
+- `operator_channel_boundary_regressions = 0`
+- `planningops_repo_local_path_leaks = 0`
+
+## Risks and Mitigations
+- risk: deepagents introduces planner nondeterminism
+  - mitigation: feature flag, planner diagnostics artifact, locked skill set, regression corpus
+- risk: skill sprawl from imported packs
+  - mitigation: namespace policy, allowlist import, lockfile pinning, no command import in v1
+- risk: sandbox cost slows delivery
+  - mitigation: start with subprocess isolation, containerize only high-risk paths later
+- risk: control-plane config starts owning repo-local runtime paths
+  - mitigation: keep `planningops` at planner hints only and move concrete paths into `monday/config/planner-runtime.json`
+- risk: canonical docs and runtime config drift during migration
+  - mitigation: explicit terminology inventory, compatibility window, doc sweep gate
+- risk: deepagents adoption leaks into transport or control-plane ownership
+  - mitigation: preserve current CLI/MCP adapter and messaging-adapter boundaries
+
+## Validation Commands
+```bash
+bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
+bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all
+```
+
+Expected sibling-repo validation during implementation:
+
+```bash
+cd ../monday
+pnpm typecheck
+bash scripts/test_operator_channel_delivery_cli.sh
+bash scripts/test_supervisor_status_update_cli.sh
+bash scripts/test_supervisor_goal_completion_cli.sh
+bash scripts/test_runtime_guardrails.sh
+```
+
+## References
+- DeepAgents official docs and repo
+- OpenClaw gateway/skills docs
+- NanoClaw official repo
+- `docs/workbench/unified-personal-agent-platform/audits/nanoclaw-fit-assessment.md`
+- `docs/initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md`
+- `docs/initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/2026-02-27-uap-contract-first-foundation.execution-plan.md`

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-reference-assimilation-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-reference-assimilation-plan.md
@@ -1,0 +1,356 @@
+---
+title: plan: MONDAY Agent Harness Reference Assimilation
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines how to use oh-my-claudecode, oh-my-openagent, and oh-my-codex as reference architectures for MONDAY Agent without collapsing platform-planningops into an execution harness.
+related_docs:
+  - ../../../../planningops/adr/adr-0001-ralph-loop-harness-topology.md
+  - ../../../initiatives/unified-personal-agent-platform/00-governance/uap-monday-identity.meta.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/runtime-skeleton-ready-implementation-pack.md
+  - ./2026-03-16-plan-deepagents-core-skillctl-and-sandbox-rollout-plan.md
+---
+
+# plan: MONDAY Agent Harness Reference Assimilation
+
+## Overview
+
+This plan reframes three external projects as **reference inputs for `monday`**, not as integration targets for `platform-planningops`.
+
+The boundary is explicit:
+
+- `platform-planningops` is the development orchestration layer and control plane
+- `monday` is the execution plane and the correct home for an agent harness
+
+Therefore:
+
+- no full harness should be imported into `platform-planningops`
+- external harnesses should be studied, decomposed, and selectively reimplemented inside `monday`
+- `platform-planningops` should only encode the contracts, gates, and evidence surfaces that `monday` must satisfy
+
+## Snapshot Date
+
+This analysis is based on the public repository state observed on **March 23, 2026**:
+
+- [Yeachan-Heo/oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode)
+- [code-yeongyu/oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)
+- [junghwaYang/oh-my-codex](https://github.com/junghwaYang/oh-my-codex)
+
+## Decision
+
+### Chosen approach
+
+Adopt a **reference-driven assimilation** strategy:
+
+1. study external harnesses as architecture references
+2. extract reusable patterns
+3. map those patterns onto `monday` runtime ownership
+4. express required boundaries and gates in `platform-planningops`
+5. avoid vendoring or direct runtime embedding inside `platform-planningops`
+
+### Explicit non-goals
+
+- importing `oh-my-openagent` or `oh-my-claudecode` into `platform-planningops`
+- turning `platform-planningops` into a tmux worker runtime, session host, or multi-agent execution shell
+- copying external command surfaces and magic keywords as-is
+- inheriting upstream model-routing assumptions without `monday`-specific constraints
+
+## Why This Boundary Is Correct
+
+## `platform-planningops` owns
+
+- contracts
+- boundary rules
+- readiness and gate semantics
+- evidence schemas
+- rollout plans and verification policy
+
+In short: **what must be true**
+
+## `monday` owns
+
+- worker runtime
+- team orchestration
+- session lifecycle
+- tool routing
+- retry/completion loops
+- replay and local state artifacts
+- provider/tool execution policy
+
+In short: **how work gets done**
+
+This matches the existing identity and topology docs:
+
+- `M.O.N.D.A.Y.` is already the canonical agent identity
+- `platform-planningops` is already positioned as the organization-level planning/control repository
+- `monday` already has the right execution-repo role for harness evolution
+
+## Reference Repository Analysis
+
+## A. `oh-my-openagent`
+
+### Observed structure
+
+The repository is product-scale and runtime-heavy. Public structure includes:
+
+- `.opencode/`
+- `.sisyphus/rules/`
+- `bin/`
+- `docs/`
+- `packages/`
+- `script/`
+- `signatures/`
+- `src/`
+- `tests/`
+- `uvscripts/`
+- `AGENTS.md`
+
+### What it is good at
+
+- large harness composition
+- discipline-agent orchestration
+- background workers
+- edit discipline
+- strong runtime/tooling surface
+- session-centric execution environment
+
+### What MONDAY should learn from it
+
+- worker specialization categories instead of model-specific handoff logic
+- session/replay/state artifact discipline
+- structured tool surface with explicit routing
+- persistence loops that do not stop at the first incomplete result
+- strong runtime utilities around diagnostics, background work, and interactive terminals
+
+### What MONDAY should not copy literally
+
+- upstream command semantics
+- upstream provider assumptions
+- full runtime topology
+- project branding, keywords, or agent personas
+
+## B. `oh-my-claudecode`
+
+### Observed structure
+
+The repository presents a plugin-first, team-first orchestration shape with public emphasis on:
+
+- teams
+- staged pipeline execution
+- skill management
+- hooks
+- documentation
+- tmux CLI workers
+
+### Most useful pattern
+
+Its clearest transferable idea is the explicit staged pipeline:
+
+`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`
+
+This is valuable because it converts “multi-agent” from a vague concept into a contractable execution lifecycle.
+
+### What MONDAY should learn from it
+
+- phase-based team orchestration
+- pre-execution clarification/interview mode for vague tasks
+- operator-facing worker status surface
+- advisory worker pattern for architecture, review, and UI feedback
+- skill auto-loading and skill lifecycle discipline
+
+### What MONDAY should not copy literally
+
+- slash-command vocabulary
+- Claude-specific environment assumptions
+- plugin packaging model
+
+## C. `oh-my-codex`
+
+### Observed structure
+
+It appears to be a lighter Codex-oriented orchestration wrapper with emphasis on:
+
+- `.codex/skills`
+- orchestration shortcuts
+- model routing
+- agent catalog
+- lightweight config-driven execution
+
+### What MONDAY should learn from it
+
+- Codex-native ergonomics
+- thinner wrapper patterns
+- small, understandable orchestration layers
+
+### What MONDAY should not assume
+
+- that a thin wrapper is sufficient for the full MONDAY runtime
+- that Codex-centric defaults generalize to a federated execution platform
+
+## Assimilation Matrix
+
+| Capability | Best reference | Adoption strategy in `monday` |
+|---|---|---|
+| staged multi-agent lifecycle | `oh-my-claudecode` | reimplement as MONDAY team phases |
+| worker specialization model | `oh-my-openagent` | adapt into MONDAY role taxonomy |
+| session and replay artifacts | `oh-my-openagent` | implement repo-owned run/session state |
+| Codex-native thin wrapper | `oh-my-codex` | use for local CLI ergonomics only |
+| skill lifecycle and auto-load | `oh-my-claudecode` | adapt into MONDAY skill registry and resolution |
+| persistent completion loop | `oh-my-openagent` | reimplement with MONDAY gate/evidence rules |
+| magic keyword UX | mixed | reject as canonical surface; keep explicit commands |
+
+## Target MONDAY Harness Shape
+
+## Proposed runtime topology inside `monday`
+
+```text
+monday/
+  agents/
+    orchestrator/
+    planner/
+    executor/
+    verifier/
+    fixer/
+    advisors/
+  skills/
+    bundled/
+    vendor/
+    registry/
+  runtimes/
+    local/
+    tmux/
+    subprocess/
+  sessions/
+    active/
+    archived/
+  replay/
+    jsonl/
+  tools/
+    router/
+    policies/
+  contracts/
+    harness/
+  config/
+    harness-runtime.json
+    worker-pool.json
+    skill-registry.json
+```
+
+## Canonical execution phases
+
+MONDAY should prefer one explicit lifecycle:
+
+1. `clarify`
+2. `plan`
+3. `design`
+4. `execute`
+5. `verify`
+6. `repair`
+7. `publish-evidence`
+
+This should be the runtime analogue of the team/staged pipeline patterns seen upstream, but adapted to MONDAY’s run contracts and queue semantics.
+
+## Required MONDAY capabilities
+
+- explicit worker role taxonomy
+- deterministic handoff metadata
+- run/session artifact persistence
+- replayable action log
+- skill resolution with precedence
+- tool policy boundary
+- completion loop with evidence gating
+- operator inspection surface
+- safe interruption/resume behavior
+
+## `platform-planningops` Follow-through
+
+`platform-planningops` should not host the harness, but it should add or refine:
+
+- harness capability contract
+- worker-state evidence schema
+- session replay evidence schema
+- team-phase completion contract
+- harness readiness gate
+- adoption scorecard for external-reference parity
+
+This keeps planningops in the role of **governance and verification**, not runtime ownership.
+
+## Phased Rollout
+
+## Phase 1: Reference capture
+
+- document the external references and extracted patterns
+- define MONDAY-owned target capabilities
+- freeze boundary: planningops governs, monday executes
+
+## Phase 2: MONDAY harness skeleton
+
+- add MONDAY-native runtime directories and config
+- introduce worker roles and phase lifecycle
+- land session/replay artifacts
+- keep feature scope local and non-production by default
+
+## Phase 3: Skill and tool discipline
+
+- implement skill registry and precedence
+- add tool-router policy
+- make unsafe tool execution fail-closed
+
+## Phase 4: Evidence-driven autonomy
+
+- attach phase completion to verification evidence
+- add repair loop semantics
+- expose operator-facing status and interruption controls
+
+## Phase 5: PlanningOps governance closure
+
+- promote stable workbench decisions into canonical contracts
+- add readiness gates and validation suites
+- keep MONDAY harness evolution bounded by explicit contracts
+
+## Adoption Rules
+
+## Allowed
+
+- architecture borrowing
+- lifecycle borrowing
+- state/evidence pattern borrowing
+- role taxonomy borrowing
+- UX pattern borrowing after renaming and boundary adaptation
+
+## Forbidden
+
+- repo vendoring into `platform-planningops`
+- direct copy of command surface as canonical interface
+- uncontrolled model/provider routing imported from upstream
+- hidden runtime side effects outside MONDAY evidence contracts
+
+## Success Criteria
+
+This plan is successful only if:
+
+- `platform-planningops` remains a control plane repository
+- `monday` becomes the only harness owner
+- external references accelerate MONDAY design without dictating it
+- future MONDAY harness phases can be validated by planningops-owned contracts
+- no planningops-local runtime execution layer is introduced by convenience
+
+## Immediate Next Steps
+
+1. create a MONDAY-focused gap analysis against the three references
+2. define a MONDAY harness capability matrix
+3. draft a MONDAY team-phase contract
+4. define session/replay artifact schemas
+5. convert the stable parts into canonical planningops contracts only after MONDAY-side ownership is clear
+
+## Final Principle
+
+Use the external harnesses as **reference architectures**, not as **dependencies**.
+
+The correct operating model is:
+
+- `platform-planningops` defines the protocol
+- `monday` implements the machine

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-implementation-issue-pack.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-implementation-issue-pack.md
@@ -1,0 +1,187 @@
+---
+title: plan: MONDAY Agent Harness Wave 1 Implementation Issue Pack
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the first executable implementation wave for monday-owned agent harness capabilities, covering team-phase execution, session and replay artifacts, evidence publication, and planningops-facing projections without collapsing repo boundaries.
+tags:
+  - uap
+  - monday
+  - planningops
+  - harness
+  - runtime
+  - issue-pack
+  - backlog
+related_docs:
+  - ./2026-03-23-monday-agent-harness-reference-assimilation-plan.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-gap-analysis.md
+  - ./2026-03-23-monday-team-phase-contract-draft.md
+  - ./2026-03-23-monday-session-replay-evidence-draft.md
+  - ./2026-03-23-monday-harness-capability-contract-draft.md
+  - ./2026-03-23-monday-planningops-evidence-projection-contract-draft.md
+---
+
+# plan: MONDAY Agent Harness Wave 1 Implementation Issue Pack
+
+## Preconditions
+
+This issue pack is valid because:
+
+- the reference-assimilation plan exists and fixes the repo boundary
+- the gap analysis already classifies what to adopt, adapt, defer, and reject
+- the team-phase, session/replay, capability, and planningops-projection drafts now exist as one coherent design set
+- the next uncertainty is no longer architecture direction, but phased implementation order
+
+## Goal
+
+Land the first monday-owned harness wave without collapsing runtime ownership back into `platform-planningops`.
+
+The rule for this wave is strict:
+
+- `monday` implements mission intake, phase execution, worker state, session persistence, replay lineage, and evidence publication
+- `planningops` does not host live runtime state
+- `planningops` may only validate stable projections after monday artifact shapes stop moving
+
+## Selected Rollout Order
+
+This issue pack selects one dependency-safe order:
+
+1. mission intake and team-phase skeleton
+2. session state and replay artifact baseline
+3. worker coordination and tool-lineage recording
+4. verification, repair, and evidence publication
+5. planningops-facing projection publication
+6. planningops control-plane validation and readiness gates
+
+## Wave 1 Items
+
+| ID | Order | Target | Component | Initial State | Output |
+| --- | --- | --- | --- | --- | --- |
+| `MH10` | 10 | `rather-not-work-on/monday` | `mission-intake` | `ready_implementation` | mission intake record + team-phase status skeleton |
+| `MH20` | 20 | `rather-not-work-on/monday` | `runtime-state` | `ready_implementation` | `session-state.json`, `worker-snapshot.json`, `replay-log.jsonl` baseline |
+| `MH30` | 30 | `rather-not-work-on/monday` | `worker-orchestrator` | `ready_implementation` | worker role taxonomy + task assignment and tool-lineage records |
+| `MH40` | 40 | `rather-not-work-on/monday` | `verify-repair` | `ready_implementation` | verify/repair loop + `execution-evidence-bundle.json` |
+| `MH50` | 50 | `rather-not-work-on/monday` | `projection-publisher` | `ready_implementation` | completion/readiness/verification/operator-handoff projections |
+| `MH60` | 60 | `rather-not-work-on/platform-planningops` | `control-plane-contract` | `backlog` | promoted projection contract candidate + doctor/gate issue draft |
+
+## Decomposition Rules
+
+- `MH10` defines the machine-readable phase vocabulary and transition model, but must not yet claim canonical control-plane readiness semantics.
+- `MH20` adds monday-owned runtime artifacts only. These files are runtime state, not control-plane truth.
+- `MH30` records worker and tool lineage in replay history, but must not expose internal scratchpad content as an operator surface.
+- `MH40` is the first step allowed to publish sealed evidence and terminal verdicts.
+- `MH50` may publish control-plane-facing projections only from sealed evidence, never from live in-memory state.
+- `MH60` may add planningops-side contracts only after `MH50` artifact shape stabilizes.
+
+## Dependencies
+
+- `MH20` depends on `MH10`
+- `MH30` depends on `MH10`, `MH20`
+- `MH40` depends on `MH20`, `MH30`
+- `MH50` depends on `MH40`
+- `MH60` depends on `MH50`
+
+## Hold Rules
+
+- do not let `planningops` consume `session-state.json` as canonical status
+- do not publish `ready` projections before verify/repair semantics exist
+- do not allow `execute -> done` shortcuts
+- do not publish operator-facing success when replay lineage is missing
+- do not freeze planningops schemas while monday artifact names and field sets are still moving
+
+## Go / Hold Criteria by Stage
+
+### `MH10` Go
+
+- phase ids are explicit and machine-readable
+- forbidden transitions fail closed
+- mission and run identity are stable
+
+### `MH20` Go
+
+- session state is resumable
+- replay log is append-only
+- worker snapshot references known replay events
+
+### `MH30` Go
+
+- each tool action is attributable to worker, phase, and task lineage
+- worker role taxonomy is explicit
+- no hidden mutation path bypasses replay recording
+
+### `MH40` Go
+
+- verification verdicts are explicit
+- repair attempts are counted
+- sealed evidence bundle points back to replay/session/snapshot artifacts
+
+### `MH50` Go
+
+- completion summary, readiness projection, verification projection, and operator handoff summary all agree on `run_id`
+- projections are derived from sealed evidence only
+- blocked and ready states cannot contradict each other
+
+### `MH60` Go
+
+- monday projection shape has stayed stable long enough to be validated externally
+- planningops-side schemas reflect projections only, not runtime-private state
+- doctor/gate semantics consume published outputs rather than monday internals
+
+## Explicit Non-Goals
+
+- no vendor import of `oh-my-*` runtime code
+- no planningops-owned worker scheduler
+- no direct planningops ownership of monday prompt memory
+- no canonical readiness promotion before monday publishes stable projections
+- no UI or operator shell design work in this wave
+
+## Expected Implementation Outputs
+
+Inside `monday`, this wave should eventually produce:
+
+- one mission intake surface
+- one team-phase status surface
+- one session state artifact
+- one replay log artifact
+- one worker snapshot artifact
+- one sealed execution evidence bundle
+- four planningops-facing derived projections
+
+Inside `planningops`, this wave should eventually produce:
+
+- one promoted evidence projection contract candidate
+- one readiness validation/gate issue draft
+
+## Validation Commands
+
+```bash
+bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
+bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all
+```
+
+Expected sibling-repo validation during implementation:
+
+```bash
+cd ../monday
+pnpm test
+pnpm typecheck
+```
+
+## Decision Note
+
+This wave is intentionally conservative.
+
+It prefers:
+
+- runtime ownership before control-plane validation
+- replay-backed evidence before readiness claims
+- derived projections before promoted gates
+
+It rejects:
+
+- doc-first readiness fiction
+- control-plane takeover of runtime internals
+- prompt-only agent behavior with no artifact lineage

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-sub-issue-decomposition.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-sub-issue-decomposition.md
@@ -1,0 +1,145 @@
+---
+title: plan: MONDAY Agent Harness Wave 1 Sub-Issue Decomposition
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Breaks the MONDAY Agent Harness Wave 1 issue pack into implementation-ready sub-issues that can be registered directly in monday and later consumed by planningops promotion work.
+tags:
+  - uap
+  - monday
+  - planningops
+  - harness
+  - issue-decomposition
+  - backlog
+related_docs:
+  - ./2026-03-23-monday-agent-harness-wave1-implementation-issue-pack.md
+  - ./2026-03-23-monday-runtime-artifact-map-draft.md
+  - ./2026-03-23-monday-harness-capability-contract-draft.md
+  - ./2026-03-23-monday-planningops-evidence-projection-contract-draft.md
+  - ./2026-03-23-monday-team-phase-contract-draft.md
+  - ./2026-03-23-monday-session-replay-evidence-draft.md
+---
+
+# plan: MONDAY Agent Harness Wave 1 Sub-Issue Decomposition
+
+## Goal
+
+Convert `MH10` through `MH60` into implementation-ready sub-issues with one dominant output artifact or behavior each.
+
+This document is the bridge between:
+
+- design drafts
+- the wave1 issue pack
+- repo-local monday issue creation
+
+## Decomposition Rules
+
+- keep each sub-issue scoped to one dominant artifact or behavior
+- keep runtime ownership inside `monday`
+- do not let planningops-side work start before stable monday projections exist
+- prefer testable vertical slices over abstract umbrella tasks
+
+## Sub-Issue Matrix
+
+| Key | Parent | Target Repo | Lane | Output | Depends On | Hard Gate |
+| --- | --- | --- | --- | --- | --- | --- |
+| `MH10A` | `MH10` | `rather-not-work-on/monday` | phase-contract | phase id vocabulary + transition validator | - | phase graph rejects forbidden transitions |
+| `MH10B` | `MH10` | `rather-not-work-on/monday` | mission-intake | mission intake record + `run_id`/`session_id` generation | `MH10A` | stable identity survives one dry-run lifecycle |
+| `MH10C` | `MH10` | `rather-not-work-on/monday` | phase-status | `team-phase-status.json` writer/reader | `MH10A`,`MH10B` | phase status stays coherent across one pass |
+| `MH20A` | `MH20` | `rather-not-work-on/monday` | session-state | `session-state.json` baseline | `MH10C` | session load/save roundtrip passes |
+| `MH20B` | `MH20` | `rather-not-work-on/monday` | replay-log | append-only `replay-log.jsonl` baseline | `MH10C` | replay append invariant passes |
+| `MH20C` | `MH20` | `rather-not-work-on/monday` | worker-snapshot | `worker-snapshot.json` + replay pointer checks | `MH20A`,`MH20B` | snapshot points only to known events |
+| `MH30A` | `MH30` | `rather-not-work-on/monday` | worker-topology | worker role taxonomy + assignment model | `MH20A`,`MH20C` | worker role resolution is deterministic |
+| `MH30B` | `MH30` | `rather-not-work-on/monday` | tool-lineage | tool invocation lineage in replay events | `MH20B`,`MH30A` | every mutation-capable tool event has worker/phase/task lineage |
+| `MH30C` | `MH30` | `rather-not-work-on/monday` | task-coordination | task receipt/completion linkage model | `MH30A`,`MH30B` | no orphan task completion remains |
+| `MH40A` | `MH40` | `rather-not-work-on/monday` | verification | explicit verification verdict surface | `MH30B`,`MH30C` | pass/fail verdict is machine-readable |
+| `MH40B` | `MH40` | `rather-not-work-on/monday` | repair-loop | bounded verify-repair attempt accounting | `MH40A` | retry budget exhaustion fails closed |
+| `MH40C` | `MH40` | `rather-not-work-on/monday` | sealed-evidence | `execution-evidence-bundle.json` publication | `MH20A`,`MH20B`,`MH20C`,`MH40A`,`MH40B` | evidence bundle lineage is internally consistent |
+| `MH50A` | `MH50` | `rather-not-work-on/monday` | completion-summary | `completion-summary.json` | `MH40C` | completion summary matches evidence bundle |
+| `MH50B` | `MH50` | `rather-not-work-on/monday` | readiness-projection | `readiness-projection.json` | `MH40C` | ready/blocked semantics are coherent |
+| `MH50C` | `MH50` | `rather-not-work-on/monday` | verification-projection | `verification-projection.json` | `MH40C` | verification projection matches verification lineage |
+| `MH50D` | `MH50` | `rather-not-work-on/monday` | handoff-projection | `operator-handoff-summary.json` | `MH40C` | blocked runs emit actionable handoff data |
+| `MH60A` | `MH60` | `rather-not-work-on/platform-planningops` | contract-candidate | promoted projection contract candidate | `MH50A`,`MH50B`,`MH50C`,`MH50D` | contract reads projections only |
+| `MH60B` | `MH60` | `rather-not-work-on/platform-planningops` | gate-design | doctor/gate issue draft for readiness consumption | `MH60A` | gate inputs exclude runtime-private artifacts |
+
+## Suggested Registration Order
+
+1. `MH10A -> MH10B -> MH10C`
+2. `MH20A` and `MH20B` in parallel after `MH10C`
+3. `MH20C`
+4. `MH30A -> MH30B -> MH30C`
+5. `MH40A -> MH40B -> MH40C`
+6. `MH50A`,`MH50B`,`MH50C`,`MH50D` in parallel
+7. `MH60A -> MH60B`
+
+## Repo Ownership Split
+
+### monday-only
+
+These sub-issues belong only in `monday`:
+
+- `MH10A` to `MH50D`
+
+### planningops-later
+
+These sub-issues belong only in `platform-planningops`:
+
+- `MH60A`
+- `MH60B`
+
+The split is deliberate. `MH60*` must not be opened as active implementation work until `MH50*` artifacts are stable.
+
+## Issue Card Template
+
+Use this skeleton when registering monday or planningops issues:
+
+```markdown
+## Planning Context
+- plan_item_id: `<KEY>`
+- parent_pack_id: `MH10|MH20|MH30|MH40|MH50|MH60`
+- target_repo: `<owner/repo>`
+- component: `<component>`
+- workflow_state: `<ready-implementation|ready-contract|backlog>`
+- execution_order: `<number>`
+- depends_on: `<keys>`
+
+## Problem Statement
+- <single dominant problem>
+
+## Output
+- <artifact path or behavior surface>
+
+## Interfaces and Dependencies
+- <contracts, runtime surfaces, or sibling issues>
+
+## Acceptance Criteria
+- [ ] <artifact exists or behavior is implemented>
+- [ ] <machine-readable validation path exists>
+- [ ] <repo-local tests cover the dominant failure mode>
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] Evidence artifact or projection is emitted
+- [ ] No planningops boundary violation is introduced
+```
+
+## Immediate Seed-Issue Candidates
+
+If only three issues are opened first, open these:
+
+1. `MH10A` because everything else depends on explicit phase vocabulary
+2. `MH20B` because replay lineage is the backbone of later evidence
+3. `MH40C` only after prerequisites exist, because sealed evidence is the first control-plane bridge
+
+## Stop Conditions
+
+Stop decomposition-driven implementation when:
+
+- monday artifact filenames are still changing weekly
+- verification semantics are not yet agreed
+- projections are being derived from mutable state rather than sealed evidence
+
+At that point, update the issue pack first instead of opening more sub-issues.

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-harness-capability-contract-draft.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-harness-capability-contract-draft.md
@@ -1,0 +1,296 @@
+---
+title: plan: MONDAY Harness Capability Contract Draft
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the monday-owned agent harness capability boundary that combines staged execution, worker orchestration, session persistence, replay evidence, and planningops-facing projections.
+related_docs:
+  - ./2026-03-23-monday-agent-harness-reference-assimilation-plan.md
+  - ./2026-03-23-monday-team-phase-contract-draft.md
+  - ./2026-03-23-monday-session-replay-evidence-draft.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-gap-analysis.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/runtime-interface-wiring-pack.md
+---
+
+# plan: MONDAY Harness Capability Contract Draft
+
+## Purpose
+
+Define the minimum capability contract that `monday` should eventually satisfy as the execution-plane agent harness for the unified personal agent platform.
+
+This draft combines the previously separated workbench drafts into one higher-order contract surface:
+
+- staged team-phase execution
+- worker orchestration
+- session persistence
+- replay and evidence publication
+- operator control
+- planningops-facing derived projections
+
+## Core Boundary
+
+The boundary remains strict:
+
+- `monday` owns runtime behavior
+- `platform-planningops` owns governance, readiness, and control-plane validation
+
+Therefore:
+
+- MONDAY must implement the machine
+- PlanningOps must define the protocol
+- PlanningOps must not become a hidden runtime harness
+
+## Design Principle
+
+The harness contract should be:
+
+- reference-informed, not vendor-imported
+- phase-aware, not prompt-only
+- evidence-first, not assertion-first
+- resumable, not fire-and-forget
+- operator-legible, not opaque
+
+## Capability Families
+
+MONDAY should expose nine capability families.
+
+## 1. Mission Intake and Task Classification
+
+Purpose:
+
+- normalize incoming user intent
+- classify execution risk
+- determine whether autonomous execution is allowed
+
+Minimum expectations:
+
+- stable mission identifier
+- risk classification
+- user-gated boundary detection
+- explicit execution mode selection
+
+Required outputs:
+
+- mission record
+- assumptions list
+- autonomy classification
+
+## 2. Team-Phase Execution Lifecycle
+
+Purpose:
+
+- drive complex work through one bounded lifecycle
+
+Default required phases:
+
+1. `clarify`
+2. `plan`
+3. `design`
+4. `execute`
+5. `verify`
+6. `repair`
+7. `publish_evidence`
+8. `done`
+
+Contract rule:
+
+- phase transitions must be machine-readable
+- forbidden shortcuts must fail closed
+- completion without verification is invalid
+
+## 3. Worker Topology and Coordination
+
+Purpose:
+
+- allow multiple workers or roles to collaborate without losing responsibility boundaries
+
+Minimum expectations:
+
+- explicit worker role taxonomy
+- task assignment surface
+- per-worker state reporting
+- bounded retry and reassignment semantics
+
+Suggested role families:
+
+- planner
+- implementer
+- verifier
+- repairer
+- operator-advisor
+
+## 4. Tool Routing and Execution Discipline
+
+Purpose:
+
+- let workers act through auditable tool surfaces rather than hidden free-form mutation
+
+Minimum expectations:
+
+- tool invocation records in replay history
+- clear success/failure status per tool action
+- tool-level artifact references
+- refusal path when a requested action crosses policy boundaries
+
+Contract rule:
+
+- nontrivial repo mutation must be attributable to a worker, a phase, and a tool call lineage
+
+## 5. Session State Persistence
+
+Purpose:
+
+- support resume, diagnosis, and operator inspection
+
+Minimum artifacts:
+
+- `session-state.json`
+- `worker-snapshot.json`
+
+Required fields include:
+
+- `session_id`
+- `run_id`
+- `mission_id`
+- `current_phase`
+- `status`
+- `attempt_budget`
+- `active_worker_roles`
+
+Contract rule:
+
+- live session state is monday-owned runtime data, not planningops state
+
+## 6. Replay Log and Evidence Publication
+
+Purpose:
+
+- reconstruct what happened
+- justify why the system believes the run is complete or blocked
+
+Minimum artifacts:
+
+- `replay-log.jsonl`
+- `execution-evidence-bundle.json`
+
+Contract rule:
+
+- replay must be append-only
+- published evidence must be immutable after publication
+- evidence must point back to replay/session/snapshot surfaces
+
+## 7. Verification and Repair Loop
+
+Purpose:
+
+- enforce evidence-backed completion
+- support bounded self-correction
+
+Minimum expectations:
+
+- explicit verification verdicts
+- failure taxonomy
+- repair attempt accounting
+- stop condition when retry budget is exhausted
+
+Contract rule:
+
+- `verify -> repair -> verify` loop is allowed
+- `execute -> done` is forbidden
+
+## 8. Operator Control and Intervention
+
+Purpose:
+
+- keep the system inspectable and interruptible by humans
+
+Minimum expectations:
+
+- readable status summary
+- blocked-state explanation
+- resume eligibility signal
+- explicit handoff surface when autonomy stops
+
+Operator controls should eventually support:
+
+- inspect
+- pause
+- resume
+- abort
+- publish current evidence
+
+## 9. PlanningOps-Facing Derived Projections
+
+Purpose:
+
+- expose stable derived surfaces that the control plane may validate
+
+Allowed PlanningOps consumption:
+
+- published evidence bundle
+- readiness projection
+- contract validation reports
+- explicit status summaries derived from immutable or sealed outputs
+
+Forbidden PlanningOps consumption:
+
+- raw mutable session state as canonical status
+- direct orchestration of worker internals
+- runtime memory ownership
+
+## Capability Mapping to Reference Sources
+
+The external references should guide implementation patterns, not ownership.
+
+| Capability family | Best reference | Adoption mode |
+| --- | --- | --- |
+| mission intake and runtime composition | `oh-my-openagent` | adapt |
+| staged team lifecycle | `oh-my-claudecode` | adapt |
+| codex-native runtime ergonomics | `oh-my-codex` | defer/selective adapt |
+| session and replay discipline | `oh-my-openagent` | adapt |
+| operator-facing evidence surfaces | mixed | reimplement |
+
+## Required Failure Semantics
+
+MONDAY should fail closed when:
+
+- phase transition lineage is missing
+- replay history contradicts session state
+- worker state points at unknown task or event ids
+- verification evidence is missing for a claimed success
+- published evidence does not match the run being reported
+
+The harness should stop and escalate instead of silently continuing.
+
+## Non-Goals
+
+This contract does not require PlanningOps to:
+
+- host runtime worker sessions
+- own prompt templates for monday internals
+- store mutable monday memory
+- decide intra-run worker scheduling
+
+This contract also does not require MONDAY to copy upstream reference projects structurally.
+
+## Promotion Path
+
+The likely promotion order is:
+
+1. promote the phase contract into monday-owned canonical docs
+2. promote the session/replay artifact contract into monday-owned canonical docs
+3. promote one control-plane-facing evidence projection contract into PlanningOps
+4. implement validation gates only after runtime artifact ownership is stable
+
+## Immediate Next Steps
+
+Use this draft to create:
+
+1. a monday-side capability matrix with `must / should / later`
+2. a monday runtime artifact taxonomy doc
+3. a planningops-facing evidence projection contract
+4. an issue pack for phased harness implementation

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-planningops-evidence-projection-contract-draft.md
@@ -1,0 +1,218 @@
+---
+title: plan: MONDAY PlanningOps Evidence Projection Contract Draft
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the derived evidence surfaces that monday may publish for planningops consumption without transferring agent harness ownership into the control plane.
+related_docs:
+  - ./2026-03-23-monday-harness-capability-contract-draft.md
+  - ./2026-03-23-monday-team-phase-contract-draft.md
+  - ./2026-03-23-monday-session-replay-evidence-draft.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-gap-analysis.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md
+---
+
+# plan: MONDAY PlanningOps Evidence Projection Contract Draft
+
+## Purpose
+
+Define the narrow set of monday-published evidence projections that `platform-planningops` may consume as control-plane inputs.
+
+This draft exists to preserve the boundary:
+
+- `monday` owns runtime state
+- `planningops` consumes only sealed or derived evidence
+
+## Boundary Rule
+
+PlanningOps may validate and gate only stable projections.
+
+PlanningOps must not directly consume:
+
+- mutable session state
+- mutable worker snapshots
+- internal prompt memory
+- in-flight task queues
+- runtime-private orchestration metadata
+
+## Source of Truth Model
+
+The source of truth for runtime behavior remains inside `monday`.
+
+The source of truth for control-plane readiness remains inside `planningops`.
+
+The bridge between them should be one small projection layer published by `monday`.
+
+## Allowed Projection Surfaces
+
+MONDAY should eventually publish four control-plane-facing projections.
+
+## 1. Completion Summary
+
+Purpose:
+
+- provide one stable machine-readable statement of terminal run outcome
+
+Suggested path:
+
+- `artifacts/runtime/completion-summary.json`
+
+Minimum fields:
+
+- `run_id`
+- `session_id`
+- `mission_id`
+- `final_phase`
+- `final_status`
+- `verification_verdict`
+- `completed_at_utc`
+- `evidence_bundle_path`
+
+## 2. Readiness Projection
+
+Purpose:
+
+- expose whether the run is usable for downstream automation or operator promotion
+
+Suggested path:
+
+- `artifacts/runtime/readiness-projection.json`
+
+Minimum fields:
+
+- `run_id`
+- `readiness_status`
+- `reason`
+- `blocking_conditions`
+- `required_evidence_refs`
+- `generated_at_utc`
+
+## 3. Verification Projection
+
+Purpose:
+
+- summarize whether declared success criteria were actually checked
+
+Suggested path:
+
+- `artifacts/runtime/verification-projection.json`
+
+Minimum fields:
+
+- `run_id`
+- `verification_verdict`
+- `verification_report_refs`
+- `failed_checks`
+- `repair_attempts`
+- `generated_at_utc`
+
+## 4. Operator Handoff Summary
+
+Purpose:
+
+- make blocked or user-gated stops legible to the control plane and operators
+
+Suggested path:
+
+- `artifacts/runtime/operator-handoff-summary.json`
+
+Minimum fields:
+
+- `run_id`
+- `handoff_status`
+- `handoff_reason`
+- `next_required_actor`
+- `recommended_next_step`
+- `blocking_question_set`
+- `generated_at_utc`
+
+## Projection Derivation Rules
+
+Each projection must be derived from monday-owned evidence, not invented independently.
+
+Allowed sources:
+
+- `execution-evidence-bundle.json`
+- sealed verification outputs
+- replay-backed completion metadata
+
+Forbidden sources:
+
+- live worker memory only
+- transient in-process state
+- unlogged prompt text with no artifact lineage
+
+## Projection Quality Rules
+
+Each projection must be:
+
+- machine-readable
+- immutable after publication for the same run stamp
+- attributable to exactly one `run_id`
+- internally self-consistent
+- reproducible from published evidence
+
+## PlanningOps Validation Rule
+
+PlanningOps may validate:
+
+- field presence
+- lineage consistency
+- freshness
+- verdict/readiness coherence
+- path existence for referenced stable artifacts
+
+PlanningOps must not validate:
+
+- monday-internal scheduling heuristics
+- prompt wording choices
+- worker-private scratchpad contents
+
+## Required Cross-Projection Invariants
+
+These must agree across all projections for the same run:
+
+- `run_id`
+- `session_id` when present
+- `verification_verdict`
+- readiness vs blocking semantics
+
+Examples of hard failures:
+
+- `completion-summary.final_status=complete` but `verification-projection.verification_verdict=fail`
+- `readiness_status=ready` while `operator-handoff-summary.handoff_status=required`
+- `evidence_bundle_path` missing or unreadable
+
+## Ownership Split
+
+`monday` owns:
+
+- projection generation
+- evidence lineage
+- artifact publication
+
+`planningops` owns:
+
+- schemas for control-plane gates, if promoted
+- doctor/gate semantics over published projections
+- readiness and promotion policy
+
+## Promotion Strategy
+
+Recommended order:
+
+1. implement projections in monday docs as runtime-owned outputs
+2. stabilize field sets and filenames
+3. promote one planningops-side contract for readiness consumption
+4. add planningops doctor/gate only after repeated runtime shape stability
+
+## Immediate Next Steps
+
+Use this draft to create:
+
+1. a monday runtime artifact map that includes projection outputs
+2. one planningops-side readiness contract candidate
+3. one monday issue pack for projection publication and validation wiring

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-runtime-artifact-map-draft.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-runtime-artifact-map-draft.md
@@ -1,0 +1,230 @@
+---
+title: plan: MONDAY Runtime Artifact Map Draft
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Maps monday-owned runtime artifacts by class, mutability, lineage, and control-plane visibility so harness implementation can proceed without blurring runtime and planningops responsibilities.
+related_docs:
+  - ./2026-03-23-monday-team-phase-contract-draft.md
+  - ./2026-03-23-monday-session-replay-evidence-draft.md
+  - ./2026-03-23-monday-harness-capability-contract-draft.md
+  - ./2026-03-23-monday-planningops-evidence-projection-contract-draft.md
+  - ./2026-03-23-monday-agent-harness-wave1-implementation-issue-pack.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-gap-analysis.md
+---
+
+# plan: MONDAY Runtime Artifact Map Draft
+
+## Purpose
+
+Define one runtime artifact taxonomy for `monday` so implementation work can distinguish:
+
+- live runtime state
+- append-only replay data
+- sealed evidence
+- planningops-facing derived projections
+
+## Boundary
+
+Artifact ownership is split by function, not by convenience.
+
+- `monday` owns all runtime artifacts
+- `planningops` may consume only the derived projections and later validation outputs
+
+No runtime artifact in this map should become control-plane truth just because it is easy to read.
+
+## Artifact Classes
+
+MONDAY runtime artifacts should fall into four classes.
+
+## 1. Live Runtime State
+
+Purpose:
+
+- represent the current execution snapshot
+- support resume and runtime coordination
+
+Suggested artifacts:
+
+- `artifacts/runtime/session-state.json`
+- `artifacts/runtime/worker-snapshot.json`
+- `artifacts/runtime/team-phase-status.json`
+
+Mutability:
+
+- mutable
+
+PlanningOps visibility:
+
+- forbidden as canonical input
+
+## 2. Append-Only Replay Surfaces
+
+Purpose:
+
+- preserve action lineage and transition history
+
+Suggested artifacts:
+
+- `artifacts/runtime/replay-log.jsonl`
+- `artifacts/runtime/team-phase-transitions.jsonl`
+
+Mutability:
+
+- append-only
+
+PlanningOps visibility:
+
+- indirect only through sealed evidence or projection refs
+
+## 3. Sealed Evidence Surfaces
+
+Purpose:
+
+- justify final or blocked outcomes with stable references
+
+Suggested artifacts:
+
+- `artifacts/runtime/execution-evidence-bundle.json`
+- `artifacts/runtime/completion-summary.json`
+
+Mutability:
+
+- immutable after publication
+
+PlanningOps visibility:
+
+- allowed
+
+## 4. Derived Control-Plane Projections
+
+Purpose:
+
+- present narrow, stable summaries for control-plane validation
+
+Suggested artifacts:
+
+- `artifacts/runtime/readiness-projection.json`
+- `artifacts/runtime/verification-projection.json`
+- `artifacts/runtime/operator-handoff-summary.json`
+
+Mutability:
+
+- immutable after publication for the same run stamp
+
+PlanningOps visibility:
+
+- allowed
+
+## Ownership and Residency Table
+
+| Artifact | Owner | Class | Mutability | Primary Consumer |
+| --- | --- | --- | --- | --- |
+| `session-state.json` | `monday` | live runtime state | mutable | runtime resume logic |
+| `worker-snapshot.json` | `monday` | live runtime state | mutable | runtime operator/debug path |
+| `team-phase-status.json` | `monday` | live runtime state | mutable | runtime orchestration |
+| `replay-log.jsonl` | `monday` | append-only replay | append-only | runtime diagnosis and evidence publication |
+| `team-phase-transitions.jsonl` | `monday` | append-only replay | append-only | runtime phase audit |
+| `execution-evidence-bundle.json` | `monday` | sealed evidence | immutable | operators and downstream projections |
+| `completion-summary.json` | `monday` | sealed evidence | immutable | operators and planningops gates |
+| `readiness-projection.json` | `monday` | derived projection | immutable | planningops readiness path |
+| `verification-projection.json` | `monday` | derived projection | immutable | planningops validation path |
+| `operator-handoff-summary.json` | `monday` | derived projection | immutable | planningops/operator blocked path |
+
+## Required Lineage Rules
+
+Every artifact published after `execute` should be attributable to:
+
+- one `run_id`
+- one `session_id`
+- one current or final phase
+- one evidence lineage chain
+
+At minimum:
+
+- projections must point to sealed evidence
+- sealed evidence must point to replay/session/snapshot surfaces
+- replay events must point to worker/task/tool lineage where applicable
+
+## Visibility Rules
+
+### Runtime-Private
+
+These stay runtime-private even if stored on disk:
+
+- live task queues
+- in-process worker scratchpads
+- partial reasoning buffers
+- prompt assembly internals
+
+### Operator-Visible
+
+These may be operator-visible:
+
+- completion summary
+- evidence bundle
+- operator handoff summary
+
+### PlanningOps-Visible
+
+These are the only target surfaces planningops should later validate:
+
+- completion summary
+- readiness projection
+- verification projection
+- operator handoff summary
+
+## Mutability and Promotion Rules
+
+- mutable artifacts may change while the run is active
+- append-only artifacts may only grow
+- sealed evidence may not be rewritten once published for a run stamp
+- derived projections may be regenerated only as a new stamped publication, not silently rewritten in place with contradictory content
+
+## Anti-Patterns
+
+The implementation should reject these patterns:
+
+- using `session-state.json` as a readiness gate input
+- deriving `ready=true` from replay history without sealed evidence
+- publishing projections that do not carry stable run lineage
+- mixing mutable runtime state and sealed evidence in one file
+- letting planningops schemas reach into monday-private artifacts
+
+## Suggested Directory Shape
+
+```text
+artifacts/runtime/
+  session-state.json
+  worker-snapshot.json
+  team-phase-status.json
+  replay-log.jsonl
+  team-phase-transitions.jsonl
+  execution-evidence-bundle.json
+  completion-summary.json
+  readiness-projection.json
+  verification-projection.json
+  operator-handoff-summary.json
+```
+
+Optional stamped publication shape:
+
+```text
+artifacts/runtime/history/<run_id>/
+  session-state.json
+  worker-snapshot.json
+  replay-log.jsonl
+  execution-evidence-bundle.json
+  readiness-projection.json
+```
+
+## Immediate Next Steps
+
+Use this map to:
+
+1. scope `MH20`, `MH40`, and `MH50` implementation boundaries
+2. define monday-side artifact naming and residency rules
+3. keep future planningops contracts limited to projection surfaces only

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-session-replay-evidence-draft.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-session-replay-evidence-draft.md
@@ -1,0 +1,292 @@
+---
+title: plan: MONDAY Session and Replay Evidence Draft
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Drafts the monday-owned session state and replay evidence surfaces needed for resumable multi-agent execution without moving runtime ownership into platform-planningops.
+related_docs:
+  - ./2026-03-23-monday-agent-harness-reference-assimilation-plan.md
+  - ./2026-03-23-monday-team-phase-contract-draft.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-gap-analysis.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/runtime-interface-wiring-pack.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md
+---
+
+# plan: MONDAY Session and Replay Evidence Draft
+
+## Purpose
+
+Define the minimum monday-owned artifact surfaces required to support:
+
+- resumable agent execution
+- post-run diagnosis
+- phase-aware repair loops
+- stable operator evidence
+
+This draft exists because the current gap analysis shows that MONDAY is still weak in:
+
+- durable session state
+- replay log structure
+- stable execution evidence beyond one-off runtime outputs
+
+## Boundary
+
+The core rule is unchanged:
+
+- `monday` owns session and replay artifacts
+- `platform-planningops` may only consume stable derived evidence or readiness projections
+
+PlanningOps must not become the storage home for active harness session state.
+
+## Problem Statement
+
+Without a clear session and replay model, MONDAY cannot safely support:
+
+- interrupted execution
+- bounded resume
+- worker coordination across phases
+- operator diagnosis after autonomous changes
+- trustworthy verify/repair loops
+
+## Required Artifact Classes
+
+MONDAY should eventually expose at least four artifact classes.
+
+## 1. Session State
+
+Purpose:
+
+- represent the current run/session snapshot
+- support resume and operator inspection
+
+Suggested path:
+
+- `artifacts/runtime/session-state.json`
+
+Minimum fields:
+
+- `session_id`
+- `run_id`
+- `mission_id`
+- `status`
+- `current_phase`
+- `phase_attempt`
+- `attempt_budget`
+- `started_at_utc`
+- `updated_at_utc`
+- `active_worker_roles`
+- `pending_tasks`
+- `completed_tasks`
+- `blocked_reason`
+
+## 2. Replay Log
+
+Purpose:
+
+- provide append-only execution history
+- reconstruct what happened without trusting mutable in-memory state
+
+Suggested path:
+
+- `artifacts/runtime/replay-log.jsonl`
+
+Minimum event fields:
+
+- `timestamp_utc`
+- `session_id`
+- `run_id`
+- `event_id`
+- `event_type`
+- `phase`
+- `worker_role`
+- `action`
+- `artifact_ref`
+- `summary`
+
+## 3. Worker Snapshot
+
+Purpose:
+
+- record the latest known state of each active worker without scanning the full replay stream
+
+Suggested path:
+
+- `artifacts/runtime/worker-snapshot.json`
+
+Minimum fields:
+
+- `session_id`
+- `run_id`
+- `workers[]`
+  - `role`
+  - `state`
+  - `assigned_task_id`
+  - `last_event_id`
+  - `updated_at_utc`
+
+## 4. Published Evidence Bundle
+
+Purpose:
+
+- expose the stable post-run surface that downstream systems may inspect
+
+Suggested path:
+
+- `artifacts/runtime/execution-evidence-bundle.json`
+
+Minimum fields:
+
+- `session_id`
+- `run_id`
+- `final_phase`
+- `final_status`
+- `verification_verdict`
+- `verification_report_refs`
+- `replay_log_path`
+- `session_state_path`
+- `worker_snapshot_path`
+- `output_artifact_refs`
+
+## Artifact Relationship Model
+
+```text
+session-state.json
+    ├─ references current phase + task pointers
+    ├─ references worker-snapshot.json
+    └─ references replay-log.jsonl
+
+replay-log.jsonl
+    └─ append-only history of transitions and worker actions
+
+worker-snapshot.json
+    └─ latest per-worker derived state
+
+execution-evidence-bundle.json
+    └─ stable published summary for operators and downstream control-plane readers
+```
+
+## Mutability Rules
+
+## Mutable
+
+- `session-state.json`
+- `worker-snapshot.json`
+
+These may be rewritten as the run progresses.
+
+## Append-only
+
+- `replay-log.jsonl`
+
+This must never be rewritten in place except for explicit archival/compaction workflows.
+
+## Immutable after publish
+
+- `execution-evidence-bundle.json`
+
+After publish, this should be treated as immutable evidence for that completed run/session.
+
+## Phase Integration Rules
+
+The session model must align with the team-phase contract.
+
+Required mappings:
+
+- `current_phase` in session state must be one of the approved phase ids
+- replay events must carry the same phase id vocabulary
+- verification and repair events must be distinguishable from execution events
+- `publish_evidence` must freeze refs to the replay/session/snapshot surfaces used to justify completion
+
+## Resume Rules
+
+Resume is allowed only when:
+
+- a readable `session-state.json` exists
+- the referenced replay log exists
+- `current_phase` is not terminal
+- the session is not marked irrecoverably blocked
+
+Resume must fail closed when:
+
+- replay history is missing
+- replay history contradicts session state
+- worker snapshot points to unknown replay events
+- the attempt budget is already exhausted
+
+## Contradiction Rules
+
+MONDAY should treat these mismatches as hard failures:
+
+- `session_state.run_id != replay_event.run_id`
+- `worker_snapshot.last_event_id` not present in replay stream
+- `execution_evidence_bundle.session_id != session_state.session_id`
+- `execution_evidence_bundle.replay_log_path` missing or unreadable
+
+## PlanningOps Consumption Rule
+
+PlanningOps should not consume live mutable artifacts directly.
+
+Allowed later:
+
+- read one published evidence bundle
+- read a readiness projection derived from the evidence bundle
+- read explicit validation reports derived from stable outputs
+
+Forbidden:
+
+- using `session-state.json` as the canonical control-plane status
+- using `worker-snapshot.json` as a governance SoT
+- interpreting raw replay events inside planningops business logic
+
+## Suggested Future MONDAY-Owned Contracts
+
+Likely candidates for `monday/contracts/`:
+
+- `team-session-state.schema.json`
+- `team-replay-event.schema.json`
+- `worker-snapshot.schema.json`
+- `execution-evidence-bundle.schema.json`
+
+## Suggested Future PlanningOps-Governed Contracts
+
+Likely candidates for `planningops/contracts/`:
+
+- session-evidence readiness contract
+- replay/evidence publication invariants
+- operator-facing diagnosis contract
+
+## Retention and Archival Direction
+
+Recommended default behavior:
+
+- active mutable session artifacts stay in runtime-local storage
+- replay logs are archived by run/session
+- published evidence bundle becomes the long-lived pointer surface
+
+This keeps operational detail in `monday` while still exposing stable evidence upward.
+
+## Non-Goals
+
+- define the final storage backend
+- define the final UI or CLI for replay inspection
+- define all observability sink payloads
+- define cross-repo artifact transport
+
+## Promotion Path
+
+If this draft holds, promotion should happen in two steps:
+
+1. `monday` freezes the runtime-owned artifact schemas
+2. `planningops` freezes the governance surfaces that depend on published evidence only
+
+## Immediate Next Step
+
+Use this draft and the team-phase draft to create one MONDAY capability contract covering:
+
+- phase-aware session state
+- replay consistency
+- evidence publishing
+- resume safety

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-team-phase-contract-draft.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-team-phase-contract-draft.md
@@ -1,0 +1,313 @@
+---
+title: plan: MONDAY Team-Phase Contract Draft
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Drafts the staged execution contract that MONDAY Agent should use for multi-agent work, including phase semantics, transition rules, ownership, and evidence expectations.
+related_docs:
+  - ./2026-03-23-monday-agent-harness-reference-assimilation-plan.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-gap-analysis.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/runtime-interface-wiring-pack.md
+  - ../../../initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/runtime-skeleton-ready-implementation-pack.md
+---
+
+# plan: MONDAY Team-Phase Contract Draft
+
+## Purpose
+
+Define the staged execution contract that `monday` should use for team-style multi-agent work.
+
+This is not yet a canonical contract. It is a workbench draft that clarifies:
+
+- the allowed phase model
+- phase transition rules
+- what evidence each phase must produce
+- what `planningops` may consume versus what remains runtime-internal
+
+## Boundary
+
+- `monday` owns phase execution behavior
+- `platform-planningops` owns only the governance and gate expectations around those phases
+
+Therefore:
+
+- phase runtime state belongs in `monday`
+- phase evidence projections may later be validated by planningops-owned gates
+- planningops must not become the executor of these phases
+
+## Proposed Canonical Phase Set
+
+MONDAY should expose one default lifecycle for complex multi-agent work:
+
+1. `clarify`
+2. `plan`
+3. `design`
+4. `execute`
+5. `verify`
+6. `repair`
+7. `publish_evidence`
+8. `done`
+
+### Optional fast path
+
+For trivial tasks, MONDAY may allow:
+
+`plan -> execute -> verify -> publish_evidence -> done`
+
+but only when the task is explicitly classified as low-risk and no clarification/design phase is required.
+
+## Phase Semantics
+
+## `clarify`
+
+Purpose:
+
+- resolve ambiguity
+- extract missing constraints
+- decide whether autonomous execution is allowed
+
+Outputs:
+
+- clarified objective
+- explicit assumptions
+- unresolved questions list
+
+Exit rule:
+
+- may advance only if ambiguity is below the configured threshold
+- must stop or request user input if the task crosses a user-gated boundary
+
+## `plan`
+
+Purpose:
+
+- create an actionable execution plan
+- identify worker roles and dependencies
+- shape work into bounded tasks
+
+Outputs:
+
+- task graph or ordered task set
+- worker assignment intent
+- success criteria
+
+Exit rule:
+
+- may advance only if at least one executable task exists and success criteria are explicit
+
+## `design`
+
+Purpose:
+
+- resolve architecture, interface, or UX choices before code mutation
+
+Outputs:
+
+- accepted design notes
+- boundary decisions
+- implementation constraints
+
+Exit rule:
+
+- may advance only if design blockers are resolved or explicitly deferred
+
+## `execute`
+
+Purpose:
+
+- perform the actual implementation or repo mutation work
+
+Outputs:
+
+- code/doc/config changes
+- execution logs
+- worker result summaries
+
+Exit rule:
+
+- may advance only if execution produced candidate outputs for verification
+
+## `verify`
+
+Purpose:
+
+- determine whether execution outputs satisfy declared success criteria
+
+Outputs:
+
+- test/build/lint/contract evidence
+- pass/fail verdict
+- failure taxonomy when failing
+
+Exit rule:
+
+- pass -> `publish_evidence`
+- fail with repairable cause -> `repair`
+- fail with blocked cause -> stop with machine-readable blocked status
+
+## `repair`
+
+Purpose:
+
+- apply bounded corrective action after failed verification
+
+Outputs:
+
+- repair attempt summary
+- updated candidate outputs
+- retry counter increment
+
+Exit rule:
+
+- returns to `verify`
+- must stop when attempt budget is exhausted
+
+## `publish_evidence`
+
+Purpose:
+
+- freeze the outcome into stable artifacts for operators and downstream systems
+
+Outputs:
+
+- machine-readable completion summary
+- pointers to verification evidence
+- phase transcript/replay references
+
+Exit rule:
+
+- may advance only if the published evidence is internally consistent and complete
+
+## `done`
+
+Purpose:
+
+- terminal success state
+
+Outputs:
+
+- no new runtime behavior
+- stable references only
+
+## Allowed Transitions
+
+```text
+clarify -> plan
+plan -> design
+plan -> execute
+design -> execute
+execute -> verify
+verify -> repair
+verify -> publish_evidence
+repair -> verify
+publish_evidence -> done
+```
+
+## Forbidden Transitions
+
+- `execute -> done`
+- `execute -> publish_evidence`
+- `repair -> done`
+- `clarify -> execute`
+- `plan -> done`
+
+These shortcuts remove the verification guarantee and should be rejected by default.
+
+## Phase Ownership Model
+
+| concern | owner |
+|---|---|
+| phase execution runtime | `monday` |
+| phase transition enforcement | `monday` |
+| verification evidence generation | `monday` |
+| downstream governance checks | `platform-planningops` |
+| cross-repo readiness policy | `platform-planningops` |
+
+## Worker Role Expectations
+
+The phase contract assumes role-based workers, not provider-named workers.
+
+Minimum role taxonomy:
+
+- `orchestrator`
+- `planner`
+- `designer`
+- `executor`
+- `verifier`
+- `repairer`
+- `advisor`
+
+MONDAY may map those roles to concrete models or local runtimes, but the phase contract should stay role-first.
+
+## Evidence Expectations Per Phase
+
+| phase | minimum evidence |
+|---|---|
+| `clarify` | assumptions, ambiguity verdict |
+| `plan` | task list or task graph |
+| `design` | decision note or explicit no-design-needed marker |
+| `execute` | mutation summary and worker result refs |
+| `verify` | pass/fail verdict plus validation refs |
+| `repair` | retry number and repair summary |
+| `publish_evidence` | final evidence bundle refs |
+
+## Proposed Future MONDAY-Owned Artifacts
+
+These should live in `monday`, not in `planningops`:
+
+- `artifacts/runtime/team-phase-status.json`
+- `artifacts/runtime/team-phase-transitions.jsonl`
+- `artifacts/runtime/team-execution-summary.json`
+- `artifacts/runtime/team-verification-report.json`
+
+## Proposed Future PlanningOps-Governed Surfaces
+
+PlanningOps should later govern only stable derived expectations such as:
+
+- phase order invariants
+- required evidence fields
+- forbidden transition rules
+- readiness projection semantics
+
+PlanningOps should not govern:
+
+- tmux session behavior
+- in-memory worker coordination
+- internal retry loop mechanics beyond exposed evidence
+
+## Default Stop Conditions
+
+MONDAY must stop and expose blocked status when:
+
+- clarification reveals user-gated choices
+- attempt budget is exhausted
+- verification fails with non-repairable cause
+- required evidence cannot be produced
+- worker runtime becomes unavailable in a way that prevents trustworthy continuation
+
+## Non-Goals
+
+- define provider routing policy in this draft
+- define tmux-specific lifecycle details
+- define UI/CLI command syntax
+- define all worker personas
+
+## Promotion Path
+
+If this draft stabilizes, split it into:
+
+1. a `monday`-owned runtime contract for phase execution
+2. a `planningops`-owned governance/gate contract for evidence and readiness
+
+## Immediate Next Step
+
+Use this phase draft together with the session/replay evidence draft to define one MONDAY capability contract around:
+
+- staged execution
+- resumability
+- operator diagnosis
+- evidence-first completion


### PR DESCRIPTION
## Summary
- track the existing Monday harness reference workbench docs that were already linked from the UAP hub
- promote the coherent 2026-03-16 / 2026-03-23 MONDAY harness reference closure as tracked docs-only content
- restore clean-clone traceability for the reference, wave1, and contract-draft documentation lane

## Validation
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

Closes #609

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. Docs-only workbench closure that promotes already-referenced files into git-tracked state.
