### PR TITLE
feat(query-engine): add triage feed surface

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -224,6 +224,15 @@ class TriageQueueRecord:
     target_domain_counts: dict[str, int]
 
 
+@dataclass(frozen=True)
+class TriageFeedRecord:
+    source_kind: str
+    target_limit: int
+    overview: TriageOverviewRecord
+    queue_records: list[TriageQueueRecord]
+    target_records: list[TriageTargetRecord]
+
+
 def resolve_root(path_text: str, default: Path) -> Path:
     candidate = Path(path_text)
     if not candidate.is_absolute():
@@ -1342,6 +1351,65 @@ def render_triage_queue_markdown(records: list[TriageQueueRecord]) -> str:
     return "\n".join(lines)
 
 
+def build_triage_feed_record(
+    *,
+    records: list[SummaryRecord],
+    family: str | None,
+    run_id_prefix: str | None,
+    source_kind: str,
+    target_limit: int,
+) -> TriageFeedRecord:
+    overview = build_triage_overview_record(
+        records=records,
+        family=family,
+        run_id_prefix=run_id_prefix,
+        source_kind=source_kind,
+    )
+    queue_records = build_triage_queue_records(
+        records=records,
+        family=family,
+        run_id_prefix=run_id_prefix,
+        source_kind=source_kind,
+    )
+    target_records = build_triage_target_records(
+        records=records,
+        family=family,
+        run_id_prefix=run_id_prefix,
+        source_kind=source_kind,
+    )[:target_limit]
+    return TriageFeedRecord(
+        source_kind=source_kind,
+        target_limit=target_limit,
+        overview=overview,
+        queue_records=queue_records,
+        target_records=target_records,
+    )
+
+
+def render_triage_feed_table(record: TriageFeedRecord) -> str:
+    sections = [
+        f"source_kind\t{record.source_kind}",
+        f"target_limit\t{record.target_limit}",
+        "overview",
+        render_triage_overview_table(record.overview),
+        "queue",
+        render_triage_queue_table(record.queue_records),
+        "targets",
+        render_triage_targets_table(record.target_records),
+    ]
+    return "\n".join(sections)
+
+
+def render_triage_feed_markdown(record: TriageFeedRecord) -> str:
+    sections = [
+        f"## Triage Feed\n\n- source_kind: `{record.source_kind}`\n- target_limit: `{record.target_limit}`",
+        "### Overview\n\n" + render_triage_overview_markdown(record.overview),
+        "### Queue\n\n" + render_triage_queue_markdown(record.queue_records),
+        "### Targets\n\n" + render_triage_targets_markdown(record.target_records),
+    ]
+    return "\n\n".join(sections)
+
+
 def select_record(
     *,
     records: list[SummaryRecord],
@@ -2087,6 +2155,19 @@ def parse_args() -> argparse.Namespace:
     triage_queue_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_queue_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     triage_queue_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+
+    triage_feed_parser = subparsers.add_parser(
+        "triage-feed",
+        help="show one operator snapshot that bundles overview, queue, and top triage targets",
+    )
+    triage_feed_parser.add_argument("--family", default=None)
+    triage_feed_parser.add_argument("--run-id-prefix", default=None)
+    triage_feed_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
+    triage_feed_parser.add_argument("--target-limit", type=int, default=3)
+    triage_feed_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    triage_feed_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    triage_feed_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    triage_feed_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     return parser.parse_args()
 
 
@@ -2316,6 +2397,23 @@ def main() -> int:
             print(render_triage_queue_markdown(queue_records))
             return 0
         print(render_triage_queue_table(queue_records))
+        return 0
+
+    if args.command == "triage-feed":
+        record = build_triage_feed_record(
+            records=records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+            target_limit=args.target_limit,
+        )
+        if args.format == "json":
+            print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_triage_feed_markdown(record))
+            return 0
+        print(render_triage_feed_table(record))
         return 0
 
     if args.command == "reconcile-status":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -489,6 +489,8 @@ TRIAGE_TARGETS_ALL_OUTPUT="$TMP_DIR/triage-targets-all.json"
 TRIAGE_QUEUE_OUTPUT="$TMP_DIR/triage-queue.json"
 TRIAGE_QUEUE_LAGGING_OUTPUT="$TMP_DIR/triage-queue-lagging.json"
 TRIAGE_QUEUE_ALL_OUTPUT="$TMP_DIR/triage-queue-all.json"
+TRIAGE_FEED_OUTPUT="$TMP_DIR/triage-feed.json"
+TRIAGE_FEED_ALL_OUTPUT="$TMP_DIR/triage-feed-all.json"
 RECONCILE_HEALTHY_OUTPUT="$TMP_DIR/reconcile-healthy.json"
 RECONCILE_RESTORED_OUTPUT="$TMP_DIR/reconcile-restored.json"
 RECONCILE_SCAN_OUTPUT="$TMP_DIR/reconcile-scan.json"
@@ -1378,6 +1380,61 @@ assert record["newest_target_source_kind"] == "latest", record
 assert record["newest_target_kind"] == "latest-gap", record
 assert record["target_kind_counts"] == {"latest-gap": 2}, record
 assert record["target_domain_counts"] == {"checkpoint": 1, "readiness": 2, "reconcile": 2}, record
+PY
+
+python3 "$QUERY_PATH" triage-feed \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_FEED_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_FEED_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["source_kind"] == "stamped", record
+assert record["target_limit"] == 3, record
+assert record["overview"]["triage_status_counts"] == {"active": 1, "lagging": 1}, record
+assert [queue["priority_bucket"] for queue in record["queue_records"]] == ["active", "lagging"], record
+assert [target["family"] for target in record["target_records"]] == [
+    "federated-ci-local",
+    "federated-ci-runtime-gates",
+], record
+assert record["target_records"][0]["priority_bucket"] == "active", record
+assert record["target_records"][1]["priority_bucket"] == "lagging", record
+PY
+
+python3 "$QUERY_PATH" triage-feed \
+  --source-kind all \
+  --target-limit 1 \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_FEED_ALL_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_FEED_ALL_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["source_kind"] == "all", record
+assert record["target_limit"] == 1, record
+assert record["overview"]["triage_status_counts"] == {"active": 2}, record
+assert len(record["queue_records"]) == 1, record
+queue = record["queue_records"][0]
+assert queue["priority_bucket"] == "active", queue
+assert queue["target_count"] == 2, queue
+assert queue["newest_target_family"] == "federated-ci-runtime-gates", queue
+assert len(record["target_records"]) == 1, record
+target = record["target_records"][0]
+assert target["family"] == "federated-ci-runtime-gates", target
+assert target["priority_bucket"] == "active", target
+assert target["target_source_kind"] == "latest", target
 PY
 
 python3 "$QUERY_PATH" reconcile-status \


### PR DESCRIPTION
## Summary
- add a triage-feed query surface that bundles overview, queue, and top targets into one operator snapshot
- keep the feed aligned with the existing triage-overview, triage-queue, and triage-targets semantics
- support source-kind filtering and a bounded top-target window

## Scope
- add triage-feed record construction and renderers in the federated CI query engine
- add triage-feed CLI parsing and output wiring
- extend contract fixtures to lock default and source-kind all operator snapshots

## Linked Issues
- Closes #918

## Validation
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- triage-feed is a composed read surface, so regressions in overview, queue, or target helpers would cascade here
- feed output intentionally mirrors existing triage semantics rather than introducing a new state model

## Review Checklist
- confirm triage-feed overview, queue, and target sections stay internally consistent
- confirm target-limit trims only the target section and not queue or overview aggregation
- confirm source-kind all still reflects latest summary material rather than stamped-only history

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required because this change only extends local query and triage tooling over existing federated CI artifacts.