### PR TITLE
chore(backlog-history): track wave25 fail artifact packet

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-31-backlog-materialize-wave25-fail-artifact-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-31-backlog-materialize-wave25-fail-artifact-packet.md
@@ -1,0 +1,47 @@
+---
+title: plan: Backlog Materialize Wave25 Fail Artifact Packet
+type: plan
+date: 2026-03-31
+updated: 2026-03-31
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Captures the historical wave25 backlog replay artifacts, including the fail-state materialization report and the derived local issue, label, quality, and manifest evidence.
+related_docs:
+  - ./2026-03-10-runtime-mission-wave25.execution-contract.json
+  - ./runtime-mission-wave25-supervisor-inbox-payload-issue-pack.md
+  - ./2026-03-31-backlog-materialize-wave27-history-artifact-packet.md
+---
+
+# plan: Backlog Materialize Wave25 Fail Artifact Packet
+
+## Purpose
+
+Track the historical wave25 backlog replay evidence as a fail-state packet. This packet preserves the network-failure materialization report together with the locally produced projected issues, label application report, issue-quality report, and program-manifest validation evidence.
+
+## Scope
+
+This packet includes:
+
+- `planningops/artifacts/backlog/materialize-report-wave25.json`
+- `planningops/artifacts/backlog/projected-issues-wave25.json`
+- `planningops/artifacts/validation/issue-label-backfill-report-wave25.json`
+- `planningops/artifacts/validation/issue-quality-report-wave25.json`
+- `planningops/artifacts/validation/program-manifest-report-wave25.json`
+
+This packet does not include:
+
+- current canonical latest backlog artifacts
+- pass-state historical wave22 or wave27 replay evidence
+- code changes to backlog materialization behavior
+
+## Verification
+
+- fail-state materialization corresponds to `uap-runtime-mission-wave25`
+- failure mode remains the recorded GitHub connectivity error during issue listing
+- derived projected issues and validation artifacts remain internally consistent with the stored fail-state replay
+
+## Notes
+
+- treat these files as historical replay evidence, not as current backlog outputs
+- keep unrelated untracked backlog and CI residue outside this packet

--- a/planningops/artifacts/backlog/materialize-report-wave25.json
+++ b/planningops/artifacts/backlog/materialize-report-wave25.json
@@ -1,0 +1,37 @@
+{
+  "generated_at_utc": "2026-03-17T14:02:43.593437+00:00",
+  "mode": "dry-run",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave25.execution-contract.json",
+  "repo": "rather-not-work-on/platform-planningops",
+  "initiative": "unified-personal-agent-platform",
+  "steps": [
+    {
+      "name": "compile_plan_to_backlog",
+      "command": [
+        "python3",
+        "planningops/scripts/compile_plan_to_backlog.py",
+        "--contract-file",
+        "docs/workbench/unified-personal-agent-platform/plans/2026-03-10-runtime-mission-wave25.execution-contract.json",
+        "--config",
+        "planningops/config/project-field-ids.json",
+        "--blueprint-defaults-config",
+        "planningops/config/ready-implementation-blueprint-defaults.json",
+        "--output",
+        "planningops/artifacts/validation/plan-compile-report-wave25.json"
+      ],
+      "output_path": "planningops/artifacts/validation/plan-compile-report-wave25.json",
+      "rc": 1,
+      "stdout": "",
+      "stderr": "Traceback (most recent call last):\n  File \"/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/compile_plan_to_backlog.py\", line 738, in <module>\n    sys.exit(main())\n             ~~~~^^\n  File \"/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/compile_plan_to_backlog.py\", line 685, in main\n    open_issues = list_existing_issues(CONTROL_REPO, \"open\")\n  File \"/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/compile_plan_to_backlog.py\", line 277, in list_existing_issues\n    raise RuntimeError(f\"failed to list issues (state={state}, page={page}): {err}\")\nRuntimeError: failed to list issues (state=open, page=1): error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com",
+      "verdict": "fail"
+    }
+  ],
+  "plan_id": "uap-runtime-mission-wave25",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave25-supervisor-inbox-payload-issue-pack.md",
+  "items_total": 3,
+  "projected_issues_output": "planningops/artifacts/backlog/projected-issues-wave25.json",
+  "projected_issue_count": 3,
+  "step_count": 4,
+  "verdict": "fail"
+}

--- a/planningops/artifacts/backlog/projected-issues-wave25.json
+++ b/planningops/artifacts/backlog/projected-issues-wave25.json
@@ -1,0 +1,71 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 10,
+    "state": "open",
+    "updated_at": "2026-03-17T14:03:15.646544+00:00",
+    "title": "plan: [10] planningops supervisor inbox payload sidecar",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave25-supervisor-inbox-payload-issue-pack.md`\n- plan_id: `uap-runtime-mission-wave25`\n- plan_revision: `1`\n- plan_item_id: `AQ10`\n- execution_order: `10`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `-`\n- primary_output: `planningops/scripts/autonomous_supervisor_loop.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave25-supervisor-inbox-payload-issue-pack.md`\n- `planningops/scripts/autonomous_supervisor_loop.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: planningops/contracts/requirements-contract.md\npackage_topology_ref: planningops/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md\n",
+    "labels": [
+      {
+        "name": "area/planningops"
+      },
+      {
+        "name": "p2"
+      },
+      {
+        "name": "task"
+      },
+      {
+        "name": "type/hardening"
+      }
+    ]
+  },
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 20,
+    "state": "open",
+    "updated_at": "2026-03-17T14:03:15.646544+00:00",
+    "title": "plan: [20] planningops supervisor contract inbox payload output",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave25-supervisor-inbox-payload-issue-pack.md`\n- plan_id: `uap-runtime-mission-wave25`\n- plan_revision: `1`\n- plan_item_id: `AQ20`\n- execution_order: `20`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `AQ10`\n- primary_output: `planningops/contracts/autonomous-supervisor-loop-contract.md`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `AQ10`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave25-supervisor-inbox-payload-issue-pack.md`\n- `planningops/contracts/autonomous-supervisor-loop-contract.md`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: planningops/contracts/requirements-contract.md\npackage_topology_ref: planningops/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md\n",
+    "labels": [
+      {
+        "name": "area/planningops"
+      },
+      {
+        "name": "p2"
+      },
+      {
+        "name": "task"
+      },
+      {
+        "name": "type/hardening"
+      }
+    ]
+  },
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 30,
+    "state": "open",
+    "updated_at": "2026-03-17T14:03:15.646544+00:00",
+    "title": "plan: [30] runtime mission wave25 review",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave25-supervisor-inbox-payload-issue-pack.md`\n- plan_id: `uap-runtime-mission-wave25`\n- plan_revision: `1`\n- plan_item_id: `AQ30`\n- execution_order: `30`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `review_gate`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `AQ10,AQ20`\n- primary_output: `planningops/artifacts/validation/runtime-mission-wave25-review.json`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `AQ10,AQ20`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave25-supervisor-inbox-payload-issue-pack.md`\n- `planningops/artifacts/validation/runtime-mission-wave25-review.json`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
+    "labels": [
+      {
+        "name": "area/planningops"
+      },
+      {
+        "name": "p2"
+      },
+      {
+        "name": "task"
+      },
+      {
+        "name": "type/governance"
+      }
+    ]
+  }
+]

--- a/planningops/artifacts/validation/issue-label-backfill-report-wave25.json
+++ b/planningops/artifacts/validation/issue-label-backfill-report-wave25.json
@@ -1,0 +1,55 @@
+{
+  "generated_at_utc": "2026-03-17T14:03:15.685077+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_file": "planningops/artifacts/backlog/projected-issues-wave25.json",
+  "write_updated_issues_file": "planningops/artifacts/backlog/projected-issues-wave25.json",
+  "mode": "apply",
+  "issues_in_scope": 3,
+  "issues_with_missing_labels": 3,
+  "issues_applied": 3,
+  "rows": [
+    {
+      "number": 10,
+      "title": "plan: [10] planningops supervisor inbox payload sidecar",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied_local",
+      "error": ""
+    },
+    {
+      "number": 20,
+      "title": "plan: [20] planningops supervisor contract inbox payload output",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/hardening"
+      ],
+      "apply_status": "applied_local",
+      "error": ""
+    },
+    {
+      "number": 30,
+      "title": "plan: [30] runtime mission wave25 review",
+      "url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
+      "existing_labels": [],
+      "planned_labels": [
+        "area/planningops",
+        "p2",
+        "task",
+        "type/governance"
+      ],
+      "apply_status": "applied_local",
+      "error": ""
+    }
+  ]
+}

--- a/planningops/artifacts/validation/issue-quality-report-wave25.json
+++ b/planningops/artifacts/validation/issue-quality-report-wave25.json
@@ -1,0 +1,10 @@
+{
+  "generated_at_utc": "2026-03-17T14:03:15.764865+00:00",
+  "repo": "rather-not-work-on/platform-planningops",
+  "rules_path": "planningops/config/issue-quality-rules.json",
+  "issues_scanned": 3,
+  "issues_in_scope": 3,
+  "violation_count": 0,
+  "violations": [],
+  "verdict": "pass"
+}

--- a/planningops/artifacts/validation/program-manifest-report-wave25.json
+++ b/planningops/artifacts/validation/program-manifest-report-wave25.json
@@ -1,0 +1,27 @@
+{
+  "generated_at_utc": "2026-03-17T14:05:53.561693+00:00",
+  "program_id": "uap-po-ct-program",
+  "initiative": "unified-personal-agent-platform",
+  "source_plan": "docs/workbench/unified-personal-agent-platform/plans/runtime-mission-wave25-supervisor-inbox-payload-issue-pack.md",
+  "repos": [
+    "rather-not-work-on/platform-planningops",
+    "rather-not-work-on/platform-contracts",
+    "rather-not-work-on/platform-provider-gateway",
+    "rather-not-work-on/platform-observability-gateway",
+    "rather-not-work-on/monday"
+  ],
+  "issues_file": "planningops/artifacts/backlog/projected-issues-wave25.json",
+  "verdict": "pass",
+  "errors": [],
+  "issues_scanned": 3,
+  "filtered_out_count": 0,
+  "item_count": 3,
+  "duplicate_group_count": 0,
+  "duplicate_groups": [],
+  "track_summary": {
+    "control_plane": 3,
+    "federated_runtime": 0,
+    "reconciliation": 0,
+    "unknown": 0
+  }
+}


### PR DESCRIPTION
## Summary
- add a packet for the historical wave25 fail-state backlog materialization artifacts
- track the fail report, projected issues, and derived validation snapshots
- link the work to issue #696

## Testing
- bash planningops/scripts/test_backlog_materialization_contract.sh
- bash planningops/scripts/test_build_program_manifest_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. Historical artifact packet only.

Closes #696