### PR TITLE
docs(monday-harness): track wave1 seed workbench closure

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-projection-contract-candidate.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-projection-contract-candidate.md
@@ -1,0 +1,167 @@
+---
+title: plan: MONDAY Agent Harness Projection Contract Candidate
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Captures the now-implemented monday MH50 projection field set so planningops can prepare projection-only validation without reaching into monday runtime-private state.
+related_docs:
+  - ./2026-03-23-monday-planningops-evidence-projection-contract-draft.md
+  - ./2026-03-23-monday-agent-harness-wave1-projection-seed-packet.md
+  - ./2026-03-23-monday-runtime-artifact-map-draft.md
+  - ./2026-03-23-monday-agent-harness-wave1-implementation-handoff-packet.md
+---
+
+# plan: MONDAY Agent Harness Projection Contract Candidate
+
+## Goal
+
+Freeze the first control-plane-facing candidate surface that `planningops` may later validate.
+
+This candidate is based on the implemented `monday` MH50 publication layer, not on the earlier abstract draft alone.
+
+## Boundary
+
+PlanningOps may consume only these monday-published projections:
+
+- `runtime-artifacts/agent-harness/completion-summary.json`
+- `runtime-artifacts/agent-harness/readiness-projection.json`
+- `runtime-artifacts/agent-harness/verification-projection.json`
+- `runtime-artifacts/agent-harness/operator-handoff-summary.json`
+
+PlanningOps must not consume directly:
+
+- `runtime-artifacts/agent-harness/session-state.json`
+- `runtime-artifacts/agent-harness/worker-snapshot.json`
+- `runtime-artifacts/agent-harness/replay-log.jsonl`
+- `runtime-artifacts/agent-harness/verification-verdict.json`
+- `runtime-artifacts/agent-harness/repair-loop-state.json`
+
+## Implemented Producer Shape
+
+The current monday implementation publishes projections from:
+
+- sealed evidence bundle
+- verification verdict
+- optional repair-loop state
+
+The projections are written immutably per run stamp and fail closed when rewritten with contradictory content.
+
+## Candidate Field Set
+
+### Completion Summary
+
+Required fields:
+
+- `missionId`
+- `runId`
+- `sessionId`
+- `finalPhase`
+- `finalStatus`
+- `verificationVerdict`
+- `completedAtUtc`
+- `evidenceBundlePath`
+
+### Readiness Projection
+
+Required fields:
+
+- `missionId`
+- `runId`
+- `sessionId`
+- `readinessStatus`
+- `reason`
+- `verificationVerdict`
+- `blockingConditions`
+- `requiredEvidenceRefs`
+- `generatedAtUtc`
+- `evidenceBundlePath`
+
+Current readiness statuses:
+
+- `ready`
+- `blocked`
+- `not_ready`
+
+### Verification Projection
+
+Required fields:
+
+- `missionId`
+- `runId`
+- `sessionId`
+- `verificationVerdict`
+- `verificationReportRefs`
+- `failedChecks`
+- `repairAttempts`
+- `generatedAtUtc`
+- `evidenceBundlePath`
+
+### Operator Handoff Summary
+
+Required fields:
+
+- `missionId`
+- `runId`
+- `sessionId`
+- `finalStatus`
+- `verificationVerdict`
+- `handoffStatus`
+- `handoffReason`
+- `nextRequiredActor`
+- `recommendedNextStep`
+- `blockingQuestionSet`
+- `generatedAtUtc`
+- `evidenceBundlePath`
+
+Current handoff statuses:
+
+- `not_required`
+- `required`
+
+## Cross-Projection Invariants
+
+The monday implementation now enforces these invariants:
+
+- all four projections agree on `runId`
+- all four projections agree on `sessionId`
+- all four projections agree on `verificationVerdict`
+- all four projections agree on `evidenceBundlePath`
+- `finalStatus=succeeded` implies `verificationVerdict=pass`
+- `readinessStatus=ready` implies `handoffStatus=not_required`
+- `finalStatus=blocked` implies `handoffStatus=required`
+- `reasonCode=missing_question_set` implies non-empty `blockingQuestionSet`
+
+## Control-Plane Consumption Rule
+
+PlanningOps-side validation may check only:
+
+- field presence
+- allowed enum values
+- shared lineage agreement
+- freshness
+- projection-to-projection coherence
+
+PlanningOps-side validation must not check:
+
+- task-level replay lineage
+- worker snapshot details
+- repair-loop internal history
+- monday prompt or tool internals
+
+## Promotion Preconditions
+
+Promote this candidate only after:
+
+- repeated monday-local runs preserve the same projection filenames
+- repeated monday-local runs preserve the same required field set
+- monday projection publication remains sealed-evidence-only
+
+## Immediate Follow-On
+
+Use this candidate to author:
+
+1. one planningops-side readiness/verification schema set over projection surfaces only
+2. one doctor/gate issue draft that consumes the readiness and handoff projections only

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-readiness-gate-issue-draft.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-readiness-gate-issue-draft.md
@@ -1,0 +1,96 @@
+---
+title: plan: MONDAY Agent Harness Readiness Gate Issue Draft
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Drafts the first planningops-side doctor and gate rollout over monday MH50 projections without violating the runtime-private boundary.
+related_docs:
+  - ./2026-03-23-monday-agent-harness-projection-contract-candidate.md
+  - ./2026-03-23-monday-planningops-evidence-projection-contract-draft.md
+  - ./2026-03-23-monday-agent-harness-wave1-projection-seed-packet.md
+---
+
+# plan: MONDAY Agent Harness Readiness Gate Issue Draft
+
+## Intent
+
+Prepare the first `planningops` doctor and gate issue over monday-published projection surfaces.
+
+This remains a draft until monday projection filenames and field sets stay stable across repeated runs.
+
+## Scope
+
+PlanningOps should consume only:
+
+- `completion-summary.json`
+- `readiness-projection.json`
+- `verification-projection.json`
+- `operator-handoff-summary.json`
+
+PlanningOps should not consume:
+
+- replay logs
+- session state
+- worker snapshots
+- verification verdict sidecars
+- repair-loop sidecars
+
+## Proposed Checks
+
+### Doctor
+
+The doctor should report:
+
+- whether projection files exist
+- whether `runId` and `sessionId` agree across all projections
+- whether readiness and handoff semantics agree
+- whether verification and completion verdicts agree
+- whether a blocked run names an actionable next actor and next step
+
+### Gate
+
+The first gate should fail closed when:
+
+- required projection files are missing
+- projections disagree on run lineage
+- `readinessStatus=ready` while `handoffStatus=required`
+- `finalStatus=succeeded` while `verificationVerdict!=pass`
+- `finalStatus=blocked` while `handoffStatus!=required`
+
+## Suggested Output Surfaces
+
+If promoted, planningops should produce:
+
+- one validation report over monday projections
+- one doctor summary over that validation report
+- one shell gate entrypoint for fail-closed readiness enforcement
+
+## Deliberate Deferrals
+
+Do not include yet:
+
+- replay freshness heuristics
+- monday worker inventory checks
+- task or tool-level lineage validation
+- operator-channel delivery validation
+
+Those remain monday-owned runtime concerns.
+
+## Ready-to-Open Issue Shape
+
+- repo: `rather-not-work-on/platform-planningops`
+- parent pack: `MH60`
+- depends on: stable `MH50A`, `MH50B`, `MH50C`, `MH50D`
+- component: `projection-readiness-gate`
+- workflow state: `backlog until monday projection stability is demonstrated`
+
+## Exit Condition
+
+This draft becomes actionable only when monday can supply:
+
+- one sample artifact set with all four projections
+- one repeated run proving the same field set
+- one explicit invariant list shared by all four projections

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-evidence-seed-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-evidence-seed-packet.md
@@ -1,0 +1,253 @@
+---
+title: plan: MONDAY Agent Harness Wave 1 Evidence Seed Packet
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Provides ready-to-file issue cards for the second MONDAY Agent harness wave1 batch, covering worker topology, tool lineage, task coordination, verification, repair, and sealed evidence publication.
+tags:
+  - uap
+  - monday
+  - harness
+  - issue-seed
+  - evidence
+  - backlog
+related_docs:
+  - ./2026-03-23-monday-agent-harness-wave1-opening-seed-packet.md
+  - ./2026-03-23-monday-agent-harness-wave1-sub-issue-decomposition.md
+  - ./2026-03-23-monday-agent-harness-wave1-implementation-issue-pack.md
+  - ./2026-03-23-monday-runtime-artifact-map-draft.md
+  - ./2026-03-23-monday-planningops-evidence-projection-contract-draft.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-traceability-map.md
+---
+
+# plan: MONDAY Agent Harness Wave 1 Evidence Seed Packet
+
+## Purpose
+
+Provide the next ready-to-file issue cards after the opening seed packet.
+
+This packet covers the chain that turns runtime state into trustworthy sealed evidence:
+
+- worker topology
+- tool lineage
+- task coordination
+- verification
+- repair
+- evidence publication
+
+## Registration Order
+
+1. `MH30A`
+2. `MH30B`
+3. `MH30C`
+4. `MH40A`
+5. `MH40B`
+6. `MH40C`
+
+## Issue Card: `MH30A`
+
+## Planning Context
+- plan_item_id: `MH30A`
+- parent_pack_id: `MH30`
+- target_repo: `rather-not-work-on/monday`
+- component: `worker-topology`
+- workflow_state: `ready-implementation`
+- execution_order: `70`
+- depends_on: `MH20A, MH20C`
+
+## Problem Statement
+- MONDAY cannot coordinate multi-worker execution safely because there is no explicit worker role taxonomy or deterministic assignment model.
+
+## Output
+- worker role taxonomy and task assignment model
+
+## Interfaces and Dependencies
+- `MH20A`
+- `MH20C`
+- `2026-03-23-monday-harness-capability-contract-draft.md`
+
+## Acceptance Criteria
+- [ ] one explicit worker role vocabulary exists for planner/implementer/verifier/repairer or equivalent monday-native roles
+- [ ] task assignment resolves deterministically for the same runtime inputs
+- [ ] repo-local tests cover worker role resolution and invalid assignment cases
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] worker roles are machine-readable and replay-compatible
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH30B`
+
+## Planning Context
+- plan_item_id: `MH30B`
+- parent_pack_id: `MH30`
+- target_repo: `rather-not-work-on/monday`
+- component: `tool-lineage`
+- workflow_state: `ready-implementation`
+- execution_order: `80`
+- depends_on: `MH20B, MH30A`
+
+## Problem Statement
+- MONDAY still has no auditable mutation path that ties tool actions back to worker, phase, and task lineage.
+
+## Output
+- replay events that record tool invocation lineage for mutation-capable actions
+
+## Interfaces and Dependencies
+- `MH20B`
+- `MH30A`
+- `2026-03-23-monday-agent-harness-reference-traceability-map.md`
+
+## Acceptance Criteria
+- [ ] every mutation-capable tool event records worker role, phase id, task id, and tool action lineage
+- [ ] repo-local tests fail when required lineage fields are missing
+- [ ] replay events remain append-only after lineage enrichment
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] tool lineage is replay-backed and not stored only in transient memory
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH30C`
+
+## Planning Context
+- plan_item_id: `MH30C`
+- parent_pack_id: `MH30`
+- target_repo: `rather-not-work-on/monday`
+- component: `task-coordination`
+- workflow_state: `ready-implementation`
+- execution_order: `90`
+- depends_on: `MH30A, MH30B`
+
+## Problem Statement
+- MONDAY does not yet link task receipt, execution, and completion coherently across workers, so orphan completions and unverifiable task states are possible.
+
+## Output
+- task receipt/completion linkage model integrated with worker and replay lineage
+
+## Interfaces and Dependencies
+- `MH30A`
+- `MH30B`
+- monday task queue or equivalent mission decomposition layer
+
+## Acceptance Criteria
+- [ ] task receipt and completion records share stable task identity
+- [ ] repo-local tests catch orphan completion and double-completion cases
+- [ ] task state remains attributable to worker and replay lineage
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] task coordination state is consistent with replay history
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH40A`
+
+## Planning Context
+- plan_item_id: `MH40A`
+- parent_pack_id: `MH40`
+- target_repo: `rather-not-work-on/monday`
+- component: `verification`
+- workflow_state: `ready-implementation`
+- execution_order: `100`
+- depends_on: `MH30B, MH30C`
+
+## Problem Statement
+- MONDAY cannot justify success or failure yet because verification verdicts are not emitted as one machine-readable runtime surface.
+
+## Output
+- explicit verification verdict surface with pass/fail and failure taxonomy
+
+## Interfaces and Dependencies
+- `MH30B`
+- `MH30C`
+- `2026-03-23-monday-team-phase-contract-draft.md`
+
+## Acceptance Criteria
+- [ ] one verification verdict surface exists for candidate outputs
+- [ ] pass/fail and blocked semantics are distinguishable
+- [ ] repo-local tests cover success, repairable failure, and blocked verification cases
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] verification semantics are machine-readable and phase-aware
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH40B`
+
+## Planning Context
+- plan_item_id: `MH40B`
+- parent_pack_id: `MH40`
+- target_repo: `rather-not-work-on/monday`
+- component: `repair-loop`
+- workflow_state: `ready-implementation`
+- execution_order: `110`
+- depends_on: `MH40A`
+
+## Problem Statement
+- Even with verification verdicts, MONDAY has no bounded repair accounting, so self-correction can become untracked or unbounded.
+
+## Output
+- verify-repair attempt accounting with retry budget enforcement
+
+## Interfaces and Dependencies
+- `MH40A`
+- `2026-03-23-monday-session-replay-evidence-draft.md`
+
+## Acceptance Criteria
+- [ ] repair attempts increment explicit counters tied to run and phase lineage
+- [ ] retry budget exhaustion fails closed
+- [ ] repo-local tests cover successful repair, repeated failure, and exhausted budget cases
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] repair attempts are visible in runtime artifacts and replay history
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH40C`
+
+## Planning Context
+- plan_item_id: `MH40C`
+- parent_pack_id: `MH40`
+- target_repo: `rather-not-work-on/monday`
+- component: `sealed-evidence`
+- workflow_state: `ready-implementation`
+- execution_order: `120`
+- depends_on: `MH20A, MH20B, MH20C, MH40A, MH40B`
+
+## Problem Statement
+- MONDAY still lacks one sealed evidence surface that freezes the runtime outcome and points back to the session, snapshot, replay, and verification lineage used to justify it.
+
+## Output
+- `artifacts/runtime/execution-evidence-bundle.json`
+
+## Interfaces and Dependencies
+- `MH20A`
+- `MH20B`
+- `MH20C`
+- `MH40A`
+- `MH40B`
+- `2026-03-23-monday-runtime-artifact-map-draft.md`
+
+## Acceptance Criteria
+- [ ] one execution evidence bundle is published after verification or blocked termination
+- [ ] the bundle references session, replay, worker snapshot, and verification lineage consistently
+- [ ] repo-local tests catch contradictory lineage and missing artifact refs
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] the evidence bundle is immutable after publication for a run stamp
+- [ ] no planningops boundary violation is introduced
+
+## Handoff Note
+
+After this packet, the next packet should cover:
+
+- `MH50A`
+- `MH50B`
+- `MH50C`
+- `MH50D`
+
+Do not open `MH60*` planningops issues until `MH50*` shapes are stable.

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-implementation-handoff-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-implementation-handoff-packet.md
@@ -1,0 +1,138 @@
+---
+title: plan: MONDAY Agent Harness Wave 1 Implementation Handoff Packet
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Provides one concise handoff packet that a monday execution owner can use to start MONDAY Agent harness wave1 implementation without rereading the full planning chain.
+tags:
+  - uap
+  - monday
+  - planningops
+  - harness
+  - handoff
+related_docs:
+  - ./2026-03-23-monday-agent-harness-wave1-registration-runbook.md
+  - ./2026-03-23-monday-agent-harness-wave1-opening-seed-packet.md
+  - ./2026-03-23-monday-agent-harness-wave1-evidence-seed-packet.md
+  - ./2026-03-23-monday-agent-harness-wave1-projection-seed-packet.md
+  - ./2026-03-23-monday-runtime-artifact-map-draft.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-traceability-map.md
+---
+
+# plan: MONDAY Agent Harness Wave 1 Implementation Handoff Packet
+
+## Purpose
+
+Give one monday execution owner the minimum packet needed to begin work.
+
+This packet answers only:
+
+- what to start now
+- what not to start yet
+- what evidence to bring back
+
+## Execution Owner Brief
+
+Implement the first monday-owned harness backbone without moving runtime ownership into `platform-planningops`.
+
+The rule is simple:
+
+- monday owns runtime state, replay, evidence, and projection generation
+- planningops waits until projection shapes stabilize
+
+## Start Now
+
+Open and execute these issues first:
+
+1. `MH10A`
+2. `MH10B`
+3. `MH10C`
+4. `MH20A`
+5. `MH20B`
+6. `MH20C`
+
+Then move to:
+
+7. `MH30A`
+8. `MH30B`
+9. `MH30C`
+10. `MH40A`
+11. `MH40B`
+12. `MH40C`
+
+Only after that, open:
+
+13. `MH50A`
+14. `MH50B`
+15. `MH50C`
+16. `MH50D`
+
+## Do Not Start Yet
+
+Do not start these until monday projection shapes are stable:
+
+- `MH60A`
+- `MH60B`
+
+Do not let planningops consume:
+
+- `session-state.json`
+- `worker-snapshot.json`
+- `team-phase-status.json`
+- raw replay logs as control-plane truth
+
+## Required monday Artifact Backbone
+
+By the end of the monday side of wave1, these artifacts should exist:
+
+- `artifacts/runtime/team-phase-status.json`
+- `artifacts/runtime/session-state.json`
+- `artifacts/runtime/replay-log.jsonl`
+- `artifacts/runtime/worker-snapshot.json`
+- `artifacts/runtime/execution-evidence-bundle.json`
+- `artifacts/runtime/completion-summary.json`
+- `artifacts/runtime/readiness-projection.json`
+- `artifacts/runtime/verification-projection.json`
+- `artifacts/runtime/operator-handoff-summary.json`
+
+## Success Conditions
+
+The monday side is ready to hand back when all of these are true:
+
+- phase transitions are explicit and forbidden shortcuts fail closed
+- run/session identity is stable
+- replay is append-only
+- tool actions are attributable to worker/phase/task lineage
+- verification and repair are machine-readable
+- sealed evidence exists
+- projections are derived from sealed evidence only
+
+## Failure / Stop Conditions
+
+Stop and rescope if:
+
+- artifact filenames are still changing weekly
+- replay and session lineage contradict each other
+- evidence bundle fields are unstable between runs
+- projections require mutable runtime state to compute
+
+## Reference Priority
+
+When choosing which external reference to lean on:
+
+1. prefer `oh-my-openagent` for replay, session, lineage, and evidence patterns
+2. prefer `oh-my-claudecode` for phase lifecycle and blocked/handoff logic
+3. treat `oh-my-codex` as optional thin ergonomics only
+
+## Return Packet to PlanningOps
+
+When monday reaches stable `MH50*` outputs, return with:
+
+- one sample run artifact set
+- one description of stable filenames and field sets
+- one list of invariants guaranteed across the projection files
+
+That is the earliest point where planningops should begin `MH60A`.

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-opening-seed-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-opening-seed-packet.md
@@ -1,0 +1,253 @@
+---
+title: plan: MONDAY Agent Harness Wave 1 Opening Seed Packet
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Provides ready-to-file opening issue cards for the first monday-owned MONDAY Agent harness wave so implementation can begin from the highest-leverage dependency chain.
+tags:
+  - uap
+  - monday
+  - harness
+  - issue-seed
+  - backlog
+related_docs:
+  - ./2026-03-23-monday-agent-harness-wave1-implementation-issue-pack.md
+  - ./2026-03-23-monday-agent-harness-wave1-sub-issue-decomposition.md
+  - ./2026-03-23-monday-runtime-artifact-map-draft.md
+  - ./2026-03-23-monday-team-phase-contract-draft.md
+  - ./2026-03-23-monday-session-replay-evidence-draft.md
+  - ./2026-03-23-monday-harness-capability-contract-draft.md
+---
+
+# plan: MONDAY Agent Harness Wave 1 Opening Seed Packet
+
+## Purpose
+
+Turn the first wave of monday harness work into issue cards that can be registered immediately.
+
+This packet intentionally covers only the opening dependency chain:
+
+- phase vocabulary
+- mission and run identity
+- team-phase status
+- session state
+- replay log
+- worker snapshot
+
+Later cards should be generated from the sub-issue decomposition only after this opening chain is accepted.
+
+## Registration Order
+
+1. `MH10A`
+2. `MH10B`
+3. `MH10C`
+4. `MH20A`
+5. `MH20B`
+6. `MH20C`
+
+## Issue Card: `MH10A`
+
+## Planning Context
+- plan_item_id: `MH10A`
+- parent_pack_id: `MH10`
+- target_repo: `rather-not-work-on/monday`
+- component: `phase-contract`
+- workflow_state: `ready-implementation`
+- execution_order: `10`
+- depends_on: `-`
+
+## Problem Statement
+- MONDAY does not yet have one machine-readable team-phase vocabulary and transition validator, so later runtime artifacts cannot encode stable lifecycle semantics.
+
+## Output
+- phase id vocabulary and transition validator for `clarify -> plan -> design -> execute -> verify -> repair -> publish_evidence -> done`
+
+## Interfaces and Dependencies
+- `2026-03-23-monday-team-phase-contract-draft.md`
+- monday runtime phase executor or equivalent orchestration layer
+
+## Acceptance Criteria
+- [ ] one canonical phase id set exists in monday runtime code
+- [ ] forbidden shortcuts such as `execute -> done` fail closed
+- [ ] repo-local tests cover valid and invalid transition graphs
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] transition validation is machine-readable, not prompt-only
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH10B`
+
+## Planning Context
+- plan_item_id: `MH10B`
+- parent_pack_id: `MH10`
+- target_repo: `rather-not-work-on/monday`
+- component: `mission-intake`
+- workflow_state: `ready-implementation`
+- execution_order: `20`
+- depends_on: `MH10A`
+
+## Problem Statement
+- MONDAY lacks a stable mission intake record with deterministic `run_id` and `session_id`, so replay, evidence, and projection artifacts cannot share one reliable lineage root.
+
+## Output
+- mission intake record surface with `mission_id`, `run_id`, `session_id`, and autonomy classification
+
+## Interfaces and Dependencies
+- `MH10A`
+- `2026-03-23-monday-harness-capability-contract-draft.md`
+- monday mission entrypoint and runtime startup path
+
+## Acceptance Criteria
+- [ ] one mission intake surface emits stable identifiers before phase execution starts
+- [ ] one dry-run lifecycle preserves the same identifiers across phase transitions
+- [ ] repo-local tests cover identity generation and propagation
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] mission/run/session identity is emitted before mutable runtime artifacts are written
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH10C`
+
+## Planning Context
+- plan_item_id: `MH10C`
+- parent_pack_id: `MH10`
+- target_repo: `rather-not-work-on/monday`
+- component: `phase-status`
+- workflow_state: `ready-implementation`
+- execution_order: `30`
+- depends_on: `MH10A, MH10B`
+
+## Problem Statement
+- Even with phase ids and stable run identity, MONDAY still lacks a runtime-owned team-phase status artifact that operators and later artifact writers can read consistently.
+
+## Output
+- `artifacts/runtime/team-phase-status.json` writer and reader
+
+## Interfaces and Dependencies
+- `MH10A`
+- `MH10B`
+- `2026-03-23-monday-runtime-artifact-map-draft.md`
+
+## Acceptance Criteria
+- [ ] one phase status artifact is emitted and updated coherently through a dry-run lifecycle
+- [ ] the artifact carries `run_id`, `session_id`, current phase, and transition timestamp data
+- [ ] repo-local tests cover phase status consistency and forbidden transition handling
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] `team-phase-status.json` is runtime-owned and not projected as planningops truth
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH20A`
+
+## Planning Context
+- plan_item_id: `MH20A`
+- parent_pack_id: `MH20`
+- target_repo: `rather-not-work-on/monday`
+- component: `session-state`
+- workflow_state: `ready-implementation`
+- execution_order: `40`
+- depends_on: `MH10C`
+
+## Problem Statement
+- MONDAY cannot resume or diagnose interrupted runs safely because there is no runtime-owned session state artifact with explicit phase, task, and attempt information.
+
+## Output
+- `artifacts/runtime/session-state.json`
+
+## Interfaces and Dependencies
+- `MH10C`
+- `2026-03-23-monday-session-replay-evidence-draft.md`
+- `2026-03-23-monday-runtime-artifact-map-draft.md`
+
+## Acceptance Criteria
+- [ ] one session state artifact records `run_id`, `session_id`, current phase, attempt budget, and task pointers
+- [ ] session load/save roundtrip passes without losing identity or phase state
+- [ ] repo-local tests cover resumable and blocked session cases
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] `session-state.json` is treated as mutable runtime state only
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH20B`
+
+## Planning Context
+- plan_item_id: `MH20B`
+- parent_pack_id: `MH20`
+- target_repo: `rather-not-work-on/monday`
+- component: `replay-log`
+- workflow_state: `ready-implementation`
+- execution_order: `50`
+- depends_on: `MH10C`
+
+## Problem Statement
+- MONDAY has no append-only replay backbone, so later evidence bundles and projections would have to trust mutable state instead of auditable history.
+
+## Output
+- `artifacts/runtime/replay-log.jsonl`
+
+## Interfaces and Dependencies
+- `MH10C`
+- `2026-03-23-monday-session-replay-evidence-draft.md`
+- `2026-03-23-monday-agent-harness-reference-traceability-map.md`
+
+## Acceptance Criteria
+- [ ] one append-only replay log records phase transitions and runtime events with `run_id` lineage
+- [ ] replay append invariants are enforced by repo-local tests
+- [ ] replay events are attributable to phase and action type even before worker topology is fully implemented
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] replay history is append-only and not silently rewritten
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH20C`
+
+## Planning Context
+- plan_item_id: `MH20C`
+- parent_pack_id: `MH20`
+- target_repo: `rather-not-work-on/monday`
+- component: `worker-snapshot`
+- workflow_state: `ready-implementation`
+- execution_order: `60`
+- depends_on: `MH20A, MH20B`
+
+## Problem Statement
+- MONDAY still lacks a compact worker state surface that points back to replay lineage, making runtime inspection expensive and contradiction detection weak.
+
+## Output
+- `artifacts/runtime/worker-snapshot.json`
+
+## Interfaces and Dependencies
+- `MH20A`
+- `MH20B`
+- `2026-03-23-monday-runtime-artifact-map-draft.md`
+
+## Acceptance Criteria
+- [ ] one worker snapshot artifact records latest worker state and last replay event reference
+- [ ] snapshot-to-replay pointer validation fails closed on unknown event ids
+- [ ] repo-local tests cover valid and contradictory worker snapshot cases
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] `worker-snapshot.json` never points to unknown replay events
+- [ ] no planningops boundary violation is introduced
+
+## Handoff Note
+
+After these six issues are registered, the next packet should cover:
+
+- `MH30A`
+- `MH30B`
+- `MH30C`
+- `MH40A`
+- `MH40B`
+- `MH40C`
+
+Do not open `MH60*` planningops issues yet.

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-projection-seed-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-projection-seed-packet.md
@@ -1,0 +1,248 @@
+---
+title: plan: MONDAY Agent Harness Wave 1 Projection Seed Packet
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Provides ready-to-file issue cards for monday projection publication and the follow-on planningops contract/gate work that should begin only after monday runtime artifact shapes stabilize.
+tags:
+  - uap
+  - monday
+  - planningops
+  - harness
+  - projection
+  - issue-seed
+  - backlog
+related_docs:
+  - ./2026-03-23-monday-agent-harness-wave1-evidence-seed-packet.md
+  - ./2026-03-23-monday-agent-harness-wave1-sub-issue-decomposition.md
+  - ./2026-03-23-monday-planningops-evidence-projection-contract-draft.md
+  - ./2026-03-23-monday-runtime-artifact-map-draft.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-traceability-map.md
+---
+
+# plan: MONDAY Agent Harness Wave 1 Projection Seed Packet
+
+## Purpose
+
+Provide the closing wave1 issue cards:
+
+- monday-side projection publication
+- planningops-side contract and gate preparation
+
+This packet must start only after `MH40C` is stable.
+
+## Registration Order
+
+1. `MH50A`
+2. `MH50B`
+3. `MH50C`
+4. `MH50D`
+5. `MH60A`
+6. `MH60B`
+
+## Start Condition
+
+Do not start this packet until:
+
+- `execution-evidence-bundle.json` exists
+- evidence lineage is stable across repeated runs
+- monday artifact names are no longer drifting weekly
+
+## Issue Card: `MH50A`
+
+## Planning Context
+- plan_item_id: `MH50A`
+- parent_pack_id: `MH50`
+- target_repo: `rather-not-work-on/monday`
+- component: `completion-summary`
+- workflow_state: `ready-implementation`
+- execution_order: `130`
+- depends_on: `MH40C`
+
+## Problem Statement
+- MONDAY still lacks one stable terminal summary that operators and downstream systems can read without understanding all runtime-private artifacts.
+
+## Output
+- `artifacts/runtime/completion-summary.json`
+
+## Interfaces and Dependencies
+- `MH40C`
+- `2026-03-23-monday-planningops-evidence-projection-contract-draft.md`
+
+## Acceptance Criteria
+- [ ] one completion summary is published per run stamp
+- [ ] the summary agrees with the execution evidence bundle on `run_id`, `session_id`, phase, and final status
+- [ ] repo-local tests catch contradictory completion metadata
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] completion summary is immutable after publication for a run stamp
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH50B`
+
+## Planning Context
+- plan_item_id: `MH50B`
+- parent_pack_id: `MH50`
+- target_repo: `rather-not-work-on/monday`
+- component: `readiness-projection`
+- workflow_state: `ready-implementation`
+- execution_order: `140`
+- depends_on: `MH40C`
+
+## Problem Statement
+- MONDAY has no narrow readiness surface that a control plane could eventually validate without reading runtime-private state.
+
+## Output
+- `artifacts/runtime/readiness-projection.json`
+
+## Interfaces and Dependencies
+- `MH40C`
+- `2026-03-23-monday-planningops-evidence-projection-contract-draft.md`
+
+## Acceptance Criteria
+- [ ] readiness projection is derived from sealed evidence only
+- [ ] `ready`, `blocked`, and `not_ready` semantics are explicit and non-contradictory
+- [ ] repo-local tests fail when readiness claims disagree with evidence lineage
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] readiness projection does not read mutable runtime state directly
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH50C`
+
+## Planning Context
+- plan_item_id: `MH50C`
+- parent_pack_id: `MH50`
+- target_repo: `rather-not-work-on/monday`
+- component: `verification-projection`
+- workflow_state: `ready-implementation`
+- execution_order: `150`
+- depends_on: `MH40C`
+
+## Problem Statement
+- MONDAY still lacks a stable surface summarizing verification outcomes in a way that downstream gates could eventually consume.
+
+## Output
+- `artifacts/runtime/verification-projection.json`
+
+## Interfaces and Dependencies
+- `MH40C`
+- `MH50A`
+- `2026-03-23-monday-planningops-evidence-projection-contract-draft.md`
+
+## Acceptance Criteria
+- [ ] verification projection summarizes verdict, failed checks, and repair attempts coherently
+- [ ] the projection points back to sealed evidence or stable verification refs
+- [ ] repo-local tests catch verdict drift between evidence bundle and verification projection
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] verification projection is stable enough for downstream validation
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH50D`
+
+## Planning Context
+- plan_item_id: `MH50D`
+- parent_pack_id: `MH50`
+- target_repo: `rather-not-work-on/monday`
+- component: `handoff-projection`
+- workflow_state: `ready-implementation`
+- execution_order: `160`
+- depends_on: `MH40C`
+
+## Problem Statement
+- Blocked or user-gated runs still need one stable operator handoff surface instead of ad hoc runtime messages.
+
+## Output
+- `artifacts/runtime/operator-handoff-summary.json`
+
+## Interfaces and Dependencies
+- `MH40C`
+- `2026-03-23-monday-agent-harness-reference-traceability-map.md`
+
+## Acceptance Criteria
+- [ ] blocked or user-gated runs emit actionable handoff data
+- [ ] handoff summaries never claim ready/complete semantics for blocked runs
+- [ ] repo-local tests cover missing-question, user-gated, and blocked-runtime cases
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] operator handoff summary is evidence-backed and non-contradictory
+- [ ] no planningops boundary violation is introduced
+
+## Issue Card: `MH60A`
+
+## Planning Context
+- plan_item_id: `MH60A`
+- parent_pack_id: `MH60`
+- target_repo: `rather-not-work-on/platform-planningops`
+- component: `contract-candidate`
+- workflow_state: `ready-contract`
+- execution_order: `170`
+- depends_on: `MH50A, MH50B, MH50C, MH50D`
+
+## Problem Statement
+- PlanningOps cannot safely validate monday outcomes until one promoted contract candidate exists that reads projection surfaces only.
+
+## Output
+- promoted projection contract candidate
+
+## Interfaces and Dependencies
+- `MH50A`
+- `MH50B`
+- `MH50C`
+- `MH50D`
+- `2026-03-23-monday-planningops-evidence-projection-contract-draft.md`
+
+## Acceptance Criteria
+- [ ] the contract candidate names only completion summary and projection surfaces
+- [ ] no mutable monday runtime artifact is treated as control-plane truth
+- [ ] repo-local contract checks cover lineage, freshness, and contradiction rules
+
+## Definition of Done
+- [ ] Repo-local tests pass
+- [ ] the contract candidate reads projections only
+- [ ] no planningops/runtime ownership collapse is introduced
+
+## Issue Card: `MH60B`
+
+## Planning Context
+- plan_item_id: `MH60B`
+- parent_pack_id: `MH60`
+- target_repo: `rather-not-work-on/platform-planningops`
+- component: `gate-design`
+- workflow_state: `backlog`
+- execution_order: `180`
+- depends_on: `MH60A`
+
+## Problem Statement
+- Even with a contract candidate, PlanningOps still needs an explicit doctor/gate issue draft so readiness consumption can be introduced without ad hoc expansion.
+
+## Output
+- doctor/gate issue draft for readiness consumption
+
+## Interfaces and Dependencies
+- `MH60A`
+- planningops federated doctor/gate conventions
+
+## Acceptance Criteria
+- [ ] one issue draft exists for doctor/gate introduction over monday projections
+- [ ] gate inputs exclude runtime-private artifacts by construction
+- [ ] repo-local tests or contract docs define the intended gate boundary
+
+## Definition of Done
+- [ ] Repo-local tests or docs pass
+- [ ] the draft remains projection-only
+- [ ] no planningops/runtime ownership collapse is introduced
+
+## Close-Out Note
+
+Once this packet is complete, wave1 planning should be considered fully seeded.
+
+The next step after that is no longer planning depth. It is execution in `monday`, followed by shape-stability checks before promoting any planningops-side gate.

--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-registration-runbook.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-23-monday-agent-harness-wave1-registration-runbook.md
@@ -1,0 +1,158 @@
+---
+title: plan: MONDAY Agent Harness Wave 1 Registration Runbook
+type: plan
+date: 2026-03-23
+updated: 2026-03-23
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines how to register and start the MONDAY Agent harness wave1 issue cards in the correct order, with stop conditions and checkpoint rules that preserve the runtime-versus-control-plane boundary.
+tags:
+  - uap
+  - monday
+  - planningops
+  - harness
+  - runbook
+  - issue-registration
+related_docs:
+  - ./2026-03-23-monday-agent-harness-wave1-opening-seed-packet.md
+  - ./2026-03-23-monday-agent-harness-wave1-evidence-seed-packet.md
+  - ./2026-03-23-monday-agent-harness-wave1-projection-seed-packet.md
+  - ./2026-03-23-monday-agent-harness-wave1-sub-issue-decomposition.md
+  - ./2026-03-23-monday-runtime-artifact-map-draft.md
+  - ./2026-03-23-monday-planningops-evidence-projection-contract-draft.md
+  - ../audits/2026-03-23-monday-agent-harness-reference-traceability-map.md
+---
+
+# plan: MONDAY Agent Harness Wave 1 Registration Runbook
+
+## Purpose
+
+Provide one bounded operational sequence for opening and starting MONDAY Agent harness wave1 work.
+
+This runbook is intentionally narrow:
+
+- it tells operators which issue packet to use
+- it tells them when to stop opening new issues
+- it prevents planningops from taking runtime ownership by accident
+
+## Primary Rule
+
+Register monday issues first.
+
+Do not start planningops-side `MH60*` work until monday runtime artifact shapes are stable through `MH50*`.
+
+## Inputs
+
+Use these documents in order:
+
+1. [MONDAY Agent Harness Wave 1 Opening Seed Packet](./2026-03-23-monday-agent-harness-wave1-opening-seed-packet.md)
+2. [MONDAY Agent Harness Wave 1 Evidence Seed Packet](./2026-03-23-monday-agent-harness-wave1-evidence-seed-packet.md)
+3. [MONDAY Agent Harness Wave 1 Projection Seed Packet](./2026-03-23-monday-agent-harness-wave1-projection-seed-packet.md)
+
+Supporting references:
+
+- [MONDAY Runtime Artifact Map Draft](./2026-03-23-monday-runtime-artifact-map-draft.md)
+- [MONDAY PlanningOps Evidence Projection Contract Draft](./2026-03-23-monday-planningops-evidence-projection-contract-draft.md)
+- [MONDAY Agent Harness Reference Traceability Map](../audits/2026-03-23-monday-agent-harness-reference-traceability-map.md)
+
+## Registration Sequence
+
+### Batch 1: Runtime Identity and State Backbone
+
+Open in this exact order:
+
+1. `MH10A`
+2. `MH10B`
+3. `MH10C`
+4. `MH20A`
+5. `MH20B`
+6. `MH20C`
+
+Checkpoint after batch 1:
+
+- phase vocabulary is explicit
+- run/session identity is stable
+- session state and replay log exist
+- worker snapshot points only to known replay events
+
+### Batch 2: Evidence Backbone
+
+Open only after batch 1 is accepted:
+
+1. `MH30A`
+2. `MH30B`
+3. `MH30C`
+4. `MH40A`
+5. `MH40B`
+6. `MH40C`
+
+Checkpoint after batch 2:
+
+- worker role taxonomy exists
+- tool lineage is replay-backed
+- verification and repair semantics exist
+- execution evidence bundle is sealed and internally consistent
+
+### Batch 3: Projection and Control-Plane Bridge
+
+Open only after batch 2 is stable:
+
+1. `MH50A`
+2. `MH50B`
+3. `MH50C`
+4. `MH50D`
+
+Open only after `MH50*` shapes are stable:
+
+5. `MH60A`
+6. `MH60B`
+
+Checkpoint after batch 3:
+
+- projections are derived from sealed evidence only
+- no monday mutable artifact is being treated as control-plane truth
+- planningops contract candidate reads projections only
+
+## Stop Conditions
+
+Stop opening new issues when any of these happen:
+
+- artifact filenames are still changing weekly
+- replay lineage does not survive repeated runs
+- `MH40C` evidence bundle shape is unstable
+- projections are computed from mutable state instead of sealed evidence
+- planningops work starts to reference monday-private runtime internals
+
+If any stop condition is hit, return to the issue pack and update scope before opening more cards.
+
+## Anti-Drift Rules
+
+- do not open `MH60A` or `MH60B` early
+- do not merge planningops-side schemas before monday projection shape stabilizes
+- do not collapse replay, state, and evidence into one file
+- do not treat reference repos as implementation sources of truth
+
+## Minimal Evidence Expected From monday Before PlanningOps Starts
+
+Before `MH60A`, monday should be able to show:
+
+- `execution-evidence-bundle.json`
+- `completion-summary.json`
+- `readiness-projection.json`
+- `verification-projection.json`
+- `operator-handoff-summary.json`
+
+All five should agree on:
+
+- `run_id`
+- final/blocked semantics
+- evidence lineage
+
+## Exit Condition
+
+This runbook is complete when:
+
+- all wave1 monday cards are registered in order
+- `MH60*` is still held until monday artifact stability exists
+- the next action is implementation in `monday`, not more planning depth in `planningops`


### PR DESCRIPTION
## Summary
- track the untracked MONDAY harness wave1 seed and runbook workbench docs already linked from the UAP hub
- promote the projection, opening, evidence, implementation-handoff, registration-runbook, and readiness draft lane as one docs-only closure
- restore clean-clone traceability for the remaining 2026-03-23 wave1 reference documents

## Validation
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

Closes #611

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. Docs-only workbench closure that promotes already-referenced files into git-tracked state.
