### PR TITLE
feat(local-runtime): add monday local codex readiness check

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -1,0 +1,177 @@
+---
+title: plan: Monday Local Codex Runtime Rollout
+type: plan
+date: 2026-04-01
+updated: 2026-04-01
+initiative: unified-personal-agent-platform
+lifecycle: workbench
+status: active
+summary: Defines the planningops-owned rollout for running monday locally with a local LLM path and Codex as the operator shell, using readiness-first evidence instead of ad hoc repo hopping.
+related_docs:
+  - ./2026-04-01-query-engine-and-harness-upgrade-plan.md
+  - ./2026-03-23-monday-agent-harness-reference-assimilation-plan.md
+  - ./2026-03-14-autonomous-scheduler-queue-control-plane-plan.md
+---
+
+# plan: Monday Local Codex Runtime Rollout
+
+## Why This Exists
+
+The local pieces already exist, but they are still spread across repo boundaries:
+
+- `planningops` can orchestrate sibling-repo local stack smoke
+- `monday` already exposes `local`, `local_ollama`, and `local_lmstudio` planner profiles
+- provider and observability gateways already have local launcher surfaces
+- Codex already works as the operator shell on this machine
+
+What is missing is a planningops-owned readiness view that answers a simpler question:
+
+Can we run `monday` locally, with a local LLM path available, and use Codex as the operator shell without manually rediscovering the wiring every time?
+
+## External Reference Patterns
+
+The public reference page for Claude Code is useful for local runtime design because it makes four things explicit:
+
+- the system runs as an agentic loop: request, context assembly, tool execution, observe, repeat
+- the runtime treats context as a first-class object rather than accidental shell state
+- the query engine and tool dispatcher are separate from the higher-level runtime shell
+- the terminal process is the execution boundary, not a hidden remote server
+
+That maps cleanly onto the current repo split:
+
+- `Codex` is the operator shell and tool surface
+- `monday` is the mission runtime and planner execution host
+- local LLM infrastructure is a selectable backend, not the operator shell itself
+- `planningops` owns readiness, evidence, governance, and promotion rules
+
+## Target Local Operating Model
+
+### Operator shell
+
+Codex remains the human-facing operator shell for:
+
+- triage
+- plan selection
+- handoff packet generation
+- smoke invocation
+- evidence review
+
+### Runtime host
+
+`monday` remains the runtime owner for:
+
+- planner profile selection
+- mission execution
+- handoff generation
+- runtime-private memory and queue behavior
+
+### Model path
+
+The local model path must support two valid shapes:
+
+1. gateway-first local mode
+   - `monday local -> LiteLLM/provider gateway -> Gemini primary or local fallback`
+2. direct local LLM mode
+   - `monday local_ollama -> Ollama`
+   - `monday local_lmstudio -> LM Studio`
+
+### Governance owner
+
+`planningops` must not become the mission executor. It should own:
+
+- readiness checks
+- federated smoke orchestration
+- report and artifact indexing
+- next-step recommendations
+
+## Phase Plan
+
+### Phase 0. Structural readiness
+
+Make the wiring visible from `planningops` without touching runtime internals.
+
+Deliverables:
+
+- a planningops-owned readiness assessor for:
+  - sibling repo presence
+  - local gateway-first alignment
+  - direct local LLM profile presence
+  - Codex shell availability
+- deterministic next-step commands for:
+  - federated local stack smoke
+  - monday direct profile smoke
+  - gateway bootstrap
+
+### Phase 1. Local smoke promotion lane
+
+Promote a repeatable operator entrypoint:
+
+- one `planningops` command that:
+  - checks readiness
+  - runs federated local stack smoke
+  - optionally runs direct monday profile smoke
+  - stores one stamped local operator report
+
+### Phase 2. Codex-to-monday handoff packet
+
+Add a stable packet for Codex-originated local mission execution:
+
+- mission objective
+- planner profile
+- local model route
+- expected evidence outputs
+- rollback instruction when live prerequisites fail
+
+### Phase 3. Operator-grade local report
+
+Expose a report shaped for handoff and reuse:
+
+- headline
+- active planner profile
+- local LLM route
+- readiness blockers
+- recommended commands
+- latest smoke evidence
+
+## Immediate Commands
+
+Gateway-first local smoke:
+
+```bash
+python3 planningops/scripts/federation/run_local_runtime_stack_smoke.py --workspace-root .. --profile local --run-id monday-local-stack-smoke
+```
+
+Direct monday smoke via local Ollama:
+
+```bash
+cd ../monday
+python3 scripts/run_local_runtime_smoke.py --profile local_ollama --run-id monday-local-ollama-smoke
+```
+
+Direct monday smoke via LM Studio:
+
+```bash
+cd ../monday
+python3 scripts/run_local_runtime_smoke.py --profile local_lmstudio --run-id monday-local-lmstudio-smoke
+```
+
+Provider gateway bootstrap:
+
+```bash
+cd ../platform-provider-gateway
+bash scripts/litellm_stack_launcher.sh --mode start
+```
+
+## Success Criteria
+
+- `planningops` can say whether `monday + local LLM + Codex` is structurally ready without repo hopping
+- the report contains exact commands for the next smoke step
+- `monday` local profiles stay runtime-owned
+- `planningops` remains evidence-first and fail-closed
+- the next implementation packet can focus on one operator entrypoint instead of rediscovering prerequisites
+
+## Next Natural Packets
+
+1. add a single planningops wrapper that runs readiness then launches federated local smoke
+2. stamp a local operator report artifact family under `planningops/artifacts/validation`
+3. add a Codex-to-monday mission packet contract so local operator prompts become reproducible inputs

--- a/planningops/scripts/assess_monday_local_codex_readiness.py
+++ b/planningops/scripts/assess_monday_local_codex_readiness.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import socket
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT = REPO_ROOT / "planningops/artifacts/validation/monday-local-codex-readiness-report.json"
+LOCAL_PROFILE_NAMES = ("local", "local_ollama", "local_lmstudio")
+DIRECT_LOCAL_LLM_PROFILE_NAMES = ("local_ollama", "local_lmstudio")
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in [current] + list(current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return REPO_ROOT
+
+
+def resolve_workspace_root(repo_root: Path, raw_workspace_root: str) -> Path:
+    candidates = [
+        Path(raw_workspace_root).resolve(),
+        (repo_root / raw_workspace_root).resolve(),
+        repo_root.parent,
+    ]
+    for candidate in candidates:
+        if (candidate / "monday").exists() and (candidate / "platform-provider-gateway").exists():
+            return candidate
+    return candidates[0]
+
+
+def resolve_file(base: Path, raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (base / path).resolve()
+
+
+def normalize_origin(url: str | None) -> str | None:
+    if not isinstance(url, str) or not url.strip():
+        return None
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.hostname:
+        return None
+    port = parsed.port
+    if port is None:
+        port = 443 if parsed.scheme == "https" else 80
+    return f"{parsed.scheme}://{parsed.hostname}:{port}"
+
+
+def probe_endpoint(url: str | None, mode: str) -> dict:
+    if mode == "off":
+        return {"status": "skipped", "detail": "probe_disabled"}
+    if not isinstance(url, str) or not url.strip():
+        return {"status": "missing", "detail": "base_url_missing"}
+
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        return {"status": "invalid", "detail": "hostname_missing"}
+
+    port = parsed.port
+    if port is None:
+        port = 443 if parsed.scheme == "https" else 80
+
+    try:
+        with socket.create_connection((parsed.hostname, port), timeout=1.0):
+            return {"status": "reachable", "detail": "tcp_connect_ok"}
+    except OSError as exc:
+        return {"status": "unreachable", "detail": str(exc)}
+
+
+def resolve_codex_binary(raw_value: str) -> str | None:
+    candidate = Path(raw_value)
+    if candidate.is_absolute():
+        return str(candidate.resolve()) if candidate.exists() else None
+    discovered = shutil.which(raw_value)
+    if discovered:
+        return str(Path(discovered).resolve())
+    return None
+
+
+def build_profile_summary(name: str, payload: dict, probe_mode: str) -> dict:
+    base_url = payload.get("deepagents_base_url")
+    probe = probe_endpoint(base_url, probe_mode)
+    return {
+        "profile_name": name,
+        "planner_engine": payload.get("planner_engine"),
+        "model_backend": payload.get("deepagents_model_backend"),
+        "model": payload.get("deepagents_model"),
+        "base_url": base_url,
+        "endpoint_probe_status": probe["status"],
+        "endpoint_probe_detail": probe["detail"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assess planningops-owned readiness for running monday locally with local LLM profiles and Codex."
+    )
+    parser.add_argument("--workspace-root", default="..", help="Workspace root containing sibling repositories.")
+    parser.add_argument(
+        "--planningops-runtime-profile-file",
+        default="planningops/config/runtime-profiles.json",
+        help="Path to planningops runtime profile catalog.",
+    )
+    parser.add_argument(
+        "--monday-planner-runtime-file",
+        default="monday/config/planner-runtime.json",
+        help="Path to monday planner runtime config.",
+    )
+    parser.add_argument(
+        "--probe-endpoints",
+        choices=["on", "off"],
+        default="on",
+        help="Whether to TCP probe configured local endpoints.",
+    )
+    parser.add_argument("--codex-bin", default="codex", help="Codex CLI name or absolute path.")
+    parser.add_argument("--output", default=str(DEFAULT_REPORT), help="Output JSON report path.")
+    args = parser.parse_args()
+
+    repo_root = resolve_repo_root()
+    workspace_root = resolve_workspace_root(repo_root, args.workspace_root)
+    planningops_runtime_path = resolve_file(repo_root, args.planningops_runtime_profile_file)
+    monday_runtime_path = resolve_file(workspace_root, args.monday_planner_runtime_file)
+    output_path = resolve_file(repo_root, args.output)
+
+    planningops_runtime = load_json(planningops_runtime_path)
+    monday_runtime = load_json(monday_runtime_path)
+
+    planningops_profiles = planningops_runtime.get("profiles") or {}
+    monday_profiles = monday_runtime.get("profiles") or {}
+    planningops_local = planningops_profiles.get("local") or {}
+    monday_local = monday_profiles.get("local") or {}
+
+    local_profiles = [
+        build_profile_summary(name, monday_profiles[name], args.probe_endpoints)
+        for name in LOCAL_PROFILE_NAMES
+        if isinstance(monday_profiles.get(name), dict)
+    ]
+    direct_local_profiles = [row for row in local_profiles if row["profile_name"] in DIRECT_LOCAL_LLM_PROFILE_NAMES]
+
+    codex_binary = resolve_codex_binary(args.codex_bin)
+    planningops_local_origin = normalize_origin(planningops_local.get("litellm_base_url"))
+    monday_local_origin = normalize_origin(monday_local.get("deepagents_base_url"))
+
+    workspace_components = {
+        "monday": {
+            "path": str((workspace_root / "monday").resolve()),
+            "present": (workspace_root / "monday").exists(),
+        },
+        "platform_provider_gateway": {
+            "path": str((workspace_root / "platform-provider-gateway").resolve()),
+            "present": (workspace_root / "platform-provider-gateway").exists(),
+        },
+        "platform_observability_gateway": {
+            "path": str((workspace_root / "platform-observability-gateway").resolve()),
+            "present": (workspace_root / "platform-observability-gateway").exists(),
+        },
+    }
+
+    capabilities = {
+        "gateway_first_configured": bool(monday_local) and planningops_local_origin == monday_local_origin,
+        "direct_local_llm_configured": bool(direct_local_profiles),
+        "codex_cli_available": codex_binary is not None,
+        "workspace_components_present": all(row["present"] for row in workspace_components.values()),
+        "gateway_endpoint_reachable": any(
+            row["profile_name"] == "local" and row["endpoint_probe_status"] == "reachable" for row in local_profiles
+        ),
+        "direct_local_llm_endpoint_reachable": any(
+            row["endpoint_probe_status"] == "reachable" for row in direct_local_profiles
+        ),
+    }
+    capabilities["structural_ready"] = (
+        capabilities["gateway_first_configured"]
+        and capabilities["direct_local_llm_configured"]
+        and capabilities["codex_cli_available"]
+        and capabilities["workspace_components_present"]
+    )
+
+    blocking_details: list[dict[str, str]] = []
+    bootstrap_details: list[dict[str, str]] = []
+
+    for name, component in workspace_components.items():
+        if not component["present"]:
+            blocking_details.append({"reason_code": "workspace_component_missing", "component": name})
+
+    if not planningops_local:
+        blocking_details.append({"reason_code": "planningops_local_profile_missing", "component": "planningops"})
+    if not monday_local:
+        blocking_details.append({"reason_code": "monday_local_profile_missing", "component": "monday"})
+    if planningops_local and monday_local and planningops_local_origin != monday_local_origin:
+        blocking_details.append(
+            {
+                "reason_code": "local_profile_endpoint_mismatch",
+                "component": "gateway_first",
+            }
+        )
+    if not direct_local_profiles:
+        blocking_details.append({"reason_code": "direct_local_llm_profiles_missing", "component": "monday"})
+    if codex_binary is None:
+        blocking_details.append({"reason_code": "codex_cli_missing", "component": "codex"})
+
+    if args.probe_endpoints == "on" and not blocking_details:
+        gateway_profile = next((row for row in local_profiles if row["profile_name"] == "local"), None)
+        if gateway_profile and gateway_profile["endpoint_probe_status"] != "reachable":
+            bootstrap_details.append(
+                {
+                    "reason_code": "gateway_endpoint_unreachable",
+                    "component": "platform_provider_gateway",
+                }
+            )
+        if direct_local_profiles and not capabilities["direct_local_llm_endpoint_reachable"]:
+            bootstrap_details.append(
+                {
+                    "reason_code": "direct_local_llm_endpoint_unreachable",
+                    "component": "monday",
+                }
+            )
+
+    if blocking_details:
+        assessment_status = "blocked"
+    elif bootstrap_details:
+        assessment_status = "bootstrap_required"
+    else:
+        assessment_status = "ready"
+
+    recommended_commands = {
+        "planningops_stack_smoke": "python3 planningops/scripts/federation/run_local_runtime_stack_smoke.py --workspace-root .. --profile local --run-id monday-local-stack-smoke",
+        "monday_local_gateway_smoke": "python3 scripts/run_local_runtime_smoke.py --profile local --run-id monday-local-gateway-smoke",
+        "monday_local_ollama_smoke": "python3 scripts/run_local_runtime_smoke.py --profile local_ollama --run-id monday-local-ollama-smoke",
+        "monday_local_lmstudio_smoke": "python3 scripts/run_local_runtime_smoke.py --profile local_lmstudio --run-id monday-local-lmstudio-smoke",
+        "monday_live_prerequisites": "npm run assess:deepagents-live-prerequisites",
+    }
+
+    recommended_next_steps: list[str] = []
+    if any(item["reason_code"] == "codex_cli_missing" for item in blocking_details):
+        recommended_next_steps.append("Expose the Codex CLI on PATH before attempting monday local operator flows.")
+    if any(item["reason_code"] == "direct_local_llm_profiles_missing" for item in blocking_details):
+        recommended_next_steps.append("Keep at least one direct local LLM profile (`local_ollama` or `local_lmstudio`) in monday/config/planner-runtime.json.")
+    if any(item["reason_code"] == "local_profile_endpoint_mismatch" for item in blocking_details):
+        recommended_next_steps.append("Align planningops local LiteLLM endpoint and monday local planner endpoint before smoke execution.")
+    if any(item["reason_code"] == "gateway_endpoint_unreachable" for item in bootstrap_details):
+        recommended_next_steps.append(
+            "Start the provider gateway stack: bash ../platform-provider-gateway/scripts/litellm_stack_launcher.sh --mode start"
+        )
+    if any(item["reason_code"] == "direct_local_llm_endpoint_unreachable" for item in bootstrap_details):
+        recommended_next_steps.append(
+            "Start either Ollama on http://127.0.0.1:11434 or LM Studio on http://127.0.0.1:1234/v1, then rerun the readiness check."
+        )
+    if assessment_status == "ready":
+        recommended_next_steps.append(
+            "Run the planningops federated local smoke, then run a monday direct profile smoke for the target local LLM profile."
+        )
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "workspace_root": str(workspace_root),
+        "planningops_repo_root": str(repo_root),
+        "planningops_runtime_profile_file": str(planningops_runtime_path),
+        "monday_planner_runtime_file": str(monday_runtime_path),
+        "probe_mode": args.probe_endpoints,
+        "assessment_status": assessment_status,
+        "verdict": "pass" if assessment_status == "ready" else "fail",
+        "planningops_runtime": {
+            "active_profile": planningops_runtime.get("active_profile"),
+            "local_profile_present": bool(planningops_local),
+            "local_litellm_base_url": planningops_local.get("litellm_base_url"),
+            "local_langfuse_host": planningops_local.get("langfuse_host"),
+        },
+        "monday_runtime": {
+            "active_profile": monday_runtime.get("active_profile"),
+            "local_profile_present": bool(monday_local),
+            "local_profiles": local_profiles,
+        },
+        "codex": {
+            "configured_bin": args.codex_bin,
+            "resolved_bin": codex_binary,
+            "available": codex_binary is not None,
+        },
+        "workspace_components": workspace_components,
+        "capabilities": capabilities,
+        "blocking_details": blocking_details,
+        "bootstrap_details": bootstrap_details,
+        "recommended_commands": recommended_commands,
+        "recommended_next_steps": recommended_next_steps,
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+    print(f"report written: {output_path}")
+    print(f"assessment_status={assessment_status} verdict={report['verdict']}")
+    return 0 if report["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/test_assess_monday_local_codex_readiness.sh
+++ b/planningops/scripts/test_assess_monday_local_codex_readiness.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/assess_monday_local_codex_readiness.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+workspace_root="$TMP_DIR/workspace"
+mkdir -p "$workspace_root/monday/config"
+mkdir -p "$workspace_root/platform-provider-gateway"
+mkdir -p "$workspace_root/platform-observability-gateway"
+
+planningops_runtime="$TMP_DIR/runtime-profiles.json"
+cat >"$planningops_runtime" <<'JSON'
+{
+  "active_profile": "local",
+  "profiles": {
+    "local": {
+      "execution_mode": "local",
+      "litellm_base_url": "http://127.0.0.1:4000",
+      "langfuse_host": "http://127.0.0.1:3001"
+    }
+  }
+}
+JSON
+
+monday_runtime_ready="$workspace_root/monday/config/planner-runtime-ready.json"
+cat >"$monday_runtime_ready" <<'JSON'
+{
+  "config_version": 1,
+  "active_profile": "local",
+  "profiles": {
+    "local": {
+      "planner_engine": "deepagents",
+      "deepagents_model_backend": "openai_compatible",
+      "deepagents_model": "gemini-2.5-flash-lite",
+      "deepagents_base_url": "http://127.0.0.1:4000/v1"
+    },
+    "local_ollama": {
+      "planner_engine": "deepagents",
+      "deepagents_model_backend": "ollama",
+      "deepagents_model": "llama-3.1:8b",
+      "deepagents_base_url": "http://127.0.0.1:11434"
+    },
+    "local_lmstudio": {
+      "planner_engine": "deepagents",
+      "deepagents_model_backend": "openai_compatible",
+      "deepagents_model": "local-model",
+      "deepagents_base_url": "http://127.0.0.1:1234/v1"
+    }
+  }
+}
+JSON
+
+fake_codex="$TMP_DIR/codex"
+cat >"$fake_codex" <<'EOF'
+#!/usr/bin/env bash
+echo "codex 0.test"
+EOF
+chmod +x "$fake_codex"
+
+ready_report="$TMP_DIR/ready.json"
+python3 "$SCRIPT_PATH" \
+  --workspace-root "$workspace_root" \
+  --planningops-runtime-profile-file "$planningops_runtime" \
+  --monday-planner-runtime-file "$monday_runtime_ready" \
+  --probe-endpoints off \
+  --codex-bin "$fake_codex" \
+  --output "$ready_report"
+
+python3 - <<'PY' "$ready_report"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["assessment_status"] == "ready", report
+assert report["verdict"] == "pass", report
+assert report["capabilities"]["gateway_first_configured"] is True, report
+assert report["capabilities"]["direct_local_llm_configured"] is True, report
+assert report["capabilities"]["codex_cli_available"] is True, report
+assert report["capabilities"]["structural_ready"] is True, report
+assert report["blocking_details"] == [], report
+assert report["bootstrap_details"] == [], report
+assert report["recommended_commands"]["planningops_stack_smoke"].startswith(
+    "python3 planningops/scripts/federation/run_local_runtime_stack_smoke.py"
+), report
+assert report["monday_runtime"]["local_profiles"][0]["endpoint_probe_status"] == "skipped", report
+assert any(
+    "planningops federated local smoke" in step
+    for step in report["recommended_next_steps"]
+), report
+PY
+
+monday_runtime_blocked="$workspace_root/monday/config/planner-runtime-blocked.json"
+cat >"$monday_runtime_blocked" <<'JSON'
+{
+  "config_version": 1,
+  "active_profile": "local",
+  "profiles": {
+    "local": {
+      "planner_engine": "deepagents",
+      "deepagents_model_backend": "openai_compatible",
+      "deepagents_model": "gemini-2.5-flash-lite",
+      "deepagents_base_url": "http://127.0.0.1:4000/v1"
+    }
+  }
+}
+JSON
+
+blocked_report="$TMP_DIR/blocked.json"
+set +e
+python3 "$SCRIPT_PATH" \
+  --workspace-root "$workspace_root" \
+  --planningops-runtime-profile-file "$planningops_runtime" \
+  --monday-planner-runtime-file "$monday_runtime_blocked" \
+  --probe-endpoints off \
+  --codex-bin "$TMP_DIR/missing-codex" \
+  --output "$blocked_report"
+status=$?
+set -e
+
+test "$status" -ne 0
+
+python3 - <<'PY' "$blocked_report"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["assessment_status"] == "blocked", report
+assert report["verdict"] == "fail", report
+reason_codes = {row["reason_code"] for row in report["blocking_details"]}
+assert "codex_cli_missing" in reason_codes, report
+assert "direct_local_llm_profiles_missing" in reason_codes, report
+assert any("Codex CLI" in step for step in report["recommended_next_steps"]), report
+assert any("direct local LLM profile" in step for step in report["recommended_next_steps"]), report
+PY
+
+echo "monday local codex readiness contract ok"


### PR DESCRIPTION
## Summary
- add a planningops-owned readiness assessor for running `monday` locally with a local LLM path and Codex operator shell
- add a contract test that fixes the expected ready vs blocked surfaces
- add a workbench rollout plan for the next monday local operator packets

## Scope
- add `planningops/scripts/assess_monday_local_codex_readiness.py`
- add `planningops/scripts/test_assess_monday_local_codex_readiness.sh`
- add `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #924

## Validation
- `bash planningops/scripts/test_assess_monday_local_codex_readiness.sh`
- `python3 -m py_compile planningops/scripts/assess_monday_local_codex_readiness.py`
- `python3 planningops/scripts/assess_monday_local_codex_readiness.py --probe-endpoints off --output /tmp/monday-local-codex-readiness-report.json`
- `python3 planningops/scripts/assess_monday_local_codex_readiness.py --probe-endpoints on --output /tmp/monday-local-codex-readiness-live.json`
- `bash planningops/scripts/test_local_runtime_stack_smoke_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- the readiness assessor is structural first, so operator teams may still need a second step to bring live endpoints up
- live probe coverage is intentionally narrow (TCP reachability), not a substitute for mission smoke evidence

## Review Checklist
- [x] readiness output distinguishes blocked vs bootstrap-required vs ready
- [x] monday direct local LLM profiles are surfaced explicitly
- [x] Codex shell availability is checked from planningops rather than assumed
- [x] workbench rollout document matches the new assessor surface

## Post-Deploy Monitoring & Validation
- Run `python3 planningops/scripts/assess_monday_local_codex_readiness.py --probe-endpoints on`
- Healthy signal: `assessment_status=ready`
- Failure signal: `assessment_status=bootstrap_required` with `gateway_endpoint_unreachable` or `assessment_status=blocked`
- Validation window: immediate after merge on the local workspace
- Owner: Codex / local operator
