### PR TITLE
feat(query-engine): add triage report surface

### DIFF
--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -250,6 +250,19 @@ class TriageBriefRecord:
     target_lines: list[str]
 
 
+@dataclass(frozen=True)
+class TriageReportRecord:
+    source_kind: str
+    target_limit: int
+    headline: str
+    attention_summary: str
+    newest_failing_summary: str
+    newest_recovered_summary: str | None
+    queue_lines: list[str]
+    target_lines: list[str]
+    markdown: str
+
+
 def resolve_root(path_text: str, default: Path) -> Path:
     candidate = Path(path_text)
     if not candidate.is_absolute():
@@ -1523,6 +1536,86 @@ def render_triage_brief_markdown(record: TriageBriefRecord) -> str:
     return "\n".join(lines)
 
 
+def build_triage_report_record(
+    *,
+    records: list[SummaryRecord],
+    family: str | None,
+    run_id_prefix: str | None,
+    source_kind: str,
+    target_limit: int,
+) -> TriageReportRecord:
+    brief = build_triage_brief_record(
+        records=records,
+        family=family,
+        run_id_prefix=run_id_prefix,
+        source_kind=source_kind,
+        target_limit=target_limit,
+    )
+    headline = f"Federated CI triage report: {brief.attention_family_count} attention families"
+    attention_summary = (
+        f"active={brief.active_family_count}, lagging={brief.lagging_family_count}, clear={brief.clear_family_count}"
+    )
+    newest_failing_summary = (
+        f"{brief.newest_failing_family or 'none'} / {brief.newest_failing_run_id or 'none'} / "
+        f"{brief.newest_failing_triage_status or 'none'}"
+    )
+    newest_recovered_summary = None
+    if brief.newest_recovered_family or brief.newest_recovered_run_id:
+        newest_recovered_summary = f"{brief.newest_recovered_family or 'none'} / {brief.newest_recovered_run_id or 'none'}"
+    markdown_lines = [
+        "## Federated CI Triage Report",
+        "",
+        "### Snapshot",
+        f"- source_kind: `{brief.source_kind}`",
+        f"- top target window: `{brief.target_limit}`",
+        f"- attention families: `{brief.attention_family_count}` ({attention_summary})",
+        f"- newest failing pointer: `{brief.newest_failing_family or ''}` / `{brief.newest_failing_run_id or ''}` ({brief.newest_failing_triage_status or 'none'})",
+    ]
+    if newest_recovered_summary is not None:
+        markdown_lines.append(
+            f"- newest recovered pointer: `{brief.newest_recovered_family or ''}` / `{brief.newest_recovered_run_id or ''}`"
+        )
+    markdown_lines.extend(
+        [
+            "",
+            "### Queue",
+            *[f"- {line}" for line in brief.queue_lines],
+            "",
+            "### Top Targets",
+            *[f"{index}. {line}" for index, line in enumerate(brief.target_lines, start=1)],
+        ]
+    )
+    return TriageReportRecord(
+        source_kind=brief.source_kind,
+        target_limit=brief.target_limit,
+        headline=headline,
+        attention_summary=attention_summary,
+        newest_failing_summary=newest_failing_summary,
+        newest_recovered_summary=newest_recovered_summary,
+        queue_lines=brief.queue_lines,
+        target_lines=brief.target_lines,
+        markdown="\n".join(markdown_lines),
+    )
+
+
+def render_triage_report_table(record: TriageReportRecord) -> str:
+    sections = [
+        f"headline\t{record.headline}",
+        f"source_kind\t{record.source_kind}",
+        f"target_limit\t{record.target_limit}",
+        f"attention_summary\t{record.attention_summary}",
+        f"newest_failing\t{record.newest_failing_summary}",
+    ]
+    if record.newest_recovered_summary is not None:
+        sections.append(f"newest_recovered\t{record.newest_recovered_summary}")
+    sections.extend(["queue", *record.queue_lines, "targets", *record.target_lines])
+    return "\n".join(sections)
+
+
+def render_triage_report_markdown(record: TriageReportRecord) -> str:
+    return record.markdown
+
+
 def select_record(
     *,
     records: list[SummaryRecord],
@@ -2294,6 +2387,19 @@ def parse_args() -> argparse.Namespace:
     triage_brief_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_brief_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     triage_brief_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+
+    triage_report_parser = subparsers.add_parser(
+        "triage-report",
+        help="show a fixed-format markdown report derived from the triage brief surface",
+    )
+    triage_report_parser.add_argument("--family", default=None)
+    triage_report_parser.add_argument("--run-id-prefix", default=None)
+    triage_report_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
+    triage_report_parser.add_argument("--target-limit", type=int, default=3)
+    triage_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
+    triage_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    triage_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    triage_report_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     return parser.parse_args()
 
 
@@ -2557,6 +2663,23 @@ def main() -> int:
             print(render_triage_brief_markdown(record))
             return 0
         print(render_triage_brief_table(record))
+        return 0
+
+    if args.command == "triage-report":
+        record = build_triage_report_record(
+            records=records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+            target_limit=args.target_limit,
+        )
+        if args.format == "json":
+            print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_triage_report_markdown(record))
+            return 0
+        print(render_triage_report_table(record))
         return 0
 
     if args.command == "reconcile-status":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -493,6 +493,8 @@ TRIAGE_FEED_OUTPUT="$TMP_DIR/triage-feed.json"
 TRIAGE_FEED_ALL_OUTPUT="$TMP_DIR/triage-feed-all.json"
 TRIAGE_BRIEF_OUTPUT="$TMP_DIR/triage-brief.json"
 TRIAGE_BRIEF_ALL_OUTPUT="$TMP_DIR/triage-brief-all.json"
+TRIAGE_REPORT_OUTPUT="$TMP_DIR/triage-report.json"
+TRIAGE_REPORT_ALL_OUTPUT="$TMP_DIR/triage-report-all.json"
 RECONCILE_HEALTHY_OUTPUT="$TMP_DIR/reconcile-healthy.json"
 RECONCILE_RESTORED_OUTPUT="$TMP_DIR/reconcile-restored.json"
 RECONCILE_SCAN_OUTPUT="$TMP_DIR/reconcile-scan.json"
@@ -1501,6 +1503,68 @@ assert record["queue_lines"] == [
 assert record["target_lines"] == [
     "[active/latest-gap] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun26 domains=readiness,reconcile",
 ], record
+PY
+
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_REPORT_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["source_kind"] == "stamped", record
+assert record["target_limit"] == 3, record
+assert record["headline"] == "Federated CI triage report: 2 attention families", record
+assert record["attention_summary"] == "active=1, lagging=1, clear=0", record
+assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun30 / lagging", record
+assert record["newest_recovered_summary"] is None, record
+assert record["queue_lines"] == [
+    "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1",
+    "lagging: targets=1 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint=1,readiness=1,reconcile=1",
+], record
+assert record["target_lines"] == [
+    "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "[lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile",
+], record
+assert "## Federated CI Triage Report" in record["markdown"], record
+assert "### Queue" in record["markdown"], record
+assert "### Top Targets" in record["markdown"], record
+PY
+
+python3 "$QUERY_PATH" triage-report \
+  --source-kind all \
+  --target-limit 1 \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" >"$TRIAGE_REPORT_ALL_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_ALL_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["source_kind"] == "all", record
+assert record["target_limit"] == 1, record
+assert record["headline"] == "Federated CI triage report: 2 attention families", record
+assert record["attention_summary"] == "active=2, lagging=0, clear=0", record
+assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun26 / active", record
+assert record["newest_recovered_summary"] is None, record
+assert record["queue_lines"] == [
+    "active: targets=2 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun26 domains=checkpoint=1,readiness=2,reconcile=2",
+], record
+assert record["target_lines"] == [
+    "[active/latest-gap] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun26 domains=readiness,reconcile",
+], record
+assert "source_kind: `all`" in record["markdown"], record
 PY
 
 python3 "$QUERY_PATH" reconcile-status \


### PR DESCRIPTION
## Summary
- add a triage-report query surface for fixed-format markdown status output
- derive the report from the existing brief and feed surfaces rather than introducing a new state model
- keep source-kind filtering and top-target trimming available for handoff and report use

## Scope
- add triage-report record construction and renderers in the federated CI query engine
- add triage-report CLI parsing and output wiring
- extend contract fixtures to lock stamped and source-kind all report snapshots

## Linked Issues
- Closes #922

## Validation
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_federated_ci_workflow_summary_contract.sh
- bash planningops/scripts/test_validate_federated_ci_summary_tmp_reconcile_contract.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- triage-report is a composed read surface, so regressions in brief or feed helpers would cascade here
- report output intentionally mirrors existing triage semantics rather than introducing a separate reporting state model

## Review Checklist
- confirm triage-report headline, snapshot lines, queue lines, and top target lines stay internally consistent
- confirm source-kind all still reflects latest summary material instead of stamped-only history
- confirm target-limit trims only the report target list and not the summary counts

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required because this change only extends local query and triage tooling over existing federated CI artifacts.