### PR TITLE
feat(query-engine): add readiness selectors

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -32,6 +32,10 @@ class SummaryRecord:
     shell_exit_code: int | None
     missing_required_checks: list[str]
     failure_domains: list[str]
+    failed_checks: list[str]
+    readiness_status: str
+    ready: bool | None
+    blocking_reasons: list[str]
     has_summary_validation: bool
     has_readiness: bool
     has_readiness_validation: bool
@@ -49,6 +53,15 @@ def resolve_root(path_text: str, default: Path) -> Path:
 
 def source_kind_for_summary_path(path: Path) -> str:
     return "latest" if path.name == "federated-ci-summary.json" else "stamped"
+
+
+def load_optional_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return load_json(path)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
 
 
 def build_sidecar_paths(
@@ -87,11 +100,12 @@ def build_summary_record(
         validation_root=validation_root,
         conformance_root=conformance_root,
     )
-    failures = [
-        str(check.get("domain"))
-        for check in list(summary_doc.get("checks") or [])
-        if check.get("verdict") == "fail" and isinstance(check.get("domain"), str)
-    ]
+    failing_checks = [check for check in list(summary_doc.get("checks") or []) if check.get("verdict") == "fail"]
+    failures = [str(check.get("domain")) for check in failing_checks if isinstance(check.get("domain"), str)]
+    failed_checks = [str(check.get("name") or "unknown") for check in failing_checks]
+    readiness_doc = load_optional_json(sidecars["readiness"])
+    raw_readiness_status = readiness_doc.get("readiness_status") if isinstance(readiness_doc, dict) else None
+    raw_ready = readiness_doc.get("ready") if isinstance(readiness_doc, dict) else None
     return SummaryRecord(
         run_id=run_id,
         family=infer_family_from_run_id(run_id),
@@ -104,6 +118,18 @@ def build_summary_record(
         shell_exit_code=summary_doc.get("shell_exit_code"),
         missing_required_checks=[str(name) for name in list(summary_doc.get("missing_required_checks") or [])],
         failure_domains=sorted(set(failures)),
+        failed_checks=failed_checks,
+        readiness_status=(
+            str(raw_readiness_status)
+            if isinstance(raw_readiness_status, str) and raw_readiness_status.strip()
+            else ("unknown" if sidecars["readiness"].exists() else "missing")
+        ),
+        ready=raw_ready if isinstance(raw_ready, bool) else None,
+        blocking_reasons=(
+            [str(reason) for reason in list(readiness_doc.get("blocking_reasons") or [])]
+            if isinstance(readiness_doc, dict)
+            else []
+        ),
         has_summary_validation=sidecars["summary_validation"].exists(),
         has_readiness=sidecars["readiness"].exists(),
         has_readiness_validation=sidecars["readiness_validation"].exists(),
@@ -155,7 +181,7 @@ def discover_summary_records(
 
 def render_runs_table(records: list[SummaryRecord]) -> str:
     lines = [
-        "family\trun_id\tsource\tverdict\tstatus\tchecks\ttimestamp",
+        "family\trun_id\tsource\tverdict\treadiness\tfailed_checks\tstatus\tchecks\ttimestamp",
     ]
     for record in records:
         lines.append(
@@ -165,6 +191,8 @@ def render_runs_table(records: list[SummaryRecord]) -> str:
                     record.run_id,
                     record.source_kind,
                     str(record.verdict or ""),
+                    record.readiness_status,
+                    ",".join(record.failed_checks),
                     str(record.overall_status or ""),
                     str(record.check_count if record.check_count is not None else ""),
                     record.timestamp_utc,
@@ -176,13 +204,14 @@ def render_runs_table(records: list[SummaryRecord]) -> str:
 
 def render_runs_markdown(records: list[SummaryRecord]) -> str:
     lines = [
-        "| family | run_id | source | verdict | status | checks | timestamp |",
-        "| --- | --- | --- | --- | --- | ---: | --- |",
+        "| family | run_id | source | verdict | readiness | failed_checks | status | checks | timestamp |",
+        "| --- | --- | --- | --- | --- | --- | --- | ---: | --- |",
     ]
     for record in records:
         lines.append(
             f"| {record.family} | `{record.run_id}` | {record.source_kind} | "
-            f"{record.verdict or ''} | {record.overall_status or ''} | "
+            f"{record.verdict or ''} | {record.readiness_status} | "
+            f"{', '.join(record.failed_checks)} | {record.overall_status or ''} | "
             f"{record.check_count if record.check_count is not None else ''} | {record.timestamp_utc} |"
         )
     return "\n".join(lines)
@@ -238,8 +267,11 @@ def parse_args() -> argparse.Namespace:
     runs_parser = subparsers.add_parser("runs", help="list indexed federated CI summaries")
     runs_parser.add_argument("--family", default=None)
     runs_parser.add_argument("--run-id-prefix", default=None)
+    runs_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="all")
     runs_parser.add_argument("--verdict", choices=["pass", "fail"], default=None)
     runs_parser.add_argument("--status", choices=["complete", "interrupted"], default=None)
+    runs_parser.add_argument("--readiness-status", choices=["ready", "blocked", "missing", "unknown"], default=None)
+    runs_parser.add_argument("--failed-check", default=None)
     runs_parser.add_argument("--limit", type=int, default=20)
     runs_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
     runs_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
@@ -273,10 +305,16 @@ def main() -> int:
             filtered = [record for record in filtered if record.family == args.family]
         if args.run_id_prefix:
             filtered = [record for record in filtered if record.run_id.startswith(args.run_id_prefix)]
+        if args.source_kind != "all":
+            filtered = [record for record in filtered if record.source_kind == args.source_kind]
         if args.verdict:
             filtered = [record for record in filtered if record.verdict == args.verdict]
         if args.status:
             filtered = [record for record in filtered if record.overall_status == args.status]
+        if args.readiness_status:
+            filtered = [record for record in filtered if record.readiness_status == args.readiness_status]
+        if args.failed_check:
+            filtered = [record for record in filtered if args.failed_check in record.failed_checks]
         filtered = filtered[: args.limit]
         if args.format == "json":
             print(json.dumps({"records": [asdict(record) for record in filtered]}, ensure_ascii=True, indent=2))

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -71,6 +71,38 @@ cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun26.json" <<'JSON'
 }
 JSON
 
+cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun27.json" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun27",
+  "started_at_utc": "2026-03-19T00:00:30+00:00",
+  "generated_at_utc": "2026-03-19T00:10:30+00:00",
+  "finished_at_utc": "2026-03-19T00:10:30+00:00",
+  "checks": [
+    {
+      "name": "runtime-handoff",
+      "domain": "runtime",
+      "exit_code": 1,
+      "verdict": "fail",
+      "stdout_log": "/tmp/runtime.stdout.log",
+      "stderr_log": "/tmp/runtime.stderr.log"
+    }
+  ],
+  "required_checks": [
+    "runtime-handoff"
+  ],
+  "overall_status": "complete",
+  "check_count": 1,
+  "missing_required_checks": [],
+  "failure_classification": {
+    "count": 1,
+    "domains": ["runtime"],
+    "deterministic_rule": "demo"
+  },
+  "verdict": "fail",
+  "shell_exit_code": 1
+}
+JSON
+
 cat >"$CI_DIR/federated-ci-summary.json" <<'JSON'
 {
   "run_id": "federated-ci-runtime-gates-20260319-rerun26",
@@ -148,16 +180,35 @@ Path(sys.argv[1]).write_bytes(b"\x00\xffappledouble")
 PY
 
 touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-validation.json"
-touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-readiness.json"
+cat >"$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-readiness.json" <<'JSON'
+{
+  "summary_run_id": "federated-ci-runtime-gates-20260319-rerun26",
+  "readiness_status": "ready",
+  "ready": true,
+  "blocking_reasons": []
+}
+JSON
 touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-readiness-validation.json"
 touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-tmp-reconcile.json"
 touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun26-summary-tmp-reconcile-validation.json"
+touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun27-summary-validation.json"
+cat >"$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun27-summary-readiness.json" <<'JSON'
+{
+  "summary_run_id": "federated-ci-runtime-gates-20260319-rerun27",
+  "readiness_status": "blocked",
+  "ready": false,
+  "blocking_reasons": ["summary_verdict_fail"]
+}
+JSON
+touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun27-summary-readiness-validation.json"
 touch "$VALIDATION_DIR/federated-ci-summary-validation.json"
 touch "$CONFORMANCE_DIR/federated-ci-runtime-gates-20260319-rerun26-contract.json"
 
 RUNS_OUTPUT="$TMP_DIR/runs.json"
 CHECKS_OUTPUT="$TMP_DIR/checks.json"
 CHECKS_AUTO_OUTPUT="$TMP_DIR/checks-auto.json"
+FAILED_OUTPUT="$TMP_DIR/failed.json"
+LATEST_OUTPUT="$TMP_DIR/latest.json"
 
 python3 "$QUERY_PATH" runs \
   --family federated-ci-runtime-gates \
@@ -173,25 +224,81 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 records = doc["records"]
-assert len(records) == 2, records
+assert len(records) == 3, records
 assert records[0]["source_kind"] == "latest", records
-assert records[1]["source_kind"] == "stamped", records
+assert records[1]["run_id"] == "federated-ci-runtime-gates-20260319-rerun27", records
+assert records[2]["source_kind"] == "stamped", records
 
 latest = records[0]
-stamped = records[1]
+failed = records[1]
+stamped = records[2]
 
 assert latest["has_summary_validation"] is True, latest
 assert latest["has_readiness"] is False, latest
+assert latest["readiness_status"] == "missing", latest
 assert latest["has_conformance_contract"] is True, latest
+
+assert failed["verdict"] == "fail", failed
+assert failed["source_kind"] == "stamped", failed
+assert failed["readiness_status"] == "blocked", failed
+assert failed["ready"] is False, failed
+assert failed["failed_checks"] == ["runtime-handoff"], failed
+assert failed["failure_domains"] == ["runtime"], failed
 
 assert stamped["run_id"] == "federated-ci-runtime-gates-20260319-rerun26", stamped
 assert stamped["family"] == "federated-ci-runtime-gates", stamped
 assert stamped["has_summary_validation"] is True, stamped
 assert stamped["has_readiness"] is True, stamped
+assert stamped["readiness_status"] == "ready", stamped
+assert stamped["ready"] is True, stamped
 assert stamped["has_readiness_validation"] is True, stamped
 assert stamped["has_reconcile_report"] is True, stamped
 assert stamped["has_reconcile_validation"] is True, stamped
 assert stamped["has_conformance_contract"] is True, stamped
+PY
+
+python3 "$QUERY_PATH" runs \
+  --family federated-ci-runtime-gates \
+  --source-kind stamped \
+  --readiness-status blocked \
+  --failed-check runtime-handoff \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$FAILED_OUTPUT"
+
+python3 - <<'PY' "$FAILED_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+assert records[0]["run_id"] == "federated-ci-runtime-gates-20260319-rerun27", records
+assert records[0]["readiness_status"] == "blocked", records
+assert records[0]["failed_checks"] == ["runtime-handoff"], records
+PY
+
+python3 "$QUERY_PATH" runs \
+  --family federated-ci-runtime-gates \
+  --source-kind latest \
+  --readiness-status missing \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$LATEST_OUTPUT"
+
+python3 - <<'PY' "$LATEST_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+assert records[0]["source_kind"] == "latest", records
+assert records[0]["readiness_status"] == "missing", records
 PY
 
 python3 "$QUERY_PATH" checks \


### PR DESCRIPTION
## Summary
- enrich federated CI query records with readiness state, failed check names, and blocking reasons
- add `runs` selectors for `--source-kind`, `--readiness-status`, and `--failed-check`
- extend the query contract fixture so stamped/latest, ready/blocked/missing, and failed-check selection are all covered

## Scope
- `planningops/scripts/federation/query_federated_ci_artifacts.py`
- `planningops/scripts/test_query_federated_ci_artifacts.sh`

## Linked Issues
- Closes #890

## Validation
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- low: this is a read-side selector expansion only; it does not change harness write semantics or artifact schemas
- mitigated by keeping the existing `checks` behavior intact and expanding fixture-backed query assertions instead of changing live artifact families

## Review Checklist
- [x] latest vs stamped run selection is explicit on `runs`
- [x] readiness state is visible without reopening readiness JSON by hand
- [x] failed check name filtering works against indexed summary checks

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required because this change only expands local/CLI read-side querying over existing artifacts
