### PR TITLE
refactor(federated-ci): extract artifact write plan

### DIFF
--- a/planningops/scripts/federation/federated_ci_runtime_state.py
+++ b/planningops/scripts/federation/federated_ci_runtime_state.py
@@ -92,6 +92,14 @@ class FederatedCICheckpointReconcileState:
         return "restored" if self.restored else "healthy"
 
 
+@dataclass(frozen=True)
+class FederatedCISummaryArtifactWritePlan:
+    stamped_path: Path
+    latest_path: Path
+    stamped_validation_output: Path | None
+    latest_validation_output: Path | None
+
+
 def build_check_record(
     *,
     name: str,
@@ -126,6 +134,21 @@ def initialize_summary_doc(
         required_checks=tuple(required_checks),
         checks=(),
     ).to_doc()
+
+
+def build_summary_artifact_write_plan(
+    *,
+    stamped_path: Path,
+    latest_path: Path,
+    stamped_validation_output: Path | None = None,
+    latest_validation_output: Path | None = None,
+) -> FederatedCISummaryArtifactWritePlan:
+    return FederatedCISummaryArtifactWritePlan(
+        stamped_path=stamped_path,
+        latest_path=latest_path,
+        stamped_validation_output=stamped_validation_output,
+        latest_validation_output=latest_validation_output,
+    )
 
 
 def finalize_summary_doc(
@@ -264,3 +287,25 @@ def build_reconcile_report(
         "reconcile_count": reconcile_state.reconcile_count,
         "restored_check_names": list(reconcile_state.restored_check_names),
     }
+
+
+def write_summary_artifacts(
+    summary_doc: dict[str, Any],
+    *,
+    plan: FederatedCISummaryArtifactWritePlan,
+    validator_module: Any,
+    schema_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    write_json(plan.stamped_path, summary_doc)
+    write_json(plan.latest_path, summary_doc)
+
+    schema_doc = validator_module.load_json(schema_path)
+    stamped_report = validator_module.build_report(plan.stamped_path, schema_path, summary_doc, schema_doc)
+    latest_report = validator_module.build_report(plan.latest_path, schema_path, summary_doc, schema_doc)
+
+    if plan.stamped_validation_output is not None:
+        validator_module.write_json(plan.stamped_validation_output, stamped_report)
+    if plan.latest_validation_output is not None:
+        validator_module.write_json(plan.latest_validation_output, latest_report)
+
+    return stamped_report, latest_report

--- a/planningops/scripts/federation/federated_ci_summary.py
+++ b/planningops/scripts/federation/federated_ci_summary.py
@@ -10,9 +10,11 @@ from typing import Any
 
 from federated_ci_runtime_state import (
     build_check_record,
+    build_summary_artifact_write_plan,
     finalize_summary_doc,
     initialize_summary_doc,
     load_json,
+    write_summary_artifacts,
     write_json,
 )
 
@@ -67,22 +69,25 @@ def command_finalize(args: argparse.Namespace) -> int:
     )
     failures = [check for check in list(doc.get("checks") or []) if check.get("verdict") == "fail"]
 
-    stamped_path = Path(args.stamped_path)
-    latest_path = Path(args.latest_path)
-    write_json(stamped_path, doc)
-    write_json(latest_path, doc)
-
     validator = load_validator_module()
     schema_path = Path(__file__).resolve().parents[2] / "schemas" / "federated-ci-summary.schema.json"
-    schema_doc = validator.load_json(schema_path)
-
-    stamped_report = validator.build_report(stamped_path, schema_path, doc, schema_doc)
-    latest_report = validator.build_report(latest_path, schema_path, doc, schema_doc)
-
-    if args.stamped_validation_output is not None:
-        validator.write_json(Path(args.stamped_validation_output), stamped_report)
-    if args.latest_validation_output is not None:
-        validator.write_json(Path(args.latest_validation_output), latest_report)
+    stamped_path = Path(args.stamped_path)
+    latest_path = Path(args.latest_path)
+    stamped_report, latest_report = write_summary_artifacts(
+        doc,
+        plan=build_summary_artifact_write_plan(
+            stamped_path=stamped_path,
+            latest_path=latest_path,
+            stamped_validation_output=None
+            if args.stamped_validation_output is None
+            else Path(args.stamped_validation_output),
+            latest_validation_output=None
+            if args.latest_validation_output is None
+            else Path(args.latest_validation_output),
+        ),
+        validator_module=validator,
+        schema_path=schema_path,
+    )
 
     if stamped_report["verdict"] != "pass":
         print(f"federated stamped summary validation failed: {stamped_report['errors']}", file=sys.stderr)

--- a/planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
+++ b/planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
@@ -25,7 +25,7 @@ bash "$SCRIPT_PATH" \
   --stamped-readiness-validation-path "$tmp_dir/ci-pass-summary-readiness-validation.json" \
   --latest-readiness-validation-path "$tmp_dir/federated-ci-summary-readiness-validation.json"
 
-python3 - <<'PY' "$tmp_dir/ci-pass.json" "$tmp_dir/federated-ci-summary-readiness.json" "$tmp_dir/ci-pass.tmp.json"
+python3 - <<'PY' "$tmp_dir/ci-pass.json" "$tmp_dir/federated-ci-summary-readiness.json" "$tmp_dir/ci-pass.tmp.json" "$tmp_dir/ci-pass-summary-validation.json" "$tmp_dir/federated-ci-summary-validation.json"
 import json
 import sys
 from pathlib import Path
@@ -33,12 +33,18 @@ from pathlib import Path
 summary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 readiness = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
 tmp_summary_path = Path(sys.argv[3])
+stamped_validation = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
+latest_validation = json.loads(Path(sys.argv[5]).read_text(encoding="utf-8"))
 
 assert summary["run_id"] == "ci-pass", summary
 assert isinstance(summary["started_at_utc"], str) and summary["started_at_utc"], summary
 assert summary["verdict"] == "pass", summary
 assert summary["overall_status"] == "complete", summary
 assert summary["check_count"] == 7, summary
+assert stamped_validation["verdict"] == "pass", stamped_validation
+assert stamped_validation["summary_run_id"] == "ci-pass", stamped_validation
+assert latest_validation["verdict"] == "pass", latest_validation
+assert latest_validation["summary_run_id"] == "ci-pass", latest_validation
 assert readiness["summary_run_id"] == "ci-pass", readiness
 assert readiness["readiness_status"] == "ready", readiness
 assert readiness["ready"] is True, readiness
@@ -70,18 +76,24 @@ set -e
 
 test "$rc" -eq 1
 
-python3 - <<'PY' "$tmp_dir/ci-fail.json" "$tmp_dir/federated-ci-summary-fail-readiness.json"
+python3 - <<'PY' "$tmp_dir/ci-fail.json" "$tmp_dir/federated-ci-summary-fail-readiness.json" "$tmp_dir/ci-fail-summary-validation.json" "$tmp_dir/federated-ci-summary-fail-validation.json"
 import json
 import sys
 from pathlib import Path
 
 summary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 readiness = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+stamped_validation = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+latest_validation = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
 
 assert summary["run_id"] == "ci-fail", summary
 assert summary["verdict"] == "fail", summary
 assert summary["overall_status"] == "complete", summary
 assert summary["failure_classification"]["count"] == 1, summary
+assert stamped_validation["verdict"] == "pass", stamped_validation
+assert stamped_validation["summary_run_id"] == "ci-fail", stamped_validation
+assert latest_validation["verdict"] == "pass", latest_validation
+assert latest_validation["summary_run_id"] == "ci-fail", latest_validation
 assert readiness["summary_run_id"] == "ci-fail", readiness
 assert readiness["readiness_status"] == "blocked", readiness
 assert readiness["ready"] is False, readiness


### PR DESCRIPTION
## Summary
- extract a shared write plan for stamped/latest summary artifacts and validation outputs
- make summary finalize delegate artifact emission to the shared writer helper
- strengthen smoke coverage so stamped/latest validation outputs are asserted for pass and fail runs

## Validation
- bash planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
- bash planningops/scripts/test_run_federated_summary_ci_check_contract.sh
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

Closes #884