### PR TITLE
feat(query-engine): promote handoff reports into validation artifacts

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -121,6 +121,9 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-operator-stack`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report` now carry the latest local operator stack pointer
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` emits a handoff-ready operator packet
+- `planningops/scripts/federation/query_federated_ci_artifacts.py write-handoff-report`
+- `planningops/artifacts/validation/operator-handoff-report.json`
+- `planningops/artifacts/validation/<report-id>-operator-handoff-report.json`
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -182,6 +185,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether the handoff packet should mirror into validation artifacts or stay query-only
-2. add a Codex-to-monday mission packet contract so local operator prompts become reproducible inputs
-3. add a validation freshness surface so local operator stamped/latest mirrors can be promoted with the same evidence-first rules as federated CI summaries
+1. add a Codex-to-monday mission packet contract so local operator prompts become reproducible inputs
+2. add a validation freshness surface so local operator stamped/latest mirrors and handoff packets can be promoted with the same evidence-first rules as federated CI summaries
+3. decide whether handoff promotion should also emit an inbox-ready day packet or stay as a reusable validation-sidecar primitive

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 import sys
@@ -345,6 +346,19 @@ def resolve_artifact_path(path_text: Any) -> Path | None:
     if not isinstance(path_text, str) or not path_text.strip():
         return None
     return Path(path_text).expanduser().resolve()
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def utc_timestamp_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def write_json(path: Path, doc: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 
 
 def build_reconcile_validation_path(report_path: Path | None) -> Path | None:
@@ -2022,6 +2036,26 @@ def render_handoff_report_markdown(record: HandoffReportRecord) -> str:
     return record.markdown
 
 
+def build_handoff_artifact_document(
+    *,
+    record: HandoffReportRecord,
+    report_id: str,
+    latest_report_path: Path,
+    stamped_report_path: Path,
+    output_path: Path | None,
+) -> dict[str, Any]:
+    return {
+        "generated_at_utc": now_utc(),
+        "report_id": report_id,
+        "artifact_paths": {
+            "latest_report_path": str(latest_report_path.resolve()),
+            "stamped_report_path": str(stamped_report_path.resolve()),
+            "output_path": None if output_path is None else str(output_path.resolve()),
+        },
+        "record": asdict(record),
+    }
+
+
 def select_record(
     *,
     records: list[SummaryRecord],
@@ -2824,6 +2858,22 @@ def parse_args() -> argparse.Namespace:
     handoff_report_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     handoff_report_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
 
+    write_handoff_report_parser = subparsers.add_parser(
+        "write-handoff-report",
+        help="write a handoff-friendly operator report into latest + stamped validation artifacts",
+    )
+    write_handoff_report_parser.add_argument("--family", default=None)
+    write_handoff_report_parser.add_argument("--run-id-prefix", default=None)
+    write_handoff_report_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
+    write_handoff_report_parser.add_argument("--target-limit", type=int, default=3)
+    write_handoff_report_parser.add_argument("--report-id", default=None)
+    write_handoff_report_parser.add_argument("--output", default=None)
+    write_handoff_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="json")
+    write_handoff_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
+    write_handoff_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    write_handoff_report_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
+    write_handoff_report_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
+
     local_operator_parser = subparsers.add_parser(
         "local-operator-stack",
         help="list planningops-owned monday local operator stack aggregate reports",
@@ -3167,6 +3217,40 @@ def main() -> int:
         )
         if args.format == "json":
             print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_handoff_report_markdown(record))
+            return 0
+        print(render_handoff_report_table(record))
+        return 0
+
+    if args.command == "write-handoff-report":
+        local_records = discover_local_operator_stack_records(local_root=local_root)
+        record = build_handoff_report_record(
+            records=records,
+            local_records=local_records,
+            family=args.family,
+            run_id_prefix=args.run_id_prefix,
+            source_kind=args.source_kind,
+            target_limit=args.target_limit,
+        )
+        report_id = args.report_id or f"operator-handoff-{utc_timestamp_slug()}"
+        latest_report_path = validation_root / "operator-handoff-report.json"
+        stamped_report_path = validation_root / f"{report_id}-operator-handoff-report.json"
+        output_path = resolve_optional_path(args.output)
+        doc = build_handoff_artifact_document(
+            record=record,
+            report_id=report_id,
+            latest_report_path=latest_report_path,
+            stamped_report_path=stamped_report_path,
+            output_path=output_path,
+        )
+        write_json(latest_report_path, doc)
+        write_json(stamped_report_path, doc)
+        if output_path is not None:
+            write_json(output_path, doc)
+        if args.format == "json":
+            print(json.dumps(doc, ensure_ascii=True, indent=2))
             return 0
         if args.format == "markdown":
             print(render_handoff_report_markdown(record))

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -648,6 +648,7 @@ TRIAGE_REPORT_OUTPUT="$TMP_DIR/triage-report.json"
 TRIAGE_REPORT_ALL_OUTPUT="$TMP_DIR/triage-report-all.json"
 HANDOFF_REPORT_OUTPUT="$TMP_DIR/handoff-report.json"
 HANDOFF_REPORT_ALL_OUTPUT="$TMP_DIR/handoff-report-all.json"
+HANDOFF_WRITE_OUTPUT="$TMP_DIR/handoff-write.json"
 LOCAL_OPERATOR_OUTPUT="$TMP_DIR/local-operator-stack.json"
 LOCAL_OPERATOR_FILTERED_OUTPUT="$TMP_DIR/local-operator-stack-filtered.json"
 LOCAL_OPERATOR_DETAIL_OUTPUT="$TMP_DIR/local-operator-stack-detail.json"
@@ -1835,6 +1836,50 @@ assert record["immediate_action_lines"] == [
 ], record
 assert "source_kind: `all`" in record["markdown"], record
 assert "### Immediate Actions" in record["markdown"], record
+PY
+
+python3 "$QUERY_PATH" write-handoff-report \
+  --report-id operator-handoff-20260401T070000Z \
+  --output "$HANDOFF_WRITE_OUTPUT" \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" >"$HANDOFF_WRITE_OUTPUT.stdout"
+
+python3 - <<'PY' "$HANDOFF_WRITE_OUTPUT.stdout" "$HANDOFF_WRITE_OUTPUT" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+stdout_doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_doc = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+validation_dir = Path(sys.argv[3]).resolve()
+latest_path = validation_dir / "operator-handoff-report.json"
+stamped_path = validation_dir / "operator-handoff-20260401T070000Z-operator-handoff-report.json"
+latest_doc = json.loads(latest_path.read_text(encoding="utf-8"))
+stamped_doc = json.loads(stamped_path.read_text(encoding="utf-8"))
+
+for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
+    assert doc["report_id"] == "operator-handoff-20260401T070000Z", doc
+    assert doc["artifact_paths"]["latest_report_path"] == str(latest_path), doc
+    assert doc["artifact_paths"]["stamped_report_path"] == str(stamped_path), doc
+    assert doc["record"]["headline"] == "Operator handoff report: 2 attention families", doc
+    assert doc["record"]["source_kind"] == "stamped", doc
+    assert doc["record"]["local_operator_summary"] == (
+        "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
+        "stack=skipped direct=skipped mode=both reason=readiness_blocked"
+    ), doc
+    assert doc["record"]["immediate_action_lines"] == [
+        "local-runtime: Expose Codex and add a direct local LLM profile.",
+        "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+        "follow-up: [lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile",
+    ], doc
+
+assert stdout_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stdout_doc
+assert output_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), output_doc
+assert latest_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), latest_doc
+assert stamped_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stamped_doc
 PY
 
 python3 "$QUERY_PATH" reconcile-status \


### PR DESCRIPTION
## Summary
- add a `write-handoff-report` surface that promotes operator handoff packets into latest + stamped validation artifacts
- keep the existing `handoff-report` query surface read-only while emitting reusable validation-sidecar handoff packets
- extend the query contract and monday local Codex rollout plan to reflect the promoted handoff lane

## Scope
- `planningops/scripts/federation/query_federated_ci_artifacts.py`
- `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #936

## Validation
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- the latest handoff artifact is intentionally mutable and will be replaced by later handoff writes
- downstream consumers should treat the stamped handoff path as the promotion-safe reference, not the latest path

## Review Checklist
- [ ] confirm `write-handoff-report` preserves the existing `handoff-report` query surface without changing its semantics
- [ ] confirm latest + stamped validation paths are deterministic and reusable
- [ ] confirm rollout plan reflects the new promoted handoff lane and updated next packets

## Post-Deploy Monitoring & Validation
- inspect `planningops/artifacts/validation/operator-handoff-report.json` after the next handoff write
- inspect `planningops/artifacts/validation/<report-id>-operator-handoff-report.json` for the stamped handoff packet
- verify the next mission-packet packet reuses the stamped handoff artifact instead of recomputing ad hoc handoff state
