### PR TITLE
chore(backlog-history): track wave26 fail artifact packet

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-03-31-backlog-materialize-wave26-fail-artifact-packet.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-03-31-backlog-materialize-wave26-fail-artifact-packet.md
@@ -1,0 +1,44 @@
+---
+title: plan: Backlog Materialize Wave26 Fail Artifact Packet
+type: plan
+date: 2026-03-31
+updated: 2026-03-31
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Captures the historical wave26 backlog replay fail artifact set for the first goal-driven-autonomy wave21 materialization attempt.
+related_docs:
+  - ./2026-03-15-goal-driven-autonomy-wave21.execution-contract.json
+  - ./2026-03-15-goal-driven-autonomy-wave21-issue-pack.md
+  - ./2026-03-31-backlog-materialize-wave27-history-artifact-packet.md
+---
+
+# plan: Backlog Materialize Wave26 Fail Artifact Packet
+
+## Purpose
+
+Track the historical wave26 backlog replay evidence as a fail-state packet. This packet preserves the first goal-driven-autonomy wave21 materialization attempt that stopped after compiling projected issues because the control-repo issue listing step failed against GitHub.
+
+## Scope
+
+This packet includes:
+
+- `planningops/artifacts/backlog/materialize-report-wave26.json`
+- `planningops/artifacts/backlog/projected-issues-wave26.json`
+
+This packet does not include:
+
+- current canonical latest backlog artifacts
+- pass-state historical wave27 replay evidence
+- code changes to backlog materialization behavior
+
+## Verification
+
+- fail-state materialization corresponds to `uap-goal-driven-autonomy-wave21`
+- failure mode remains the recorded GitHub connectivity error during issue listing
+- projected issues snapshot remains internally consistent with the stored fail-state replay
+
+## Notes
+
+- treat these files as historical replay evidence, not as current backlog outputs
+- keep unrelated untracked backlog and CI residue outside this packet

--- a/planningops/artifacts/backlog/materialize-report-wave26.json
+++ b/planningops/artifacts/backlog/materialize-report-wave26.json
@@ -1,0 +1,37 @@
+{
+  "generated_at_utc": "2026-03-17T15:02:21.962617+00:00",
+  "mode": "dry-run",
+  "contract_file": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json",
+  "repo": "rather-not-work-on/platform-planningops",
+  "initiative": "unified-personal-agent-platform",
+  "steps": [
+    {
+      "name": "compile_plan_to_backlog",
+      "command": [
+        "python3",
+        "planningops/scripts/compile_plan_to_backlog.py",
+        "--contract-file",
+        "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21.execution-contract.json",
+        "--config",
+        "planningops/config/project-field-ids.json",
+        "--blueprint-defaults-config",
+        "planningops/config/ready-implementation-blueprint-defaults.json",
+        "--output",
+        "planningops/artifacts/validation/plan-compile-report.json"
+      ],
+      "output_path": "planningops/artifacts/validation/plan-compile-report.json",
+      "rc": 1,
+      "stdout": "",
+      "stderr": "Traceback (most recent call last):\n  File \"/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/compile_plan_to_backlog.py\", line 738, in <module>\n    sys.exit(main())\n             ~~~~^^\n  File \"/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/compile_plan_to_backlog.py\", line 685, in main\n    open_issues = list_existing_issues(CONTROL_REPO, \"open\")\n  File \"/Volumes/T7 Touch/mini/rather-not-work-on/platform-planningops/planningops/scripts/compile_plan_to_backlog.py\", line 277, in list_existing_issues\n    raise RuntimeError(f\"failed to list issues (state={state}, page={page}): {err}\")\nRuntimeError: failed to list issues (state=open, page=1): error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com",
+      "verdict": "fail"
+    }
+  ],
+  "plan_id": "uap-goal-driven-autonomy-wave21",
+  "plan_revision": 1,
+  "source_of_truth": "docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md",
+  "items_total": 4,
+  "projected_issues_output": "planningops/artifacts/backlog/projected-issues-wave26.json",
+  "projected_issue_count": 4,
+  "step_count": 4,
+  "verdict": "fail"
+}

--- a/planningops/artifacts/backlog/projected-issues-wave26.json
+++ b/planningops/artifacts/backlog/projected-issues-wave26.json
@@ -1,0 +1,42 @@
+[
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 10,
+    "state": "open",
+    "updated_at": "2026-03-17T15:02:21.964204+00:00",
+    "title": "plan: [10] Freeze monday scheduled delivery queue admission contract",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/10",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md`\n- plan_id: `uap-goal-driven-autonomy-wave21`\n- plan_revision: `1`\n- plan_item_id: `U10`\n- execution_order: `10`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_contract`\n- loop_profile: `l1_contract_clarification`\n- plan_lane: `m1_contract_freeze`\n- depends_on: `-`\n- primary_output: `planningops/contracts/scheduled-delivery-queue-admission-contract.md`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `-`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md`\n- `planningops/contracts/scheduled-delivery-queue-admission-contract.md`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
+    "labels": []
+  },
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 20,
+    "state": "open",
+    "updated_at": "2026-03-17T15:02:21.964204+00:00",
+    "title": "plan: [20] Define monday scheduled delivery queue admission entrypoint",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/20",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md`\n- plan_id: `uap-goal-driven-autonomy-wave21`\n- plan_revision: `1`\n- plan_item_id: `U20`\n- execution_order: `20`\n- target_repo: `rather-not-work-on/monday`\n- component: `runtime`\n- workflow_state: `ready_implementation`\n- loop_profile: `l3_implementation_tdd`\n- plan_lane: `m2_sync_core`\n- depends_on: `U10`\n- primary_output: `monday/scripts/enqueue_scheduled_delivery_work_item.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/monday`\n- depends_on: `U10`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md`\n- `monday/scripts/enqueue_scheduled_delivery_work_item.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: docs/initiatives/unified-personal-agent-platform/20-repos/monday/20-architecture/2026-02-27-uap-contract-first-requirements.architecture.md\npackage_topology_ref: docs/initiatives/unified-personal-agent-platform/20-repos/monday/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/initiatives/unified-personal-agent-platform/20-repos/monday/30-execution-plan/2026-02-27-uap-contract-first-foundation.execution-plan.md\n",
+    "labels": []
+  },
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 30,
+    "state": "open",
+    "updated_at": "2026-03-17T15:02:21.964204+00:00",
+    "title": "plan: [30] Delegate planningops recurring delivery through monday queue admission",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/30",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md`\n- plan_id: `uap-goal-driven-autonomy-wave21`\n- plan_revision: `1`\n- plan_item_id: `U30`\n- execution_order: `30`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `ready_implementation`\n- loop_profile: `l3_implementation_tdd`\n- plan_lane: `m2_sync_core`\n- depends_on: `U10,U20`\n- primary_output: `planningops/scripts/federation/run_reflection_delivery_cycle.py`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `U10,U20`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md`\n- `planningops/scripts/federation/run_reflection_delivery_cycle.py`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence\n\n## Implementation Blueprint Refs\ninterface_contract_refs: planningops/contracts/requirements-contract.md\npackage_topology_ref: planningops/README.md\ndependency_manifest_ref: planningops/config/runtime-profiles.json\nfile_plan_ref: docs/workbench/unified-personal-agent-platform/plans/2026-03-03-fix-gate-bootstrap-review-findings-plan.md\n",
+    "labels": []
+  },
+  {
+    "repo": "rather-not-work-on/platform-planningops",
+    "number": 40,
+    "state": "open",
+    "updated_at": "2026-03-17T15:02:21.964204+00:00",
+    "title": "plan: [40] Review goal-driven autonomy wave 21 scheduled queue admission delegation",
+    "url": "https://github.com/rather-not-work-on/platform-planningops/issues/40",
+    "body": "## Planning Context\n- plan_doc: `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md`\n- plan_id: `uap-goal-driven-autonomy-wave21`\n- plan_revision: `1`\n- plan_item_id: `U40`\n- execution_order: `40`\n- target_repo: `rather-not-work-on/platform-planningops`\n- component: `planningops`\n- workflow_state: `review_gate`\n- loop_profile: `l4_integration_reconcile`\n- plan_lane: `m3_guardrails`\n- depends_on: `U10,U20,U30`\n- primary_output: `planningops/artifacts/validation/goal-driven-autonomy-wave21-review.json`\n\n## Problem Statement\n- Resolve this plan item with deterministic artifacts and contract-aligned updates.\n\n## Interfaces & Dependencies\n- target_repo: `rather-not-work-on/platform-planningops`\n- depends_on: `U10,U20,U30`\n\n## Evidence\n- `docs/workbench/unified-personal-agent-platform/plans/2026-03-15-goal-driven-autonomy-wave21-issue-pack.md`\n- `planningops/artifacts/validation/goal-driven-autonomy-wave21-review.json`\n\n## Acceptance Criteria\n- [ ] Required artifact created and linked under Evidence.\n- [ ] Contract/path references are updated and validated.\n\n## Definition of Done\n- [ ] Required artifact created\n- [ ] Validation report attached\n- [ ] Project fields updated with evidence",
+    "labels": []
+  }
+]


### PR DESCRIPTION
## Summary
- add a packet for the historical wave26 fail-state backlog materialization artifacts
- track the fail report and projected issues snapshot
- link the work to issue #698

## Testing
- bash planningops/scripts/test_backlog_materialization_contract.sh
- bash planningops/scripts/test_build_program_manifest_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. Historical artifact packet only.

Closes #698