### PR TITLE
feat(query-engine): add combined health scan

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -34,6 +34,8 @@ class SummaryRecord:
     source_kind: str
     summary_path: str
     timestamp_utc: str
+    health_status: str
+    health_reasons: list[str]
     verdict: str | None
     overall_status: str | None
     check_count: int | None
@@ -249,12 +251,30 @@ def build_summary_record(
         validation_root=validation_root,
         conformance_root=conformance_root,
     )
+    readiness_status = (
+        str(raw_readiness_status)
+        if isinstance(raw_readiness_status, str) and raw_readiness_status.strip()
+        else ("unknown" if sidecars["readiness"].exists() else "missing")
+    )
+    health_status, health_reasons = build_summary_health_fields(
+        verdict=summary_doc.get("verdict"),
+        overall_status=summary_doc.get("overall_status"),
+        missing_required_checks=[str(name) for name in list(summary_doc.get("missing_required_checks") or [])],
+        failed_checks=failed_checks,
+        readiness_status=readiness_status,
+        reconcile_status=str(reconcile_fields["reconcile_status"]),
+        reconcile_artifact_state=str(reconcile_fields["reconcile_artifact_state"]),
+        reconcile_validation_state=str(reconcile_fields["reconcile_validation_state"]),
+        checkpoint_state=str(reconcile_fields["checkpoint_state"]),
+    )
     return SummaryRecord(
         run_id=run_id,
         family=infer_family_from_run_id(run_id),
         source_kind=source_kind,
         summary_path=str(summary_path.resolve()),
         timestamp_utc=summary_timestamp(summary_doc),
+        health_status=health_status,
+        health_reasons=health_reasons,
         verdict=summary_doc.get("verdict"),
         overall_status=summary_doc.get("overall_status"),
         check_count=summary_doc.get("check_count"),
@@ -262,11 +282,7 @@ def build_summary_record(
         missing_required_checks=[str(name) for name in list(summary_doc.get("missing_required_checks") or [])],
         failure_domains=sorted(set(failures)),
         failed_checks=failed_checks,
-        readiness_status=(
-            str(raw_readiness_status)
-            if isinstance(raw_readiness_status, str) and raw_readiness_status.strip()
-            else ("unknown" if sidecars["readiness"].exists() else "missing")
-        ),
+        readiness_status=readiness_status,
         ready=raw_ready if isinstance(raw_ready, bool) else None,
         blocking_reasons=(
             [str(reason) for reason in list(readiness_doc.get("blocking_reasons") or [])]
@@ -333,9 +349,102 @@ def discover_summary_records(
     return records
 
 
+def build_summary_health_fields(
+    *,
+    verdict: Any,
+    overall_status: Any,
+    missing_required_checks: list[str],
+    failed_checks: list[str],
+    readiness_status: str,
+    reconcile_status: str,
+    reconcile_artifact_state: str,
+    reconcile_validation_state: str,
+    checkpoint_state: str,
+) -> tuple[str, list[str]]:
+    unknown_reasons: list[str] = []
+    if checkpoint_state != "present":
+        unknown_reasons.append(f"checkpoint_{checkpoint_state}")
+    if reconcile_status == "unknown":
+        unknown_reasons.append("reconcile_unknown")
+    if unknown_reasons:
+        return "unknown", unknown_reasons
+
+    blocked_reasons: list[str] = []
+    if verdict == "fail":
+        blocked_reasons.append("summary_verdict_fail")
+    if isinstance(overall_status, str) and overall_status and overall_status != "complete":
+        blocked_reasons.append(f"summary_status_{overall_status}")
+    if missing_required_checks:
+        blocked_reasons.append("missing_required_checks")
+    if failed_checks:
+        blocked_reasons.append("failed_checks_present")
+    if readiness_status == "blocked":
+        blocked_reasons.append("readiness_blocked")
+    if blocked_reasons:
+        return "blocked", blocked_reasons
+
+    degraded_reasons: list[str] = []
+    if readiness_status in {"missing", "unknown"}:
+        degraded_reasons.append(f"readiness_{readiness_status}")
+    if reconcile_status == "restored":
+        degraded_reasons.append("reconcile_restored")
+    if reconcile_artifact_state != "fresh":
+        degraded_reasons.append(f"reconcile_artifact_{reconcile_artifact_state}")
+    if reconcile_validation_state != "fresh":
+        degraded_reasons.append(f"reconcile_validation_{reconcile_validation_state}")
+    if degraded_reasons:
+        return "degraded", degraded_reasons
+
+    return "healthy", []
+
+
+def filter_summary_records(
+    *,
+    records: list[SummaryRecord],
+    family: str | None = None,
+    run_id_prefix: str | None = None,
+    source_kind: str = "all",
+    verdict: str | None = None,
+    status: str | None = None,
+    readiness_status: str | None = None,
+    health_status: str | None = None,
+    reconcile_status: str | None = None,
+    reconcile_artifact_state: str | None = None,
+    reconcile_validation_state: str | None = None,
+    checkpoint_state: str | None = None,
+    failed_check: str | None = None,
+) -> list[SummaryRecord]:
+    filtered = records
+    if family:
+        filtered = [record for record in filtered if record.family == family]
+    if run_id_prefix:
+        filtered = [record for record in filtered if record.run_id.startswith(run_id_prefix)]
+    if source_kind != "all":
+        filtered = [record for record in filtered if record.source_kind == source_kind]
+    if verdict:
+        filtered = [record for record in filtered if record.verdict == verdict]
+    if status:
+        filtered = [record for record in filtered if record.overall_status == status]
+    if readiness_status:
+        filtered = [record for record in filtered if record.readiness_status == readiness_status]
+    if health_status:
+        filtered = [record for record in filtered if record.health_status == health_status]
+    if reconcile_status:
+        filtered = [record for record in filtered if record.reconcile_status == reconcile_status]
+    if reconcile_artifact_state:
+        filtered = [record for record in filtered if record.reconcile_artifact_state == reconcile_artifact_state]
+    if reconcile_validation_state:
+        filtered = [record for record in filtered if record.reconcile_validation_state == reconcile_validation_state]
+    if checkpoint_state:
+        filtered = [record for record in filtered if record.checkpoint_state == checkpoint_state]
+    if failed_check:
+        filtered = [record for record in filtered if failed_check in record.failed_checks]
+    return filtered
+
+
 def render_runs_table(records: list[SummaryRecord]) -> str:
     lines = [
-        "family\trun_id\tsource\tverdict\treadiness\treconcile\tartifact_state\tcheckpoint\tfailed_checks\tstatus\tchecks\ttimestamp",
+        "family\trun_id\tsource\thealth\tverdict\treadiness\treconcile\tartifact_state\tcheckpoint\tfailed_checks\tstatus\tchecks\ttimestamp",
     ]
     for record in records:
         lines.append(
@@ -344,6 +453,7 @@ def render_runs_table(records: list[SummaryRecord]) -> str:
                     record.family,
                     record.run_id,
                     record.source_kind,
+                    record.health_status,
                     str(record.verdict or ""),
                     record.readiness_status,
                     record.reconcile_status,
@@ -361,16 +471,56 @@ def render_runs_table(records: list[SummaryRecord]) -> str:
 
 def render_runs_markdown(records: list[SummaryRecord]) -> str:
     lines = [
-        "| family | run_id | source | verdict | readiness | reconcile | artifact_state | checkpoint | failed_checks | status | checks | timestamp |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- |",
+        "| family | run_id | source | health | verdict | readiness | reconcile | artifact_state | checkpoint | failed_checks | status | checks | timestamp |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- |",
     ]
     for record in records:
         lines.append(
-            f"| {record.family} | `{record.run_id}` | {record.source_kind} | "
+            f"| {record.family} | `{record.run_id}` | {record.source_kind} | {record.health_status} | "
             f"{record.verdict or ''} | {record.readiness_status} | {record.reconcile_status} | "
             f"{record.reconcile_artifact_state} | {record.checkpoint_state} | "
             f"{', '.join(record.failed_checks)} | {record.overall_status or ''} | "
             f"{record.check_count if record.check_count is not None else ''} | {record.timestamp_utc} |"
+        )
+    return "\n".join(lines)
+
+
+def render_health_scan_table(records: list[SummaryRecord]) -> str:
+    lines = [
+        "family\trun_id\tsource\thealth\tverdict\treadiness\treconcile\tartifact_state\tfailed_checks\thealth_reasons\ttimestamp",
+    ]
+    for record in records:
+        lines.append(
+            "\t".join(
+                [
+                    record.family,
+                    record.run_id,
+                    record.source_kind,
+                    record.health_status,
+                    str(record.verdict or ""),
+                    record.readiness_status,
+                    record.reconcile_status,
+                    record.reconcile_artifact_state,
+                    ",".join(record.failed_checks),
+                    ",".join(record.health_reasons),
+                    record.timestamp_utc,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_health_scan_markdown(records: list[SummaryRecord]) -> str:
+    lines = [
+        "| family | run_id | source | health | verdict | readiness | reconcile | artifact_state | failed_checks | health_reasons | timestamp |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for record in records:
+        lines.append(
+            f"| {record.family} | `{record.run_id}` | {record.source_kind} | {record.health_status} | "
+            f"{record.verdict or ''} | {record.readiness_status} | {record.reconcile_status} | "
+            f"{record.reconcile_artifact_state} | {', '.join(record.failed_checks)} | "
+            f"{', '.join(record.health_reasons)} | {record.timestamp_utc} |"
         )
     return "\n".join(lines)
 
@@ -935,6 +1085,7 @@ def parse_args() -> argparse.Namespace:
     runs_parser.add_argument("--verdict", choices=["pass", "fail"], default=None)
     runs_parser.add_argument("--status", choices=["complete", "interrupted"], default=None)
     runs_parser.add_argument("--readiness-status", choices=["ready", "blocked", "missing", "unknown"], default=None)
+    runs_parser.add_argument("--health-status", choices=["healthy", "degraded", "blocked", "unknown"], default=None)
     runs_parser.add_argument("--reconcile-status", choices=["healthy", "restored", "unknown"], default=None)
     runs_parser.add_argument("--reconcile-artifact-state", choices=["fresh", "stale", "missing"], default=None)
     runs_parser.add_argument("--reconcile-validation-state", choices=["fresh", "stale", "missing"], default=None)
@@ -975,6 +1126,25 @@ def parse_args() -> argparse.Namespace:
     reconcile_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     reconcile_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     reconcile_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+
+    health_parser = subparsers.add_parser(
+        "health-scan",
+        help="show operator-oriented run health derived from verdict, readiness, and reconcile state",
+    )
+    health_parser.add_argument("--family", default=None)
+    health_parser.add_argument("--run-id-prefix", default=None)
+    health_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="all")
+    health_parser.add_argument("--health-status", choices=["healthy", "degraded", "blocked", "unknown"], default=None)
+    health_parser.add_argument("--readiness-status", choices=["ready", "blocked", "missing", "unknown"], default=None)
+    health_parser.add_argument("--reconcile-status", choices=["healthy", "restored", "unknown"], default=None)
+    health_parser.add_argument("--reconcile-artifact-state", choices=["fresh", "stale", "missing"], default=None)
+    health_parser.add_argument("--checkpoint-state", choices=["present", "missing", "invalid"], default=None)
+    health_parser.add_argument("--failed-check", default=None)
+    health_parser.add_argument("--limit", type=int, default=20)
+    health_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    health_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    health_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    health_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     return parser.parse_args()
 
 
@@ -990,31 +1160,21 @@ def main() -> int:
     )
 
     if args.command == "runs":
-        filtered = records
-        if args.family:
-            filtered = [record for record in filtered if record.family == args.family]
-        if args.run_id_prefix:
-            filtered = [record for record in filtered if record.run_id.startswith(args.run_id_prefix)]
-        if args.source_kind != "all":
-            filtered = [record for record in filtered if record.source_kind == args.source_kind]
-        if args.verdict:
-            filtered = [record for record in filtered if record.verdict == args.verdict]
-        if args.status:
-            filtered = [record for record in filtered if record.overall_status == args.status]
-        if args.readiness_status:
-            filtered = [record for record in filtered if record.readiness_status == args.readiness_status]
-        if args.reconcile_status:
-            filtered = [record for record in filtered if record.reconcile_status == args.reconcile_status]
-        if args.reconcile_artifact_state:
-            filtered = [record for record in filtered if record.reconcile_artifact_state == args.reconcile_artifact_state]
-        if args.reconcile_validation_state:
-            filtered = [
-                record for record in filtered if record.reconcile_validation_state == args.reconcile_validation_state
-            ]
-        if args.checkpoint_state:
-            filtered = [record for record in filtered if record.checkpoint_state == args.checkpoint_state]
-        if args.failed_check:
-            filtered = [record for record in filtered if args.failed_check in record.failed_checks]
+        filtered = filter_summary_records(
+            records=records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+            verdict=args.verdict,
+            status=args.status,
+            readiness_status=args.readiness_status,
+            health_status=args.health_status,
+            reconcile_status=args.reconcile_status,
+            reconcile_artifact_state=args.reconcile_artifact_state,
+            reconcile_validation_state=args.reconcile_validation_state,
+            checkpoint_state=args.checkpoint_state,
+            failed_check=args.failed_check,
+        )
         filtered = filtered[: args.limit]
         if args.format == "json":
             print(json.dumps({"records": [asdict(record) for record in filtered]}, ensure_ascii=True, indent=2))
@@ -1023,6 +1183,29 @@ def main() -> int:
             print(render_runs_markdown(filtered))
             return 0
         print(render_runs_table(filtered))
+        return 0
+
+    if args.command == "health-scan":
+        filtered = filter_summary_records(
+            records=records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+            readiness_status=args.readiness_status,
+            health_status=args.health_status,
+            reconcile_status=args.reconcile_status,
+            reconcile_artifact_state=args.reconcile_artifact_state,
+            checkpoint_state=args.checkpoint_state,
+            failed_check=args.failed_check,
+        )
+        filtered = filtered[: args.limit]
+        if args.format == "json":
+            print(json.dumps({"records": [asdict(record) for record in filtered]}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_health_scan_markdown(filtered))
+            return 0
+        print(render_health_scan_table(filtered))
         return 0
 
     if args.command == "reconcile-status":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -170,6 +170,38 @@ cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun29.json" <<'JSON'
 }
 JSON
 
+cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun30.json" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun30",
+  "started_at_utc": "2026-03-19T00:00:55+00:00",
+  "generated_at_utc": "2026-03-19T00:10:55+00:00",
+  "finished_at_utc": "2026-03-19T00:10:55+00:00",
+  "checks": [
+    {
+      "name": "contract-conformance",
+      "domain": "contract",
+      "exit_code": 0,
+      "verdict": "pass",
+      "stdout_log": "/tmp/contract.stdout.log",
+      "stderr_log": "/tmp/contract.stderr.log"
+    }
+  ],
+  "required_checks": [
+    "contract-conformance"
+  ],
+  "overall_status": "complete",
+  "check_count": 1,
+  "missing_required_checks": [],
+  "failure_classification": {
+    "count": 0,
+    "domains": [],
+    "deterministic_rule": "demo"
+  },
+  "verdict": "pass",
+  "shell_exit_code": 0
+}
+JSON
+
 cat >"$CI_DIR/federated-ci-summary.json" <<'JSON'
 {
   "run_id": "federated-ci-runtime-gates-20260319-rerun26",
@@ -309,6 +341,26 @@ cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun28.checkpoint.json" <<'JS
 }
 JSON
 
+cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun30.checkpoint.json" <<'JSON'
+{
+  "run_id": "federated-ci-runtime-gates-20260319-rerun30",
+  "started_at_utc": "2026-03-19T00:00:55+00:00",
+  "checks": [
+    {
+      "name": "contract-conformance",
+      "domain": "contract",
+      "exit_code": 0,
+      "verdict": "pass",
+      "stdout_log": "/tmp/contract.stdout.log",
+      "stderr_log": "/tmp/contract.stderr.log"
+    }
+  ],
+  "required_checks": [
+    "contract-conformance"
+  ]
+}
+JSON
+
 python3 - <<'PY' "$CI_DIR/._federated-ci-runtime-gates-20260319-rerun26.json"
 from pathlib import Path
 import sys
@@ -338,6 +390,16 @@ cat >"$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun27-summary-readin
 }
 JSON
 touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun27-summary-readiness-validation.json"
+touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun30-summary-validation.json"
+cat >"$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun30-summary-readiness.json" <<'JSON'
+{
+  "summary_run_id": "federated-ci-runtime-gates-20260319-rerun30",
+  "readiness_status": "ready",
+  "ready": true,
+  "blocking_reasons": []
+}
+JSON
+touch "$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun30-summary-readiness-validation.json"
 cat >"$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun28-summary-tmp-reconcile.json" <<JSON
 {
   "generated_at_utc": "2026-03-19T00:11:45+00:00",
@@ -366,15 +428,46 @@ cat >"$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun28-summary-tmp-re
   "verdict": "pass"
 }
 JSON
+cat >"$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun30-summary-tmp-reconcile.json" <<JSON
+{
+  "generated_at_utc": "2026-03-19T00:11:55+00:00",
+  "summary_path": "${CI_DIR}/federated-ci-runtime-gates-20260319-rerun30.json",
+  "checkpoint_path": "${CI_DIR}/federated-ci-runtime-gates-20260319-rerun30.checkpoint.json",
+  "output_path": "${VALIDATION_DIR}/federated-ci-runtime-gates-20260319-rerun30-summary-tmp-reconcile.json",
+  "run_id": "federated-ci-runtime-gates-20260319-rerun30",
+  "check_name": null,
+  "checkpoint_check_count": 1,
+  "summary_check_count": 1,
+  "restored": false,
+  "status": "healthy",
+  "reasons": [],
+  "reconcile_count": 0,
+  "restored_check_names": []
+}
+JSON
+cat >"$VALIDATION_DIR/federated-ci-runtime-gates-20260319-rerun30-summary-tmp-reconcile-validation.json" <<JSON
+{
+  "reconcile_report_path": "${VALIDATION_DIR}/federated-ci-runtime-gates-20260319-rerun30-summary-tmp-reconcile.json",
+  "reconcile_generated_at_utc": "2026-03-19T00:11:55+00:00",
+  "reconcile_run_id": "federated-ci-runtime-gates-20260319-rerun30",
+  "reconcile_status": "healthy",
+  "reconcile_restored": false,
+  "reconcile_count": 0,
+  "verdict": "pass"
+}
+JSON
 touch "$VALIDATION_DIR/federated-ci-summary-validation.json"
 touch "$CONFORMANCE_DIR/federated-ci-runtime-gates-20260319-rerun26-contract.json"
 
 RUNS_OUTPUT="$TMP_DIR/runs.json"
+RUNS_HEALTHY_OUTPUT="$TMP_DIR/runs-healthy.json"
 CHECKS_OUTPUT="$TMP_DIR/checks.json"
 CHECKS_AUTO_OUTPUT="$TMP_DIR/checks-auto.json"
 FAILED_OUTPUT="$TMP_DIR/failed.json"
 LATEST_OUTPUT="$TMP_DIR/latest.json"
 RUNS_RECONCILE_OUTPUT="$TMP_DIR/runs-reconcile.json"
+HEALTH_SCAN_OUTPUT="$TMP_DIR/health-scan.json"
+HEALTH_SCAN_DEGRADED_OUTPUT="$TMP_DIR/health-scan-degraded.json"
 RECONCILE_HEALTHY_OUTPUT="$TMP_DIR/reconcile-healthy.json"
 RECONCILE_RESTORED_OUTPUT="$TMP_DIR/reconcile-restored.json"
 RECONCILE_SCAN_OUTPUT="$TMP_DIR/reconcile-scan.json"
@@ -398,35 +491,61 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 records = doc["records"]
-assert len(records) == 5, records
+assert len(records) == 6, records
 assert records[0]["source_kind"] == "latest", records
-assert records[1]["run_id"] == "federated-ci-runtime-gates-20260319-rerun29", records
-assert records[2]["run_id"] == "federated-ci-runtime-gates-20260319-rerun28", records
-assert records[3]["run_id"] == "federated-ci-runtime-gates-20260319-rerun27", records
-assert records[4]["source_kind"] == "stamped", records
+assert records[1]["run_id"] == "federated-ci-runtime-gates-20260319-rerun30", records
+assert records[2]["run_id"] == "federated-ci-runtime-gates-20260319-rerun29", records
+assert records[3]["run_id"] == "federated-ci-runtime-gates-20260319-rerun28", records
+assert records[4]["run_id"] == "federated-ci-runtime-gates-20260319-rerun27", records
+assert records[5]["source_kind"] == "stamped", records
 
 latest = records[0]
-unknown = records[1]
-restored = records[2]
-failed = records[3]
-stamped = records[4]
+healthy = records[1]
+unknown = records[2]
+restored = records[3]
+failed = records[4]
+stamped = records[5]
 
 assert latest["has_summary_validation"] is True, latest
 assert latest["has_readiness"] is False, latest
 assert latest["readiness_status"] == "missing", latest
 assert latest["has_conformance_contract"] is True, latest
+assert latest["health_status"] == "degraded", latest
+assert latest["health_reasons"] == [
+    "readiness_missing",
+    "reconcile_restored",
+    "reconcile_artifact_missing",
+    "reconcile_validation_missing",
+], latest
 assert latest["reconcile_status"] == "restored", latest
 assert latest["reconcile_artifact_state"] == "missing", latest
 assert latest["reconcile_validation_state"] == "missing", latest
 assert latest["checkpoint_state"] == "present", latest
 
+assert healthy["run_id"] == "federated-ci-runtime-gates-20260319-rerun30", healthy
+assert healthy["health_status"] == "healthy", healthy
+assert healthy["health_reasons"] == [], healthy
+assert healthy["readiness_status"] == "ready", healthy
+assert healthy["reconcile_status"] == "healthy", healthy
+assert healthy["reconcile_artifact_state"] == "fresh", healthy
+assert healthy["reconcile_validation_state"] == "fresh", healthy
+assert healthy["checkpoint_state"] == "present", healthy
+
 assert unknown["run_id"] == "federated-ci-runtime-gates-20260319-rerun29", unknown
+assert unknown["health_status"] == "unknown", unknown
+assert unknown["health_reasons"] == ["checkpoint_missing", "reconcile_unknown"], unknown
 assert unknown["reconcile_status"] == "unknown", unknown
 assert unknown["reconcile_artifact_state"] == "missing", unknown
 assert unknown["reconcile_validation_state"] == "missing", unknown
 assert unknown["checkpoint_state"] == "missing", unknown
 
 assert restored["run_id"] == "federated-ci-runtime-gates-20260319-rerun28", restored
+assert restored["health_status"] == "blocked", restored
+assert restored["health_reasons"] == [
+    "summary_verdict_fail",
+    "summary_status_interrupted",
+    "missing_required_checks",
+], restored
 assert restored["check_count"] == 1, restored
 assert restored["missing_required_checks"] == ["loop-guardrails"], restored
 assert restored["reconcile_status"] == "restored", restored
@@ -441,6 +560,8 @@ assert failed["readiness_status"] == "blocked", failed
 assert failed["ready"] is False, failed
 assert failed["failed_checks"] == ["runtime-handoff"], failed
 assert failed["failure_domains"] == ["runtime"], failed
+assert failed["health_status"] == "blocked", failed
+assert failed["health_reasons"] == ["summary_verdict_fail", "failed_checks_present", "readiness_blocked"], failed
 assert failed["reconcile_status"] == "healthy", failed
 assert failed["reconcile_artifact_state"] == "missing", failed
 assert failed["checkpoint_state"] == "present", failed
@@ -455,6 +576,8 @@ assert stamped["has_readiness_validation"] is True, stamped
 assert stamped["has_reconcile_report"] is True, stamped
 assert stamped["has_reconcile_validation"] is True, stamped
 assert stamped["has_conformance_contract"] is True, stamped
+assert stamped["health_status"] == "degraded", stamped
+assert stamped["health_reasons"] == ["reconcile_artifact_stale", "reconcile_validation_stale"], stamped
 assert stamped["reconcile_status"] == "healthy", stamped
 assert stamped["reconcile_artifact_state"] == "stale", stamped
 assert stamped["reconcile_validation_verdict"] == "unknown", stamped
@@ -504,7 +627,28 @@ records = doc["records"]
 assert len(records) == 1, records
 assert records[0]["source_kind"] == "latest", records
 assert records[0]["readiness_status"] == "missing", records
+assert records[0]["health_status"] == "degraded", records
 assert records[0]["reconcile_status"] == "restored", records
+PY
+
+python3 "$QUERY_PATH" runs \
+  --family federated-ci-runtime-gates \
+  --health-status healthy \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$RUNS_HEALTHY_OUTPUT"
+
+python3 - <<'PY' "$RUNS_HEALTHY_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+assert records[0]["run_id"] == "federated-ci-runtime-gates-20260319-rerun30", records
+assert records[0]["health_status"] == "healthy", records
 PY
 
 python3 "$QUERY_PATH" runs \
@@ -550,6 +694,59 @@ assert len(records) == 1, records
 assert records[0]["run_id"] == "federated-ci-runtime-gates-20260319-rerun29", records
 assert records[0]["reconcile_status"] == "unknown", records
 assert records[0]["checkpoint_state"] == "missing", records
+PY
+
+python3 "$QUERY_PATH" health-scan \
+  --family federated-ci-runtime-gates \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$HEALTH_SCAN_OUTPUT"
+
+python3 - <<'PY' "$HEALTH_SCAN_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["run_id"] for record in records] == [
+    "federated-ci-runtime-gates-20260319-rerun26",
+    "federated-ci-runtime-gates-20260319-rerun30",
+    "federated-ci-runtime-gates-20260319-rerun29",
+    "federated-ci-runtime-gates-20260319-rerun28",
+    "federated-ci-runtime-gates-20260319-rerun27",
+    "federated-ci-runtime-gates-20260319-rerun26",
+], records
+assert [record["health_status"] for record in records] == [
+    "degraded",
+    "healthy",
+    "unknown",
+    "blocked",
+    "blocked",
+    "degraded",
+], records
+PY
+
+python3 "$QUERY_PATH" health-scan \
+  --family federated-ci-runtime-gates \
+  --source-kind stamped \
+  --health-status degraded \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$HEALTH_SCAN_DEGRADED_OUTPUT"
+
+python3 - <<'PY' "$HEALTH_SCAN_DEGRADED_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+assert records[0]["run_id"] == "federated-ci-runtime-gates-20260319-rerun26", records
+assert records[0]["health_status"] == "degraded", records
 PY
 
 python3 "$QUERY_PATH" reconcile-status \
@@ -665,12 +862,17 @@ from pathlib import Path
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 records = doc["records"]
 assert [record["run_id"] for record in records] == [
+    "federated-ci-runtime-gates-20260319-rerun30",
     "federated-ci-runtime-gates-20260319-rerun29",
     "federated-ci-runtime-gates-20260319-rerun28",
     "federated-ci-runtime-gates-20260319-rerun27",
     "federated-ci-runtime-gates-20260319-rerun26",
 ], records
-unknown, restored, missing, stale = records
+healthy, unknown, restored, missing, stale = records
+assert healthy["status"] == "healthy", healthy
+assert healthy["reconcile_artifact_state"] == "fresh", healthy
+assert healthy["reconcile_validation_state"] == "fresh", healthy
+assert healthy["checkpoint_state"] == "present", healthy
 assert unknown["status"] == "unknown", unknown
 assert unknown["checkpoint_state"] == "missing", unknown
 assert unknown["reconcile_artifact_state"] == "missing", unknown


### PR DESCRIPTION
## Summary
- add operator-oriented `health-scan` query surface for federated CI artifacts
- surface derived `health_status` and `health_reasons` on `runs` records
- expand contract fixtures to cover healthy, degraded, blocked, and unknown run states

## Scope
- update `planningops/scripts/federation/query_federated_ci_artifacts.py`
- update `planningops/scripts/test_query_federated_ci_artifacts.sh`
- no runtime harness write-path changes

## Linked Issues
- Closes #898

## Validation
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh`
- `bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- health buckets are derived heuristics, so future harness semantics may require bucket tuning
- `health-scan` currently reuses summary record indexing rather than introducing a dedicated artifact catalog

## Review Checklist
- [x] operator health buckets are covered for `healthy`, `degraded`, `blocked`, and `unknown`
- [x] `runs` and `health-scan` surfaces stay consistent on reconcile-derived fields
- [x] fixture ordering still covers `latest` vs stamped runs and missing checkpoint cases

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required; this change only extends local query/read-side tooling for federated CI artifacts.