### PR TITLE
chore(backlog-history): track wave22 artifact packet

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-31-backlog-materialize-wave22-history-artifact-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-31-backlog-materialize-wave22-history-artifact-packet.md
@@ -1,0 +1,49 @@
+---
+title: plan: Backlog Materialize Wave22 History Artifact Packet
+type: plan
+date: 2026-03-31
+updated: 2026-03-31
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Captures the historical wave22 backlog materialization pass artifacts as tracked evidence for the runtime-mission wave22 replay lane.
+related_docs:
+  - ./2026-03-10-runtime-mission-wave22.execution-contract.json
+  - ./runtime-mission-wave22-rate-limit-guidance-issue-pack.md
+  - ./2026-03-28-backlog-materialize-wave22-latest-refresh-packet.md
+---
+
+# plan: Backlog Materialize Wave22 History Artifact Packet
+
+## Purpose
+
+Track the pass-state historical artifact set for the runtime-mission wave22 backlog replay. This packet freezes the generated backlog, manifest, and validation outputs that correspond to the wave22 execution contract replay.
+
+## Scope
+
+This packet includes:
+
+- `planningops/artifacts/backlog/materialize-report-wave22.json`
+- `planningops/artifacts/backlog/projected-issues-wave22.json`
+- `planningops/artifacts/program/program-manifest-wave22.json`
+- `planningops/artifacts/validation/plan-compile-report-wave22.json`
+- `planningops/artifacts/validation/issue-label-backfill-report-wave22.json`
+- `planningops/artifacts/validation/issue-quality-report-wave22.json`
+- `planningops/artifacts/validation/program-manifest-report-wave22.json`
+
+This packet does not include:
+
+- current canonical latest backlog artifacts
+- wave25, wave26, or wave27 historical replays
+- code changes to backlog materialization behavior
+
+## Verification
+
+- artifact set corresponds to `uap-runtime-mission-wave22`
+- materialization verdict remains `pass`
+- manifest and validation snapshots remain internally consistent with the stored projected issues
+
+## Notes
+
+- treat these files as historical replay evidence, not the current default backlog lane
+- leave unrelated untracked backlog and CI residue outside this packet

--- a/planningops/artifacts/backlog/materialize-report-wave22.json
+++ b/planningops/artifacts/backlog/materialize-report-wave22.json
@@ -1,0 +1,105 @@
+{
+  "generated_at_utc": "2026-03-22T15:02:46.315712+00:00",
+  "mode": "dry-run",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave22.execution-contract.json",
+  "repo": "rather-not-work-on/platform-planningops",
+  "initiative": "unified-personal-agent-platform",
+  "steps": [
+    {
+      "name": "compile_plan_to_backlog",
+      "command": [
+        "python3",
+        "planningops/scripts/compile_plan_to_backlog.py",
+        "--contract-file",
+        "docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave22.execution-contract.json",
+        "--config",
+        "planningops/config/project-field-ids.json",
+        "--blueprint-defaults-config",
+        "planningops/config/ready-implementation-blueprint-defaults.json",
+        "--output",
+        "planningops/artifacts/validation/plan-compile-report-wave22.json",
+        "--issues-file",
+        "planningops/artifacts/backlog/projected-issues-wave22.json"
+      ],
+      "output_path": "planningops/artifacts/validation/plan-compile-report-wave22.json",
+      "rc": 0,
+      "stdout": "sue_number\": 20,\n      \"issue_url\": \"https://github.com/rather-not-work-on/platform-planningops/issues/20\",\n      \"created_issue\": false,\n      \"dedup_match_state\": \"open\",\n      \"dedup_strategy\": \"identity_exact\",\n      \"reused_closed_issue\": false,\n      \"reopened_closed_issue\": false,\n      \"closed_match_detected\": false,\n      \"closed_match_issue_number\": null,\n      \"metadata_sync_required\": true,\n      \"metadata_sync_action\": \"planned\",\n      \"field_updates\": [\n        \"initiative(text)\",\n        \"target_repo(text)\",\n        \"execution_order(number)\",\n        \"status(todo)\",\n        \"component(planningops)\",\n        \"workflow_state(ready_implementation)\",\n        \"loop_profile(l4_integration_reconcile)\",\n        \"plan_lane(m3_guardrails)\"\n      ]\n    },\n    {\n      \"plan_item_id\": \"AN30\",\n      \"execution_order\": 30,\n      \"issue_number\": 30,\n      \"issue_url\": \"https://github.com/rather-not-work-on/platform-planningops/issues/30\",\n      \"created_issue\": false,\n      \"dedup_match_state\": \"open\",\n      \"dedup_strategy\": \"identity_exact\",\n      \"reused_closed_issue\": false,\n      \"reopened_closed_issue\": false,\n      \"closed_match_detected\": false,\n      \"closed_match_issue_number\": null,\n      \"metadata_sync_required\": true,\n      \"metadata_sync_action\": \"planned\",\n      \"field_updates\": [\n        \"initiative(text)\",\n        \"target_repo(text)\",\n        \"execution_order(number)\",\n        \"status(in_progress)\",\n        \"component(planningops)\",\n        \"workflow_state(review_gate)\",\n        \"loop_profile(l4_integration_reconcile)\",\n        \"plan_lane(m3_guardrails)\"\n      ]\n    }\n  ],\n  \"plan_id\": \"uap-runtime-mission-wave22\",\n  \"plan_revision\": 1,\n  \"source_of_truth\": \"docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md\",\n  \"items_total\": 3,\n  \"issues_source\": \"file:planningops/artifacts/backlog/projected-issues-wave22.json\",\n  \"open_issues_scanned\": 3,\n  \"closed_issues_scanned\": 0,\n  \"verdict\": \"pass\"\n}",
+      "stderr": "",
+      "verdict": "pass"
+    },
+    {
+      "name": "backfill_issue_labels",
+      "command": [
+        "python3",
+        "planningops/scripts/backfill_issue_labels.py",
+        "--output",
+        "planningops/artifacts/validation/issue-label-backfill-report-wave22.json",
+        "--repo",
+        "rather-not-work-on/platform-planningops",
+        "--issues-file",
+        "planningops/artifacts/backlog/projected-issues-wave22.json",
+        "--write-updated-issues-file",
+        "planningops/artifacts/backlog/projected-issues-wave22.json",
+        "--apply"
+      ],
+      "output_path": "planningops/artifacts/validation/issue-label-backfill-report-wave22.json",
+      "rc": 0,
+      "stdout": "report written: planningops/artifacts/validation/issue-label-backfill-report-wave22.json\nmode=apply issues_in_scope=3 missing=3 applied=3",
+      "stderr": "",
+      "verdict": "pass"
+    },
+    {
+      "name": "build_program_manifest",
+      "command": [
+        "python3",
+        "planningops/scripts/build_program_manifest.py",
+        "--plan-item-regex",
+        "^(?:AN10|AN20|AN30)$",
+        "--initiative",
+        "unified-personal-agent-platform",
+        "--source-plan",
+        "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
+        "--scope-source-plan",
+        "--output",
+        "planningops/artifacts/program/program-manifest-wave22.json",
+        "--report-output",
+        "planningops/artifacts/validation/program-manifest-report-wave22.json",
+        "--strict",
+        "--issues-file",
+        "planningops/artifacts/backlog/projected-issues-wave22.json"
+      ],
+      "output_path": "planningops/artifacts/validation/program-manifest-report-wave22.json",
+      "rc": 0,
+      "stdout": "{\n  \"generated_at_utc\": \"2026-03-22T15:02:46.433909+00:00\",\n  \"program_id\": \"uap-po-ct-program\",\n  \"initiative\": \"unified-personal-agent-platform\",\n  \"source_plan\": \"docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md\",\n  \"repos\": [\n    \"rather-not-work-on/platform-planningops\",\n    \"rather-not-work-on/platform-contracts\",\n    \"rather-not-work-on/platform-provider-gateway\",\n    \"rather-not-work-on/platform-observability-gateway\",\n    \"rather-not-work-on/monday\"\n  ],\n  \"issues_file\": \"planningops/artifacts/backlog/projected-issues-wave22.json\",\n  \"verdict\": \"pass\",\n  \"errors\": [],\n  \"issues_scanned\": 3,\n  \"filtered_out_count\": 0,\n  \"item_count\": 3,\n  \"duplicate_group_count\": 0,\n  \"duplicate_groups\": [],\n  \"track_summary\": {\n    \"control_plane\": 3,\n    \"federated_runtime\": 0,\n    \"reconciliation\": 0,\n    \"unknown\": 0\n  }\n}",
+      "stderr": "",
+      "verdict": "pass"
+    },
+    {
+      "name": "validate_issue_quality",
+      "command": [
+        "python3",
+        "planningops/scripts/validate_issue_quality.py",
+        "--output",
+        "planningops/artifacts/validation/issue-quality-report-wave22.json",
+        "--strict",
+        "--issues-file",
+        "planningops/artifacts/backlog/projected-issues-wave22.json",
+        "--repo",
+        "rather-not-work-on/platform-planningops"
+      ],
+      "output_path": "planningops/artifacts/validation/issue-quality-report-wave22.json",
+      "rc": 0,
+      "stdout": "report written: planningops/artifacts/validation/issue-quality-report-wave22.json\nissues_in_scope=3 violation_count=0 verdict=pass",
+      "stderr": "",
+      "verdict": "pass"
+    }
+  ],
+  "plan_id": "uap-runtime-mission-wave22",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
+  "items_total": 3,
+  "projected_issues_output": "planningops/artifacts/backlog/projected-issues-wave22.json",
+  "projected_issue_count": 3,
+  "step_count": 4,
+  "verdict": "pass"
+}

--- a/planningops/artifacts/backlog/projected-issues-wave22.json
+++ b/planningops/artifacts/backlog/projected-issues-wave22.json
@@ -1,0 +1,71 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 10,
+    "state": "open",
+    "updated_at": "2026-03-22T15:02:46.317266+00:00",
+    "title": "plan: [10] planningops runner rate-limit guidance",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- plan_id: `uap-runtime-mission-wave22`\n- plan_revision: `1`\n- plan_item_id: `AN10`\n- execution_order: `10`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `-`\n- primary_output: `planningops/scripts/core/loop/runner.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- `planningops/scripts/core/loop/runner.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: planningops/contracts/requirements-contract.md\npackage_topology_ref: planningops/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md\n",
+    "labels": [
+      {
+        "name": "area/planningops"
+      },
+      {
+        "name": "p2"
+      },
+      {
+        "name": "task"
+      },
+      {
+        "name": "type/hardening"
+      }
+    ]
+  },
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 20,
+    "state": "open",
+    "updated_at": "2026-03-22T15:02:46.317266+00:00",
+    "title": "plan: [20] planningops supervisor rate-limit guidance summary",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- plan_id: `uap-runtime-mission-wave22`\n- plan_revision: `1`\n- plan_item_id: `AN20`\n- execution_order: `20`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `AN10`\n- primary_output: `planningops/scripts/autonomous_supervisor_loop.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `AN10`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- `planningops/scripts/autonomous_supervisor_loop.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: planningops/contracts/requirements-contract.md\npackage_topology_ref: planningops/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md\n",
+    "labels": [
+      {
+        "name": "area/planningops"
+      },
+      {
+        "name": "p2"
+      },
+      {
+        "name": "task"
+      },
+      {
+        "name": "type/hardening"
+      }
+    ]
+  },
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 30,
+    "state": "open",
+    "updated_at": "2026-03-22T15:02:46.317266+00:00",
+    "title": "plan: [30] runtime mission wave22 review",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- plan_id: `uap-runtime-mission-wave22`\n- plan_revision: `1`\n- plan_item_id: `AN30`\n- execution_order: `30`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `review_gate`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `AN10,AN20`\n- primary_output: `planningops/artifacts/validation/runtime-mission-wave22-review.json`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `AN10,AN20`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md`\n- `planningops/artifacts/validation/runtime-mission-wave22-review.json`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
+    "labels": [
+      {
+        "name": "area/planningops"
+      },
+      {
+        "name": "p2"
+      },
+      {
+        "name": "task"
+      },
+      {
+        "name": "type/governance"
+      }
+    ]
+  }
+]

--- a/planningops/artifacts/program/program-manifest-wave22.json
+++ b/planningops/artifacts/program/program-manifest-wave22.json
@@ -1,0 +1,77 @@
+{
+  "manifest_version": 1,
+  "program_id": "uap-po-ct-program",
+  "initiative": "unified-personal-agent-platform",
+  "source_plan": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
+  "scope_source_plan": true,
+  "generated_at_utc": "2026-03-22T15:02:46.434680+00:00",
+  "selection_policy": "dedupe_by_plan_item_id_and_target_repo_open_first_then_latest_update",
+  "item_count": 3,
+  "items": [
+    {
+      "plan_item_id": "AN10",
+      "track": "control_plane",
+      "execution_order": 10,
+      "target_repo": "rather-not-work-on/platform-planningops",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 10,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
+      "issue_state": "open",
+      "issue_updated_at": "2026-03-22T15:02:46.317266+00:00",
+      "component": "planningops",
+      "workflow_state": "ready_implementation",
+      "loop_profile": "l4_integration_reconcile",
+      "plan_lane": "m3_guardrails",
+      "depends_on": [],
+      "interface_contract_refs": "planningops/contracts/requirements-contract.md",
+      "package_topology_ref": "planningops/README.md",
+      "dependency_manifest_ref": "planningops/config/runtime-profiles.json",
+      "file_plan_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md"
+    },
+    {
+      "plan_item_id": "AN20",
+      "track": "control_plane",
+      "execution_order": 20,
+      "target_repo": "rather-not-work-on/platform-planningops",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 20,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
+      "issue_state": "open",
+      "issue_updated_at": "2026-03-22T15:02:46.317266+00:00",
+      "component": "planningops",
+      "workflow_state": "ready_implementation",
+      "loop_profile": "l4_integration_reconcile",
+      "plan_lane": "m3_guardrails",
+      "depends_on": [
+        "AN10"
+      ],
+      "interface_contract_refs": "planningops/contracts/requirements-contract.md",
+      "package_topology_ref": "planningops/README.md",
+      "dependency_manifest_ref": "planningops/config/runtime-profiles.json",
+      "file_plan_ref": "docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md"
+    },
+    {
+      "plan_item_id": "AN30",
+      "track": "control_plane",
+      "execution_order": 30,
+      "target_repo": "rather-not-work-on/platform-planningops",
+      "issue_repo": "rather-not-work-on/platform-planningops",
+      "issue_number": 30,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
+      "issue_state": "open",
+      "issue_updated_at": "2026-03-22T15:02:46.317266+00:00",
+      "component": "planningops",
+      "workflow_state": "review_gate",
+      "loop_profile": "l4_integration_reconcile",
+      "plan_lane": "m3_guardrails",
+      "depends_on": [
+        "AN10",
+        "AN20"
+      ],
+      "interface_contract_refs": "",
+      "package_topology_ref": "",
+      "dependency_manifest_ref": "",
+      "file_plan_ref": ""
+    }
+  ]
+}

--- a/planningops/artifacts/validation/issue-label-backfill-report-wave22.json
+++ b/planningops/artifacts/validation/issue-label-backfill-report-wave22.json
@@ -1,0 +1,55 @@
+{
+  "generated_at_utc": "2026-03-22T15:02:46.394381+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_file": "planningops/artifacts/backlog/projected-issues-wave22.json",
+  "write_updated_issues_file": "planningops/artifacts/backlog/projected-issues-wave22.json",
+  "mode": "apply",
+  "issues_in_scope": 3,
+  "issues_with_missing_labels": 3,
+  "issues_applied": 3,
+  "rows": [
+    {
+      "number": 10,
+      "title": "plan: [10] planningops runner rate-limit guidance",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied_local",
+      "error": ""
+    },
+    {
+      "number": 20,
+      "title": "plan: [20] planningops supervisor rate-limit guidance summary",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied_local",
+      "error": ""
+    },
+    {
+      "number": 30,
+      "title": "plan: [30] runtime mission wave22 review",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/governance"
+      ],
+      "apply_status": "applied_local",
+      "error": ""
+    }
+  ]
+}

--- a/planningops/artifacts/validation/issue-quality-report-wave22.json
+++ b/planningops/artifacts/validation/issue-quality-report-wave22.json
@@ -1,0 +1,10 @@
+{
+  "generated_at_utc": "2026-03-22T15:02:46.476221+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_scanned": 3,
+  "issues_in_scope": 3,
+  "violation_count": 0,
+  "violations": [],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/plan-compile-report-wave22.json
+++ b/planningops/artifacts/validation/plan-compile-report-wave22.json
@@ -1,0 +1,90 @@
+{
+  "mode": "dry-run",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave22.execution-contract.json",
+  "validation_errors": [],
+  "results": [
+    {
+      "plan_item_id": "AN10",
+      "execution_order": 10,
+      "issue_number": 10,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "closed_match_detected": false,
+      "closed_match_issue_number": null,
+      "metadata_sync_required": false,
+      "metadata_sync_action": "none",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(planningops)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l4_integration_reconcile)",
+        "plan_lane(m3_guardrails)"
+      ]
+    },
+    {
+      "plan_item_id": "AN20",
+      "execution_order": 20,
+      "issue_number": 20,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "closed_match_detected": false,
+      "closed_match_issue_number": null,
+      "metadata_sync_required": true,
+      "metadata_sync_action": "planned",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(todo)",
+        "component(planningops)",
+        "workflow_state(ready_implementation)",
+        "loop_profile(l4_integration_reconcile)",
+        "plan_lane(m3_guardrails)"
+      ]
+    },
+    {
+      "plan_item_id": "AN30",
+      "execution_order": 30,
+      "issue_number": 30,
+      "issue_url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
+      "created_issue": false,
+      "dedup_match_state": "open",
+      "dedup_strategy": "identity_exact",
+      "reused_closed_issue": false,
+      "reopened_closed_issue": false,
+      "closed_match_detected": false,
+      "closed_match_issue_number": null,
+      "metadata_sync_required": true,
+      "metadata_sync_action": "planned",
+      "field_updates": [
+        "initiative(text)",
+        "target_repo(text)",
+        "execution_order(number)",
+        "status(in_progress)",
+        "component(planningops)",
+        "workflow_state(review_gate)",
+        "loop_profile(l4_integration_reconcile)",
+        "plan_lane(m3_guardrails)"
+      ]
+    }
+  ],
+  "plan_id": "uap-runtime-mission-wave22",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
+  "items_total": 3,
+  "issues_source": "file:planningops/artifacts/backlog/projected-issues-wave22.json",
+  "open_issues_scanned": 3,
+  "closed_issues_scanned": 0,
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/program-manifest-report-wave22.json
+++ b/planningops/artifacts/validation/program-manifest-report-wave22.json
@@ -1,0 +1,27 @@
+{
+  "generated_at_utc": "2026-03-22T15:02:46.433909+00:00",
+  "program_id": "uap-po-ct-program",
+  "initiative": "unified-personal-agent-platform",
+  "source_plan": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave22-rate-limit-guidance-issue-pack.md",
+  "repos": [
+    "rather-not-work-on/platform-planningops",
+    "rather-not-work-on/platform-contracts",
+    "rather-not-work-on/platform-provider-gateway",
+    "rather-not-work-on/platform-observability-gateway",
+    "rather-not-work-on/monday"
+  ],
+  "issues_file": "planningops/artifacts/backlog/projected-issues-wave22.json",
+  "verdict": "pass",
+  "errors": [],
+  "issues_scanned": 3,
+  "filtered_out_count": 0,
+  "item_count": 3,
+  "duplicate_group_count": 0,
+  "duplicate_groups": [],
+  "track_summary": {
+    "control_plane": 3,
+    "federated_runtime": 0,
+    "reconciliation": 0,
+    "unknown": 0
+  }
+}


### PR DESCRIPTION
## Summary
- add a packet for the historical wave22 backlog materialization artifact set
- track the wave22 backlog, manifest, and validation snapshots
- link the work to issue #688

## Testing
- bash planningops/scripts/test_backlog_materialization_contract.sh
- bash planningops/scripts/test_build_program_manifest_contract.sh
- bash planningops/scripts/test_validate_issue_quality_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. Historical artifact packet only.

Closes #688