### PR TITLE
feat(query-engine): surface reconcile state in runs index

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -44,6 +44,12 @@ class SummaryRecord:
     readiness_status: str
     ready: bool | None
     blocking_reasons: list[str]
+    reconcile_status: str
+    reconcile_count: int | None
+    reconcile_artifact_state: str
+    reconcile_validation_verdict: str
+    reconcile_validation_state: str
+    checkpoint_state: str
     has_summary_validation: bool
     has_readiness: bool
     has_readiness_validation: bool
@@ -136,8 +142,87 @@ def build_sidecar_paths(
     }
 
 
+def build_runs_reconcile_fields(
+    *,
+    ci_root: Path,
+    summary_path: Path,
+    summary_doc: dict[str, Any],
+    validation_root: Path,
+    conformance_root: Path,
+) -> dict[str, Any]:
+    run_id = str(summary_doc["run_id"])
+    source_kind = source_kind_for_summary_path(summary_path)
+    sidecars = build_sidecar_paths(
+        run_id=run_id,
+        source_kind=source_kind,
+        validation_root=validation_root,
+        conformance_root=conformance_root,
+    )
+    checkpoint_path = (ci_root / f"{run_id}.checkpoint.json").resolve()
+    if not checkpoint_path.exists():
+        record = build_unknown_reconcile_status_record(
+            summary_path=summary_path,
+            checkpoint_path=checkpoint_path,
+            previous_report_path=sidecars["reconcile_report"],
+            reconcile_validation_path=sidecars["reconcile_validation"],
+            run_id=run_id,
+            source_kind=source_kind,
+            timestamp_utc=summary_timestamp(summary_doc),
+            checkpoint_state="missing",
+            reasons=["checkpoint_missing"],
+        )
+    else:
+        checkpoint_doc = load_optional_json(checkpoint_path)
+        if checkpoint_doc is None:
+            record = build_unknown_reconcile_status_record(
+                summary_path=summary_path,
+                checkpoint_path=checkpoint_path,
+                previous_report_path=sidecars["reconcile_report"],
+                reconcile_validation_path=sidecars["reconcile_validation"],
+                run_id=run_id,
+                source_kind=source_kind,
+                timestamp_utc=summary_timestamp(summary_doc),
+                checkpoint_state="invalid",
+                reasons=["checkpoint_invalid_json"],
+            )
+        else:
+            checkpoint_errors = validate_checkpoint_doc(checkpoint_doc)
+            if checkpoint_errors:
+                record = build_unknown_reconcile_status_record(
+                    summary_path=summary_path,
+                    checkpoint_path=checkpoint_path,
+                    previous_report_path=sidecars["reconcile_report"],
+                    reconcile_validation_path=sidecars["reconcile_validation"],
+                    run_id=run_id,
+                    source_kind=source_kind,
+                    timestamp_utc=summary_timestamp(summary_doc),
+                    checkpoint_state="invalid",
+                    reasons=[f"checkpoint_invalid:{error}" for error in checkpoint_errors],
+                )
+            else:
+                record = build_reconcile_status_record(
+                    summary_path=summary_path,
+                    checkpoint_path=checkpoint_path,
+                    previous_report_path=sidecars["reconcile_report"],
+                    reconcile_validation_path=sidecars["reconcile_validation"],
+                    summary_doc=summary_doc,
+                    checkpoint_doc=checkpoint_doc,
+                    check_name=None,
+                    source_kind=source_kind,
+                )
+    return {
+        "reconcile_status": record.status,
+        "reconcile_count": record.reconcile_count,
+        "reconcile_artifact_state": record.reconcile_artifact_state,
+        "reconcile_validation_verdict": record.reconcile_validation_verdict,
+        "reconcile_validation_state": record.reconcile_validation_state,
+        "checkpoint_state": record.checkpoint_state,
+    }
+
+
 def build_summary_record(
     *,
+    ci_root: Path,
     summary_path: Path,
     summary_doc: dict[str, Any],
     validation_root: Path,
@@ -157,6 +242,13 @@ def build_summary_record(
     readiness_doc = load_optional_json(sidecars["readiness"])
     raw_readiness_status = readiness_doc.get("readiness_status") if isinstance(readiness_doc, dict) else None
     raw_ready = readiness_doc.get("ready") if isinstance(readiness_doc, dict) else None
+    reconcile_fields = build_runs_reconcile_fields(
+        ci_root=ci_root,
+        summary_path=summary_path,
+        summary_doc=summary_doc,
+        validation_root=validation_root,
+        conformance_root=conformance_root,
+    )
     return SummaryRecord(
         run_id=run_id,
         family=infer_family_from_run_id(run_id),
@@ -181,6 +273,16 @@ def build_summary_record(
             if isinstance(readiness_doc, dict)
             else []
         ),
+        reconcile_status=str(reconcile_fields["reconcile_status"]),
+        reconcile_count=(
+            int(reconcile_fields["reconcile_count"])
+            if isinstance(reconcile_fields["reconcile_count"], int)
+            else None
+        ),
+        reconcile_artifact_state=str(reconcile_fields["reconcile_artifact_state"]),
+        reconcile_validation_verdict=str(reconcile_fields["reconcile_validation_verdict"]),
+        reconcile_validation_state=str(reconcile_fields["reconcile_validation_state"]),
+        checkpoint_state=str(reconcile_fields["checkpoint_state"]),
         has_summary_validation=sidecars["summary_validation"].exists(),
         has_readiness=sidecars["readiness"].exists(),
         has_readiness_validation=sidecars["readiness_validation"].exists(),
@@ -212,6 +314,7 @@ def discover_summary_records(
             continue
         records.append(
             build_summary_record(
+                ci_root=ci_root,
                 summary_path=path,
                 summary_doc=doc,
                 validation_root=validation_root,
@@ -232,7 +335,7 @@ def discover_summary_records(
 
 def render_runs_table(records: list[SummaryRecord]) -> str:
     lines = [
-        "family\trun_id\tsource\tverdict\treadiness\tfailed_checks\tstatus\tchecks\ttimestamp",
+        "family\trun_id\tsource\tverdict\treadiness\treconcile\tartifact_state\tcheckpoint\tfailed_checks\tstatus\tchecks\ttimestamp",
     ]
     for record in records:
         lines.append(
@@ -243,6 +346,9 @@ def render_runs_table(records: list[SummaryRecord]) -> str:
                     record.source_kind,
                     str(record.verdict or ""),
                     record.readiness_status,
+                    record.reconcile_status,
+                    record.reconcile_artifact_state,
+                    record.checkpoint_state,
                     ",".join(record.failed_checks),
                     str(record.overall_status or ""),
                     str(record.check_count if record.check_count is not None else ""),
@@ -255,13 +361,14 @@ def render_runs_table(records: list[SummaryRecord]) -> str:
 
 def render_runs_markdown(records: list[SummaryRecord]) -> str:
     lines = [
-        "| family | run_id | source | verdict | readiness | failed_checks | status | checks | timestamp |",
-        "| --- | --- | --- | --- | --- | --- | --- | ---: | --- |",
+        "| family | run_id | source | verdict | readiness | reconcile | artifact_state | checkpoint | failed_checks | status | checks | timestamp |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- |",
     ]
     for record in records:
         lines.append(
             f"| {record.family} | `{record.run_id}` | {record.source_kind} | "
-            f"{record.verdict or ''} | {record.readiness_status} | "
+            f"{record.verdict or ''} | {record.readiness_status} | {record.reconcile_status} | "
+            f"{record.reconcile_artifact_state} | {record.checkpoint_state} | "
             f"{', '.join(record.failed_checks)} | {record.overall_status or ''} | "
             f"{record.check_count if record.check_count is not None else ''} | {record.timestamp_utc} |"
         )
@@ -828,6 +935,10 @@ def parse_args() -> argparse.Namespace:
     runs_parser.add_argument("--verdict", choices=["pass", "fail"], default=None)
     runs_parser.add_argument("--status", choices=["complete", "interrupted"], default=None)
     runs_parser.add_argument("--readiness-status", choices=["ready", "blocked", "missing", "unknown"], default=None)
+    runs_parser.add_argument("--reconcile-status", choices=["healthy", "restored", "unknown"], default=None)
+    runs_parser.add_argument("--reconcile-artifact-state", choices=["fresh", "stale", "missing"], default=None)
+    runs_parser.add_argument("--reconcile-validation-state", choices=["fresh", "stale", "missing"], default=None)
+    runs_parser.add_argument("--checkpoint-state", choices=["present", "missing", "invalid"], default=None)
     runs_parser.add_argument("--failed-check", default=None)
     runs_parser.add_argument("--limit", type=int, default=20)
     runs_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
@@ -892,6 +1003,16 @@ def main() -> int:
             filtered = [record for record in filtered if record.overall_status == args.status]
         if args.readiness_status:
             filtered = [record for record in filtered if record.readiness_status == args.readiness_status]
+        if args.reconcile_status:
+            filtered = [record for record in filtered if record.reconcile_status == args.reconcile_status]
+        if args.reconcile_artifact_state:
+            filtered = [record for record in filtered if record.reconcile_artifact_state == args.reconcile_artifact_state]
+        if args.reconcile_validation_state:
+            filtered = [
+                record for record in filtered if record.reconcile_validation_state == args.reconcile_validation_state
+            ]
+        if args.checkpoint_state:
+            filtered = [record for record in filtered if record.checkpoint_state == args.checkpoint_state]
         if args.failed_check:
             filtered = [record for record in filtered if args.failed_check in record.failed_checks]
         filtered = filtered[: args.limit]

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -138,6 +138,38 @@ cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun28.json" <<'JSON'
 }
 JSON
 
+cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun29.json" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun29",
+  "started_at_utc": "2026-03-19T00:00:50+00:00",
+  "generated_at_utc": "2026-03-19T00:10:50+00:00",
+  "finished_at_utc": "2026-03-19T00:10:50+00:00",
+  "checks": [
+    {
+      "name": "provider-profile",
+      "domain": "infra",
+      "exit_code": 0,
+      "verdict": "pass",
+      "stdout_log": "/tmp/provider.stdout.log",
+      "stderr_log": "/tmp/provider.stderr.log"
+    }
+  ],
+  "required_checks": [
+    "provider-profile"
+  ],
+  "overall_status": "complete",
+  "check_count": 1,
+  "missing_required_checks": [],
+  "failure_classification": {
+    "count": 0,
+    "domains": [],
+    "deterministic_rule": "demo"
+  },
+  "verdict": "pass",
+  "shell_exit_code": 0
+}
+JSON
+
 cat >"$CI_DIR/federated-ci-summary.json" <<'JSON'
 {
   "run_id": "federated-ci-runtime-gates-20260319-rerun26",
@@ -342,10 +374,12 @@ CHECKS_OUTPUT="$TMP_DIR/checks.json"
 CHECKS_AUTO_OUTPUT="$TMP_DIR/checks-auto.json"
 FAILED_OUTPUT="$TMP_DIR/failed.json"
 LATEST_OUTPUT="$TMP_DIR/latest.json"
+RUNS_RECONCILE_OUTPUT="$TMP_DIR/runs-reconcile.json"
 RECONCILE_HEALTHY_OUTPUT="$TMP_DIR/reconcile-healthy.json"
 RECONCILE_RESTORED_OUTPUT="$TMP_DIR/reconcile-restored.json"
 RECONCILE_SCAN_OUTPUT="$TMP_DIR/reconcile-scan.json"
 RECONCILE_SCAN_FRESH_OUTPUT="$TMP_DIR/reconcile-scan-fresh.json"
+RUNS_UNKNOWN_OUTPUT="$TMP_DIR/runs-unknown.json"
 RESTORED_SUMMARY_PATH="$TMP_DIR/federated-ci-runtime-gates-20260319-rerun27.tmp-query.json"
 RESTORED_CHECKPOINT_PATH="$TMP_DIR/federated-ci-runtime-gates-20260319-rerun27.checkpoint.json"
 RESTORED_PREVIOUS_PATH="$TMP_DIR/federated-ci-runtime-gates-20260319-rerun27-summary-tmp-reconcile.json"
@@ -364,25 +398,42 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 records = doc["records"]
-assert len(records) == 4, records
+assert len(records) == 5, records
 assert records[0]["source_kind"] == "latest", records
-assert records[1]["run_id"] == "federated-ci-runtime-gates-20260319-rerun28", records
-assert records[2]["run_id"] == "federated-ci-runtime-gates-20260319-rerun27", records
-assert records[3]["source_kind"] == "stamped", records
+assert records[1]["run_id"] == "federated-ci-runtime-gates-20260319-rerun29", records
+assert records[2]["run_id"] == "federated-ci-runtime-gates-20260319-rerun28", records
+assert records[3]["run_id"] == "federated-ci-runtime-gates-20260319-rerun27", records
+assert records[4]["source_kind"] == "stamped", records
 
 latest = records[0]
-restored = records[1]
-failed = records[2]
-stamped = records[3]
+unknown = records[1]
+restored = records[2]
+failed = records[3]
+stamped = records[4]
 
 assert latest["has_summary_validation"] is True, latest
 assert latest["has_readiness"] is False, latest
 assert latest["readiness_status"] == "missing", latest
 assert latest["has_conformance_contract"] is True, latest
+assert latest["reconcile_status"] == "restored", latest
+assert latest["reconcile_artifact_state"] == "missing", latest
+assert latest["reconcile_validation_state"] == "missing", latest
+assert latest["checkpoint_state"] == "present", latest
+
+assert unknown["run_id"] == "federated-ci-runtime-gates-20260319-rerun29", unknown
+assert unknown["reconcile_status"] == "unknown", unknown
+assert unknown["reconcile_artifact_state"] == "missing", unknown
+assert unknown["reconcile_validation_state"] == "missing", unknown
+assert unknown["checkpoint_state"] == "missing", unknown
 
 assert restored["run_id"] == "federated-ci-runtime-gates-20260319-rerun28", restored
 assert restored["check_count"] == 1, restored
 assert restored["missing_required_checks"] == ["loop-guardrails"], restored
+assert restored["reconcile_status"] == "restored", restored
+assert restored["reconcile_artifact_state"] == "fresh", restored
+assert restored["reconcile_validation_verdict"] == "pass", restored
+assert restored["reconcile_validation_state"] == "fresh", restored
+assert restored["checkpoint_state"] == "present", restored
 
 assert failed["verdict"] == "fail", failed
 assert failed["source_kind"] == "stamped", failed
@@ -390,6 +441,9 @@ assert failed["readiness_status"] == "blocked", failed
 assert failed["ready"] is False, failed
 assert failed["failed_checks"] == ["runtime-handoff"], failed
 assert failed["failure_domains"] == ["runtime"], failed
+assert failed["reconcile_status"] == "healthy", failed
+assert failed["reconcile_artifact_state"] == "missing", failed
+assert failed["checkpoint_state"] == "present", failed
 
 assert stamped["run_id"] == "federated-ci-runtime-gates-20260319-rerun26", stamped
 assert stamped["family"] == "federated-ci-runtime-gates", stamped
@@ -401,6 +455,11 @@ assert stamped["has_readiness_validation"] is True, stamped
 assert stamped["has_reconcile_report"] is True, stamped
 assert stamped["has_reconcile_validation"] is True, stamped
 assert stamped["has_conformance_contract"] is True, stamped
+assert stamped["reconcile_status"] == "healthy", stamped
+assert stamped["reconcile_artifact_state"] == "stale", stamped
+assert stamped["reconcile_validation_verdict"] == "unknown", stamped
+assert stamped["reconcile_validation_state"] == "stale", stamped
+assert stamped["checkpoint_state"] == "present", stamped
 PY
 
 python3 "$QUERY_PATH" runs \
@@ -445,6 +504,52 @@ records = doc["records"]
 assert len(records) == 1, records
 assert records[0]["source_kind"] == "latest", records
 assert records[0]["readiness_status"] == "missing", records
+assert records[0]["reconcile_status"] == "restored", records
+PY
+
+python3 "$QUERY_PATH" runs \
+  --family federated-ci-runtime-gates \
+  --reconcile-status restored \
+  --reconcile-artifact-state fresh \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$RUNS_RECONCILE_OUTPUT"
+
+python3 - <<'PY' "$RUNS_RECONCILE_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+assert records[0]["run_id"] == "federated-ci-runtime-gates-20260319-rerun28", records
+assert records[0]["reconcile_status"] == "restored", records
+assert records[0]["reconcile_artifact_state"] == "fresh", records
+assert records[0]["reconcile_validation_state"] == "fresh", records
+PY
+
+python3 "$QUERY_PATH" runs \
+  --family federated-ci-runtime-gates \
+  --reconcile-status unknown \
+  --checkpoint-state missing \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$RUNS_UNKNOWN_OUTPUT"
+
+python3 - <<'PY' "$RUNS_UNKNOWN_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+assert records[0]["run_id"] == "federated-ci-runtime-gates-20260319-rerun29", records
+assert records[0]["reconcile_status"] == "unknown", records
+assert records[0]["checkpoint_state"] == "missing", records
 PY
 
 python3 "$QUERY_PATH" reconcile-status \
@@ -560,11 +665,15 @@ from pathlib import Path
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 records = doc["records"]
 assert [record["run_id"] for record in records] == [
+    "federated-ci-runtime-gates-20260319-rerun29",
     "federated-ci-runtime-gates-20260319-rerun28",
     "federated-ci-runtime-gates-20260319-rerun27",
     "federated-ci-runtime-gates-20260319-rerun26",
 ], records
-restored, missing, stale = records
+unknown, restored, missing, stale = records
+assert unknown["status"] == "unknown", unknown
+assert unknown["checkpoint_state"] == "missing", unknown
+assert unknown["reconcile_artifact_state"] == "missing", unknown
 assert restored["status"] == "restored", restored
 assert restored["reconcile_artifact_state"] == "fresh", restored
 assert restored["reconcile_validation_state"] == "fresh", restored


### PR DESCRIPTION
## Summary
- surface reconcile status and artifact freshness directly in the `runs` index output
- add `runs` selectors for reconcile status, artifact freshness, validation freshness, and checkpoint presence
- expand query fixtures to pin healthy/restored/unknown and fresh/stale/missing cases from the main runs surface

## Scope
- `/planningops/scripts/federation/query_federated_ci_artifacts.py`
- `/planningops/scripts/test_query_federated_ci_artifacts.sh`

## Linked Issues
- Closes #896

## Validation
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh`
- `bash planningops/scripts/test_reconcile_federated_ci_summary_tmp.sh`
- `bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- `runs` now depends on the same reconcile-sidecar contract as `reconcile-status`, so future producer path changes need to keep both read surfaces aligned
- missing or invalid checkpoints now show up as explicit `unknown` rows in the main index, which downstream callers may start depending on

## Review Checklist
- [x] enriched `runs` JSON includes reconcile state fields
- [x] `runs` selectors for reconcile state are covered by contract tests
- [x] single-run and family-scan `reconcile-status` flows remain green
- [x] unrelated tracked artifact residue was not staged

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required for this query/read-side only change beyond the validation commands above.
