### PR TITLE
feat(query-engine): add triage queue surface

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -209,6 +209,21 @@ class TriageTargetRecord:
     target_failed_checks: list[str]
 
 
+@dataclass(frozen=True)
+class TriageQueueRecord:
+    priority_bucket: str
+    target_count: int
+    families: list[str]
+    newest_target_family: str
+    newest_target_run_id: str
+    newest_target_source_kind: str
+    newest_target_health_status: str
+    newest_target_timestamp_utc: str
+    newest_target_kind: str
+    target_kind_counts: dict[str, int]
+    target_domain_counts: dict[str, int]
+
+
 def resolve_root(path_text: str, default: Path) -> Path:
     candidate = Path(path_text)
     if not candidate.is_absolute():
@@ -1233,6 +1248,100 @@ def render_triage_targets_markdown(records: list[TriageTargetRecord]) -> str:
     return "\n".join(lines)
 
 
+def build_triage_queue_records(
+    *,
+    records: list[SummaryRecord],
+    family: str | None,
+    run_id_prefix: str | None,
+    source_kind: str,
+) -> list[TriageQueueRecord]:
+    target_records = build_triage_target_records(
+        records=records,
+        family=family,
+        run_id_prefix=run_id_prefix,
+        source_kind=source_kind,
+    )
+    grouped: dict[str, list[TriageTargetRecord]] = {}
+    for record in target_records:
+        grouped.setdefault(record.priority_bucket, []).append(record)
+
+    queue_records: list[TriageQueueRecord] = []
+    for priority_bucket in ("active", "lagging"):
+        bucket_records = grouped.get(priority_bucket, [])
+        if not bucket_records:
+            continue
+        bucket_records = sorted(
+            bucket_records,
+            key=lambda record: (record.target_timestamp_utc, record.family),
+            reverse=True,
+        )
+        newest = bucket_records[0]
+        target_kind_counts: dict[str, int] = {}
+        target_domain_counts: dict[str, int] = {}
+        for record in bucket_records:
+            target_kind_counts[record.target_kind] = target_kind_counts.get(record.target_kind, 0) + 1
+            for domain in record.target_domains:
+                target_domain_counts[domain] = target_domain_counts.get(domain, 0) + 1
+        queue_records.append(
+            TriageQueueRecord(
+                priority_bucket=priority_bucket,
+                target_count=len(bucket_records),
+                families=[record.family for record in bucket_records],
+                newest_target_family=newest.family,
+                newest_target_run_id=newest.target_run_id,
+                newest_target_source_kind=newest.target_source_kind,
+                newest_target_health_status=newest.target_health_status,
+                newest_target_timestamp_utc=newest.target_timestamp_utc,
+                newest_target_kind=newest.target_kind,
+                target_kind_counts={key: target_kind_counts[key] for key in sorted(target_kind_counts)},
+                target_domain_counts={key: target_domain_counts[key] for key in sorted(target_domain_counts)},
+            )
+        )
+    return queue_records
+
+
+def render_triage_queue_table(records: list[TriageQueueRecord]) -> str:
+    lines = [
+        "priority_bucket\ttarget_count\tfamilies\tnewest_target_family\tnewest_target_run\tnewest_target_source\tnewest_target_health\tnewest_target_kind\ttarget_kind_counts\ttarget_domain_counts\tnewest_target_timestamp",
+    ]
+    for record in records:
+        lines.append(
+            "\t".join(
+                [
+                    record.priority_bucket,
+                    str(record.target_count),
+                    ",".join(record.families),
+                    record.newest_target_family,
+                    record.newest_target_run_id,
+                    record.newest_target_source_kind,
+                    record.newest_target_health_status,
+                    record.newest_target_kind,
+                    ",".join(f"{key}={value}" for key, value in record.target_kind_counts.items()),
+                    ",".join(f"{key}={value}" for key, value in record.target_domain_counts.items()),
+                    record.newest_target_timestamp_utc,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_triage_queue_markdown(records: list[TriageQueueRecord]) -> str:
+    lines = [
+        "| priority_bucket | target_count | families | newest_target_family | newest_target_run | newest_target_source | newest_target_health | newest_target_kind | target_kind_counts | target_domain_counts | newest_target_timestamp |",
+        "| --- | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for record in records:
+        lines.append(
+            f"| {record.priority_bucket} | {record.target_count} | {', '.join(record.families)} | "
+            f"{record.newest_target_family} | `{record.newest_target_run_id}` | {record.newest_target_source_kind} | "
+            f"{record.newest_target_health_status} | {record.newest_target_kind} | "
+            f"{', '.join(f'{key}={value}' for key, value in record.target_kind_counts.items())} | "
+            f"{', '.join(f'{key}={value}' for key, value in record.target_domain_counts.items())} | "
+            f"{record.newest_target_timestamp_utc} |"
+        )
+    return "\n".join(lines)
+
+
 def select_record(
     *,
     records: list[SummaryRecord],
@@ -1963,6 +2072,21 @@ def parse_args() -> argparse.Namespace:
     triage_targets_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_targets_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     triage_targets_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+
+    triage_queue_parser = subparsers.add_parser(
+        "triage-queue",
+        help="show bucketed triage target queues with newest target pointers and domain counts",
+    )
+    triage_queue_parser.add_argument("--family", default=None)
+    triage_queue_parser.add_argument("--run-id-prefix", default=None)
+    triage_queue_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
+    triage_queue_parser.add_argument("--priority-bucket", choices=["active", "lagging"], default=None)
+    triage_queue_parser.add_argument("--has-target-domain", default=None)
+    triage_queue_parser.add_argument("--limit", type=int, default=20)
+    triage_queue_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    triage_queue_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    triage_queue_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    triage_queue_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     return parser.parse_args()
 
 
@@ -2169,6 +2293,29 @@ def main() -> int:
             print(render_triage_targets_markdown(target_records))
             return 0
         print(render_triage_targets_table(target_records))
+        return 0
+
+    if args.command == "triage-queue":
+        queue_records = build_triage_queue_records(
+            records=records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+        )
+        if args.priority_bucket:
+            queue_records = [record for record in queue_records if record.priority_bucket == args.priority_bucket]
+        if args.has_target_domain:
+            queue_records = [
+                record for record in queue_records if record.target_domain_counts.get(args.has_target_domain, 0) > 0
+            ]
+        queue_records = queue_records[: args.limit]
+        if args.format == "json":
+            print(json.dumps({"records": [asdict(record) for record in queue_records]}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_triage_queue_markdown(queue_records))
+            return 0
+        print(render_triage_queue_table(queue_records))
         return 0
 
     if args.command == "reconcile-status":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -486,6 +486,9 @@ TRIAGE_OVERVIEW_ALL_OUTPUT="$TMP_DIR/triage-overview-all.json"
 TRIAGE_TARGETS_OUTPUT="$TMP_DIR/triage-targets.json"
 TRIAGE_TARGETS_LAGGING_OUTPUT="$TMP_DIR/triage-targets-lagging.json"
 TRIAGE_TARGETS_ALL_OUTPUT="$TMP_DIR/triage-targets-all.json"
+TRIAGE_QUEUE_OUTPUT="$TMP_DIR/triage-queue.json"
+TRIAGE_QUEUE_LAGGING_OUTPUT="$TMP_DIR/triage-queue-lagging.json"
+TRIAGE_QUEUE_ALL_OUTPUT="$TMP_DIR/triage-queue-all.json"
 RECONCILE_HEALTHY_OUTPUT="$TMP_DIR/reconcile-healthy.json"
 RECONCILE_RESTORED_OUTPUT="$TMP_DIR/reconcile-restored.json"
 RECONCILE_SCAN_OUTPUT="$TMP_DIR/reconcile-scan.json"
@@ -1291,6 +1294,90 @@ assert record["priority_bucket"] == "active", record
 assert record["target_kind"] == "latest-gap", record
 assert record["target_run_id"] == "federated-ci-local-20260301", record
 assert record["target_domains"] == ["checkpoint", "readiness", "reconcile"], record
+PY
+
+python3 "$QUERY_PATH" triage-queue \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_QUEUE_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_QUEUE_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["priority_bucket"] for record in records] == ["active", "lagging"], records
+
+active, lagging = records
+assert active["target_count"] == 1, active
+assert active["families"] == ["federated-ci-local"], active
+assert active["newest_target_family"] == "federated-ci-local", active
+assert active["newest_target_run_id"] == "federated-ci-local-20260301", active
+assert active["newest_target_source_kind"] == "stamped", active
+assert active["newest_target_kind"] == "latest-gap", active
+assert active["target_kind_counts"] == {"latest-gap": 1}, active
+assert active["target_domain_counts"] == {"checkpoint": 1, "readiness": 1, "reconcile": 1}, active
+
+assert lagging["target_count"] == 1, lagging
+assert lagging["families"] == ["federated-ci-runtime-gates"], lagging
+assert lagging["newest_target_family"] == "federated-ci-runtime-gates", lagging
+assert lagging["newest_target_run_id"] == "federated-ci-runtime-gates-20260319-rerun29", lagging
+assert lagging["newest_target_source_kind"] == "stamped", lagging
+assert lagging["newest_target_kind"] == "latest-alert-follow-up", lagging
+assert lagging["target_kind_counts"] == {"latest-alert-follow-up": 1}, lagging
+assert lagging["target_domain_counts"] == {"checkpoint": 1, "readiness": 1, "reconcile": 1}, lagging
+PY
+
+python3 "$QUERY_PATH" triage-queue \
+  --priority-bucket lagging \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_QUEUE_LAGGING_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_QUEUE_LAGGING_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["priority_bucket"] == "lagging", record
+assert record["families"] == ["federated-ci-runtime-gates"], record
+assert record["target_kind_counts"] == {"latest-alert-follow-up": 1}, record
+PY
+
+python3 "$QUERY_PATH" triage-queue \
+  --source-kind all \
+  --has-target-domain checkpoint \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_QUEUE_ALL_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_QUEUE_ALL_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["priority_bucket"] == "active", record
+assert record["target_count"] == 2, record
+assert record["families"] == ["federated-ci-runtime-gates", "federated-ci-local"], record
+assert record["newest_target_family"] == "federated-ci-runtime-gates", record
+assert record["newest_target_run_id"] == "federated-ci-runtime-gates-20260319-rerun26", record
+assert record["newest_target_source_kind"] == "latest", record
+assert record["newest_target_kind"] == "latest-gap", record
+assert record["target_kind_counts"] == {"latest-gap": 2}, record
+assert record["target_domain_counts"] == {"checkpoint": 1, "readiness": 2, "reconcile": 2}, record
 PY
 
 python3 "$QUERY_PATH" reconcile-status \


### PR DESCRIPTION
## Summary
- add a triage-queue query surface that groups actionable targets by priority bucket
- surface newest target pointers together with per-bucket kind and domain counts
- keep queue aggregation aligned with triage-targets ordering and source-kind filtering

## Scope
- add triage-queue record construction and renderers in the federated CI query engine
- add triage-queue CLI parsing, filtering, and output wiring
- extend contract fixtures to lock default, lagging-only, and source-kind all queue aggregation

## Linked Issues
- Closes #916

## Validation
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- triage-queue ordering depends on triage-target timestamps and bucket semantics, so regressions there would cascade here
- queue aggregation intentionally stays read-only and does not introduce a new triage state model

## Review Checklist
- confirm triage-queue returns active buckets before lagging buckets
- confirm newest target pointers and domain counts match the underlying triage-target rows
- confirm source-kind all aggregation still reflects latest summary material instead of stamped-only history

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required because this change only extends local query and triage tooling over existing federated CI artifacts.