### PR TITLE
docs(monday-memory): track wave-x bundle-readiness packet

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-monday-agent-memory-wave-x-runtime-handoff-bundle-readiness-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-monday-agent-memory-wave-x-runtime-handoff-bundle-readiness-lane-packet.md
@@ -1,0 +1,65 @@
+---
+title: plan: MONDAY Agent Memory Wave X Runtime-Handoff Bundle Readiness Lane Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes the supervisor handoff bundle-readiness assessor and validator regressions into the canonical runtime-handoff helper so the federated runtime lane owns the full planningops handoff sidecar chain used by the monday memory reflection bridges.
+related_docs:
+  - ./2026-03-26-monday-agent-memory-wave-w-runtime-handoff-supervisor-handoff-contract-lane-packet.md
+  - ./2026-03-26-monday-agent-memory-wave-m-runtime-handoff-supervisor-contract-packet.md
+  - ./2026-03-26-monday-agent-memory-wave-v-runtime-handoff-goal-policy-lane-packet.md
+---
+
+# plan: MONDAY Agent Memory Wave X Runtime-Handoff Bundle Readiness Lane Packet
+
+## Purpose
+
+Close the remaining supervisor-handoff sidecar gap under the monday memory reflection path. The canonical helper already owns the handoff artifact and validation contracts, but the bundle-readiness assessor and validator regressions still sit outside that same lane. Wave X promotes those readiness checks into `runtime-handoff`.
+
+## Scope
+
+Wave X should add:
+
+- `test_assess_supervisor_operator_handoff_bundle_readiness.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- `test_validate_supervisor_operator_handoff_bundle_readiness.sh` to the same helper-owned runtime lane
+- helper contract, wiring, README, and workbench updates freezing that expanded handoff sidecar inventory
+
+Wave X should not add:
+
+- new handoff bundle fields
+- new monday bridge behavior
+- new readiness semantics
+- another top-level CI helper
+
+## Repo Targets
+
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_runtime_handoff_ci_check.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_run_runtime_handoff_ci_check_contract.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_supervisor_handoff_bridge_wiring.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/README.md`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/federation/README.md`
+
+## Acceptance Gates
+
+- `run_runtime_handoff_ci_check.sh --print-steps` includes `test_assess_supervisor_operator_handoff_bundle_readiness.sh` and `test_validate_supervisor_operator_handoff_bundle_readiness.sh`
+- local/workflow runtime-handoff entrypoints still call only the canonical helper surface
+- runtime-handoff helper, docs, and federated matrix remain green after the promotion
+
+## Codex Prompt
+
+```text
+Continue the monday memory-aware agent harness and planningops control-plane rollout.
+
+Current state:
+- runtime-handoff already replays the supervisor handoff artifact and validator contract pair
+- the handoff bundle-readiness assessor and validator regressions still sit outside the canonical helper inventory
+
+Implement Wave X only:
+1. add test_assess_supervisor_operator_handoff_bundle_readiness.sh and test_validate_supervisor_operator_handoff_bundle_readiness.sh to run_runtime_handoff_ci_check.sh
+2. update helper contract and wiring regressions to require the bundle-readiness steps
+3. update README/workbench docs so runtime-handoff explicitly owns the handoff bundle-readiness sidecar boundary
+4. verify the helper lane and the full federated matrix remain green
+```


### PR DESCRIPTION
## Summary
- track the MONDAY memory wave-x runtime-handoff bundle-readiness packet as a docs-only closure unit
- link the work to issue #663

## Testing
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. Docs-only workbench closure.

Closes #663