### PR TITLE
refactor(federated-ci): unify readiness writer path

### DIFF
--- a/planningops/scripts/assess_federated_ci_summary_readiness.py
+++ b/planningops/scripts/assess_federated_ci_summary_readiness.py
@@ -3,26 +3,20 @@
 from __future__ import annotations
 
 import argparse
-import json
 import importlib.util
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 from doctor_federated_ci_summary import DEFAULT_SUMMARY, DEFAULT_VALIDATION, WORKSPACE_ROOT, build_status
+from federation.federated_ci_runtime_state import (
+    build_readiness_artifact_write_plan,
+    build_readiness_report,
+    write_readiness_artifacts,
+)
 
 
 DEFAULT_OUTPUT = WORKSPACE_ROOT / "planningops/artifacts/validation/federated-ci-summary-readiness.json"
 DEFAULT_VALIDATION_OUTPUT = WORKSPACE_ROOT / "planningops/artifacts/validation/federated-ci-summary-readiness-validation.json"
-
-
-def now_utc() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-def write_json(path: Path, doc) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 
 
 def load_validator_module():
@@ -33,6 +27,28 @@ def load_validator_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def assess_readiness_artifacts(
+    *,
+    summary_path: Path,
+    validation_path: Path,
+    output_path: Path,
+    validation_output_path: Path,
+) -> tuple[dict, dict]:
+    report = build_readiness_report(build_status(summary_path, validation_path))
+    validator = load_validator_module()
+    schema_path = Path(__file__).resolve().parent.parent / "schemas" / "federated-ci-summary-readiness.schema.json"
+    validation_report = write_readiness_artifacts(
+        report,
+        plan=build_readiness_artifact_write_plan(
+            output_path=output_path,
+            validation_output=validation_output_path,
+        ),
+        validator_module=validator,
+        schema_path=schema_path,
+    )
+    return report, validation_report
 
 
 def main() -> int:
@@ -58,20 +74,15 @@ def main() -> int:
     if not validation_output_path.is_absolute():
         validation_output_path = (Path.cwd() / validation_output_path).resolve()
 
-    status = build_status(summary_path, validation_path)
-    report = {
-        "generated_at_utc": now_utc(),
-        **status,
-    }
-    validator = load_validator_module()
-    schema_path = Path(__file__).resolve().parent.parent / "schemas" / "federated-ci-summary-readiness.schema.json"
-    schema_doc = validator.load_json(schema_path)
-    validation_report = validator.build_report(output_path, schema_path, report, schema_doc)
-    validator.write_json(validation_output_path, validation_report)
+    report, validation_report = assess_readiness_artifacts(
+        summary_path=summary_path,
+        validation_path=validation_path,
+        output_path=output_path,
+        validation_output_path=validation_output_path,
+    )
     if validation_report["verdict"] != "pass":
         print(f"federated summary readiness validation failed: {validation_report['errors']}", file=sys.stderr)
         return 1
-    write_json(output_path, report)
     print(f"report written: {output_path}")
     print(f"readiness_status={report['readiness_status']} ready={report['ready']}")
     return 0 if report["ready"] or not args.strict else 1

--- a/planningops/scripts/federation/federated_ci_runtime_state.py
+++ b/planningops/scripts/federation/federated_ci_runtime_state.py
@@ -100,6 +100,12 @@ class FederatedCISummaryArtifactWritePlan:
     latest_validation_output: Path | None
 
 
+@dataclass(frozen=True)
+class FederatedCIReadinessArtifactWritePlan:
+    output_path: Path
+    validation_output: Path
+
+
 def build_check_record(
     *,
     name: str,
@@ -148,6 +154,17 @@ def build_summary_artifact_write_plan(
         latest_path=latest_path,
         stamped_validation_output=stamped_validation_output,
         latest_validation_output=latest_validation_output,
+    )
+
+
+def build_readiness_artifact_write_plan(
+    *,
+    output_path: Path,
+    validation_output: Path,
+) -> FederatedCIReadinessArtifactWritePlan:
+    return FederatedCIReadinessArtifactWritePlan(
+        output_path=output_path,
+        validation_output=validation_output,
     )
 
 
@@ -309,3 +326,25 @@ def write_summary_artifacts(
         validator_module.write_json(plan.latest_validation_output, latest_report)
 
     return stamped_report, latest_report
+
+
+def build_readiness_report(status_doc: dict[str, Any], *, generated_at_utc: str | None = None) -> dict[str, Any]:
+    return {
+        "generated_at_utc": generated_at_utc or now_utc(),
+        **status_doc,
+    }
+
+
+def write_readiness_artifacts(
+    readiness_doc: dict[str, Any],
+    *,
+    plan: FederatedCIReadinessArtifactWritePlan,
+    validator_module: Any,
+    schema_path: Path,
+) -> dict[str, Any]:
+    schema_doc = validator_module.load_json(schema_path)
+    validation_report = validator_module.build_report(plan.output_path, schema_path, readiness_doc, schema_doc)
+    validator_module.write_json(plan.validation_output, validation_report)
+    if validation_report["verdict"] == "pass":
+        write_json(plan.output_path, readiness_doc)
+    return validation_report

--- a/planningops/scripts/federation/federated_ci_summary.py
+++ b/planningops/scripts/federation/federated_ci_summary.py
@@ -29,6 +29,19 @@ def load_validator_module():
     return module
 
 
+def load_readiness_module():
+    module_path = Path(__file__).resolve().parents[1] / "assess_federated_ci_summary_readiness.py"
+    spec = importlib.util.spec_from_file_location("assess_federated_ci_summary_readiness", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load readiness module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    parent_dir = str(module_path.parent)
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
+    spec.loader.exec_module(module)
+    return module
+
+
 def command_init(args: argparse.Namespace) -> int:
     summary_path = Path(args.summary)
     write_json(
@@ -105,6 +118,22 @@ def command_finalize(args: argparse.Namespace) -> int:
     return 0 if doc["verdict"] == "pass" else 1
 
 
+def command_write_readiness(args: argparse.Namespace) -> int:
+    readiness = load_readiness_module()
+    report, validation_report = readiness.assess_readiness_artifacts(
+        summary_path=Path(args.summary),
+        validation_path=Path(args.validation_report),
+        output_path=Path(args.output),
+        validation_output_path=Path(args.validation_output),
+    )
+    if validation_report["verdict"] != "pass":
+        print(f"federated summary readiness validation failed: {validation_report['errors']}", file=sys.stderr)
+        return 1
+    print(f"report written: {Path(args.output)}")
+    print(f"readiness_status={report['readiness_status']} ready={report['ready']}")
+    return 0 if report["ready"] or not args.strict else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Manage federated CI summary artifacts")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -135,6 +164,14 @@ def build_parser() -> argparse.ArgumentParser:
     finalize_parser.add_argument("--latest-validation-output", default=None)
     finalize_parser.add_argument("--keep-tmp", action="store_true")
     finalize_parser.set_defaults(func=command_finalize)
+
+    readiness_parser = subparsers.add_parser("write-readiness")
+    readiness_parser.add_argument("--summary", required=True)
+    readiness_parser.add_argument("--validation-report", required=True)
+    readiness_parser.add_argument("--output", required=True)
+    readiness_parser.add_argument("--validation-output", required=True)
+    readiness_parser.add_argument("--strict", action="store_true")
+    readiness_parser.set_defaults(func=command_write_readiness)
 
     return parser
 

--- a/planningops/scripts/run_federated_summary_ci_check.sh
+++ b/planningops/scripts/run_federated_summary_ci_check.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SUMMARY_HELPER="${ROOT_DIR}/planningops/scripts/federation/federated_ci_summary.py"
-READINESS_HELPER="${ROOT_DIR}/planningops/scripts/assess_federated_ci_summary_readiness.py"
 
 RUN_ID=""
 CONTRACT_CONFORMANCE_RESULT=""
@@ -249,20 +248,31 @@ python3 "${SUMMARY_HELPER}" finalize \
 summary_rc=$?
 set -e
 
-if [[ -f "${STAMPED_PATH}" && -f "${STAMPED_VALIDATION_PATH}" ]]; then
-  python3 "${READINESS_HELPER}" \
-    --summary "${STAMPED_PATH}" \
-    --validation-report "${STAMPED_VALIDATION_PATH}" \
-    --output "${STAMPED_READINESS_PATH}" \
-    --validation-output "${STAMPED_READINESS_VALIDATION_PATH}"
-fi
+write_readiness_artifact() {
+  local summary_path="$1"
+  local validation_path="$2"
+  local output_path="$3"
+  local validation_output_path="$4"
 
-if [[ -f "${LATEST_PATH}" && -f "${LATEST_VALIDATION_PATH}" ]]; then
-  python3 "${READINESS_HELPER}" \
-    --summary "${LATEST_PATH}" \
-    --validation-report "${LATEST_VALIDATION_PATH}" \
-    --output "${LATEST_READINESS_PATH}" \
-    --validation-output "${LATEST_READINESS_VALIDATION_PATH}"
-fi
+  if [[ -f "${summary_path}" && -f "${validation_path}" ]]; then
+    python3 "${SUMMARY_HELPER}" write-readiness \
+      --summary "${summary_path}" \
+      --validation-report "${validation_path}" \
+      --output "${output_path}" \
+      --validation-output "${validation_output_path}"
+  fi
+}
+
+write_readiness_artifact \
+  "${STAMPED_PATH}" \
+  "${STAMPED_VALIDATION_PATH}" \
+  "${STAMPED_READINESS_PATH}" \
+  "${STAMPED_READINESS_VALIDATION_PATH}"
+
+write_readiness_artifact \
+  "${LATEST_PATH}" \
+  "${LATEST_VALIDATION_PATH}" \
+  "${LATEST_READINESS_PATH}" \
+  "${LATEST_READINESS_VALIDATION_PATH}"
 
 exit "${summary_rc}"

--- a/planningops/scripts/test_run_federated_summary_ci_check_contract.sh
+++ b/planningops/scripts/test_run_federated_summary_ci_check_contract.sh
@@ -32,9 +32,9 @@ assert 'bash "${ROOT_DIR}/planningops/scripts/test_run_federated_summary_ci_chec
 assert 'python3 "${SUMMARY_HELPER}" init \\' in script, "federated-summary helper missing init command"
 assert 'python3 "${SUMMARY_HELPER}" append-check \\' in script, "federated-summary helper missing append-check command"
 assert 'python3 "${SUMMARY_HELPER}" finalize \\' in script, "federated-summary helper missing finalize command"
+assert 'python3 "${SUMMARY_HELPER}" write-readiness \\' in script, "federated-summary helper missing write-readiness command"
 assert 'append_job_result "federated-conformance" "federation" "${FEDERATED_CONFORMANCE_RESULT}"' in script, "federated-summary helper missing federated-conformance mapping"
 assert 'append_job_result "monday-harness-projection" "runtime" "${MONDAY_HARNESS_PROJECTION_RESULT}"' in script, "federated-summary helper missing monday projection mapping"
-assert 'python3 "${READINESS_HELPER}" \\' in script, "federated-summary helper missing readiness helper call"
 PY
 
 echo "federated summary ci check contract ok"


### PR DESCRIPTION
## Summary
- add a shared readiness write-plan/helper in the federated CI runtime state layer
- make both the standalone readiness assessor and the federated summary helper use the same readiness writer path
- route `run_federated_summary_ci_check.sh` through `federated_ci_summary.py write-readiness` instead of directly orchestrating readiness output writes

## Scope
- readiness write-plan helpers in `planningops/scripts/federation/federated_ci_runtime_state.py`
- readiness writer reuse in `planningops/scripts/assess_federated_ci_summary_readiness.py` and `planningops/scripts/federation/federated_ci_summary.py`
- federated summary CI helper wiring in `planningops/scripts/run_federated_summary_ci_check.sh`

## Linked Issues
- Closes #886

## Validation
- bash planningops/scripts/test_assess_federated_ci_summary_readiness.sh
- bash planningops/scripts/test_run_federated_summary_ci_check_smoke.sh
- bash planningops/scripts/test_run_federated_summary_ci_check_contract.sh
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- low: this changes helper orchestration paths, so the main regression risk is import/load behavior rather than artifact shape
- mitigated by keeping readiness JSON/validation schemas unchanged and covering both direct assessor and summary CI helper paths

## Review Checklist
- [x] readiness artifact and validation shapes remain unchanged at the contract level
- [x] federated summary CI helper now routes readiness writes through the shared helper path
- [x] summary, readiness, query, reconcile, and docs checks were run locally