### PR TITLE
docs(wave21): track completion readiness audit

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/audits/2026-03-17-wave21-queue-admission-completion-readiness-audit.md
+++ b/docs/workbench/unified-personal-agent-platform/audits/2026-03-17-wave21-queue-admission-completion-readiness-audit.md
@@ -1,0 +1,105 @@
+---
+title: audit: Wave 21 Queue Admission Completion Readiness
+type: audit
+date: 2026-03-17
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Captures the implementation, regression, dry-run, and live transition evidence showing wave21 queue-admission delegation is complete and the active-goal registry has been terminally transitioned.
+---
+
+# audit: Wave 21 Queue Admission Completion Readiness
+
+## Objective
+
+Confirm whether `uap-goal-driven-autonomy-wave21` is implementation-complete and whether the active-goal registry can be transitioned cleanly once operator completion handling is intentionally invoked.
+Confirm that `uap-goal-driven-autonomy-wave21` is implementation-complete and record the evidence for the terminal active-goal transition that closes the wave.
+
+## Scope
+
+- verify the queue-admission delegation implementation is wired through reflection, supervisor, and scheduled orchestration paths
+- confirm the wave21 review gate is green
+- confirm the active-goal lifecycle transition is valid in `dry-run`
+- record the live `apply` transition once completion semantics are intentionally invoked
+
+## Evidence Summary
+
+### Review Gate
+- `planningops/artifacts/validation/goal-driven-autonomy-wave21-review.json`
+- result: `verdict=pass`
+
+### Core Regression Coverage
+- `bash planningops/scripts/test_reflection_delivery_cycle.sh`
+- `bash planningops/scripts/test_autonomous_supervisor_loop_contract.sh`
+- `bash planningops/scripts/test_scheduled_reflection_delivery_cycle.sh`
+- `bash planningops/scripts/test_reflection_cycle_orchestration_contract.sh`
+- `bash planningops/scripts/test_reflection_action_handoff_contract.sh`
+- `bash planningops/scripts/test_reflection_delivery_cycle_contract.sh`
+- `bash planningops/scripts/test_local_delivery_cycle_orchestration_contract.sh`
+- `bash planningops/scripts/test_scheduled_delivery_queue_admission_contract.sh`
+- `bash planningops/scripts/test_scheduled_delivery_cycle_handoff_contract.sh`
+- `bash planningops/scripts/test_scheduled_reflection_delivery_cycle_contract.sh`
+- `bash planningops/scripts/test_supervisor_operator_handoff_contract.sh`
+- result: pass
+
+### Lifecycle Transition Readiness
+- `planningops/artifacts/validation/wave21-goal-transition-dry-run.json`
+- transition checked:
+  - `active -> achieved`
+  - `active_goal_key_after = ""`
+  - `goal_transition_kind = terminal_completion`
+- result: `verdict=pass`
+
+### Lifecycle Transition Apply
+- `planningops/artifacts/validation/wave21-goal-transition-apply.json`
+- transition applied:
+  - `active -> achieved`
+  - `active_goal_key_after = ""`
+  - `goal_transition_kind = terminal_completion`
+- result: `verdict=pass`
+
+## Findings
+
+1. Wave21 implementation scope is complete.
+The recurring delivery path now enters monday through scheduled queue admission for reflection delivery, supervisor goal completion, and scheduled reflection-delivery orchestration.
+
+2. Review evidence is green.
+The wave21 review artifact now confirms the required file markers and command checks, including the monday queue-admission entrypoint syntax check.
+
+3. Registry transition is now applied.
+The lifecycle mutator first accepted the terminal completion transition in `dry-run`, and the live registry mutation was then applied with the same evidence set to clear the active-goal pointer.
+
+## Recommendation
+
+- treat wave21 as implementation-complete, review-complete, and lifecycle-complete
+- use `planningops/artifacts/validation/wave21-goal-transition-apply.json` as the canonical terminal closeout artifact
+- leave `planningops/config/active-goal-registry.json` with no active goal until a successor goal is intentionally promoted
+
+## Applied Transition Command
+
+The terminal closeout was applied with:
+
+```bash
+python3 planningops/scripts/core/goals/transition_goal_state.py \
+  --registry planningops/config/active-goal-registry.json \
+  --goal-key uap-goal-driven-autonomy-wave21 \
+  --to-status achieved \
+  --reason wave21_queue_admission_completion_applied \
+  --evidence-ref planningops/artifacts/validation/goal-driven-autonomy-wave21-review.json \
+  --evidence-ref planningops/artifacts/validation/wave21-goal-transition-dry-run.json \
+  --evidence-ref docs/workbench/unified-personal-agent-platform/audits/2026-03-17-wave21-queue-admission-completion-readiness-audit.md \
+  --mode apply \
+  --output planningops/artifacts/validation/wave21-goal-transition-apply.json
+```
+
+Observed postcondition:
+- `active_goal_key = ""`
+- `uap-goal-driven-autonomy-wave21.status = "achieved"`
+
+## Verdict
+
+- implementation readiness: `pass`
+- review readiness: `pass`
+- lifecycle transition dry-run: `pass`
+- lifecycle transition apply: `pass`
+- overall: `pass`


### PR DESCRIPTION
## Summary
- track the wave21 queue admission completion readiness audit as a docs-only closure unit
- link the work to issue #684

## Testing
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. Docs-only workbench closure.

Closes #684