### PR TITLE
docs(monday-memory): track wave-y ops-summary packet

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-monday-agent-memory-wave-y-runtime-handoff-ops-summary-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-monday-agent-memory-wave-y-runtime-handoff-ops-summary-lane-packet.md
@@ -1,0 +1,64 @@
+---
+title: plan: MONDAY Agent Memory Wave Y Runtime-Handoff Ops Summary Lane Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes the automation operations summary contract regression into the canonical runtime-handoff helper so the federated runtime lane owns the operator-facing summary surface that documents the same supervisor handoff and federated-CI readiness rules.
+related_docs:
+  - ./2026-03-26-monday-agent-memory-wave-x-runtime-handoff-bundle-readiness-lane-packet.md
+  - ./2026-03-26-monday-agent-memory-wave-w-runtime-handoff-supervisor-handoff-contract-lane-packet.md
+  - ./2026-03-26-monday-agent-memory-wave-v-runtime-handoff-goal-policy-lane-packet.md
+---
+
+# plan: MONDAY Agent Memory Wave Y Runtime-Handoff Ops Summary Lane Packet
+
+## Purpose
+
+Close the remaining operator-facing summary gap under the monday memory reflection path. The canonical helper already owns the runtime behavior, handoff sidecars, and goal policy, but the automation operations summary contract still sits outside that same lane. Wave Y promotes that summary guard into `runtime-handoff`.
+
+## Scope
+
+Wave Y should add:
+
+- `test_uap_automation_operations_summary_contract.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- helper contract, wiring, README, and workbench updates freezing that expanded operator-facing summary inventory
+
+Wave Y should not add:
+
+- new supervisor artifact fields
+- new runtime behavior
+- new monday delivery behavior
+- another top-level CI helper
+
+## Repo Targets
+
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_runtime_handoff_ci_check.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_run_runtime_handoff_ci_check_contract.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_supervisor_handoff_bridge_wiring.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/README.md`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/federation/README.md`
+
+## Acceptance Gates
+
+- `run_runtime_handoff_ci_check.sh --print-steps` includes `test_uap_automation_operations_summary_contract.sh`
+- local/workflow runtime-handoff entrypoints still call only the canonical helper surface
+- runtime-handoff helper, docs, and federated matrix remain green after the promotion
+
+## Codex Prompt
+
+```text
+Continue the monday memory-aware agent harness and planningops control-plane rollout.
+
+Current state:
+- runtime-handoff already replays the supervisor handoff, bundle-readiness, reflection, delivery, and goal-policy checks
+- the automation operations summary contract still sits outside the canonical helper inventory
+
+Implement Wave Y only:
+1. add test_uap_automation_operations_summary_contract.sh to run_runtime_handoff_ci_check.sh
+2. update helper contract and wiring regressions to require the ops-summary step
+3. update README/workbench docs so runtime-handoff explicitly owns the operator-facing automation operations summary surface for this path
+4. verify the helper lane and the full federated matrix remain green
+```


### PR DESCRIPTION
## Summary
- track the MONDAY memory wave-y runtime-handoff ops-summary packet as a docs-only closure unit
- link the work to issue #665

## Testing
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. Docs-only workbench closure.

Closes #665