### PR TITLE
feat(query-engine): add operator handoff report surface

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -118,6 +118,7 @@ Current deliverables:
 - `planningops/runtime-artifacts/local/monday-local-operator-stack/<run-id>.json`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-operator-stack`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report` now carry the latest local operator stack pointer
+- `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` emits a handoff-ready operator packet
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -180,5 +181,5 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. decide whether local operator evidence should stay in `runtime-artifacts/local` or gain a validation mirror for promotion workflows
-2. add a day-level operator handoff report that fuses federated CI triage and local operator runtime status into one markdown packet
+2. decide whether the handoff packet should mirror into validation artifacts or stay query-only
 3. add a Codex-to-monday mission packet contract so local operator prompts become reproducible inputs

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -276,6 +276,23 @@ class TriageReportRecord:
 
 
 @dataclass(frozen=True)
+class HandoffReportRecord:
+    source_kind: str
+    target_limit: int
+    headline: str
+    attention_summary: str
+    newest_failing_summary: str
+    newest_recovered_summary: str | None
+    local_operator_record: LocalOperatorStackRecord | None
+    local_operator_summary: str | None
+    local_operator_next_step: str | None
+    queue_lines: list[str]
+    target_lines: list[str]
+    immediate_action_lines: list[str]
+    markdown: str
+
+
+@dataclass(frozen=True)
 class LocalOperatorStackRecord:
     run_id: str
     report_path: str
@@ -1914,6 +1931,97 @@ def render_triage_report_markdown(record: TriageReportRecord) -> str:
     return record.markdown
 
 
+def build_handoff_report_record(
+    *,
+    records: list[SummaryRecord],
+    local_records: list[LocalOperatorStackRecord] | None,
+    family: str | None,
+    run_id_prefix: str | None,
+    source_kind: str,
+    target_limit: int,
+) -> HandoffReportRecord:
+    triage_report = build_triage_report_record(
+        records=records,
+        local_records=local_records,
+        family=family,
+        run_id_prefix=run_id_prefix,
+        source_kind=source_kind,
+        target_limit=target_limit,
+    )
+    headline = f"Operator handoff report: {triage_report.headline.removeprefix('Federated CI triage report: ')}"
+    immediate_action_lines: list[str] = []
+    if triage_report.local_operator_next_step is not None:
+        immediate_action_lines.append(f"local-runtime: {triage_report.local_operator_next_step}")
+    if triage_report.target_lines:
+        immediate_action_lines.append(f"triage-target: {triage_report.target_lines[0]}")
+    if len(triage_report.target_lines) > 1:
+        immediate_action_lines.append(f"follow-up: {triage_report.target_lines[1]}")
+
+    markdown_lines = [
+        "## Operator Handoff Report",
+        "",
+        "### Snapshot",
+        f"- headline: {headline}",
+        f"- source_kind: `{triage_report.source_kind}`",
+        f"- top target window: `{triage_report.target_limit}`",
+        f"- attention families: `{triage_report.attention_summary}`",
+        f"- newest failing pointer: {triage_report.newest_failing_summary}",
+    ]
+    if triage_report.newest_recovered_summary is not None:
+        markdown_lines.append(f"- newest recovered pointer: {triage_report.newest_recovered_summary}")
+    markdown_lines.extend(["", "### Local Runtime"])
+    if triage_report.local_operator_summary is None:
+        markdown_lines.append("- local operator: unavailable")
+    else:
+        markdown_lines.append(f"- local operator: `{triage_report.local_operator_summary}`")
+    if triage_report.local_operator_next_step is not None:
+        markdown_lines.append(f"- local operator next step: {triage_report.local_operator_next_step}")
+    markdown_lines.extend(["", "### Queue", *[f"- {line}" for line in triage_report.queue_lines]])
+    markdown_lines.extend(
+        ["", "### Top Targets", *[f"{index}. {line}" for index, line in enumerate(triage_report.target_lines, start=1)]]
+    )
+    markdown_lines.extend(
+        ["", "### Immediate Actions", *[f"{index}. {line}" for index, line in enumerate(immediate_action_lines, start=1)]]
+    )
+    return HandoffReportRecord(
+        source_kind=triage_report.source_kind,
+        target_limit=triage_report.target_limit,
+        headline=headline,
+        attention_summary=triage_report.attention_summary,
+        newest_failing_summary=triage_report.newest_failing_summary,
+        newest_recovered_summary=triage_report.newest_recovered_summary,
+        local_operator_record=triage_report.local_operator_record,
+        local_operator_summary=triage_report.local_operator_summary,
+        local_operator_next_step=triage_report.local_operator_next_step,
+        queue_lines=triage_report.queue_lines,
+        target_lines=triage_report.target_lines,
+        immediate_action_lines=immediate_action_lines,
+        markdown="\n".join(markdown_lines),
+    )
+
+
+def render_handoff_report_table(record: HandoffReportRecord) -> str:
+    sections = [
+        f"headline\t{record.headline}",
+        f"source_kind\t{record.source_kind}",
+        f"target_limit\t{record.target_limit}",
+        f"attention_summary\t{record.attention_summary}",
+        f"newest_failing\t{record.newest_failing_summary}",
+    ]
+    if record.newest_recovered_summary is not None:
+        sections.append(f"newest_recovered\t{record.newest_recovered_summary}")
+    if record.local_operator_summary is not None:
+        sections.append(f"local_operator\t{record.local_operator_summary}")
+    if record.local_operator_next_step is not None:
+        sections.append(f"local_operator_next_step\t{record.local_operator_next_step}")
+    sections.extend(["queue", *record.queue_lines, "targets", *record.target_lines, "immediate_actions", *record.immediate_action_lines])
+    return "\n".join(sections)
+
+
+def render_handoff_report_markdown(record: HandoffReportRecord) -> str:
+    return record.markdown
+
+
 def select_record(
     *,
     records: list[SummaryRecord],
@@ -2702,6 +2810,20 @@ def parse_args() -> argparse.Namespace:
     triage_report_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     triage_report_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
 
+    handoff_report_parser = subparsers.add_parser(
+        "handoff-report",
+        help="show a handoff-friendly operator report combining triage state and local runtime status",
+    )
+    handoff_report_parser.add_argument("--family", default=None)
+    handoff_report_parser.add_argument("--run-id-prefix", default=None)
+    handoff_report_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
+    handoff_report_parser.add_argument("--target-limit", type=int, default=3)
+    handoff_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
+    handoff_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    handoff_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    handoff_report_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+    handoff_report_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
+
     local_operator_parser = subparsers.add_parser(
         "local-operator-stack",
         help="list planningops-owned monday local operator stack aggregate reports",
@@ -3031,6 +3153,25 @@ def main() -> int:
             print(render_triage_report_markdown(record))
             return 0
         print(render_triage_report_table(record))
+        return 0
+
+    if args.command == "handoff-report":
+        local_records = discover_local_operator_stack_records(local_root=local_root)
+        record = build_handoff_report_record(
+            records=records,
+            local_records=local_records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+            target_limit=args.target_limit,
+        )
+        if args.format == "json":
+            print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_handoff_report_markdown(record))
+            return 0
+        print(render_handoff_report_table(record))
         return 0
 
     if args.command == "reconcile-status":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -646,6 +646,8 @@ TRIAGE_BRIEF_OUTPUT="$TMP_DIR/triage-brief.json"
 TRIAGE_BRIEF_ALL_OUTPUT="$TMP_DIR/triage-brief-all.json"
 TRIAGE_REPORT_OUTPUT="$TMP_DIR/triage-report.json"
 TRIAGE_REPORT_ALL_OUTPUT="$TMP_DIR/triage-report-all.json"
+HANDOFF_REPORT_OUTPUT="$TMP_DIR/handoff-report.json"
+HANDOFF_REPORT_ALL_OUTPUT="$TMP_DIR/handoff-report-all.json"
 LOCAL_OPERATOR_OUTPUT="$TMP_DIR/local-operator-stack.json"
 LOCAL_OPERATOR_FILTERED_OUTPUT="$TMP_DIR/local-operator-stack-filtered.json"
 LOCAL_OPERATOR_DETAIL_OUTPUT="$TMP_DIR/local-operator-stack-detail.json"
@@ -1755,6 +1757,84 @@ assert record["target_lines"] == [
 ], record
 assert "source_kind: `all`" in record["markdown"], record
 assert "local operator:" in record["markdown"], record
+PY
+
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" >"$HANDOFF_REPORT_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["source_kind"] == "stamped", record
+assert record["target_limit"] == 3, record
+assert record["headline"] == "Operator handoff report: 2 attention families", record
+assert record["attention_summary"] == "active=1, lagging=1, clear=0", record
+assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun30 / lagging", record
+assert record["local_operator_summary"] == (
+    "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
+    "stack=skipped direct=skipped mode=both reason=readiness_blocked"
+), record
+assert record["local_operator_next_step"] == "Expose Codex and add a direct local LLM profile.", record
+assert record["queue_lines"] == [
+    "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1",
+    "lagging: targets=1 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint=1,readiness=1,reconcile=1",
+], record
+assert record["target_lines"] == [
+    "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "[lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile",
+], record
+assert record["immediate_action_lines"] == [
+    "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "follow-up: [lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile",
+], record
+assert "## Operator Handoff Report" in record["markdown"], record
+assert "### Snapshot" in record["markdown"], record
+assert "### Local Runtime" in record["markdown"], record
+assert "### Queue" in record["markdown"], record
+assert "### Top Targets" in record["markdown"], record
+assert "### Immediate Actions" in record["markdown"], record
+PY
+
+python3 "$QUERY_PATH" handoff-report \
+  --source-kind all \
+  --target-limit 1 \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" >"$HANDOFF_REPORT_ALL_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_ALL_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["source_kind"] == "all", record
+assert record["target_limit"] == 1, record
+assert record["headline"] == "Operator handoff report: 2 attention families", record
+assert record["attention_summary"] == "active=2, lagging=0, clear=0", record
+assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun26 / active", record
+assert record["local_operator_summary"] == (
+    "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
+    "stack=skipped direct=skipped mode=both reason=readiness_blocked"
+), record
+assert record["immediate_action_lines"] == [
+    "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "triage-target: [active/latest-gap] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun26 domains=readiness,reconcile",
+], record
+assert "source_kind: `all`" in record["markdown"], record
+assert "### Immediate Actions" in record["markdown"], record
 PY
 
 python3 "$QUERY_PATH" reconcile-status \


### PR DESCRIPTION
## Summary
- add a dedicated `handoff-report` query surface that packages federated CI triage and local operator runtime state into one handoff packet
- derive immediate action lines from the local runtime next step and top triage targets
- update the monday local codex rollout plan with the new handoff output surface

## Scope
- `planningops/scripts/federation/query_federated_ci_artifacts.py`
- `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #932

## Validation
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- the handoff packet stays query-only for now, so nothing writes a stamped handoff artifact yet
- immediate actions are intentionally heuristic and currently prefer the first target window rather than deeper prioritization logic

## Review Checklist
- verify `handoff-report` markdown includes snapshot, local runtime, queue, targets, and immediate actions
- verify stamped and `source-kind all` outputs preserve the expected local operator pointer and triage target ordering
- verify unrelated residue and `runner.py` remain unstaged

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required because this change adds a query/report surface only.
