### PR TITLE
refactor(federated-ci): share run state transitions

### DIFF
--- a/planningops/scripts/federation/federated_ci_runtime_state.py
+++ b/planningops/scripts/federation/federated_ci_runtime_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 import json
@@ -19,6 +20,7 @@ DETERMINISTIC_RULE = (
 
 RUN_ID_DATE_RE = re.compile(r"^\d{8}(?:T\d{6}Z)?$")
 RUN_ID_RERUN_RE = re.compile(r"^rerun\d+$")
+SUMMARY_REQUIRED_KEYS = ("run_id", "started_at_utc", "required_checks", "checks")
 
 
 def now_utc() -> str:
@@ -60,6 +62,36 @@ def summary_timestamp(doc: dict[str, Any]) -> str:
     return ""
 
 
+@dataclass(frozen=True)
+class FederatedCIRunState:
+    run_id: str
+    started_at_utc: str
+    required_checks: tuple[str, ...]
+    checks: tuple[dict[str, Any], ...]
+
+    def to_doc(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "started_at_utc": self.started_at_utc,
+            "required_checks": list(self.required_checks),
+            "checks": [dict(check) for check in self.checks],
+        }
+
+
+@dataclass(frozen=True)
+class FederatedCICheckpointReconcileState:
+    run_id: str
+    check_name: str | None
+    restored: bool
+    reasons: tuple[str, ...]
+    reconcile_count: int
+    restored_check_names: tuple[str, ...]
+
+    @property
+    def status(self) -> str:
+        return "restored" if self.restored else "healthy"
+
+
 def build_check_record(
     *,
     name: str,
@@ -80,6 +112,20 @@ def build_check_record(
     if result is not None:
         check["result"] = result
     return check
+
+
+def initialize_summary_doc(
+    *,
+    run_id: str,
+    required_checks: list[str] | tuple[str, ...],
+    started_at_utc: str | None = None,
+) -> dict[str, Any]:
+    return FederatedCIRunState(
+        run_id=run_id,
+        started_at_utc=started_at_utc or now_utc(),
+        required_checks=tuple(required_checks),
+        checks=(),
+    ).to_doc()
 
 
 def finalize_summary_doc(
@@ -115,3 +161,106 @@ def finalize_summary_doc(
     if shell_exit_code is not None:
         finalized["shell_exit_code"] = shell_exit_code
     return finalized
+
+
+def validate_checkpoint_doc(doc: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for key in SUMMARY_REQUIRED_KEYS:
+        if key not in doc:
+            errors.append(f"checkpoint missing required key: {key}")
+    if not isinstance(doc.get("checks"), list):
+        errors.append("checkpoint checks must be a list")
+    if not isinstance(doc.get("required_checks"), list):
+        errors.append("checkpoint required_checks must be a list")
+    if not str(doc.get("run_id") or "").strip():
+        errors.append("checkpoint run_id must be non-empty")
+    if not str(doc.get("started_at_utc") or "").strip():
+        errors.append("checkpoint started_at_utc must be non-empty")
+    return errors
+
+
+def build_reconcile_reasons(
+    summary_doc: dict[str, Any] | None,
+    checkpoint_doc: dict[str, Any],
+) -> list[str]:
+    if summary_doc is None:
+        return ["summary_missing_or_invalid"]
+
+    reasons: list[str] = []
+    for key in SUMMARY_REQUIRED_KEYS:
+        if key not in summary_doc:
+            reasons.append(f"summary_missing_{key}")
+    if reasons:
+        return reasons
+
+    if summary_doc["run_id"] != checkpoint_doc["run_id"]:
+        reasons.append("summary_run_id_mismatch")
+    if summary_doc["started_at_utc"] != checkpoint_doc["started_at_utc"]:
+        reasons.append("summary_started_at_utc_mismatch")
+    if list(summary_doc.get("required_checks") or []) != list(checkpoint_doc.get("required_checks") or []):
+        reasons.append("summary_required_checks_mismatch")
+    if len(list(summary_doc.get("checks") or [])) < len(list(checkpoint_doc.get("checks") or [])):
+        reasons.append("summary_check_count_regressed")
+    return reasons
+
+
+def build_reconcile_state(
+    summary_doc: dict[str, Any] | None,
+    checkpoint_doc: dict[str, Any],
+    *,
+    previous_report_doc: dict[str, Any] | None = None,
+    check_name: str | None = None,
+) -> FederatedCICheckpointReconcileState:
+    normalized_check_name = check_name if isinstance(check_name, str) and check_name.strip() else None
+    reasons = tuple(build_reconcile_reasons(summary_doc, checkpoint_doc))
+    restored = bool(reasons)
+
+    restored_check_names: list[str] = []
+    if (
+        isinstance(previous_report_doc, dict)
+        and previous_report_doc.get("run_id") == checkpoint_doc["run_id"]
+        and isinstance(previous_report_doc.get("restored_check_names"), list)
+    ):
+        restored_check_names = [
+            name
+            for name in previous_report_doc["restored_check_names"]
+            if isinstance(name, str) and name.strip()
+        ]
+
+    if restored and normalized_check_name is not None and normalized_check_name not in restored_check_names:
+        restored_check_names.append(normalized_check_name)
+
+    return FederatedCICheckpointReconcileState(
+        run_id=str(checkpoint_doc["run_id"]),
+        check_name=normalized_check_name,
+        restored=restored,
+        reasons=reasons,
+        reconcile_count=len(restored_check_names),
+        restored_check_names=tuple(restored_check_names),
+    )
+
+
+def build_reconcile_report(
+    *,
+    summary_path: Path,
+    checkpoint_path: Path,
+    output_path: Path | None,
+    checkpoint_doc: dict[str, Any],
+    summary_doc: dict[str, Any] | None,
+    reconcile_state: FederatedCICheckpointReconcileState,
+) -> dict[str, Any]:
+    return {
+        "generated_at_utc": now_utc(),
+        "summary_path": str(summary_path.resolve()),
+        "checkpoint_path": str(checkpoint_path.resolve()),
+        "output_path": None if output_path is None else str(output_path.resolve()),
+        "run_id": reconcile_state.run_id,
+        "check_name": reconcile_state.check_name,
+        "checkpoint_check_count": len(list(checkpoint_doc.get("checks") or [])),
+        "summary_check_count": None if summary_doc is None else len(list(summary_doc.get("checks") or [])),
+        "restored": reconcile_state.restored,
+        "status": reconcile_state.status,
+        "reasons": list(reconcile_state.reasons),
+        "reconcile_count": reconcile_state.reconcile_count,
+        "restored_check_names": list(reconcile_state.restored_check_names),
+    }

--- a/planningops/scripts/federation/federated_ci_summary.py
+++ b/planningops/scripts/federation/federated_ci_summary.py
@@ -8,7 +8,13 @@ from pathlib import Path
 import sys
 from typing import Any
 
-from federated_ci_runtime_state import build_check_record, finalize_summary_doc, load_json, write_json
+from federated_ci_runtime_state import (
+    build_check_record,
+    finalize_summary_doc,
+    initialize_summary_doc,
+    load_json,
+    write_json,
+)
 
 
 def load_validator_module():
@@ -23,13 +29,13 @@ def load_validator_module():
 
 def command_init(args: argparse.Namespace) -> int:
     summary_path = Path(args.summary)
-    doc = {
-        "run_id": args.run_id,
-        "started_at_utc": now_utc(),
-        "checks": [],
-        "required_checks": list(args.required_check),
-    }
-    write_json(summary_path, doc)
+    write_json(
+        summary_path,
+        initialize_summary_doc(
+            run_id=args.run_id,
+            required_checks=list(args.required_check),
+        ),
+    )
     return 0
 
 

--- a/planningops/scripts/federation/reconcile_federated_ci_summary_tmp.py
+++ b/planningops/scripts/federation/reconcile_federated_ci_summary_tmp.py
@@ -4,67 +4,17 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 import sys
 from typing import Any
 
-
-REQUIRED_KEYS = ("run_id", "started_at_utc", "required_checks", "checks")
-
-
-def now_utc() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-def load_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def write_json(path: Path, doc: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
-
-
-def validate_checkpoint(doc: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
-    for key in REQUIRED_KEYS:
-        if key not in doc:
-            errors.append(f"checkpoint missing required key: {key}")
-    if not isinstance(doc.get("checks"), list):
-        errors.append("checkpoint checks must be a list")
-    if not isinstance(doc.get("required_checks"), list):
-        errors.append("checkpoint required_checks must be a list")
-    if not str(doc.get("run_id") or "").strip():
-        errors.append("checkpoint run_id must be non-empty")
-    if not str(doc.get("started_at_utc") or "").strip():
-        errors.append("checkpoint started_at_utc must be non-empty")
-    return errors
-
-
-def build_status(
-    summary_doc: dict[str, Any] | None,
-    checkpoint_doc: dict[str, Any],
-) -> list[str]:
-    if summary_doc is None:
-        return ["summary_missing_or_invalid"]
-
-    reasons: list[str] = []
-    for key in REQUIRED_KEYS:
-        if key not in summary_doc:
-            reasons.append(f"summary_missing_{key}")
-    if reasons:
-        return reasons
-
-    if summary_doc["run_id"] != checkpoint_doc["run_id"]:
-        reasons.append("summary_run_id_mismatch")
-    if summary_doc["started_at_utc"] != checkpoint_doc["started_at_utc"]:
-        reasons.append("summary_started_at_utc_mismatch")
-    if list(summary_doc.get("required_checks") or []) != list(checkpoint_doc.get("required_checks") or []):
-        reasons.append("summary_required_checks_mismatch")
-    if len(list(summary_doc.get("checks") or [])) < len(list(checkpoint_doc.get("checks") or [])):
-        reasons.append("summary_check_count_regressed")
-    return reasons
+from federated_ci_runtime_state import (
+    build_reconcile_report,
+    build_reconcile_state,
+    load_json,
+    validate_checkpoint_doc,
+    write_json,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -88,7 +38,7 @@ def main() -> int:
         return 1
 
     checkpoint_doc = load_json(checkpoint_path)
-    checkpoint_errors = validate_checkpoint(checkpoint_doc)
+    checkpoint_errors = validate_checkpoint_doc(checkpoint_doc)
     if checkpoint_errors:
         print(f"invalid checkpoint: {checkpoint_errors}", file=sys.stderr)
         return 1
@@ -96,51 +46,40 @@ def main() -> int:
     summary_doc: dict[str, Any] | None
     try:
         summary_doc = load_json(summary_path) if summary_path.exists() else None
-    except json.JSONDecodeError:
+    except (UnicodeDecodeError, json.JSONDecodeError):
         summary_doc = None
 
-    reasons = build_status(summary_doc, checkpoint_doc)
-    restored = bool(reasons)
-    if restored and args.restore_in_place:
-        write_json(summary_path, checkpoint_doc)
-        summary_doc = checkpoint_doc
-
-    restored_check_names: list[str] = []
     previous_report_path = None if args.previous_report is None else Path(args.previous_report)
+    previous_doc: dict[str, Any] | None = None
     if previous_report_path is not None and previous_report_path.exists():
         try:
             previous_doc = load_json(previous_report_path)
-        except json.JSONDecodeError:
-            previous_doc = {}
-        if previous_doc.get("run_id") == checkpoint_doc["run_id"]:
-            previous_names = previous_doc.get("restored_check_names") or []
-            if isinstance(previous_names, list):
-                restored_check_names = [name for name in previous_names if isinstance(name, str) and name.strip()]
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            previous_doc = None
 
-    check_name = args.check_name if isinstance(args.check_name, str) and args.check_name.strip() else None
-    if restored and check_name is not None and check_name not in restored_check_names:
-        restored_check_names.append(check_name)
+    reconcile_state = build_reconcile_state(
+        summary_doc,
+        checkpoint_doc,
+        previous_report_doc=previous_doc,
+        check_name=args.check_name,
+    )
+    effective_summary_doc = summary_doc
+    if reconcile_state.restored and args.restore_in_place:
+        write_json(summary_path, checkpoint_doc)
+        effective_summary_doc = checkpoint_doc
 
-    reconcile_count = len(restored_check_names)
-
-    report = {
-        "generated_at_utc": now_utc(),
-        "summary_path": str(summary_path.resolve()),
-        "checkpoint_path": str(checkpoint_path.resolve()),
-        "output_path": None if args.output is None else str(Path(args.output).resolve()),
-        "run_id": checkpoint_doc["run_id"],
-        "check_name": check_name,
-        "checkpoint_check_count": len(list(checkpoint_doc.get("checks") or [])),
-        "summary_check_count": None if summary_doc is None else len(list(summary_doc.get("checks") or [])),
-        "restored": restored,
-        "status": "restored" if restored else "healthy",
-        "reasons": reasons,
-        "reconcile_count": reconcile_count,
-        "restored_check_names": restored_check_names,
-    }
+    output_path = None if args.output is None else Path(args.output)
+    report = build_reconcile_report(
+        summary_path=summary_path,
+        checkpoint_path=checkpoint_path,
+        output_path=output_path,
+        checkpoint_doc=checkpoint_doc,
+        summary_doc=effective_summary_doc,
+        reconcile_state=reconcile_state,
+    )
 
     if args.output is not None:
-        write_json(Path(args.output), report)
+        write_json(output_path, report)
     else:
         print(json.dumps(report, ensure_ascii=True, indent=2))
     return 0

--- a/planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
+++ b/planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
@@ -25,15 +25,17 @@ bash "$SCRIPT_PATH" \
   --stamped-readiness-validation-path "$tmp_dir/ci-pass-summary-readiness-validation.json" \
   --latest-readiness-validation-path "$tmp_dir/federated-ci-summary-readiness-validation.json"
 
-python3 - <<'PY' "$tmp_dir/ci-pass.json" "$tmp_dir/federated-ci-summary-readiness.json"
+python3 - <<'PY' "$tmp_dir/ci-pass.json" "$tmp_dir/federated-ci-summary-readiness.json" "$tmp_dir/ci-pass.tmp.json"
 import json
 import sys
 from pathlib import Path
 
 summary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 readiness = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+tmp_summary_path = Path(sys.argv[3])
 
 assert summary["run_id"] == "ci-pass", summary
+assert isinstance(summary["started_at_utc"], str) and summary["started_at_utc"], summary
 assert summary["verdict"] == "pass", summary
 assert summary["overall_status"] == "complete", summary
 assert summary["check_count"] == 7, summary
@@ -41,6 +43,7 @@ assert readiness["summary_run_id"] == "ci-pass", readiness
 assert readiness["readiness_status"] == "ready", readiness
 assert readiness["ready"] is True, readiness
 assert readiness["next_step"] == "none", readiness
+assert not tmp_summary_path.exists(), tmp_summary_path
 PY
 
 set +e


### PR DESCRIPTION
## Summary
- move federated CI summary init and tmp-reconcile transitions behind the shared runtime state helper
- fix the summary init regression by routing it through `initialize_summary_doc`
- strengthen smoke coverage for init timestamps and tmp cleanup

## Validation
- bash planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
- bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

Closes #882