### PR TITLE
feat(local-runtime): mirror local operator reports into validation artifacts

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -116,6 +116,8 @@ Current deliverables:
 
 - `planningops/scripts/run_monday_local_operator_stack.py`
 - `planningops/runtime-artifacts/local/monday-local-operator-stack/<run-id>.json`
+- `planningops/artifacts/validation/monday-local-operator-stack-report.json`
+- `planningops/artifacts/validation/<run-id>-monday-local-operator-stack-report.json`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-operator-stack`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report` now carry the latest local operator stack pointer
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` emits a handoff-ready operator packet
@@ -180,6 +182,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether local operator evidence should stay in `runtime-artifacts/local` or gain a validation mirror for promotion workflows
-2. decide whether the handoff packet should mirror into validation artifacts or stay query-only
-3. add a Codex-to-monday mission packet contract so local operator prompts become reproducible inputs
+1. decide whether the handoff packet should mirror into validation artifacts or stay query-only
+2. add a Codex-to-monday mission packet contract so local operator prompts become reproducible inputs
+3. add a validation freshness surface so local operator stamped/latest mirrors can be promoted with the same evidence-first rules as federated CI summaries

--- a/planningops/scripts/run_monday_local_operator_stack.py
+++ b/planningops/scripts/run_monday_local_operator_stack.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_VALIDATION_ROOT = Path("planningops/artifacts/validation")
 
 
 def now_utc() -> str:
@@ -46,6 +47,11 @@ def resolve_path(base: Path, raw_path: str) -> Path:
 
 def load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 
 
 def run_command(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
@@ -164,6 +170,11 @@ def main() -> int:
         "--output",
         default=None,
         help="Aggregate output path. Defaults to planningops/runtime-artifacts/local/monday-local-operator-stack/<run-id>.json",
+    )
+    parser.add_argument(
+        "--validation-root",
+        default=str(DEFAULT_VALIDATION_ROOT),
+        help="Validation artifact root for mirrored latest + stamped operator reports.",
     )
     args = parser.parse_args()
 
@@ -285,6 +296,18 @@ def main() -> int:
             reason_code = "monday_local_operator_stack_ok"
             recommended_next_steps.append("Inspect the stamped reports and use the monday direct smoke output as the next handoff evidence.")
 
+    output_path = (
+        Path(args.output)
+        if args.output
+        else repo_root / "planningops" / "runtime-artifacts" / "local" / "monday-local-operator-stack" / f"{args.run_id}.json"
+    )
+    if not output_path.is_absolute():
+        output_path = (repo_root / output_path).resolve()
+
+    validation_root = resolve_path(repo_root, args.validation_root)
+    validation_latest_report_path = validation_root / "monday-local-operator-stack-report.json"
+    validation_stamped_report_path = validation_root / f"{args.run_id}-monday-local-operator-stack-report.json"
+
     report = {
         "generated_at_utc": now_utc(),
         "run_id": args.run_id,
@@ -303,17 +326,16 @@ def main() -> int:
         "stack_smoke": stack_step,
         "direct_smoke": direct_step,
         "recommended_next_steps": recommended_next_steps,
+        "artifact_paths": {
+            "detail_dir": str(base_dir),
+            "runtime_report_path": str(output_path),
+            "validation_latest_report_path": str(validation_latest_report_path),
+            "validation_stamped_report_path": str(validation_stamped_report_path),
+        },
     }
 
-    output_path = (
-        Path(args.output)
-        if args.output
-        else repo_root / "planningops" / "runtime-artifacts" / "local" / "monday-local-operator-stack" / f"{args.run_id}.json"
-    )
-    if not output_path.is_absolute():
-        output_path = (repo_root / output_path).resolve()
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    for path in {output_path, validation_latest_report_path, validation_stamped_report_path}:
+        write_json(path, report)
 
     print(f"report written: {output_path}")
     print(f"verdict={verdict} reason_code={reason_code}")

--- a/planningops/scripts/test_run_monday_local_operator_stack.sh
+++ b/planningops/scripts/test_run_monday_local_operator_stack.sh
@@ -85,6 +85,7 @@ PY
 chmod +x "$fake_monday_smoke"
 
 ready_output="$TMP_DIR/ready-output.json"
+validation_root="$TMP_DIR/validation"
 python3 "$SCRIPT_PATH" \
   --workspace-root "$workspace_root" \
   --planningops-runtime-profile-file "$planningops_runtime" \
@@ -93,22 +94,41 @@ python3 "$SCRIPT_PATH" \
   --direct-profile local_ollama \
   --probe-endpoints off \
   --codex-bin "$fake_codex" \
+  --run-id monday-local-operator-stack-ready-test \
   --stack-smoke-script "$fake_stack_smoke" \
   --monday-smoke-script "$fake_monday_smoke" \
+  --validation-root "$validation_root" \
   --output "$ready_output"
 
-python3 - <<'PY' "$ready_output"
+python3 - <<'PY' "$ready_output" "$validation_root"
 import json
 import sys
 from pathlib import Path
 
 report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+validation_root = Path(sys.argv[2])
 assert report["verdict"] == "pass", report
 assert report["reason_code"] == "monday_local_operator_stack_ok", report
+assert report["run_id"] == "monday-local-operator-stack-ready-test", report
 assert report["readiness"]["status"] == "ready", report
 assert report["stack_smoke"]["status"] == "pass", report
 assert report["direct_smoke"]["status"] == "pass", report
 assert report["direct_smoke"]["report_summary"]["profile"] == "local_ollama", report
+artifact_paths = report["artifact_paths"]
+assert Path(artifact_paths["validation_latest_report_path"]).resolve() == (
+    validation_root / "monday-local-operator-stack-report.json"
+).resolve(), report
+assert Path(artifact_paths["validation_stamped_report_path"]).resolve() == (
+    validation_root / "monday-local-operator-stack-ready-test-monday-local-operator-stack-report.json"
+).resolve(), report
+latest_doc = json.loads((validation_root / "monday-local-operator-stack-report.json").resolve().read_text(encoding="utf-8"))
+stamped_doc = json.loads(
+    (validation_root / "monday-local-operator-stack-ready-test-monday-local-operator-stack-report.json")
+    .resolve()
+    .read_text(encoding="utf-8")
+)
+assert latest_doc["run_id"] == "monday-local-operator-stack-ready-test", latest_doc
+assert stamped_doc["run_id"] == "monday-local-operator-stack-ready-test", stamped_doc
 PY
 
 fake_readiness="$TMP_DIR/fake_readiness.py"
@@ -150,21 +170,33 @@ python3 "$SCRIPT_PATH" \
   --direct-profile local_ollama \
   --probe-endpoints off \
   --codex-bin "$fake_codex" \
+  --run-id monday-local-operator-stack-bootstrap-test \
   --readiness-script "$fake_readiness" \
   --stack-smoke-script "$fake_stack_smoke" \
   --monday-smoke-script "$fake_monday_smoke" \
+  --validation-root "$validation_root" \
   --output "$bootstrap_output"
 
-python3 - <<'PY' "$bootstrap_output"
+python3 - <<'PY' "$bootstrap_output" "$validation_root"
 import json
 import sys
 from pathlib import Path
 
 report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+validation_root = Path(sys.argv[2])
 assert report["verdict"] == "pass", report
+assert report["run_id"] == "monday-local-operator-stack-bootstrap-test", report
 assert report["readiness"]["status"] == "bootstrap_required", report
 assert report["stack_smoke"]["status"] == "skipped", report
 assert report["direct_smoke"]["status"] == "pass", report
+latest_doc = json.loads((validation_root / "monday-local-operator-stack-report.json").resolve().read_text(encoding="utf-8"))
+stamped_doc = json.loads(
+    (validation_root / "monday-local-operator-stack-bootstrap-test-monday-local-operator-stack-report.json")
+    .resolve()
+    .read_text(encoding="utf-8")
+)
+assert latest_doc["run_id"] == "monday-local-operator-stack-bootstrap-test", latest_doc
+assert stamped_doc["run_id"] == "monday-local-operator-stack-bootstrap-test", stamped_doc
 PY
 
 blocked_readiness="$TMP_DIR/blocked_readiness.py"
@@ -207,24 +239,36 @@ python3 "$SCRIPT_PATH" \
   --direct-profile local_ollama \
   --probe-endpoints off \
   --codex-bin "$fake_codex" \
+  --run-id monday-local-operator-stack-blocked-test \
   --readiness-script "$blocked_readiness" \
   --stack-smoke-script "$fake_stack_smoke" \
   --monday-smoke-script "$fake_monday_smoke" \
+  --validation-root "$validation_root" \
   --output "$blocked_output"
 status=$?
 set -e
 test "$status" -ne 0
 
-python3 - <<'PY' "$blocked_output"
+python3 - <<'PY' "$blocked_output" "$validation_root"
 import json
 import sys
 from pathlib import Path
 
 report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+validation_root = Path(sys.argv[2])
 assert report["verdict"] == "fail", report
+assert report["run_id"] == "monday-local-operator-stack-blocked-test", report
 assert report["reason_code"] == "readiness_blocked", report
 assert report["stack_smoke"]["status"] == "skipped", report
 assert report["direct_smoke"]["status"] == "skipped", report
+latest_doc = json.loads((validation_root / "monday-local-operator-stack-report.json").resolve().read_text(encoding="utf-8"))
+stamped_doc = json.loads(
+    (validation_root / "monday-local-operator-stack-blocked-test-monday-local-operator-stack-report.json")
+    .resolve()
+    .read_text(encoding="utf-8")
+)
+assert latest_doc["run_id"] == "monday-local-operator-stack-blocked-test", latest_doc
+assert stamped_doc["run_id"] == "monday-local-operator-stack-blocked-test", stamped_doc
 PY
 
 echo "monday local operator stack contract ok"


### PR DESCRIPTION
## Summary
- mirror monday local operator aggregate reports into `planningops/artifacts/validation` as latest + stamped artifacts
- include promoted artifact paths in the wrapper output so downstream handoff and promotion flows can resolve them directly
- update the rollout plan and contract coverage around the promoted local operator evidence

## Scope
- `planningops/scripts/run_monday_local_operator_stack.py`
- `planningops/scripts/test_run_monday_local_operator_stack.sh`
- `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #934

## Validation
- `bash planningops/scripts/test_run_monday_local_operator_stack.sh`
- `python3 -m py_compile planningops/scripts/run_monday_local_operator_stack.py`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- local operator evidence now writes a latest mirror on every wrapper run, so later runs intentionally replace the latest validation view
- stamped mirror names now become part of downstream promotion expectations, so follow-up packets should reuse this naming rather than fork it

## Review Checklist
- [ ] confirm latest + stamped validation mirror paths are stable and deterministic
- [ ] confirm runtime-artifacts/local remains the primary execution evidence root
- [ ] confirm rollout plan reflects the mirror decision and next packet ordering

## Post-Deploy Monitoring & Validation
- inspect `planningops/artifacts/validation/monday-local-operator-stack-report.json` after the next local operator run
- inspect `planningops/artifacts/validation/<run-id>-monday-local-operator-stack-report.json` for stamped promotion evidence
- verify the next handoff/query packet reads the promoted paths instead of rediscovering runtime-only locations
