### PR TITLE
chore(issue-quality): refresh test artifact timestamps

### DIFF
--- a/planningops/artifacts/validation/issue-quality-invalid.test.json
+++ b/planningops/artifacts/validation/issue-quality-invalid.test.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-03-30T15:11:41.377837+00:00",
+  "generated_at_utc": "2026-03-30T15:14:36.323626+00:00",
   "repo": "rather-not-work-on/platform-planningops",
   "rules_path": "planningops/config/issue-quality-rules.json",
   "issues_scanned": 1,

--- a/planningops/artifacts/validation/issue-quality-valid.test.json
+++ b/planningops/artifacts/validation/issue-quality-valid.test.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-03-30T15:11:41.323743+00:00",
+  "generated_at_utc": "2026-03-30T15:14:36.276454+00:00",
   "repo": "rather-not-work-on/platform-planningops",
   "rules_path": "planningops/config/issue-quality-rules.json",
   "issues_scanned": 1,


### PR DESCRIPTION
## Summary
- refresh tracked issue-quality valid/invalid test artifact timestamps after wave27 validation
- link the work to issue #694

## Testing
- bash planningops/scripts/test_validate_issue_quality_contract.sh

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. Deterministic test artifact refresh only.

Closes #694