### PR TITLE
docs(monday-memory): track wave-ab tmp-reconcile-root packet

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-monday-agent-memory-wave-ab-runtime-handoff-tmp-reconcile-root-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-monday-agent-memory-wave-ab-runtime-handoff-tmp-reconcile-root-lane-packet.md
@@ -1,0 +1,66 @@
+---
+title: plan: MONDAY Agent Memory Wave AB Runtime-Handoff Tmp-Reconcile Root Lane Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes the root tmp-summary reconcile repair, validator, and resolver regressions into the runtime-handoff helper so the monday memory reflection lane owns the first repair surface underneath the federated-summary contract and readiness layers.
+related_docs:
+  - ./2026-03-26-monday-agent-memory-wave-aa-runtime-handoff-federated-summary-contract-lane-packet.md
+  - ./2026-03-26-monday-agent-memory-wave-z-runtime-handoff-federated-summary-readiness-lane-packet.md
+  - ./2026-03-26-monday-agent-memory-wave-y-runtime-handoff-ops-summary-lane-packet.md
+---
+
+# plan: MONDAY Agent Memory Wave AB Runtime-Handoff Tmp-Reconcile Root Lane Packet
+
+## Purpose
+
+Close the first tmp-summary reconcile gap under the monday memory reflection path. The canonical helper already owns the base federated-summary contract and readiness/doctor/gate ring, but the root tmp-summary reconcile repair, validation, and resolution surface still sits outside the helper inventory even though the summary doctor and gate consume it directly.
+
+## Scope
+
+Wave AB should add:
+
+- `test_reconcile_federated_ci_summary_tmp.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- `test_validate_federated_ci_summary_tmp_reconcile_contract.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- `test_resolve_federated_ci_summary_tmp_reconcile.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- helper contract, wiring, README, and workbench updates freezing that root tmp-summary reconcile inventory
+
+Wave AB should not add:
+
+- tmp-summary reconcile bundle-status ladder regressions
+- outer doctor-owned bundle layers
+- new monday runtime behavior
+- a separate tmp-reconcile helper lane
+
+## Repo Targets
+
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_runtime_handoff_ci_check.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_run_runtime_handoff_ci_check_contract.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_supervisor_handoff_bridge_wiring.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/README.md`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/federation/README.md`
+
+## Acceptance Gates
+
+- `run_runtime_handoff_ci_check.sh --print-steps` includes the root tmp-summary reconcile repair, validator, and resolver regressions
+- local/workflow runtime-handoff entrypoints still call only the canonical helper surface
+- runtime-handoff helper, docs, and federated matrix remain green after the promotion
+
+## Codex Prompt
+
+```text
+Continue the monday memory-aware agent harness and planningops control-plane rollout.
+
+Current state:
+- runtime-handoff already owns the base federated-summary contract plus the readiness, doctor, and gate ring
+- those surfaces still depend on the root tmp-summary reconcile repair, validation, and resolution tests outside the helper inventory
+
+Implement Wave AB only:
+1. add test_reconcile_federated_ci_summary_tmp.sh, test_validate_federated_ci_summary_tmp_reconcile_contract.sh, and test_resolve_federated_ci_summary_tmp_reconcile.sh to run_runtime_handoff_ci_check.sh
+2. update helper contract and wiring regressions to require those tmp-reconcile root steps
+3. update README/workbench docs so runtime-handoff explicitly owns the root tmp-summary reconcile surface under the already-promoted summary and readiness rings
+4. verify the helper lane and the full federated matrix remain green
+```


### PR DESCRIPTION
## Summary
- track the MONDAY memory wave-ab runtime-handoff tmp-reconcile-root packet as a docs-only closure unit
- link the work to issue #671

## Testing
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. Docs-only workbench closure.

Closes #671