### PR TITLE
feat(local-runtime): add monday local operator stack wrapper

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -112,6 +112,11 @@ Promote a repeatable operator entrypoint:
   - optionally runs direct monday profile smoke
   - stores one stamped local operator report
 
+Current deliverables:
+
+- `planningops/scripts/run_monday_local_operator_stack.py`
+- `planningops/runtime-artifacts/local/monday-local-operator-stack/<run-id>.json`
+
 ### Phase 2. Codex-to-monday handoff packet
 
 Add a stable packet for Codex-originated local mission execution:

--- a/planningops/scripts/run_monday_local_operator_stack.py
+++ b/planningops/scripts/run_monday_local_operator_stack.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in [current] + list(current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return REPO_ROOT
+
+
+def resolve_workspace_root(repo_root: Path, raw_workspace_root: str) -> Path:
+    candidates = [
+        Path(raw_workspace_root).resolve(),
+        (repo_root / raw_workspace_root).resolve(),
+        repo_root.parent,
+    ]
+    for candidate in candidates:
+        if (candidate / "monday").exists():
+            return candidate
+    return candidates[0]
+
+
+def resolve_path(base: Path, raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (base / path).resolve()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_command(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
+    completed = subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True)
+    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
+
+
+def build_step_record(
+    name: str,
+    command: list[str],
+    cwd: Path,
+    report_path: Path,
+    dry_run: bool,
+) -> dict:
+    record = {
+        "name": name,
+        "command": command,
+        "cwd": str(cwd),
+        "report_path": str(report_path),
+        "report_exists": False,
+        "report_summary": None,
+        "status": "planned" if dry_run else "skipped",
+        "exit_code": None,
+        "stdout_tail": "",
+        "stderr_tail": "",
+    }
+    if dry_run:
+        return record
+
+    rc, out, err = run_command(command, cwd)
+    record["exit_code"] = rc
+    record["stdout_tail"] = out[-1000:]
+    record["stderr_tail"] = err[-1000:]
+    record["report_exists"] = report_path.exists()
+    if report_path.exists():
+        record["report_summary"] = load_json(report_path)
+    record["status"] = "pass" if rc == 0 else "fail"
+    return record
+
+
+def build_readiness_command(args, repo_root: Path, report_path: Path) -> list[str]:
+    readiness_script = resolve_path(repo_root, args.readiness_script)
+    return [
+        args.planningops_python,
+        str(readiness_script),
+        "--workspace-root",
+        str(args.workspace_root),
+        "--planningops-runtime-profile-file",
+        args.planningops_runtime_profile_file,
+        "--monday-planner-runtime-file",
+        args.monday_planner_runtime_file,
+        "--probe-endpoints",
+        args.probe_endpoints,
+        "--codex-bin",
+        args.codex_bin,
+        "--output",
+        str(report_path),
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the planningops-owned monday local operator wrapper.")
+    parser.add_argument("--workspace-root", default="..", help="Workspace root containing sibling repositories.")
+    parser.add_argument(
+        "--planningops-runtime-profile-file",
+        default="planningops/config/runtime-profiles.json",
+        help="Path to planningops runtime profile catalog.",
+    )
+    parser.add_argument(
+        "--monday-planner-runtime-file",
+        default="monday/config/planner-runtime.json",
+        help="Path to monday planner runtime config.",
+    )
+    parser.add_argument(
+        "--execution-mode",
+        choices=["stack", "direct", "both"],
+        default="stack",
+        help="Which operator lane to run after readiness.",
+    )
+    parser.add_argument(
+        "--direct-profile",
+        choices=["local_ollama", "local_lmstudio"],
+        default="local_ollama",
+        help="Direct monday local LLM profile used for direct or both modes.",
+    )
+    parser.add_argument("--probe-endpoints", choices=["on", "off"], default="on")
+    parser.add_argument("--codex-bin", default="codex")
+    parser.add_argument("--planningops-python", default="python3")
+    parser.add_argument("--monday-python", default="python3")
+    parser.add_argument(
+        "--readiness-script",
+        default="planningops/scripts/assess_monday_local_codex_readiness.py",
+        help="Readiness script path.",
+    )
+    parser.add_argument(
+        "--stack-smoke-script",
+        default="planningops/scripts/federation/run_local_runtime_stack_smoke.py",
+        help="Planningops local stack smoke script path.",
+    )
+    parser.add_argument(
+        "--monday-smoke-script",
+        default="scripts/run_local_runtime_smoke.py",
+        help="Monday local smoke script path, resolved relative to monday repo when not absolute.",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=f"monday-local-operator-stack-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
+        help="Aggregate run id.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Render the plan and readiness without executing smoke commands.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Aggregate output path. Defaults to planningops/runtime-artifacts/local/monday-local-operator-stack/<run-id>.json",
+    )
+    args = parser.parse_args()
+
+    repo_root = resolve_repo_root()
+    workspace_root = resolve_workspace_root(repo_root, args.workspace_root)
+    monday_repo = (workspace_root / "monday").resolve()
+    stack_smoke_script = resolve_path(repo_root, args.stack_smoke_script)
+    monday_smoke_script = resolve_path(monday_repo, args.monday_smoke_script)
+
+    base_dir = repo_root / "planningops" / "runtime-artifacts" / "local" / "monday-local-operator-stack" / args.run_id
+    readiness_report_path = base_dir / "readiness.json"
+    stack_report_path = base_dir / "stack-smoke.json"
+    direct_report_path = base_dir / f"{args.direct_profile}.json"
+
+    readiness_command = build_readiness_command(args, repo_root, readiness_report_path)
+    readiness_step = build_step_record(
+        name="readiness",
+        command=readiness_command,
+        cwd=repo_root,
+        report_path=readiness_report_path,
+        dry_run=False,
+    )
+    readiness_report = load_json(readiness_report_path) if readiness_report_path.exists() else None
+    if readiness_step["status"] == "fail" and readiness_report is not None:
+        readiness_step["status"] = "report_only"
+
+    stack_step = {
+        "name": "stack_smoke",
+        "command": [],
+        "cwd": str(repo_root),
+        "report_path": str(stack_report_path),
+        "report_exists": False,
+        "report_summary": None,
+        "status": "skipped",
+        "exit_code": None,
+        "stdout_tail": "",
+        "stderr_tail": "",
+    }
+    direct_step = {
+        "name": "direct_smoke",
+        "command": [],
+        "cwd": str(monday_repo),
+        "report_path": str(direct_report_path),
+        "report_exists": False,
+        "report_summary": None,
+        "status": "skipped",
+        "exit_code": None,
+        "stdout_tail": "",
+        "stderr_tail": "",
+    }
+
+    recommended_next_steps = list((readiness_report or {}).get("recommended_next_steps") or [])
+    reason_code = "monday_local_operator_stack_ok"
+    verdict = "pass"
+
+    readiness_status = (readiness_report or {}).get("assessment_status")
+    if readiness_step["status"] == "fail" and readiness_report is None:
+        verdict = "fail"
+        reason_code = "readiness_command_failed"
+    elif readiness_status == "blocked":
+        verdict = "fail"
+        reason_code = "readiness_blocked"
+    elif args.execution_mode in {"stack", "both"} and readiness_status != "ready":
+        verdict = "fail"
+        reason_code = "stack_requires_ready_readiness"
+        recommended_next_steps.append("Rerun after the gateway-first local readiness becomes `ready`, or switch to `--execution-mode direct`.")
+    else:
+        if args.execution_mode in {"stack", "both"}:
+            stack_command = [
+                args.planningops_python,
+                str(stack_smoke_script),
+                "--workspace-root",
+                str(args.workspace_root),
+                "--profile",
+                "local",
+                "--run-id",
+                f"{args.run_id}-stack",
+                "--output",
+                str(stack_report_path),
+            ]
+            stack_step = build_step_record(
+                name="stack_smoke",
+                command=stack_command,
+                cwd=repo_root,
+                report_path=stack_report_path,
+                dry_run=args.dry_run,
+            )
+
+        if args.execution_mode in {"direct", "both"}:
+            direct_command = [
+                args.monday_python,
+                str(monday_smoke_script),
+                "--profile",
+                args.direct_profile,
+                "--run-id",
+                f"{args.run_id}-{args.direct_profile}",
+                "--output",
+                str(direct_report_path),
+            ]
+            direct_step = build_step_record(
+                name="direct_smoke",
+                command=direct_command,
+                cwd=monday_repo,
+                report_path=direct_report_path,
+                dry_run=args.dry_run,
+            )
+
+        executed_steps = [step for step in (stack_step, direct_step) if step["status"] in {"pass", "fail", "planned"}]
+        failing_steps = [step["name"] for step in executed_steps if step["status"] == "fail"]
+        if failing_steps:
+            verdict = "fail"
+            reason_code = "operator_stack_execution_failed"
+            recommended_next_steps.append(f"Inspect failed steps: {', '.join(failing_steps)}")
+        elif args.dry_run:
+            verdict = "planned"
+            reason_code = "operator_stack_dry_run_only"
+        else:
+            verdict = "pass"
+            reason_code = "monday_local_operator_stack_ok"
+            recommended_next_steps.append("Inspect the stamped reports and use the monday direct smoke output as the next handoff evidence.")
+
+    report = {
+        "generated_at_utc": now_utc(),
+        "run_id": args.run_id,
+        "workspace_root": str(workspace_root),
+        "execution_mode": args.execution_mode,
+        "direct_profile": args.direct_profile if args.execution_mode in {"direct", "both"} else None,
+        "dry_run": args.dry_run,
+        "verdict": verdict,
+        "reason_code": reason_code,
+        "readiness": {
+            "status": readiness_status,
+            "report_path": str(readiness_report_path),
+            "report": readiness_report,
+            "step": readiness_step,
+        },
+        "stack_smoke": stack_step,
+        "direct_smoke": direct_step,
+        "recommended_next_steps": recommended_next_steps,
+    }
+
+    output_path = (
+        Path(args.output)
+        if args.output
+        else repo_root / "planningops" / "runtime-artifacts" / "local" / "monday-local-operator-stack" / f"{args.run_id}.json"
+    )
+    if not output_path.is_absolute():
+        output_path = (repo_root / output_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+    print(f"report written: {output_path}")
+    print(f"verdict={verdict} reason_code={reason_code}")
+    return 0 if verdict in {"pass", "planned"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planningops/scripts/test_run_monday_local_operator_stack.sh
+++ b/planningops/scripts/test_run_monday_local_operator_stack.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/planningops/scripts/run_monday_local_operator_stack.py"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+workspace_root="$TMP_DIR/workspace"
+mkdir -p "$workspace_root/monday/config" "$workspace_root/monday/scripts"
+mkdir -p "$workspace_root/platform-provider-gateway" "$workspace_root/platform-observability-gateway"
+
+planningops_runtime="$TMP_DIR/runtime-profiles.json"
+cat >"$planningops_runtime" <<'JSON'
+{
+  "active_profile": "local",
+  "profiles": {
+    "local": {
+      "execution_mode": "local",
+      "litellm_base_url": "http://127.0.0.1:4000",
+      "langfuse_host": "http://127.0.0.1:3001"
+    }
+  }
+}
+JSON
+
+monday_runtime_ready="$workspace_root/monday/config/planner-runtime-ready.json"
+cat >"$monday_runtime_ready" <<'JSON'
+{
+  "config_version": 1,
+  "active_profile": "local",
+  "profiles": {
+    "local": {
+      "planner_engine": "deepagents",
+      "deepagents_model_backend": "openai_compatible",
+      "deepagents_model": "gemini-2.5-flash-lite",
+      "deepagents_base_url": "http://127.0.0.1:4000/v1"
+    },
+    "local_ollama": {
+      "planner_engine": "deepagents",
+      "deepagents_model_backend": "ollama",
+      "deepagents_model": "llama-3.1:8b",
+      "deepagents_base_url": "http://127.0.0.1:11434"
+    }
+  }
+}
+JSON
+
+fake_codex="$TMP_DIR/codex"
+cat >"$fake_codex" <<'EOF'
+#!/usr/bin/env bash
+echo "codex 0.test"
+EOF
+chmod +x "$fake_codex"
+
+fake_stack_smoke="$TMP_DIR/fake_stack_smoke.py"
+cat >"$fake_stack_smoke" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+output = Path(args[args.index("--output") + 1])
+output.parent.mkdir(parents=True, exist_ok=True)
+output.write_text(json.dumps({"verdict": "pass", "failure_count": 0, "component_runs": []}, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+print(f"report written: {output}")
+PY
+chmod +x "$fake_stack_smoke"
+
+fake_monday_smoke="$workspace_root/monday/scripts/run_local_runtime_smoke.py"
+cat >"$fake_monday_smoke" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+output = Path(args[args.index("--output") + 1])
+profile = args[args.index("--profile") + 1]
+output.parent.mkdir(parents=True, exist_ok=True)
+output.write_text(json.dumps({"verdict": "pass", "profile": profile, "runtime_run_id": "fake-runtime"}, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+print(f"report written: {output}")
+PY
+chmod +x "$fake_monday_smoke"
+
+ready_output="$TMP_DIR/ready-output.json"
+python3 "$SCRIPT_PATH" \
+  --workspace-root "$workspace_root" \
+  --planningops-runtime-profile-file "$planningops_runtime" \
+  --monday-planner-runtime-file "$monday_runtime_ready" \
+  --execution-mode both \
+  --direct-profile local_ollama \
+  --probe-endpoints off \
+  --codex-bin "$fake_codex" \
+  --stack-smoke-script "$fake_stack_smoke" \
+  --monday-smoke-script "$fake_monday_smoke" \
+  --output "$ready_output"
+
+python3 - <<'PY' "$ready_output"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "pass", report
+assert report["reason_code"] == "monday_local_operator_stack_ok", report
+assert report["readiness"]["status"] == "ready", report
+assert report["stack_smoke"]["status"] == "pass", report
+assert report["direct_smoke"]["status"] == "pass", report
+assert report["direct_smoke"]["report_summary"]["profile"] == "local_ollama", report
+PY
+
+fake_readiness="$TMP_DIR/fake_readiness.py"
+cat >"$fake_readiness" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+output = Path(args[args.index("--output") + 1])
+report = {
+    "assessment_status": "bootstrap_required",
+    "verdict": "fail",
+    "capabilities": {
+        "direct_local_llm_configured": True,
+        "codex_cli_available": True,
+        "workspace_components_present": True,
+        "structural_ready": True,
+        "direct_local_llm_endpoint_reachable": True,
+        "gateway_endpoint_reachable": False
+    },
+    "recommended_next_steps": ["Start the provider gateway stack first if you want stack mode."],
+}
+output.parent.mkdir(parents=True, exist_ok=True)
+output.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+print(f"report written: {output}")
+print("assessment_status=bootstrap_required verdict=fail")
+sys.exit(1)
+PY
+chmod +x "$fake_readiness"
+
+bootstrap_output="$TMP_DIR/bootstrap-output.json"
+python3 "$SCRIPT_PATH" \
+  --workspace-root "$workspace_root" \
+  --planningops-runtime-profile-file "$planningops_runtime" \
+  --monday-planner-runtime-file "$monday_runtime_ready" \
+  --execution-mode direct \
+  --direct-profile local_ollama \
+  --probe-endpoints off \
+  --codex-bin "$fake_codex" \
+  --readiness-script "$fake_readiness" \
+  --stack-smoke-script "$fake_stack_smoke" \
+  --monday-smoke-script "$fake_monday_smoke" \
+  --output "$bootstrap_output"
+
+python3 - <<'PY' "$bootstrap_output"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "pass", report
+assert report["readiness"]["status"] == "bootstrap_required", report
+assert report["stack_smoke"]["status"] == "skipped", report
+assert report["direct_smoke"]["status"] == "pass", report
+PY
+
+blocked_readiness="$TMP_DIR/blocked_readiness.py"
+cat >"$blocked_readiness" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+output = Path(args[args.index("--output") + 1])
+report = {
+    "assessment_status": "blocked",
+    "verdict": "fail",
+    "capabilities": {
+        "direct_local_llm_configured": False,
+        "codex_cli_available": False,
+        "workspace_components_present": True,
+        "structural_ready": False,
+        "direct_local_llm_endpoint_reachable": False,
+        "gateway_endpoint_reachable": False
+    },
+    "recommended_next_steps": ["Expose Codex and add a direct local LLM profile."],
+}
+output.parent.mkdir(parents=True, exist_ok=True)
+output.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+print(f"report written: {output}")
+print("assessment_status=blocked verdict=fail")
+sys.exit(1)
+PY
+chmod +x "$blocked_readiness"
+
+blocked_output="$TMP_DIR/blocked-output.json"
+set +e
+python3 "$SCRIPT_PATH" \
+  --workspace-root "$workspace_root" \
+  --planningops-runtime-profile-file "$planningops_runtime" \
+  --monday-planner-runtime-file "$monday_runtime_ready" \
+  --execution-mode both \
+  --direct-profile local_ollama \
+  --probe-endpoints off \
+  --codex-bin "$fake_codex" \
+  --readiness-script "$blocked_readiness" \
+  --stack-smoke-script "$fake_stack_smoke" \
+  --monday-smoke-script "$fake_monday_smoke" \
+  --output "$blocked_output"
+status=$?
+set -e
+test "$status" -ne 0
+
+python3 - <<'PY' "$blocked_output"
+import json
+import sys
+from pathlib import Path
+
+report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert report["verdict"] == "fail", report
+assert report["reason_code"] == "readiness_blocked", report
+assert report["stack_smoke"]["status"] == "skipped", report
+assert report["direct_smoke"]["status"] == "skipped", report
+PY
+
+echo "monday local operator stack contract ok"


### PR DESCRIPTION
## Summary
- add a planningops wrapper that turns monday local readiness and smoke into one operator entrypoint
- support stack mode, direct local LLM mode, and combined mode with one aggregate report
- update the rollout plan so the wrapper is now a concrete Phase 1 deliverable

## Scope
- add `planningops/scripts/run_monday_local_operator_stack.py`
- add `planningops/scripts/test_run_monday_local_operator_stack.sh`
- update `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #926

## Validation
- `bash planningops/scripts/test_run_monday_local_operator_stack.sh`
- `python3 -m py_compile planningops/scripts/run_monday_local_operator_stack.py`
- `python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode stack --probe-endpoints off --dry-run --output /tmp/monday-local-operator-stack-dry.json`
- `bash planningops/scripts/test_assess_monday_local_codex_readiness.sh`
- `bash planningops/scripts/test_local_runtime_stack_smoke_contract.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- non-dry-run stack mode still depends on the same gateway/bootstrap preconditions as the underlying local stack smoke
- direct mode assumes monday direct local LLM profiles remain runtime-owned and stable in the sibling repo

## Review Checklist
- [x] readiness runs before any smoke execution
- [x] stack mode requires `ready` readiness
- [x] direct mode can proceed from `bootstrap_required` when the direct local LLM path is the intended lane
- [x] aggregate report stores readiness, stack, and direct smoke step state together

## Post-Deploy Monitoring & Validation
- Run `python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode stack --probe-endpoints on`
- Healthy signal: aggregate report `verdict=pass` with `readiness.status=ready`
- Alternate healthy signal: `--execution-mode direct --direct-profile local_ollama` returns `verdict=pass` when direct local LLM mode is the intended lane
- Failure signal: `reason_code=readiness_blocked`, `stack_requires_ready_readiness`, or `operator_stack_execution_failed`
- Validation window: immediate after merge on the local workspace
- Owner: Codex / local operator
