### PR TITLE
feat(federated-ci): add query engine skeleton

### DIFF
--- a/planningops/scripts/federation/federated_ci_runtime_state.py
+++ b/planningops/scripts/federation/federated_ci_runtime_state.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import json
+import re
+from typing import Any
+
+
+DETERMINISTIC_RULE = (
+    "contract-conformance->contract, "
+    "provider-profile/provider-gateway-ready/o11y-replay->infra, "
+    "runtime-handoff/runtime-operations-ready->runtime, "
+    "federated-conformance->federation, "
+    "loop-guardrails->policy"
+)
+
+RUN_ID_DATE_RE = re.compile(r"^\d{8}(?:T\d{6}Z)?$")
+RUN_ID_RERUN_RE = re.compile(r"^rerun\d+$")
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
+    if not path.exists():
+        return {} if default is None else dict(default)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, doc: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
+def is_summary_document(doc: dict[str, Any]) -> bool:
+    return (
+        isinstance(doc, dict)
+        and isinstance(doc.get("run_id"), str)
+        and isinstance(doc.get("checks"), list)
+        and isinstance(doc.get("required_checks"), list)
+    )
+
+
+def infer_family_from_run_id(run_id: str) -> str:
+    parts = [part for part in run_id.split("-") if part]
+    while parts and (RUN_ID_RERUN_RE.match(parts[-1]) or RUN_ID_DATE_RE.match(parts[-1])):
+        parts.pop()
+    return "-".join(parts) if parts else run_id
+
+
+def summary_timestamp(doc: dict[str, Any]) -> str:
+    for key in ("generated_at_utc", "finished_at_utc", "started_at_utc"):
+        value = doc.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+def build_check_record(
+    *,
+    name: str,
+    domain: str,
+    exit_code: int,
+    stdout_log: str,
+    stderr_log: str,
+    result: str | None = None,
+) -> dict[str, Any]:
+    check = {
+        "name": name,
+        "domain": domain,
+        "exit_code": exit_code,
+        "verdict": "pass" if exit_code == 0 else "fail",
+        "stdout_log": stdout_log,
+        "stderr_log": stderr_log,
+    }
+    if result is not None:
+        check["result"] = result
+    return check
+
+
+def finalize_summary_doc(
+    doc: dict[str, Any],
+    *,
+    status: str,
+    shell_exit_code: int | None = None,
+    generated_at_utc: str | None = None,
+    finished_at_utc: str | None = None,
+) -> dict[str, Any]:
+    checks = list(doc.get("checks") or [])
+    required_checks = list(doc.get("required_checks") or [])
+    check_names = [str(check.get("name") or "") for check in checks]
+    failures = [check for check in checks if check.get("verdict") == "fail"]
+    missing_required = [name for name in required_checks if name not in check_names]
+
+    finalized = dict(doc)
+    finalized["generated_at_utc"] = generated_at_utc or now_utc()
+    finalized["finished_at_utc"] = finished_at_utc or now_utc()
+    finalized["overall_status"] = status
+    finalized["check_count"] = len(checks)
+    finalized["missing_required_checks"] = missing_required
+    finalized["failure_classification"] = {
+        "count": len(failures),
+        "domains": sorted({failure.get("domain") for failure in failures}),
+        "deterministic_rule": DETERMINISTIC_RULE,
+    }
+    finalized["verdict"] = (
+        "pass"
+        if status == "complete" and not failures and not missing_required
+        else "fail"
+    )
+    if shell_exit_code is not None:
+        finalized["shell_exit_code"] = shell_exit_code
+    return finalized

--- a/planningops/scripts/federation/federated_ci_summary.py
+++ b/planningops/scripts/federation/federated_ci_summary.py
@@ -4,35 +4,11 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import json
-from datetime import datetime, timezone
 from pathlib import Path
 import sys
 from typing import Any
 
-
-DETERMINISTIC_RULE = (
-    "contract-conformance->contract, "
-    "provider-profile/provider-gateway-ready/o11y-replay->infra, "
-    "runtime-handoff/runtime-operations-ready->runtime, "
-    "federated-conformance->federation, "
-    "loop-guardrails->policy"
-)
-
-
-def now_utc() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-def load_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
-    if not path.exists():
-        return {} if default is None else dict(default)
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def write_json(path: Path, doc: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2), encoding="utf-8")
+from federated_ci_runtime_state import build_check_record, finalize_summary_doc, load_json, write_json
 
 
 def load_validator_module():
@@ -61,17 +37,16 @@ def command_append_check(args: argparse.Namespace) -> int:
     summary_path = Path(args.summary)
     doc = load_json(summary_path, default={"checks": []})
     checks = list(doc.get("checks") or [])
-    check = {
-        "name": args.name,
-        "domain": args.domain,
-        "exit_code": args.exit_code,
-        "verdict": "pass" if args.exit_code == 0 else "fail",
-        "stdout_log": args.stdout_log,
-        "stderr_log": args.stderr_log,
-    }
-    if args.result is not None:
-        check["result"] = args.result
-    checks.append(check)
+    checks.append(
+        build_check_record(
+            name=args.name,
+            domain=args.domain,
+            exit_code=args.exit_code,
+            stdout_log=args.stdout_log,
+            stderr_log=args.stderr_log,
+            result=args.result,
+        )
+    )
     doc["checks"] = checks
     write_json(summary_path, doc)
     return 0
@@ -79,31 +54,12 @@ def command_append_check(args: argparse.Namespace) -> int:
 
 def command_finalize(args: argparse.Namespace) -> int:
     summary_path = Path(args.summary)
-    doc = load_json(summary_path, default={"checks": [], "required_checks": []})
-    checks = list(doc.get("checks") or [])
-    required_checks = list(doc.get("required_checks") or [])
-    check_names = [str(check.get("name") or "") for check in checks]
-    failures = [check for check in checks if check.get("verdict") == "fail"]
-    missing_required = [name for name in required_checks if name not in check_names]
-    overall_status = args.status
-
-    doc["generated_at_utc"] = now_utc()
-    doc["finished_at_utc"] = now_utc()
-    doc["overall_status"] = overall_status
-    doc["check_count"] = len(checks)
-    doc["missing_required_checks"] = missing_required
-    doc["failure_classification"] = {
-        "count": len(failures),
-        "domains": sorted({failure.get("domain") for failure in failures}),
-        "deterministic_rule": DETERMINISTIC_RULE,
-    }
-    doc["verdict"] = (
-        "pass"
-        if overall_status == "complete" and not failures and not missing_required
-        else "fail"
+    doc = finalize_summary_doc(
+        load_json(summary_path, default={"checks": [], "required_checks": []}),
+        status=args.status,
+        shell_exit_code=args.shell_exit_code,
     )
-    if args.shell_exit_code is not None:
-        doc["shell_exit_code"] = args.shell_exit_code
+    failures = [check for check in list(doc.get("checks") or []) if check.get("verdict") == "fail"]
 
     stamped_path = Path(args.stamped_path)
     latest_path = Path(args.latest_path)

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+from federated_ci_runtime_state import infer_family_from_run_id, is_summary_document, load_json, summary_timestamp
+
+
+# /planningops/scripts/federation lives one level below the repo's planningops package.
+WORKSPACE_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_CI_ROOT = WORKSPACE_ROOT / "planningops/artifacts/ci"
+DEFAULT_VALIDATION_ROOT = WORKSPACE_ROOT / "planningops/artifacts/validation"
+DEFAULT_CONFORMANCE_ROOT = WORKSPACE_ROOT / "planningops/artifacts/conformance"
+
+
+@dataclass(frozen=True)
+class SummaryRecord:
+    run_id: str
+    family: str
+    source_kind: str
+    summary_path: str
+    timestamp_utc: str
+    verdict: str | None
+    overall_status: str | None
+    check_count: int | None
+    shell_exit_code: int | None
+    missing_required_checks: list[str]
+    failure_domains: list[str]
+    has_summary_validation: bool
+    has_readiness: bool
+    has_readiness_validation: bool
+    has_reconcile_report: bool
+    has_reconcile_validation: bool
+    has_conformance_contract: bool
+
+
+def resolve_root(path_text: str, default: Path) -> Path:
+    candidate = Path(path_text)
+    if not candidate.is_absolute():
+        candidate = (WORKSPACE_ROOT / candidate).resolve()
+    return candidate if path_text else default
+
+
+def source_kind_for_summary_path(path: Path) -> str:
+    return "latest" if path.name == "federated-ci-summary.json" else "stamped"
+
+
+def build_sidecar_paths(
+    *,
+    run_id: str,
+    source_kind: str,
+    validation_root: Path,
+    conformance_root: Path,
+) -> dict[str, Path]:
+    if source_kind == "latest":
+        prefix = "federated-ci-summary"
+    else:
+        prefix = f"{run_id}-summary"
+    return {
+        "summary_validation": validation_root / f"{prefix}-validation.json",
+        "readiness": validation_root / f"{prefix}-readiness.json",
+        "readiness_validation": validation_root / f"{prefix}-readiness-validation.json",
+        "reconcile_report": validation_root / f"{prefix}-tmp-reconcile.json",
+        "reconcile_validation": validation_root / f"{prefix}-tmp-reconcile-validation.json",
+        "conformance_contract": conformance_root / f"{run_id}-contract.json",
+    }
+
+
+def build_summary_record(
+    *,
+    summary_path: Path,
+    summary_doc: dict[str, Any],
+    validation_root: Path,
+    conformance_root: Path,
+) -> SummaryRecord:
+    run_id = str(summary_doc["run_id"])
+    source_kind = source_kind_for_summary_path(summary_path)
+    sidecars = build_sidecar_paths(
+        run_id=run_id,
+        source_kind=source_kind,
+        validation_root=validation_root,
+        conformance_root=conformance_root,
+    )
+    failures = [
+        str(check.get("domain"))
+        for check in list(summary_doc.get("checks") or [])
+        if check.get("verdict") == "fail" and isinstance(check.get("domain"), str)
+    ]
+    return SummaryRecord(
+        run_id=run_id,
+        family=infer_family_from_run_id(run_id),
+        source_kind=source_kind,
+        summary_path=str(summary_path.resolve()),
+        timestamp_utc=summary_timestamp(summary_doc),
+        verdict=summary_doc.get("verdict"),
+        overall_status=summary_doc.get("overall_status"),
+        check_count=summary_doc.get("check_count"),
+        shell_exit_code=summary_doc.get("shell_exit_code"),
+        missing_required_checks=[str(name) for name in list(summary_doc.get("missing_required_checks") or [])],
+        failure_domains=sorted(set(failures)),
+        has_summary_validation=sidecars["summary_validation"].exists(),
+        has_readiness=sidecars["readiness"].exists(),
+        has_readiness_validation=sidecars["readiness_validation"].exists(),
+        has_reconcile_report=sidecars["reconcile_report"].exists(),
+        has_reconcile_validation=sidecars["reconcile_validation"].exists(),
+        has_conformance_contract=sidecars["conformance_contract"].exists(),
+    )
+
+
+def discover_summary_records(
+    *,
+    ci_root: Path,
+    validation_root: Path,
+    conformance_root: Path,
+) -> list[SummaryRecord]:
+    records: list[SummaryRecord] = []
+    for path in sorted(ci_root.glob("*.json")):
+        if (
+            path.name.startswith(".")
+            or path.name.endswith(".tmp.json")
+            or path.name.endswith(".checkpoint.json")
+        ):
+            continue
+        try:
+            doc = load_json(path)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if not is_summary_document(doc):
+            continue
+        records.append(
+            build_summary_record(
+                summary_path=path,
+                summary_doc=doc,
+                validation_root=validation_root,
+                conformance_root=conformance_root,
+            )
+        )
+    records.sort(
+        key=lambda record: (
+            record.timestamp_utc,
+            record.run_id,
+            1 if record.source_kind == "latest" else 0,
+            record.summary_path,
+        ),
+        reverse=True,
+    )
+    return records
+
+
+def render_runs_table(records: list[SummaryRecord]) -> str:
+    lines = [
+        "family\trun_id\tsource\tverdict\tstatus\tchecks\ttimestamp",
+    ]
+    for record in records:
+        lines.append(
+            "\t".join(
+                [
+                    record.family,
+                    record.run_id,
+                    record.source_kind,
+                    str(record.verdict or ""),
+                    str(record.overall_status or ""),
+                    str(record.check_count if record.check_count is not None else ""),
+                    record.timestamp_utc,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_runs_markdown(records: list[SummaryRecord]) -> str:
+    lines = [
+        "| family | run_id | source | verdict | status | checks | timestamp |",
+        "| --- | --- | --- | --- | --- | ---: | --- |",
+    ]
+    for record in records:
+        lines.append(
+            f"| {record.family} | `{record.run_id}` | {record.source_kind} | "
+            f"{record.verdict or ''} | {record.overall_status or ''} | "
+            f"{record.check_count if record.check_count is not None else ''} | {record.timestamp_utc} |"
+        )
+    return "\n".join(lines)
+
+
+def select_record(
+    *,
+    records: list[SummaryRecord],
+    run_id: str,
+    source_kind: str,
+) -> SummaryRecord | None:
+    matches = [record for record in records if record.run_id == run_id]
+    if not matches:
+        return None
+    if source_kind != "auto":
+        narrowed = [record for record in matches if record.source_kind == source_kind]
+        return narrowed[0] if narrowed else None
+    stamped = [record for record in matches if record.source_kind == "stamped"]
+    return stamped[0] if stamped else matches[0]
+
+
+def load_checks_payload(summary_path: Path) -> list[dict[str, Any]]:
+    doc = load_json(summary_path)
+    return list(doc.get("checks") or [])
+
+
+def render_checks_table(record: SummaryRecord, checks: list[dict[str, Any]]) -> str:
+    lines = [
+        f"run_id={record.run_id}",
+        f"source_kind={record.source_kind}",
+        f"summary_path={record.summary_path}",
+        "name\tdomain\tverdict\texit_code\tresult",
+    ]
+    for check in checks:
+        lines.append(
+            "\t".join(
+                [
+                    str(check.get("name") or ""),
+                    str(check.get("domain") or ""),
+                    str(check.get("verdict") or ""),
+                    str(check.get("exit_code") if check.get("exit_code") is not None else ""),
+                    str(check.get("result") or ""),
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Query federated CI summary artifacts from planningops artifact roots")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    runs_parser = subparsers.add_parser("runs", help="list indexed federated CI summaries")
+    runs_parser.add_argument("--family", default=None)
+    runs_parser.add_argument("--run-id-prefix", default=None)
+    runs_parser.add_argument("--verdict", choices=["pass", "fail"], default=None)
+    runs_parser.add_argument("--status", choices=["complete", "interrupted"], default=None)
+    runs_parser.add_argument("--limit", type=int, default=20)
+    runs_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    runs_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    runs_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    runs_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+
+    checks_parser = subparsers.add_parser("checks", help="show checks for one federated CI run id")
+    checks_parser.add_argument("--run-id", required=True)
+    checks_parser.add_argument("--source-kind", choices=["auto", "stamped", "latest"], default="auto")
+    checks_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    checks_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    checks_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    checks_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    ci_root = resolve_root(args.ci_root, DEFAULT_CI_ROOT)
+    validation_root = resolve_root(args.validation_root, DEFAULT_VALIDATION_ROOT)
+    conformance_root = resolve_root(args.conformance_root, DEFAULT_CONFORMANCE_ROOT)
+    records = discover_summary_records(
+        ci_root=ci_root,
+        validation_root=validation_root,
+        conformance_root=conformance_root,
+    )
+
+    if args.command == "runs":
+        filtered = records
+        if args.family:
+            filtered = [record for record in filtered if record.family == args.family]
+        if args.run_id_prefix:
+            filtered = [record for record in filtered if record.run_id.startswith(args.run_id_prefix)]
+        if args.verdict:
+            filtered = [record for record in filtered if record.verdict == args.verdict]
+        if args.status:
+            filtered = [record for record in filtered if record.overall_status == args.status]
+        filtered = filtered[: args.limit]
+        if args.format == "json":
+            print(json.dumps({"records": [asdict(record) for record in filtered]}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_runs_markdown(filtered))
+            return 0
+        print(render_runs_table(filtered))
+        return 0
+
+    record = select_record(records=records, run_id=args.run_id, source_kind=args.source_kind)
+    if record is None:
+        print(f"run not found: {args.run_id}", file=sys.stderr)
+        return 1
+    checks = load_checks_payload(Path(record.summary_path))
+    if args.format == "json":
+        print(json.dumps({"record": asdict(record), "checks": checks}, ensure_ascii=True, indent=2))
+        return 0
+    if args.format == "markdown":
+        lines = [
+            f"# `{record.run_id}` checks",
+            "",
+            f"- source_kind: `{record.source_kind}`",
+            f"- summary_path: `{record.summary_path}`",
+            "",
+            "| name | domain | verdict | exit_code | result |",
+            "| --- | --- | --- | ---: | --- |",
+        ]
+        for check in checks:
+            lines.append(
+                f"| {check.get('name') or ''} | {check.get('domain') or ''} | "
+                f"{check.get('verdict') or ''} | {check.get('exit_code') if check.get('exit_code') is not None else ''} | "
+                f"{check.get('result') or ''} |"
+            )
+        print("\n".join(lines))
+        return 0
+    print(render_checks_table(record, checks))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+QUERY_PATH="$ROOT_DIR/scripts/federation/query_federated_ci_artifacts.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+python3 - <<'PY' "$QUERY_PATH" "$ROOT_DIR"
+import importlib.util
+import sys
+from pathlib import Path
+
+query_path = Path(sys.argv[1])
+root_dir = Path(sys.argv[2]).resolve().parent
+
+spec = importlib.util.spec_from_file_location("query_federated_ci_artifacts", query_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.path.insert(0, str(query_path.parent))
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+assert module.WORKSPACE_ROOT == root_dir, (module.WORKSPACE_ROOT, root_dir)
+assert module.DEFAULT_CI_ROOT == root_dir / "planningops/artifacts/ci", module.DEFAULT_CI_ROOT
+PY
+
+CI_DIR="$TMP_DIR/ci"
+VALIDATION_DIR="$TMP_DIR/validation"
+CONFORMANCE_DIR="$TMP_DIR/conformance"
+mkdir -p "$CI_DIR" "$VALIDATION_DIR" "$CONFORMANCE_DIR"
+
+cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun26.json" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun26",
+  "started_at_utc": "2026-03-19T00:00:00+00:00",
+  "generated_at_utc": "2026-03-19T00:10:00+00:00",
+  "finished_at_utc": "2026-03-19T00:10:00+00:00",
+  "checks": [
+    {
+      "name": "contract-conformance",
+      "domain": "contract",
+      "exit_code": 0,
+      "verdict": "pass",
+      "stdout_log": "/tmp/contract.stdout.log",
+      "stderr_log": "/tmp/contract.stderr.log"
+    },
+    {
+      "name": "loop-guardrails",
+      "domain": "policy",
+      "exit_code": 0,
+      "verdict": "pass",
+      "stdout_log": "/tmp/policy.stdout.log",
+      "stderr_log": "/tmp/policy.stderr.log"
+    }
+  ],
+  "required_checks": [
+    "contract-conformance",
+    "loop-guardrails"
+  ],
+  "overall_status": "complete",
+  "check_count": 2,
+  "missing_required_checks": [],
+  "failure_classification": {
+    "count": 0,
+    "domains": [],
+    "deterministic_rule": "demo"
+  },
+  "verdict": "pass",
+  "shell_exit_code": 0
+}
+JSON
+
+cat >"$CI_DIR/federated-ci-summary.json" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun26",
+  "started_at_utc": "2026-03-19T00:00:00+00:00",
+  "generated_at_utc": "2026-03-19T00:11:00+00:00",
+  "finished_at_utc": "2026-03-19T00:11:00+00:00",
+  "checks": [
+    {
+      "name": "contract-conformance",
+      "domain": "contract",
+      "exit_code": 0,
+      "verdict": "pass",
+      "stdout_log": "/tmp/contract.stdout.log",
+      "stderr_log": "/tmp/contract.stderr.log"
+    }
+  ],
+  "required_checks": [
+    "contract-conformance"
+  ],
+  "overall_status": "complete",
+  "check_count": 1,
+  "missing_required_checks": [],
+  "failure_classification": {
+    "count": 0,
+    "domains": [],
+    "deterministic_rule": "demo"
+  },
+  "verdict": "pass",
+  "shell_exit_code": 0
+}
+JSON
+
+cat >"$CI_DIR/federated-ci-local-20260301.json" <<'JSON'
+{
+  "run_id": "federated-ci-local-20260301",
+  "started_at_utc": "2026-03-01T00:00:00+00:00",
+  "generated_at_utc": "2026-03-01T00:05:00+00:00",
+  "finished_at_utc": "2026-03-01T00:05:00+00:00",
+  "checks": [],
+  "required_checks": [],
+  "overall_status": "complete",
+  "check_count": 0,
+  "missing_required_checks": [],
+  "failure_classification": {
+    "count": 0,
+    "domains": [],
+    "deterministic_rule": "demo"
+  },
+  "verdict": "pass",
+  "shell_exit_code": 0
+}
+JSON
+
+cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun26.tmp.json" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun26",
+  "checks": [],
+  "required_checks": []
+}
+JSON
+
+cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun26.checkpoint.json" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun26",
+  "checks": [],
+  "required_checks": []
+}
+JSON
+
+python3 - <<'PY' "$CI_DIR/._federated-ci-runtime-gates-20260319-rerun26.json"
+from pathlib import Path
+import sys
+
+Path(sys.argv[1]).write_bytes(b"\x00\xffappledouble")
+PY
+
+touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-validation.json"
+touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-readiness.json"
+touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-readiness-validation.json"
+touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-tmp-reconcile.json"
+touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-tmp-reconcile-validation.json"
+touch "$VALIDATION_DIR/federated-ci-summary-validation.json"
+touch "$CONFORMANCE_DIR/federated-ci-runtime-gates-20260319-rerun26-contract.json"
+
+RUNS_OUTPUT="$TMP_DIR/runs.json"
+CHECKS_OUTPUT="$TMP_DIR/checks.json"
+CHECKS_AUTO_OUTPUT="$TMP_DIR/checks-auto.json"
+
+python3 "$QUERY_PATH" runs \
+  --family federated-ci-runtime-gates \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$RUNS_OUTPUT"
+
+python3 - <<'PY' "$RUNS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 2, records
+assert records[0]["source_kind"] == "latest", records
+assert records[1]["source_kind"] == "stamped", records
+
+latest = records[0]
+stamped = records[1]
+
+assert latest["has_summary_validation"] is True, latest
+assert latest["has_readiness"] is False, latest
+assert latest["has_conformance_contract"] is True, latest
+
+assert stamped["run_id"] == "federated-ci-runtime-gates-20260319-rerun26", stamped
+assert stamped["family"] == "federated-ci-runtime-gates", stamped
+assert stamped["has_summary_validation"] is True, stamped
+assert stamped["has_readiness"] is True, stamped
+assert stamped["has_readiness_validation"] is True, stamped
+assert stamped["has_reconcile_report"] is True, stamped
+assert stamped["has_reconcile_validation"] is True, stamped
+assert stamped["has_conformance_contract"] is True, stamped
+PY
+
+python3 "$QUERY_PATH" checks \
+  --run-id federated-ci-runtime-gates-20260319-rerun26 \
+  --source-kind stamped \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$CHECKS_OUTPUT"
+
+python3 - <<'PY' "$CHECKS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+checks = doc["checks"]
+
+assert record["source_kind"] == "stamped", record
+assert len(checks) == 2, checks
+assert checks[0]["name"] == "contract-conformance", checks
+assert checks[1]["name"] == "loop-guardrails", checks
+PY
+
+python3 "$QUERY_PATH" checks \
+  --run-id federated-ci-runtime-gates-20260319-rerun26 \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$CHECKS_AUTO_OUTPUT"
+
+python3 - <<'PY' "$CHECKS_AUTO_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"]["source_kind"] == "stamped", doc
+PY
+
+echo "query federated ci artifacts ok"


### PR DESCRIPTION
## Summary
- extract shared federated CI summary state helpers for append/finalize flows
- add a query CLI for indexed federated CI summary artifacts and checks
- cover default-root resolution and hidden/checkpoint/tmp artifact filtering in contract tests

## Validation
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

Closes #880