### PR TITLE
feat(query-engine): add triage summary surface

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -155,6 +155,20 @@ class OperatorTriageRecord:
     latest_failure_domains: list[str]
 
 
+@dataclass(frozen=True)
+class TriageSummaryRecord:
+    triage_status: str
+    family_count: int
+    families: list[str]
+    newest_family: str
+    newest_run_id: str
+    newest_run_source_kind: str
+    newest_run_timestamp_utc: str
+    alert_alignment_counts: dict[str, int]
+    latest_gap_domain_counts: dict[str, int]
+    latest_alert_domain_counts: dict[str, int]
+
+
 def resolve_root(path_text: str, default: Path) -> Path:
     candidate = Path(path_text)
     if not candidate.is_absolute():
@@ -889,6 +903,94 @@ def render_operator_triage_markdown(records: list[OperatorTriageRecord]) -> str:
     return "\n".join(lines)
 
 
+def build_triage_summary_records(
+    *,
+    records: list[SummaryRecord],
+    family: str | None,
+    run_id_prefix: str | None,
+    source_kind: str,
+) -> list[TriageSummaryRecord]:
+    triage_records = build_operator_triage_records(
+        records=records,
+        family=family,
+        run_id_prefix=run_id_prefix,
+        source_kind=source_kind,
+    )
+    grouped: dict[str, list[OperatorTriageRecord]] = {}
+    for record in triage_records:
+        grouped.setdefault(record.triage_status, []).append(record)
+
+    summaries: list[TriageSummaryRecord] = []
+    for triage_status, bucket_records in grouped.items():
+        newest = bucket_records[0]
+        alert_alignment_counts: dict[str, int] = {}
+        latest_gap_domain_counts: dict[str, int] = {}
+        latest_alert_domain_counts: dict[str, int] = {}
+        for record in bucket_records:
+            alert_alignment_counts[record.alert_alignment] = alert_alignment_counts.get(record.alert_alignment, 0) + 1
+            for domain in record.latest_gap_domains:
+                latest_gap_domain_counts[domain] = latest_gap_domain_counts.get(domain, 0) + 1
+            for domain in record.latest_alert_domains:
+                latest_alert_domain_counts[domain] = latest_alert_domain_counts.get(domain, 0) + 1
+        summaries.append(
+            TriageSummaryRecord(
+                triage_status=triage_status,
+                family_count=len(bucket_records),
+                families=[record.family for record in bucket_records],
+                newest_family=newest.family,
+                newest_run_id=newest.latest_run_id,
+                newest_run_source_kind=newest.latest_run_source_kind,
+                newest_run_timestamp_utc=newest.latest_run_timestamp_utc,
+                alert_alignment_counts={key: alert_alignment_counts[key] for key in sorted(alert_alignment_counts)},
+                latest_gap_domain_counts={key: latest_gap_domain_counts[key] for key in sorted(latest_gap_domain_counts)},
+                latest_alert_domain_counts={key: latest_alert_domain_counts[key] for key in sorted(latest_alert_domain_counts)},
+            )
+        )
+    summaries.sort(key=lambda record: (record.newest_run_timestamp_utc, record.triage_status), reverse=True)
+    return summaries
+
+
+def render_triage_summary_table(records: list[TriageSummaryRecord]) -> str:
+    lines = [
+        "triage_status\tfamily_count\tfamilies\tnewest_family\tnewest_run\tnewest_source\talert_alignment_counts\tlatest_gap_domain_counts\tlatest_alert_domain_counts\tnewest_timestamp",
+    ]
+    for record in records:
+        lines.append(
+            "\t".join(
+                [
+                    record.triage_status,
+                    str(record.family_count),
+                    ",".join(record.families),
+                    record.newest_family,
+                    record.newest_run_id,
+                    record.newest_run_source_kind,
+                    ",".join(f"{key}={value}" for key, value in record.alert_alignment_counts.items()),
+                    ",".join(f"{key}={value}" for key, value in record.latest_gap_domain_counts.items()),
+                    ",".join(f"{key}={value}" for key, value in record.latest_alert_domain_counts.items()),
+                    record.newest_run_timestamp_utc,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_triage_summary_markdown(records: list[TriageSummaryRecord]) -> str:
+    lines = [
+        "| triage_status | family_count | families | newest_family | newest_run | newest_source | alert_alignment_counts | latest_gap_domain_counts | latest_alert_domain_counts | newest_timestamp |",
+        "| --- | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for record in records:
+        lines.append(
+            f"| {record.triage_status} | {record.family_count} | {', '.join(record.families)} | "
+            f"{record.newest_family} | `{record.newest_run_id}` | {record.newest_run_source_kind} | "
+            f"{', '.join(f'{key}={value}' for key, value in record.alert_alignment_counts.items())} | "
+            f"{', '.join(f'{key}={value}' for key, value in record.latest_gap_domain_counts.items())} | "
+            f"{', '.join(f'{key}={value}' for key, value in record.latest_alert_domain_counts.items())} | "
+            f"{record.newest_run_timestamp_utc} |"
+        )
+    return "\n".join(lines)
+
+
 def select_record(
     *,
     records: list[SummaryRecord],
@@ -1576,6 +1678,22 @@ def parse_args() -> argparse.Namespace:
     operator_triage_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     operator_triage_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     operator_triage_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+
+    triage_summary_parser = subparsers.add_parser(
+        "triage-summary",
+        help="show bucketed counts and newest families for operator triage statuses",
+    )
+    triage_summary_parser.add_argument("--family", default=None)
+    triage_summary_parser.add_argument("--run-id-prefix", default=None)
+    triage_summary_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
+    triage_summary_parser.add_argument("--triage-status", choices=["clear", "active", "lagging"], default=None)
+    triage_summary_parser.add_argument("--has-latest-gap-domain", default=None)
+    triage_summary_parser.add_argument("--has-latest-alert-domain", default=None)
+    triage_summary_parser.add_argument("--limit", type=int, default=20)
+    triage_summary_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    triage_summary_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    triage_summary_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    triage_summary_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     return parser.parse_args()
 
 
@@ -1714,6 +1832,37 @@ def main() -> int:
             print(render_operator_triage_markdown(triage_records))
             return 0
         print(render_operator_triage_table(triage_records))
+        return 0
+
+    if args.command == "triage-summary":
+        summaries = build_triage_summary_records(
+            records=records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+        )
+        if args.triage_status:
+            summaries = [record for record in summaries if record.triage_status == args.triage_status]
+        if args.has_latest_gap_domain:
+            summaries = [
+                record
+                for record in summaries
+                if record.latest_gap_domain_counts.get(args.has_latest_gap_domain, 0) > 0
+            ]
+        if args.has_latest_alert_domain:
+            summaries = [
+                record
+                for record in summaries
+                if record.latest_alert_domain_counts.get(args.has_latest_alert_domain, 0) > 0
+            ]
+        summaries = summaries[: args.limit]
+        if args.format == "json":
+            print(json.dumps({"records": [asdict(record) for record in summaries]}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_triage_summary_markdown(summaries))
+            return 0
+        print(render_triage_summary_table(summaries))
         return 0
 
     if args.command == "reconcile-status":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -478,6 +478,9 @@ HEALTH_SUMMARY_LATEST_RUNTIME_OUTPUT="$TMP_DIR/health-summary-latest-runtime.jso
 OPERATOR_TRIAGE_OUTPUT="$TMP_DIR/operator-triage.json"
 OPERATOR_TRIAGE_LAGGING_OUTPUT="$TMP_DIR/operator-triage-lagging.json"
 OPERATOR_TRIAGE_ACTIVE_OUTPUT="$TMP_DIR/operator-triage-active.json"
+TRIAGE_SUMMARY_OUTPUT="$TMP_DIR/triage-summary.json"
+TRIAGE_SUMMARY_ACTIVE_OUTPUT="$TMP_DIR/triage-summary-active.json"
+TRIAGE_SUMMARY_ALL_OUTPUT="$TMP_DIR/triage-summary-all.json"
 RECONCILE_HEALTHY_OUTPUT="$TMP_DIR/reconcile-healthy.json"
 RECONCILE_RESTORED_OUTPUT="$TMP_DIR/reconcile-restored.json"
 RECONCILE_SCAN_OUTPUT="$TMP_DIR/reconcile-scan.json"
@@ -1047,6 +1050,92 @@ assert record["latest_run_id"] == "federated-ci-runtime-gates-20260319-rerun26",
 assert record["latest_run_source_kind"] == "latest", record
 assert record["latest_gap_domains"] == ["readiness", "reconcile"], record
 assert record["latest_alert_domains"] == ["readiness", "reconcile"], record
+PY
+
+python3 "$QUERY_PATH" triage-summary \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_SUMMARY_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_SUMMARY_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["triage_status"] for record in records] == [
+    "lagging",
+    "active",
+], records
+
+lagging, active = records
+assert lagging["family_count"] == 1, lagging
+assert lagging["families"] == ["federated-ci-runtime-gates"], lagging
+assert lagging["newest_family"] == "federated-ci-runtime-gates", lagging
+assert lagging["newest_run_id"] == "federated-ci-runtime-gates-20260319-rerun30", lagging
+assert lagging["newest_run_source_kind"] == "stamped", lagging
+assert lagging["alert_alignment_counts"] == {"lagging": 1}, lagging
+assert lagging["latest_gap_domain_counts"] == {}, lagging
+assert lagging["latest_alert_domain_counts"] == {"checkpoint": 1, "readiness": 1, "reconcile": 1}, lagging
+
+assert active["family_count"] == 1, active
+assert active["families"] == ["federated-ci-local"], active
+assert active["newest_family"] == "federated-ci-local", active
+assert active["newest_run_id"] == "federated-ci-local-20260301", active
+assert active["newest_run_source_kind"] == "stamped", active
+assert active["alert_alignment_counts"] == {"current": 1}, active
+assert active["latest_gap_domain_counts"] == {"checkpoint": 1, "readiness": 1, "reconcile": 1}, active
+assert active["latest_alert_domain_counts"] == {"checkpoint": 1, "readiness": 1, "reconcile": 1}, active
+PY
+
+python3 "$QUERY_PATH" triage-summary \
+  --triage-status active \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_SUMMARY_ACTIVE_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_SUMMARY_ACTIVE_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+assert records[0]["triage_status"] == "active", records
+assert records[0]["families"] == ["federated-ci-local"], records
+PY
+
+python3 "$QUERY_PATH" triage-summary \
+  --source-kind all \
+  --triage-status active \
+  --has-latest-gap-domain reconcile \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_SUMMARY_ALL_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_SUMMARY_ALL_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["triage_status"] == "active", record
+assert record["family_count"] == 2, record
+assert record["families"] == ["federated-ci-runtime-gates", "federated-ci-local"], record
+assert record["newest_family"] == "federated-ci-runtime-gates", record
+assert record["newest_run_id"] == "federated-ci-runtime-gates-20260319-rerun26", record
+assert record["newest_run_source_kind"] == "latest", record
+assert record["alert_alignment_counts"] == {"current": 2}, record
+assert record["latest_gap_domain_counts"] == {"checkpoint": 1, "readiness": 2, "reconcile": 2}, record
+assert record["latest_alert_domain_counts"] == {"checkpoint": 1, "readiness": 2, "reconcile": 2}, record
 PY
 
 python3 "$QUERY_PATH" reconcile-status \


### PR DESCRIPTION
## Summary
- add a `triage-summary` bucket view on top of `operator-triage`
- expose newest family/run plus domain and alignment counts for each triage bucket
- cover stamped and `source-kind=all` triage summary cases in the query contract fixture

## Scope
- `planningops/scripts/federation/query_federated_ci_artifacts.py`
- `planningops/scripts/test_query_federated_ci_artifacts.sh`

## Linked Issues
- Closes #910

## Validation
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh`
- `bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- low: adds a new aggregate command and output shape, so downstream scripts should treat `triage-summary` as additive rather than rely on undocumented ordering outside the tested selectors

## Review Checklist
- [x] triage summary groups operator-triage records by status without changing existing triage semantics
- [x] stamped default and `source-kind=all` bucket behavior are covered
- [x] bucket-level domain and alignment counts are exercised in contract tests

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required; this change only extends the offline query and contract-test surface.