### PR TITLE
feat(query-engine): add triage brief surface

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -233,6 +233,23 @@ class TriageFeedRecord:
     target_records: list[TriageTargetRecord]
 
 
+@dataclass(frozen=True)
+class TriageBriefRecord:
+    source_kind: str
+    target_limit: int
+    attention_family_count: int
+    active_family_count: int
+    lagging_family_count: int
+    clear_family_count: int
+    newest_failing_family: str | None
+    newest_failing_run_id: str | None
+    newest_failing_triage_status: str | None
+    newest_recovered_family: str | None
+    newest_recovered_run_id: str | None
+    queue_lines: list[str]
+    target_lines: list[str]
+
+
 def resolve_root(path_text: str, default: Path) -> Path:
     candidate = Path(path_text)
     if not candidate.is_absolute():
@@ -1410,6 +1427,102 @@ def render_triage_feed_markdown(record: TriageFeedRecord) -> str:
     return "\n\n".join(sections)
 
 
+def build_triage_brief_record(
+    *,
+    records: list[SummaryRecord],
+    family: str | None,
+    run_id_prefix: str | None,
+    source_kind: str,
+    target_limit: int,
+) -> TriageBriefRecord:
+    feed = build_triage_feed_record(
+        records=records,
+        family=family,
+        run_id_prefix=run_id_prefix,
+        source_kind=source_kind,
+        target_limit=target_limit,
+    )
+    overview = feed.overview
+    queue_lines = [
+        (
+            f"{queue.priority_bucket}: targets={queue.target_count} "
+            f"newest={queue.newest_target_family}/{queue.newest_target_run_id} "
+            f"domains={','.join(f'{key}={value}' for key, value in queue.target_domain_counts.items())}"
+        )
+        for queue in feed.queue_records
+    ]
+    target_lines = [
+        (
+            f"[{target.priority_bucket}/{target.target_kind}] "
+            f"{target.family} -> {target.target_run_id} "
+            f"domains={','.join(target.target_domains)}"
+        )
+        for target in feed.target_records
+    ]
+    return TriageBriefRecord(
+        source_kind=source_kind,
+        target_limit=target_limit,
+        attention_family_count=overview.triage_status_counts.get("active", 0) + overview.triage_status_counts.get("lagging", 0),
+        active_family_count=overview.triage_status_counts.get("active", 0),
+        lagging_family_count=overview.triage_status_counts.get("lagging", 0),
+        clear_family_count=overview.triage_status_counts.get("clear", 0),
+        newest_failing_family=overview.newest_failing_family,
+        newest_failing_run_id=overview.newest_failing_run_id,
+        newest_failing_triage_status=overview.newest_failing_triage_status,
+        newest_recovered_family=overview.newest_recovered_family,
+        newest_recovered_run_id=overview.newest_recovered_run_id,
+        queue_lines=queue_lines,
+        target_lines=target_lines,
+    )
+
+
+def render_triage_brief_table(record: TriageBriefRecord) -> str:
+    sections = [
+        f"source_kind\t{record.source_kind}",
+        f"target_limit\t{record.target_limit}",
+        (
+            f"attention\tfamilies={record.attention_family_count},active={record.active_family_count},"
+            f"lagging={record.lagging_family_count},clear={record.clear_family_count}"
+        ),
+        (
+            f"newest_failing\t{record.newest_failing_family or ''}\t"
+            f"{record.newest_failing_run_id or ''}\t{record.newest_failing_triage_status or ''}"
+        ),
+        "queue",
+        *record.queue_lines,
+        "targets",
+        *record.target_lines,
+    ]
+    return "\n".join(sections)
+
+
+def render_triage_brief_markdown(record: TriageBriefRecord) -> str:
+    lines = [
+        "## Triage Brief",
+        f"- source_kind: `{record.source_kind}`",
+        f"- top target window: `{record.target_limit}`",
+        (
+            f"- attention families: `{record.attention_family_count}` "
+            f"(`active={record.active_family_count}`, `lagging={record.lagging_family_count}`, `clear={record.clear_family_count}`)"
+        ),
+        (
+            f"- newest failing pointer: `{record.newest_failing_family or ''}` / "
+            f"`{record.newest_failing_run_id or ''}` ({record.newest_failing_triage_status or 'none'})"
+        ),
+    ]
+    if record.newest_recovered_family or record.newest_recovered_run_id:
+        lines.append(
+            f"- newest recovered pointer: `{record.newest_recovered_family or ''}` / `{record.newest_recovered_run_id or ''}`"
+        )
+    lines.append("")
+    lines.append("### Queue")
+    lines.extend(f"- {line}" for line in record.queue_lines)
+    lines.append("")
+    lines.append("### Top Targets")
+    lines.extend(f"{index}. {line}" for index, line in enumerate(record.target_lines, start=1))
+    return "\n".join(lines)
+
+
 def select_record(
     *,
     records: list[SummaryRecord],
@@ -2168,6 +2281,19 @@ def parse_args() -> argparse.Namespace:
     triage_feed_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_feed_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     triage_feed_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+
+    triage_brief_parser = subparsers.add_parser(
+        "triage-brief",
+        help="show a concise operator summary derived from the triage feed surface",
+    )
+    triage_brief_parser.add_argument("--family", default=None)
+    triage_brief_parser.add_argument("--run-id-prefix", default=None)
+    triage_brief_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
+    triage_brief_parser.add_argument("--target-limit", type=int, default=3)
+    triage_brief_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
+    triage_brief_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    triage_brief_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    triage_brief_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     return parser.parse_args()
 
 
@@ -2414,6 +2540,23 @@ def main() -> int:
             print(render_triage_feed_markdown(record))
             return 0
         print(render_triage_feed_table(record))
+        return 0
+
+    if args.command == "triage-brief":
+        record = build_triage_brief_record(
+            records=records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+            target_limit=args.target_limit,
+        )
+        if args.format == "json":
+            print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_triage_brief_markdown(record))
+            return 0
+        print(render_triage_brief_table(record))
         return 0
 
     if args.command == "reconcile-status":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -491,6 +491,8 @@ TRIAGE_QUEUE_LAGGING_OUTPUT="$TMP_DIR/triage-queue-lagging.json"
 TRIAGE_QUEUE_ALL_OUTPUT="$TMP_DIR/triage-queue-all.json"
 TRIAGE_FEED_OUTPUT="$TMP_DIR/triage-feed.json"
 TRIAGE_FEED_ALL_OUTPUT="$TMP_DIR/triage-feed-all.json"
+TRIAGE_BRIEF_OUTPUT="$TMP_DIR/triage-brief.json"
+TRIAGE_BRIEF_ALL_OUTPUT="$TMP_DIR/triage-brief-all.json"
 RECONCILE_HEALTHY_OUTPUT="$TMP_DIR/reconcile-healthy.json"
 RECONCILE_RESTORED_OUTPUT="$TMP_DIR/reconcile-restored.json"
 RECONCILE_SCAN_OUTPUT="$TMP_DIR/reconcile-scan.json"
@@ -1435,6 +1437,70 @@ target = record["target_records"][0]
 assert target["family"] == "federated-ci-runtime-gates", target
 assert target["priority_bucket"] == "active", target
 assert target["target_source_kind"] == "latest", target
+PY
+
+python3 "$QUERY_PATH" triage-brief \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_BRIEF_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_BRIEF_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["source_kind"] == "stamped", record
+assert record["target_limit"] == 3, record
+assert record["attention_family_count"] == 2, record
+assert record["active_family_count"] == 1, record
+assert record["lagging_family_count"] == 1, record
+assert record["clear_family_count"] == 0, record
+assert record["newest_failing_family"] == "federated-ci-runtime-gates", record
+assert record["newest_failing_run_id"] == "federated-ci-runtime-gates-20260319-rerun30", record
+assert record["newest_failing_triage_status"] == "lagging", record
+assert record["queue_lines"] == [
+    "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1",
+    "lagging: targets=1 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint=1,readiness=1,reconcile=1",
+], record
+assert record["target_lines"] == [
+    "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "[lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile",
+], record
+PY
+
+python3 "$QUERY_PATH" triage-brief \
+  --source-kind all \
+  --target-limit 1 \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_BRIEF_ALL_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_BRIEF_ALL_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["source_kind"] == "all", record
+assert record["target_limit"] == 1, record
+assert record["attention_family_count"] == 2, record
+assert record["active_family_count"] == 2, record
+assert record["lagging_family_count"] == 0, record
+assert record["clear_family_count"] == 0, record
+assert record["newest_failing_family"] == "federated-ci-runtime-gates", record
+assert record["newest_failing_run_id"] == "federated-ci-runtime-gates-20260319-rerun26", record
+assert record["newest_failing_triage_status"] == "active", record
+assert record["queue_lines"] == [
+    "active: targets=2 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun26 domains=checkpoint=1,readiness=2,reconcile=2",
+], record
+assert record["target_lines"] == [
+    "[active/latest-gap] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun26 domains=readiness,reconcile",
+], record
 PY
 
 python3 "$QUERY_PATH" reconcile-status \


### PR DESCRIPTION
## Summary
- add a triage-brief query surface for a concise operator-facing summary
- derive the brief from the existing feed, queue, and target surfaces rather than introducing a new state model
- support source-kind filtering and bounded top-target output

## Scope
- add triage-brief record construction and renderers in the federated CI query engine
- add triage-brief CLI parsing and output wiring
- extend contract fixtures to lock stamped and source-kind all brief snapshots

## Linked Issues
- Closes #920

## Validation
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- triage-brief is a composed read surface, so regressions in feed, queue, or target helpers would cascade here
- brief output intentionally compresses existing triage semantics rather than introducing a separate operator state model

## Review Checklist
- confirm triage-brief keeps newest failing pointer, queue lines, and top target lines internally consistent
- confirm source-kind all still reflects latest summary material instead of stamped-only history
- confirm target-limit trims only the brief target list and not the attention counts

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required because this change only extends local query and triage tooling over existing federated CI artifacts.