### PR TITLE
feat(query-engine): add triage targets surface

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -189,6 +189,26 @@ class TriageOverviewRecord:
     newest_recovered_timestamp_utc: str | None
 
 
+@dataclass(frozen=True)
+class TriageTargetRecord:
+    priority_bucket: str
+    target_kind: str
+    family: str
+    triage_status: str
+    alert_alignment: str
+    latest_run_id: str
+    latest_run_source_kind: str
+    latest_run_health_status: str
+    latest_run_timestamp_utc: str
+    target_run_id: str
+    target_source_kind: str
+    target_health_status: str
+    target_timestamp_utc: str
+    target_domains: list[str]
+    target_reasons: list[str]
+    target_failed_checks: list[str]
+
+
 def resolve_root(path_text: str, default: Path) -> Path:
     candidate = Path(path_text)
     if not candidate.is_absolute():
@@ -1102,6 +1122,117 @@ def render_triage_overview_markdown(record: TriageOverviewRecord) -> str:
     )
 
 
+def build_triage_target_records(
+    *,
+    records: list[SummaryRecord],
+    family: str | None,
+    run_id_prefix: str | None,
+    source_kind: str,
+) -> list[TriageTargetRecord]:
+    triage_records = build_operator_triage_records(
+        records=records,
+        family=family,
+        run_id_prefix=run_id_prefix,
+        source_kind=source_kind,
+    )
+    active_targets: list[TriageTargetRecord] = []
+    lagging_targets: list[TriageTargetRecord] = []
+
+    for record in triage_records:
+        if record.triage_status == "clear":
+            continue
+        if record.triage_status == "active":
+            target_record = TriageTargetRecord(
+                priority_bucket="active",
+                target_kind="latest-gap",
+                family=record.family,
+                triage_status=record.triage_status,
+                alert_alignment=record.alert_alignment,
+                latest_run_id=record.latest_run_id,
+                latest_run_source_kind=record.latest_run_source_kind,
+                latest_run_health_status=record.latest_run_health_status,
+                latest_run_timestamp_utc=record.latest_run_timestamp_utc,
+                target_run_id=record.latest_run_id,
+                target_source_kind=record.latest_run_source_kind,
+                target_health_status=record.latest_run_health_status,
+                target_timestamp_utc=record.latest_run_timestamp_utc,
+                target_domains=record.latest_gap_domains,
+                target_reasons=record.latest_gap_reasons,
+                target_failed_checks=record.latest_alert_failed_checks if record.alert_alignment == "current" else [],
+            )
+            active_targets.append(target_record)
+            continue
+        if record.latest_alert_run_id is None or record.latest_alert_source_kind is None or record.latest_alert_health_status is None:
+            continue
+        lagging_targets.append(
+            TriageTargetRecord(
+                priority_bucket="lagging",
+                target_kind="latest-alert-follow-up",
+                family=record.family,
+                triage_status=record.triage_status,
+                alert_alignment=record.alert_alignment,
+                latest_run_id=record.latest_run_id,
+                latest_run_source_kind=record.latest_run_source_kind,
+                latest_run_health_status=record.latest_run_health_status,
+                latest_run_timestamp_utc=record.latest_run_timestamp_utc,
+                target_run_id=record.latest_alert_run_id,
+                target_source_kind=record.latest_alert_source_kind,
+                target_health_status=record.latest_alert_health_status,
+                target_timestamp_utc=record.latest_alert_timestamp_utc or record.latest_run_timestamp_utc,
+                target_domains=record.latest_alert_domains,
+                target_reasons=record.latest_alert_reasons,
+                target_failed_checks=record.latest_alert_failed_checks,
+            )
+        )
+    return active_targets + lagging_targets
+
+
+def render_triage_targets_table(records: list[TriageTargetRecord]) -> str:
+    lines = [
+        "priority_bucket\ttarget_kind\tfamily\ttriage_status\talert_alignment\ttarget_run\ttarget_source\ttarget_health\ttarget_domains\ttarget_reasons\ttarget_failed_checks\tlatest_run\tlatest_source\tlatest_health\tlatest_timestamp",
+    ]
+    for record in records:
+        lines.append(
+            "\t".join(
+                [
+                    record.priority_bucket,
+                    record.target_kind,
+                    record.family,
+                    record.triage_status,
+                    record.alert_alignment,
+                    record.target_run_id,
+                    record.target_source_kind,
+                    record.target_health_status,
+                    ",".join(record.target_domains),
+                    ",".join(record.target_reasons),
+                    ",".join(record.target_failed_checks),
+                    record.latest_run_id,
+                    record.latest_run_source_kind,
+                    record.latest_run_health_status,
+                    record.latest_run_timestamp_utc,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_triage_targets_markdown(records: list[TriageTargetRecord]) -> str:
+    lines = [
+        "| priority_bucket | target_kind | family | triage_status | alert_alignment | target_run | target_source | target_health | target_domains | target_reasons | target_failed_checks | latest_run | latest_source | latest_health | latest_timestamp |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for record in records:
+        lines.append(
+            f"| {record.priority_bucket} | {record.target_kind} | {record.family} | {record.triage_status} | "
+            f"{record.alert_alignment} | `{record.target_run_id}` | {record.target_source_kind} | "
+            f"{record.target_health_status} | {', '.join(record.target_domains)} | "
+            f"{', '.join(record.target_reasons)} | {', '.join(record.target_failed_checks)} | "
+            f"`{record.latest_run_id}` | {record.latest_run_source_kind} | {record.latest_run_health_status} | "
+            f"{record.latest_run_timestamp_utc} |"
+        )
+    return "\n".join(lines)
+
+
 def select_record(
     *,
     records: list[SummaryRecord],
@@ -1817,6 +1948,21 @@ def parse_args() -> argparse.Namespace:
     triage_overview_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_overview_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     triage_overview_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+
+    triage_targets_parser = subparsers.add_parser(
+        "triage-targets",
+        help="show actionable triage targets with active gaps first and lagging alert follow-ups after",
+    )
+    triage_targets_parser.add_argument("--family", default=None)
+    triage_targets_parser.add_argument("--run-id-prefix", default=None)
+    triage_targets_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
+    triage_targets_parser.add_argument("--triage-status", choices=["active", "lagging"], default=None)
+    triage_targets_parser.add_argument("--has-target-domain", default=None)
+    triage_targets_parser.add_argument("--limit", type=int, default=20)
+    triage_targets_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    triage_targets_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    triage_targets_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    triage_targets_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     return parser.parse_args()
 
 
@@ -2002,6 +2148,27 @@ def main() -> int:
             print(render_triage_overview_markdown(record))
             return 0
         print(render_triage_overview_table(record))
+        return 0
+
+    if args.command == "triage-targets":
+        target_records = build_triage_target_records(
+            records=records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+        )
+        if args.triage_status:
+            target_records = [record for record in target_records if record.triage_status == args.triage_status]
+        if args.has_target_domain:
+            target_records = [record for record in target_records if args.has_target_domain in record.target_domains]
+        target_records = target_records[: args.limit]
+        if args.format == "json":
+            print(json.dumps({"records": [asdict(record) for record in target_records]}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_triage_targets_markdown(target_records))
+            return 0
+        print(render_triage_targets_table(target_records))
         return 0
 
     if args.command == "reconcile-status":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -483,6 +483,9 @@ TRIAGE_SUMMARY_ACTIVE_OUTPUT="$TMP_DIR/triage-summary-active.json"
 TRIAGE_SUMMARY_ALL_OUTPUT="$TMP_DIR/triage-summary-all.json"
 TRIAGE_OVERVIEW_OUTPUT="$TMP_DIR/triage-overview.json"
 TRIAGE_OVERVIEW_ALL_OUTPUT="$TMP_DIR/triage-overview-all.json"
+TRIAGE_TARGETS_OUTPUT="$TMP_DIR/triage-targets.json"
+TRIAGE_TARGETS_LAGGING_OUTPUT="$TMP_DIR/triage-targets-lagging.json"
+TRIAGE_TARGETS_ALL_OUTPUT="$TMP_DIR/triage-targets-all.json"
 RECONCILE_HEALTHY_OUTPUT="$TMP_DIR/reconcile-healthy.json"
 RECONCILE_RESTORED_OUTPUT="$TMP_DIR/reconcile-restored.json"
 RECONCILE_SCAN_OUTPUT="$TMP_DIR/reconcile-scan.json"
@@ -1197,6 +1200,97 @@ assert record["newest_failing_alert_domains"] == ["readiness", "reconcile"], rec
 assert record["newest_recovered_family"] is None, record
 assert record["newest_recovered_run_id"] is None, record
 assert record["newest_recovered_source_kind"] is None, record
+PY
+
+python3 "$QUERY_PATH" triage-targets \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_TARGETS_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_TARGETS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["family"] for record in records] == [
+    "federated-ci-local",
+    "federated-ci-runtime-gates",
+], records
+
+local, runtime = records
+assert local["priority_bucket"] == "active", local
+assert local["target_kind"] == "latest-gap", local
+assert local["triage_status"] == "active", local
+assert local["target_run_id"] == "federated-ci-local-20260301", local
+assert local["target_source_kind"] == "stamped", local
+assert local["target_health_status"] == "unknown", local
+assert local["target_domains"] == ["checkpoint", "readiness", "reconcile"], local
+assert local["target_reasons"] == [
+    "readiness_missing",
+    "reconcile_unknown",
+    "reconcile_artifact_missing",
+    "reconcile_validation_missing",
+    "checkpoint_missing",
+], local
+
+assert runtime["priority_bucket"] == "lagging", runtime
+assert runtime["target_kind"] == "latest-alert-follow-up", runtime
+assert runtime["triage_status"] == "lagging", runtime
+assert runtime["target_run_id"] == "federated-ci-runtime-gates-20260319-rerun29", runtime
+assert runtime["target_source_kind"] == "stamped", runtime
+assert runtime["target_health_status"] == "unknown", runtime
+assert runtime["target_domains"] == ["checkpoint", "readiness", "reconcile"], runtime
+assert runtime["target_reasons"] == ["checkpoint_missing", "reconcile_unknown"], runtime
+PY
+
+python3 "$QUERY_PATH" triage-targets \
+  --triage-status lagging \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_TARGETS_LAGGING_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_TARGETS_LAGGING_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["family"] == "federated-ci-runtime-gates", record
+assert record["priority_bucket"] == "lagging", record
+assert record["target_kind"] == "latest-alert-follow-up", record
+assert record["target_run_id"] == "federated-ci-runtime-gates-20260319-rerun29", record
+assert record["target_domains"] == ["checkpoint", "readiness", "reconcile"], record
+PY
+
+python3 "$QUERY_PATH" triage-targets \
+  --source-kind all \
+  --has-target-domain checkpoint \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_TARGETS_ALL_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_TARGETS_ALL_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["family"] == "federated-ci-local", record
+assert record["priority_bucket"] == "active", record
+assert record["target_kind"] == "latest-gap", record
+assert record["target_run_id"] == "federated-ci-local-20260301", record
+assert record["target_domains"] == ["checkpoint", "readiness", "reconcile"], record
 PY
 
 python3 "$QUERY_PATH" reconcile-status \


### PR DESCRIPTION
## Summary
- add a triage-targets query surface for actionable family ordering
- surface active latest-gap targets before lagging alert follow-ups
- keep target filtering aligned with the existing operator-triage source-kind surface

## Scope
- add triage-target record construction and renderers in the federated CI query engine
- add triage-targets CLI parsing, filtering, and output wiring
- extend contract fixtures to lock default, lagging-only, and source-kind all target selection

## Linked Issues
- Closes #914

## Validation
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- triage-target ordering now depends on operator-triage sort order, so regressions there would cascade here
- target surface intentionally reuses latest-gap versus latest-alert semantics instead of introducing a new state model

## Review Checklist
- confirm triage-targets returns active latest-gap rows before lagging follow-up rows
- confirm source-kind all filtering still reflects latest summary material rather than stamped-only history
- confirm no unrelated artifact residue is staged in the PR

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required because this change only extends local query/triage tooling over existing federated CI artifacts.