### PR TITLE
feat(query-engine): add reconcile-status subcommand

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -9,7 +9,15 @@ from pathlib import Path
 import sys
 from typing import Any
 
-from federated_ci_runtime_state import infer_family_from_run_id, is_summary_document, load_json, summary_timestamp
+from federated_ci_runtime_state import (
+    build_reconcile_report,
+    build_reconcile_state,
+    infer_family_from_run_id,
+    is_summary_document,
+    load_json,
+    summary_timestamp,
+    validate_checkpoint_doc,
+)
 
 
 # /planningops/scripts/federation lives one level below the repo's planningops package.
@@ -44,11 +52,36 @@ class SummaryRecord:
     has_conformance_contract: bool
 
 
+@dataclass(frozen=True)
+class ReconcileStatusRecord:
+    generated_at_utc: str
+    run_id: str
+    family: str
+    source_kind: str
+    summary_path: str
+    checkpoint_path: str
+    previous_report_path: str | None
+    check_name: str | None
+    status: str
+    restored: bool
+    reasons: list[str]
+    reconcile_count: int
+    restored_check_names: list[str]
+    checkpoint_check_count: int
+    summary_check_count: int | None
+
+
 def resolve_root(path_text: str, default: Path) -> Path:
     candidate = Path(path_text)
     if not candidate.is_absolute():
         candidate = (WORKSPACE_ROOT / candidate).resolve()
     return candidate if path_text else default
+
+
+def resolve_optional_path(path_text: str | None) -> Path | None:
+    if path_text is None:
+        return None
+    return resolve_root(path_text, WORKSPACE_ROOT)
 
 
 def source_kind_for_summary_path(path: Path) -> str:
@@ -260,6 +293,168 @@ def render_checks_table(record: SummaryRecord, checks: list[dict[str, Any]]) -> 
     return "\n".join(lines)
 
 
+def render_reconcile_table(record: ReconcileStatusRecord) -> str:
+    return "\n".join(
+        [
+            "family\trun_id\tsource\tstatus\trestored\treconcile_count\tcheck_name\treasons\trestored_checks",
+            "\t".join(
+                [
+                    record.family,
+                    record.run_id,
+                    record.source_kind,
+                    record.status,
+                    "true" if record.restored else "false",
+                    str(record.reconcile_count),
+                    str(record.check_name or ""),
+                    ",".join(record.reasons),
+                    ",".join(record.restored_check_names),
+                ]
+            ),
+        ]
+    )
+
+
+def render_reconcile_markdown(record: ReconcileStatusRecord) -> str:
+    lines = [
+        f"# `{record.run_id}` reconcile status",
+        "",
+        f"- family: `{record.family}`",
+        f"- source_kind: `{record.source_kind}`",
+        f"- status: `{record.status}`",
+        f"- restored: `{str(record.restored).lower()}`",
+        f"- reconcile_count: `{record.reconcile_count}`",
+        f"- check_name: `{record.check_name or ''}`",
+        f"- summary_path: `{record.summary_path}`",
+        f"- checkpoint_path: `{record.checkpoint_path}`",
+    ]
+    if record.previous_report_path is not None:
+        lines.append(f"- previous_report_path: `{record.previous_report_path}`")
+    lines.extend(
+        [
+            "",
+            "| reasons | restored_check_names | checkpoint_check_count | summary_check_count |",
+            "| --- | --- | ---: | ---: |",
+            (
+                f"| {', '.join(record.reasons)} | {', '.join(record.restored_check_names)} | "
+                f"{record.checkpoint_check_count} | "
+                f"{record.summary_check_count if record.summary_check_count is not None else ''} |"
+            ),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_reconcile_status_record(
+    *,
+    summary_path: Path,
+    checkpoint_path: Path,
+    previous_report_path: Path | None,
+    summary_doc: dict[str, Any] | None,
+    checkpoint_doc: dict[str, Any],
+    check_name: str | None,
+    source_kind: str,
+) -> ReconcileStatusRecord:
+    previous_doc = load_optional_json(previous_report_path) if previous_report_path is not None else None
+    reconcile_state = build_reconcile_state(
+        summary_doc,
+        checkpoint_doc,
+        previous_report_doc=previous_doc,
+        check_name=check_name,
+    )
+    report = build_reconcile_report(
+        summary_path=summary_path,
+        checkpoint_path=checkpoint_path,
+        output_path=previous_report_path,
+        checkpoint_doc=checkpoint_doc,
+        summary_doc=summary_doc,
+        reconcile_state=reconcile_state,
+    )
+    return ReconcileStatusRecord(
+        generated_at_utc=str(report["generated_at_utc"]),
+        run_id=str(report["run_id"]),
+        family=infer_family_from_run_id(str(report["run_id"])),
+        source_kind=source_kind,
+        summary_path=str(report["summary_path"]),
+        checkpoint_path=str(report["checkpoint_path"]),
+        previous_report_path=None if previous_report_path is None else str(previous_report_path.resolve()),
+        check_name=report["check_name"],
+        status=str(report["status"]),
+        restored=bool(report["restored"]),
+        reasons=[str(reason) for reason in list(report.get("reasons") or [])],
+        reconcile_count=int(report["reconcile_count"]),
+        restored_check_names=[str(name) for name in list(report.get("restored_check_names") or [])],
+        checkpoint_check_count=int(report["checkpoint_check_count"]),
+        summary_check_count=(
+            int(report["summary_check_count"]) if isinstance(report.get("summary_check_count"), int) else None
+        ),
+    )
+
+
+def resolve_reconcile_status_record(
+    *,
+    args: argparse.Namespace,
+    records: list[SummaryRecord],
+    ci_root: Path,
+    validation_root: Path,
+    conformance_root: Path,
+) -> ReconcileStatusRecord:
+    source_kind = "stamped"
+    summary_path: Path
+    summary_doc: dict[str, Any] | None
+    run_id: str | None = None
+
+    if args.summary is not None:
+        summary_path = resolve_root(args.summary, WORKSPACE_ROOT)
+        summary_doc = load_optional_json(summary_path)
+        source_kind = source_kind_for_summary_path(summary_path)
+        if isinstance(summary_doc, dict) and is_summary_document(summary_doc):
+            run_id = str(summary_doc["run_id"])
+    else:
+        record = select_record(records=records, run_id=args.run_id, source_kind=args.source_kind)
+        if record is None:
+            raise ValueError(f"run not found: {args.run_id}")
+        summary_path = Path(record.summary_path)
+        summary_doc = load_optional_json(summary_path)
+        run_id = record.run_id
+        source_kind = record.source_kind
+
+    if args.checkpoint is None and run_id is None:
+        raise ValueError("checkpoint required when summary path does not contain a valid federated CI summary document")
+
+    checkpoint_path = (
+        resolve_optional_path(args.checkpoint)
+        if args.checkpoint is not None
+        else (ci_root / f"{run_id}.checkpoint.json").resolve()
+    )
+    if checkpoint_path is None or not checkpoint_path.exists():
+        raise ValueError(f"checkpoint missing: {checkpoint_path}")
+    checkpoint_doc = load_json(checkpoint_path)
+    checkpoint_errors = validate_checkpoint_doc(checkpoint_doc)
+    if checkpoint_errors:
+        raise ValueError(f"invalid checkpoint: {checkpoint_errors}")
+    if run_id is None:
+        run_id = str(checkpoint_doc["run_id"])
+
+    previous_report_path = resolve_optional_path(args.previous_report)
+    if previous_report_path is None:
+        previous_report_path = build_sidecar_paths(
+            run_id=run_id,
+            source_kind=source_kind,
+            validation_root=validation_root,
+            conformance_root=conformance_root,
+        )["reconcile_report"]
+
+    return build_reconcile_status_record(
+        summary_path=summary_path,
+        checkpoint_path=checkpoint_path,
+        previous_report_path=previous_report_path,
+        summary_doc=summary_doc,
+        checkpoint_doc=checkpoint_doc,
+        check_name=args.check_name,
+        source_kind=source_kind,
+    )
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Query federated CI summary artifacts from planningops artifact roots")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -285,6 +480,22 @@ def parse_args() -> argparse.Namespace:
     checks_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     checks_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     checks_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+
+    reconcile_parser = subparsers.add_parser(
+        "reconcile-status",
+        help="show tmp/checkpoint reconcile state for one federated CI run or explicit summary/checkpoint pair",
+    )
+    reconcile_target = reconcile_parser.add_mutually_exclusive_group(required=True)
+    reconcile_target.add_argument("--run-id", default=None)
+    reconcile_target.add_argument("--summary", default=None)
+    reconcile_parser.add_argument("--checkpoint", default=None)
+    reconcile_parser.add_argument("--previous-report", default=None)
+    reconcile_parser.add_argument("--check-name", default=None)
+    reconcile_parser.add_argument("--source-kind", choices=["auto", "stamped", "latest"], default="auto")
+    reconcile_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    reconcile_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    reconcile_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    reconcile_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     return parser.parse_args()
 
 
@@ -323,6 +534,27 @@ def main() -> int:
             print(render_runs_markdown(filtered))
             return 0
         print(render_runs_table(filtered))
+        return 0
+
+    if args.command == "reconcile-status":
+        try:
+            record = resolve_reconcile_status_record(
+                args=args,
+                records=records,
+                ci_root=ci_root,
+                validation_root=validation_root,
+                conformance_root=conformance_root,
+            )
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        if args.format == "json":
+            print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_reconcile_markdown(record))
+            return 0
+        print(render_reconcile_table(record))
         return 0
 
     record = select_record(records=records, run_id=args.run_id, source_kind=args.source_kind)

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -167,8 +167,29 @@ JSON
 cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun26.checkpoint.json" <<'JSON'
 {
   "run_id": "federated-ci-runtime-gates-20260319-rerun26",
-  "checks": [],
-  "required_checks": []
+  "started_at_utc": "2026-03-19T00:00:00+00:00",
+  "checks": [
+    {
+      "name": "contract-conformance",
+      "domain": "contract",
+      "exit_code": 0,
+      "verdict": "pass",
+      "stdout_log": "/tmp/contract.stdout.log",
+      "stderr_log": "/tmp/contract.stderr.log"
+    },
+    {
+      "name": "loop-guardrails",
+      "domain": "policy",
+      "exit_code": 0,
+      "verdict": "pass",
+      "stdout_log": "/tmp/policy.stdout.log",
+      "stderr_log": "/tmp/policy.stderr.log"
+    }
+  ],
+  "required_checks": [
+    "contract-conformance",
+    "loop-guardrails"
+  ]
 }
 JSON
 
@@ -209,6 +230,11 @@ CHECKS_OUTPUT="$TMP_DIR/checks.json"
 CHECKS_AUTO_OUTPUT="$TMP_DIR/checks-auto.json"
 FAILED_OUTPUT="$TMP_DIR/failed.json"
 LATEST_OUTPUT="$TMP_DIR/latest.json"
+RECONCILE_HEALTHY_OUTPUT="$TMP_DIR/reconcile-healthy.json"
+RECONCILE_RESTORED_OUTPUT="$TMP_DIR/reconcile-restored.json"
+RESTORED_SUMMARY_PATH="$TMP_DIR/federated-ci-runtime-gates-20260319-rerun27.tmp-query.json"
+RESTORED_CHECKPOINT_PATH="$TMP_DIR/federated-ci-runtime-gates-20260319-rerun27.checkpoint.json"
+RESTORED_PREVIOUS_PATH="$TMP_DIR/federated-ci-runtime-gates-20260319-rerun27-summary-tmp-reconcile.json"
 
 python3 "$QUERY_PATH" runs \
   --family federated-ci-runtime-gates \
@@ -299,6 +325,98 @@ records = doc["records"]
 assert len(records) == 1, records
 assert records[0]["source_kind"] == "latest", records
 assert records[0]["readiness_status"] == "missing", records
+PY
+
+python3 "$QUERY_PATH" reconcile-status \
+  --run-id federated-ci-runtime-gates-20260319-rerun26 \
+  --source-kind stamped \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$RECONCILE_HEALTHY_OUTPUT"
+
+python3 - <<'PY' "$RECONCILE_HEALTHY_OUTPUT" "$CI_DIR/federated-ci-runtime-gates-20260319-rerun26.checkpoint.json"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["run_id"] == "federated-ci-runtime-gates-20260319-rerun26", record
+assert record["source_kind"] == "stamped", record
+assert record["status"] == "healthy", record
+assert record["restored"] is False, record
+assert record["reconcile_count"] == 0, record
+assert record["reasons"] == [], record
+assert record["restored_check_names"] == [], record
+assert record["checkpoint_path"] == str(Path(sys.argv[2]).resolve()), record
+assert record["summary_check_count"] == 2, record
+assert record["checkpoint_check_count"] == 2, record
+PY
+
+cat >"$RESTORED_SUMMARY_PATH" <<'JSON'
+{
+  "checks": []
+}
+JSON
+
+cat >"$RESTORED_CHECKPOINT_PATH" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun27",
+  "started_at_utc": "2026-03-19T00:00:30+00:00",
+  "checks": [
+    {
+      "name": "runtime-handoff",
+      "domain": "runtime",
+      "exit_code": 1,
+      "verdict": "fail",
+      "stdout_log": "/tmp/runtime.stdout.log",
+      "stderr_log": "/tmp/runtime.stderr.log"
+    }
+  ],
+  "required_checks": [
+    "runtime-handoff"
+  ]
+}
+JSON
+
+cat >"$RESTORED_PREVIOUS_PATH" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun27",
+  "restored_check_names": [
+    "contract-conformance"
+  ]
+}
+JSON
+
+python3 "$QUERY_PATH" reconcile-status \
+  --summary "$RESTORED_SUMMARY_PATH" \
+  --checkpoint "$RESTORED_CHECKPOINT_PATH" \
+  --previous-report "$RESTORED_PREVIOUS_PATH" \
+  --check-name runtime-handoff \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$RECONCILE_RESTORED_OUTPUT"
+
+python3 - <<'PY' "$RECONCILE_RESTORED_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["run_id"] == "federated-ci-runtime-gates-20260319-rerun27", record
+assert record["status"] == "restored", record
+assert record["restored"] is True, record
+assert "summary_missing_run_id" in record["reasons"], record
+assert "summary_missing_started_at_utc" in record["reasons"], record
+assert "summary_missing_required_checks" in record["reasons"], record
+assert record["check_name"] == "runtime-handoff", record
+assert record["reconcile_count"] == 2, record
+assert record["restored_check_names"] == ["contract-conformance", "runtime-handoff"], record
+assert record["summary_check_count"] == 0, record
+assert record["checkpoint_check_count"] == 1, record
 PY
 
 python3 "$QUERY_PATH" checks \


### PR DESCRIPTION
## Summary
- add a `reconcile-status` subcommand to the federated CI artifact query CLI
- reuse the shared reconcile state helpers instead of re-implementing tmp/checkpoint logic
- extend the query contract fixture with healthy and restored reconcile cases

## Scope
- `/planningops/scripts/federation/query_federated_ci_artifacts.py`
- `/planningops/scripts/test_query_federated_ci_artifacts.sh`

## Linked Issues
- Closes #892

## Validation
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh`
- `bash planningops/scripts/test_reconcile_federated_ci_summary_tmp.sh`
- `bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- query read-side now accepts explicit summary/checkpoint paths, so future producer-side naming changes need to keep the path derivation contract stable
- restored reconcile counts depend on prior report shape staying compatible with the shared runtime helper

## Review Checklist
- [x] `reconcile-status` works with indexed run selection
- [x] `reconcile-status` works with explicit summary/checkpoint inputs
- [x] existing `runs` and `checks` queries remain green
- [x] unrelated tracked artifact residue was not staged

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required for this query/read-side only change beyond the validation commands above.
