### PR TITLE
refactor(federated-ci): route local matrix readiness writes

### DIFF
--- a/planningops/scripts/federation/federated_ci_matrix_local.sh
+++ b/planningops/scripts/federation/federated_ci_matrix_local.sh
@@ -408,7 +408,7 @@ finalize_summary() {
   local summary_rc=$?
 
   if [[ -f "${STAMPED_PATH}" && -f "${STAMPED_VALIDATION_PATH}" ]]; then
-    python3 "${ROOT_DIR}/planningops/scripts/assess_federated_ci_summary_readiness.py" \
+    python3 "${ROOT_DIR}/planningops/scripts/federation/federated_ci_summary.py" write-readiness \
       --summary "${STAMPED_PATH}" \
       --validation-report "${STAMPED_VALIDATION_PATH}" \
       --output "${STAMPED_READINESS_PATH}" \
@@ -419,7 +419,7 @@ finalize_summary() {
     fi
   fi
   if [[ -f "${LATEST_PATH}" && -f "${LATEST_VALIDATION_PATH}" ]]; then
-    python3 "${ROOT_DIR}/planningops/scripts/assess_federated_ci_summary_readiness.py" \
+    python3 "${ROOT_DIR}/planningops/scripts/federation/federated_ci_summary.py" write-readiness \
       --summary "${LATEST_PATH}" \
       --validation-report "${LATEST_VALIDATION_PATH}" \
       --output "${LATEST_READINESS_PATH}" \

--- a/planningops/scripts/test_federated_ci_local_matrix_mode_contract.sh
+++ b/planningops/scripts/test_federated_ci_local_matrix_mode_contract.sh
@@ -155,6 +155,7 @@ required_snippets = [
     'local restore_errexit=0',
     'case "$-" in',
     '*e*) restore_errexit=1 ;;',
+    'python3 "${ROOT_DIR}/planningops/scripts/federation/federated_ci_summary.py" write-readiness \\',
     'local stamped_readiness_rc=$?',
     'local latest_readiness_rc=$?',
     'if [[ "${restore_errexit}" -eq 1 ]]; then',
@@ -259,6 +260,8 @@ required_snippets = [
 
 for snippet in required_snippets:
     assert snippet in script, f"missing local matrix mode snippet: {snippet}"
+
+assert "assess_federated_ci_summary_readiness.py" not in script, "local matrix should route readiness writes through federated summary helper"
 
 for step in guardrails:
     snippet = step["local_matrix_command"]


### PR DESCRIPTION
## Summary
- route local federated CI matrix readiness emission through the shared `federated_ci_summary.py write-readiness` helper
- keep local matrix readiness exit-code behavior unchanged while aligning artifact writes with the GitHub helper path
- pin the helper path in the local matrix contract test and forbid the old direct assessor path

## Scope
- `planningops/scripts/federation/federated_ci_matrix_local.sh`
- `planningops/scripts/test_federated_ci_local_matrix_mode_contract.sh`

## Linked Issues
- Closes #888

## Validation
- `bash planningops/scripts/test_federated_ci_local_matrix_mode_contract.sh`
- `bash planningops/scripts/test_assess_federated_ci_summary_readiness.sh`
- `bash planningops/scripts/test_run_federated_summary_ci_check_contract.sh`
- `bash planningops/scripts/test_run_federated_summary_ci_check_smoke.sh`
- `bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh`
- `bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- low: this changes only the readiness writer entrypoint, not the readiness schema or readiness verdict logic
- mitigated by preserving the existing local matrix exit-code handling and adding a contract assertion against the old direct path

## Review Checklist
- [x] local matrix still finalizes summary before readiness writes
- [x] stamped and latest readiness artifacts still emit from the local matrix path
- [x] contract coverage now protects the shared helper route

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required because this is a local harness path refactor with no production runtime surface
