### PR TITLE
docs(monday-memory): track wave-ae tmp-reconcile-status-bundle-status-bundle-status packet

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-monday-agent-memory-wave-ae-runtime-handoff-tmp-reconcile-status-bundle-status-bundle-status-lane-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-26-monday-agent-memory-wave-ae-runtime-handoff-tmp-reconcile-status-bundle-status-bundle-status-lane-packet.md
@@ -1,0 +1,67 @@
+---
+title: plan: MONDAY Agent Memory Wave AE Runtime-Handoff Tmp-Reconcile Status-Bundle-Status-Bundle-Status Lane Packet
+type: plan
+date: 2026-03-26
+updated: 2026-03-26
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Promotes the next outer tmp-summary reconcile status-bundle-status-bundle-status layer into the runtime-handoff helper so the monday memory reflection lane owns the next status validator, resolver, resolved-bundle validator, doctor, and gate ring above the current status-bundle-status layer.
+related_docs:
+  - ./2026-03-26-monday-agent-memory-wave-ad-runtime-handoff-tmp-reconcile-status-bundle-status-lane-packet.md
+  - ./2026-03-26-monday-agent-memory-wave-ac-runtime-handoff-tmp-reconcile-bundle-status-lane-packet.md
+  - ./2026-03-26-monday-agent-memory-wave-ab-runtime-handoff-tmp-reconcile-root-lane-packet.md
+---
+
+# plan: MONDAY Agent Memory Wave AE Runtime-Handoff Tmp-Reconcile Status-Bundle-Status-Bundle-Status Lane Packet
+
+## Purpose
+
+Close the next outer tmp-summary reconcile doctor-owned gap under the monday memory reflection path. The canonical helper already owns the `status-bundle-status` layer, but the next `status-bundle-status-bundle-status` validator, resolver, resolved-bundle validator, doctor, and gate still sit outside the helper inventory.
+
+## Scope
+
+Wave AE should add:
+
+- `test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_contract.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- `test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- `test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- `test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- `test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.sh` to the canonical `run_runtime_handoff_ci_check.sh` inventory
+- helper contract, wiring, README, and workbench updates freezing that next outer ring
+
+Wave AE should not add:
+
+- deeper outer ladders beyond this ring
+- new monday runtime behavior
+- a separate helper lane
+
+## Repo Targets
+
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/run_runtime_handoff_ci_check.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_run_runtime_handoff_ci_check_contract.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/test_supervisor_handoff_bridge_wiring.sh`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/README.md`
+- `/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/federation/README.md`
+
+## Acceptance Gates
+
+- `run_runtime_handoff_ci_check.sh --print-steps` includes the `status-bundle-status-bundle-status` layer
+- local/workflow runtime-handoff entrypoints still call only the canonical helper surface
+- runtime-handoff helper, docs, and federated matrix remain green after the promotion
+
+## Codex Prompt
+
+```text
+Continue the monday memory-aware agent harness and planningops control-plane rollout.
+
+Current state:
+- runtime-handoff already owns the status-bundle-status outer doctor layer
+- the next coherent dependency ring is the status-bundle-status-bundle-status layer: status validator, resolver, resolved-bundle validator, doctor, and gate
+
+Implement Wave AE only:
+1. add test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_contract.sh, test_resolve_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status.sh, test_validate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle_validation_contract.sh, test_doctor_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.sh, and test_gate_federated_ci_summary_tmp_reconcile_bundle_status_bundle_status_bundle_status_bundle.sh to run_runtime_handoff_ci_check.sh
+2. update helper contract and wiring regressions to require that next outer ring
+3. update README/workbench docs so runtime-handoff explicitly owns that status-bundle-status-bundle-status surface
+4. verify the helper lane and the full federated matrix remain green
+```


### PR DESCRIPTION
## Summary
- track the MONDAY memory wave-ae runtime-handoff tmp-reconcile-status-bundle-status-bundle-status packet as a docs-only closure unit
- link the work to issue #677

## Testing
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. Docs-only workbench closure.

Closes #677