### PR TITLE
feat(local-runtime): add monday mission packet contract

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -124,6 +124,10 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py write-handoff-report`
 - `planningops/artifacts/validation/operator-handoff-report.json`
 - `planningops/artifacts/validation/<report-id>-operator-handoff-report.json`
+- `planningops/contracts/monday-local-mission-packet-contract.md`
+- `planningops/scripts/write_monday_local_mission_packet.py`
+- `planningops/artifacts/validation/monday-local-mission-packet.json`
+- `planningops/artifacts/validation/<packet-id>-monday-local-mission-packet.json`
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -185,6 +189,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. add a Codex-to-monday mission packet contract so local operator prompts become reproducible inputs
-2. add a validation freshness surface so local operator stamped/latest mirrors and handoff packets can be promoted with the same evidence-first rules as federated CI summaries
-3. decide whether handoff promotion should also emit an inbox-ready day packet or stay as a reusable validation-sidecar primitive
+1. add a validation freshness surface so local operator stamped/latest mirrors, handoff packets, and mission packets can be promoted with the same evidence-first rules as federated CI summaries
+2. decide whether mission packet promotion should also emit an inbox-ready day packet or stay as a reusable validation-sidecar primitive
+3. add a monday-native packet consumer once the repo exposes a mission executor richer than the current runtime smoke entrypoint

--- a/planningops/contracts/monday-local-mission-packet-contract.md
+++ b/planningops/contracts/monday-local-mission-packet-contract.md
@@ -1,0 +1,120 @@
+# Monday Local Mission Packet Contract
+
+## Purpose
+Define the deterministic boundary between promoted PlanningOps handoff evidence and the next local `monday` mission input packet consumed by Codex or a future monday-native mission entrypoint.
+
+This contract exists so:
+- promoted handoff artifacts stop being prompt-local suggestions and become reproducible mission inputs
+- `planningops` stays the owner of evidence, packet promotion, and rollback guidance
+- `monday` can accept one stable packet that already freezes mission objective, planner profile, model route, and expected evidence outputs
+
+## Canonical Boundary
+
+PlanningOps owns:
+- the mission packet contract
+- mission packet promotion into validation artifacts
+- deterministic packet derivation from:
+  - `planningops/artifacts/validation/operator-handoff-report.json`
+  - `planningops/artifacts/validation/monday-local-operator-stack-report.json`
+
+Monday owns:
+- the actual planner runtime
+- mission execution semantics beyond the packet boundary
+- runtime-private memory, queue behavior, and future packet-native execution CLIs
+
+PlanningOps must not:
+- invent monday-private runtime state
+- claim a packet-native monday executor exists when only a smoke or wrapper path is available
+- hide rollback expectations inside prompt-local prose
+
+## Canonical Artifacts
+
+Every promoted local mission packet must include these artifact surfaces:
+- latest packet: `planningops/artifacts/validation/monday-local-mission-packet.json`
+- stamped packet: `planningops/artifacts/validation/<packet-id>-monday-local-mission-packet.json`
+
+The packet may also be written to one caller-specified extra output path for downstream handoff tooling.
+
+## Packet Document Shape
+
+Top-level required fields:
+1. `generated_at_utc`
+2. `packet_id`
+3. `contract_ref`
+4. `artifact_paths.latest_packet_path`
+5. `artifact_paths.stamped_packet_path`
+6. `mission_packet`
+
+`mission_packet` required fields:
+1. `version` (`v1`)
+2. `packet_id`
+3. `mission_objective`
+4. `mission_prompt`
+5. `planner_profile`
+6. `launch_mode`
+7. `local_model_route`
+8. `source_kind`
+9. `primary_action`
+10. `preflight_command`
+11. `rollback_command`
+12. `expected_evidence_outputs`
+13. `immediate_actions`
+14. `target_lines`
+15. `source_artifacts.handoff_report_path`
+16. `source_artifacts.local_operator_report_path`
+
+Optional fields:
+- `attention_summary`
+- `newest_failing_summary`
+- `local_runtime_summary`
+- `local_runtime_next_step`
+- `monday_runtime_entrypoint_command`
+
+## Deterministic Resolution Rules
+
+1. Identical promoted handoff artifact, local operator artifact, and explicit CLI overrides must produce the same packet fields apart from timestamps.
+2. `launch_mode`, `planner_profile`, and `local_model_route` must be derived fail-closed:
+   - if local readiness is `ready`, prefer `launch_mode=stack`, `planner_profile=local`, `local_model_route=gateway_first_local`
+   - otherwise prefer `launch_mode=direct` with the local operator's direct profile
+   - if no direct profile is present, fall back to `local_ollama`
+3. `mission_objective` must come from the promoted handoff surface, not from prompt-local inference.
+4. `expected_evidence_outputs` must point at deterministic artifact paths that the chosen launch path is expected to refresh.
+
+## Command Rules
+
+`preflight_command` must remain PlanningOps-owned.
+
+Today that means:
+- stack launch uses `planningops/scripts/run_monday_local_operator_stack.py --execution-mode stack`
+- direct launch uses `planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct`
+
+`monday_runtime_entrypoint_command` is optional until monday exposes a packet-native mission executor. When present, it may reference the currently available monday local runtime smoke surface.
+
+`rollback_command` must be explicit and deterministic:
+- stack packets must rollback toward a direct local profile
+- direct packets must rollback toward gateway bootstrap when live prerequisites fail
+
+## Evidence Requirements
+
+Every packet must preserve the source artifact references it was derived from:
+- promoted handoff packet path
+- promoted local operator packet path
+
+Every packet must also name the mission-run evidence it expects next:
+- latest + stamped mission packet paths
+- the local operator runtime aggregate path keyed by `packet_id`
+- the stamped local operator validation mirror keyed by `packet_id`
+
+## Failure Rules
+
+- missing promoted handoff artifact is fail-fast
+- missing promoted local operator artifact is fail-fast
+- missing `record` payload in the promoted handoff artifact is fail-fast
+- empty `mission_objective`, `preflight_command`, or `rollback_command` is fail-fast
+- unsupported explicit `launch_mode`, `planner_profile`, or `local_model_route` overrides are fail-fast
+
+## Validation
+
+- `planningops/scripts/write_monday_local_mission_packet.py`
+- `planningops/scripts/test_write_monday_local_mission_packet.sh`
+- `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

--- a/planningops/scripts/test_write_monday_local_mission_packet.sh
+++ b/planningops/scripts/test_write_monday_local_mission_packet.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+VALIDATION_DIR="$TMP_DIR/validation"
+HANDOFF_REPORT="$VALIDATION_DIR/operator-handoff-report.json"
+LOCAL_OPERATOR_REPORT="$VALIDATION_DIR/monday-local-operator-stack-report.json"
+OUTPUT_PATH="$TMP_DIR/mission-packet-output.json"
+STDOUT_PATH="$TMP_DIR/mission-packet-stdout.json"
+PACKET_ID="monday-local-mission-20260401T080000Z"
+
+mkdir -p "$VALIDATION_DIR"
+
+cat >"$HANDOFF_REPORT" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T07:00:00+00:00",
+  "report_id": "operator-handoff-20260401T070000Z",
+  "artifact_paths": {
+    "latest_report_path": "/tmp/operator-handoff-report.json",
+    "stamped_report_path": "/tmp/operator-handoff-20260401T070000Z-report.json",
+    "output_path": null
+  },
+  "record": {
+    "source_kind": "stamped",
+    "target_limit": 3,
+    "headline": "Operator handoff report: 2 attention families",
+    "attention_summary": "active=1, lagging=1, clear=0",
+    "newest_failing_summary": "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun29 / lagging",
+    "newest_recovered_summary": null,
+    "local_operator_record": null,
+    "local_operator_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
+    "local_operator_next_step": "Expose Codex and add a direct local LLM profile.",
+    "queue_lines": [
+      "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1",
+      "lagging: targets=1 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint=1,readiness=1,reconcile=1"
+    ],
+    "target_lines": [
+      "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+      "[lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile"
+    ],
+    "immediate_action_lines": [
+      "local-runtime: Expose Codex and add a direct local LLM profile.",
+      "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+      "follow-up: [lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile"
+    ],
+    "markdown": "## Operator Handoff Report"
+  }
+}
+JSON
+
+cat >"$LOCAL_OPERATOR_REPORT" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T06:05:24+00:00",
+  "run_id": "monday-local-operator-stack-20260401T060524Z",
+  "workspace_root": "/tmp/workspace",
+  "execution_mode": "both",
+  "direct_profile": "local_ollama",
+  "dry_run": false,
+  "verdict": "fail",
+  "reason_code": "readiness_blocked",
+  "readiness": {
+    "status": "blocked",
+    "report_path": "/tmp/readiness.json",
+    "report": {},
+    "step": {
+      "status": "report_only"
+    }
+  },
+  "stack_smoke": {
+    "status": "skipped",
+    "report_path": "/tmp/stack-smoke.json"
+  },
+  "direct_smoke": {
+    "status": "skipped",
+    "report_path": "/tmp/local_ollama.json"
+  },
+  "recommended_next_steps": [
+    "Expose Codex and add a direct local LLM profile.",
+    "Start the provider gateway stack later if you want stack mode."
+  ],
+  "artifact_paths": {
+    "detail_dir": "/tmp/monday-local-operator-stack-20260401T060524Z",
+    "runtime_report_path": "/tmp/monday-local-operator-stack-20260401T060524Z.json",
+    "validation_latest_report_path": "/tmp/monday-local-operator-stack-report.json",
+    "validation_stamped_report_path": "/tmp/monday-local-operator-stack-20260401T060524Z-monday-local-operator-stack-report.json"
+  }
+}
+JSON
+
+python3 planningops/scripts/write_monday_local_mission_packet.py \
+  --validation-root "$VALIDATION_DIR" \
+  --handoff-report "$HANDOFF_REPORT" \
+  --local-operator-report "$LOCAL_OPERATOR_REPORT" \
+  --packet-id "$PACKET_ID" \
+  --output "$OUTPUT_PATH" >"$STDOUT_PATH"
+
+python3 - <<'PY' "$STDOUT_PATH" "$OUTPUT_PATH" "$VALIDATION_DIR" "$PACKET_ID"
+import json
+import sys
+from pathlib import Path
+
+stdout_doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_doc = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+validation_dir = Path(sys.argv[3]).resolve()
+packet_id = sys.argv[4]
+latest_path = validation_dir / "monday-local-mission-packet.json"
+stamped_path = validation_dir / f"{packet_id}-monday-local-mission-packet.json"
+latest_doc = json.loads(latest_path.read_text(encoding="utf-8"))
+stamped_doc = json.loads(stamped_path.read_text(encoding="utf-8"))
+
+contract_text = Path("planningops/contracts/monday-local-mission-packet-contract.md").read_text(encoding="utf-8")
+assert Path("planningops/contracts/monday-local-mission-packet-contract.md").exists()
+assert "mission_objective" in contract_text, contract_text
+assert "planner_profile" in contract_text, contract_text
+assert "local_model_route" in contract_text, contract_text
+assert "expected_evidence_outputs" in contract_text, contract_text
+assert "rollback_command" in contract_text, contract_text
+
+for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
+    assert doc["packet_id"] == packet_id, doc
+    assert doc["contract_ref"] == "planningops/contracts/monday-local-mission-packet-contract.md", doc
+    assert doc["artifact_paths"]["latest_packet_path"] == str(latest_path), doc
+    assert doc["artifact_paths"]["stamped_packet_path"] == str(stamped_path), doc
+    mission = doc["mission_packet"]
+    assert mission["version"] == "v1", mission
+    assert mission["packet_id"] == packet_id, mission
+    assert mission["planner_profile"] == "local_ollama", mission
+    assert mission["launch_mode"] == "direct", mission
+    assert mission["local_model_route"] == "direct_local_ollama", mission
+    assert mission["mission_objective"] == (
+        "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ), mission
+    assert mission["primary_action"] == "local-runtime: Expose Codex and add a direct local LLM profile.", mission
+    assert mission["preflight_command"] == (
+        "python3 planningops/scripts/run_monday_local_operator_stack.py "
+        f"--execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id {packet_id}"
+    ), mission
+    assert mission["monday_runtime_entrypoint_command"] == (
+        f"cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local_ollama --run-id {packet_id}"
+    ), mission
+    assert mission["rollback_command"] == "cd ../platform-provider-gateway && bash scripts/litellm_stack_launcher.sh --mode start", mission
+    assert mission["source_artifacts"]["handoff_report_path"] == str((validation_dir / "operator-handoff-report.json").resolve()), mission
+    assert mission["source_artifacts"]["local_operator_report_path"] == str((validation_dir / "monday-local-operator-stack-report.json").resolve()), mission
+    assert mission["immediate_actions"][0] == "local-runtime: Expose Codex and add a direct local LLM profile.", mission
+    assert mission["target_lines"][0].startswith("[active/latest-gap] federated-ci-local"), mission
+    assert str(latest_path) in mission["expected_evidence_outputs"], mission
+    assert str(stamped_path) in mission["expected_evidence_outputs"], mission
+    assert any(path.endswith(f"{packet_id}.json") for path in mission["expected_evidence_outputs"]), mission
+    assert any(path.endswith(f"{packet_id}-monday-local-operator-stack-report.json") for path in mission["expected_evidence_outputs"]), mission
+
+assert stdout_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stdout_doc
+assert output_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), output_doc
+assert latest_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), latest_doc
+assert stamped_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stamped_doc
+PY
+
+echo "write monday local mission packet ok"

--- a/planningops/scripts/write_monday_local_mission_packet.py
+++ b/planningops/scripts/write_monday_local_mission_packet.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_VALIDATION_ROOT = WORKSPACE_ROOT / "planningops/artifacts/validation"
+DEFAULT_HANDOFF_REPORT = DEFAULT_VALIDATION_ROOT / "operator-handoff-report.json"
+DEFAULT_LOCAL_OPERATOR_REPORT = DEFAULT_VALIDATION_ROOT / "monday-local-operator-stack-report.json"
+CONTRACT_REF = "planningops/contracts/monday-local-mission-packet-contract.md"
+
+PLANNER_PROFILE_CHOICES = ("auto", "local", "local_ollama", "local_lmstudio")
+LAUNCH_MODE_CHOICES = ("auto", "stack", "direct")
+MODEL_ROUTE_CHOICES = ("auto", "gateway_first_local", "direct_local_ollama", "direct_local_lmstudio")
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def utc_timestamp_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def resolve_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (WORKSPACE_ROOT / path).resolve()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def require_dict(doc: object, label: str) -> dict:
+    if not isinstance(doc, dict):
+        raise SystemExit(f"{label} must be a JSON object")
+    return doc
+
+
+def build_mission_objective(handoff_record: dict) -> str:
+    target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
+    if target_lines:
+        return f"Resolve {target_lines[0]}"
+    newest_failing = str(handoff_record.get("newest_failing_summary") or "").strip()
+    if newest_failing:
+        return f"Investigate {newest_failing}"
+    headline = str(handoff_record.get("headline") or "").strip()
+    if headline:
+        return headline
+    return "Inspect the latest promoted local handoff state."
+
+
+def choose_launch_parameters(
+    *,
+    local_operator_doc: dict,
+    planner_profile_arg: str,
+    launch_mode_arg: str,
+    local_model_route_arg: str,
+) -> tuple[str, str, str]:
+    readiness_status = str(require_dict(local_operator_doc.get("readiness"), "local operator readiness").get("status") or "unknown")
+    direct_profile = str(local_operator_doc.get("direct_profile") or "").strip() or "local_ollama"
+
+    if launch_mode_arg != "auto":
+        launch_mode = launch_mode_arg
+    elif readiness_status == "ready":
+        launch_mode = "stack"
+    else:
+        launch_mode = "direct"
+
+    if planner_profile_arg != "auto":
+        planner_profile = planner_profile_arg
+    elif launch_mode == "stack":
+        planner_profile = "local"
+    else:
+        planner_profile = direct_profile if direct_profile in {"local_ollama", "local_lmstudio"} else "local_ollama"
+
+    if local_model_route_arg != "auto":
+        local_model_route = local_model_route_arg
+    elif launch_mode == "stack":
+        local_model_route = "gateway_first_local"
+    elif planner_profile == "local_lmstudio":
+        local_model_route = "direct_local_lmstudio"
+    else:
+        local_model_route = "direct_local_ollama"
+
+    return launch_mode, planner_profile, local_model_route
+
+
+def build_commands(*, packet_id: str, launch_mode: str, planner_profile: str) -> tuple[str, str, str | None]:
+    if launch_mode == "stack":
+        preflight_command = (
+            "python3 planningops/scripts/run_monday_local_operator_stack.py "
+            f"--execution-mode stack --probe-endpoints on --run-id {packet_id}"
+        )
+        rollback_command = (
+            "python3 planningops/scripts/run_monday_local_operator_stack.py "
+            f"--execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id {packet_id}-rollback"
+        )
+        monday_runtime_entrypoint_command = (
+            f"cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local --run-id {packet_id}"
+        )
+        return preflight_command, rollback_command, monday_runtime_entrypoint_command
+
+    preflight_command = (
+        "python3 planningops/scripts/run_monday_local_operator_stack.py "
+        f"--execution-mode direct --direct-profile {planner_profile} --probe-endpoints on --run-id {packet_id}"
+    )
+    rollback_command = "cd ../platform-provider-gateway && bash scripts/litellm_stack_launcher.sh --mode start"
+    monday_runtime_entrypoint_command = (
+        f"cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile {planner_profile} --run-id {packet_id}"
+    )
+    return preflight_command, rollback_command, monday_runtime_entrypoint_command
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Write a deterministic monday local mission packet from promoted handoff artifacts.")
+    parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    parser.add_argument("--handoff-report", default=str(DEFAULT_HANDOFF_REPORT))
+    parser.add_argument("--local-operator-report", default=str(DEFAULT_LOCAL_OPERATOR_REPORT))
+    parser.add_argument("--packet-id", default=f"monday-local-mission-{utc_timestamp_slug()}")
+    parser.add_argument("--planner-profile", choices=PLANNER_PROFILE_CHOICES, default="auto")
+    parser.add_argument("--launch-mode", choices=LAUNCH_MODE_CHOICES, default="auto")
+    parser.add_argument("--local-model-route", choices=MODEL_ROUTE_CHOICES, default="auto")
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    validation_root = resolve_path(args.validation_root)
+    handoff_report_path = resolve_path(args.handoff_report)
+    local_operator_report_path = resolve_path(args.local_operator_report)
+    output_path = None if args.output is None else resolve_path(args.output)
+
+    if not handoff_report_path.exists():
+        raise SystemExit(f"handoff report missing: {handoff_report_path}")
+    if not local_operator_report_path.exists():
+        raise SystemExit(f"local operator report missing: {local_operator_report_path}")
+    if not (WORKSPACE_ROOT / CONTRACT_REF).exists():
+        raise SystemExit(f"mission packet contract missing: {CONTRACT_REF}")
+
+    handoff_doc = require_dict(load_json(handoff_report_path), "handoff report")
+    local_operator_doc = require_dict(load_json(local_operator_report_path), "local operator report")
+    handoff_record = require_dict(handoff_doc.get("record"), "handoff report record")
+
+    packet_id = args.packet_id
+    latest_packet_path = validation_root / "monday-local-mission-packet.json"
+    stamped_packet_path = validation_root / f"{packet_id}-monday-local-mission-packet.json"
+
+    launch_mode, planner_profile, local_model_route = choose_launch_parameters(
+        local_operator_doc=local_operator_doc,
+        planner_profile_arg=args.planner_profile,
+        launch_mode_arg=args.launch_mode,
+        local_model_route_arg=args.local_model_route,
+    )
+    preflight_command, rollback_command, monday_runtime_entrypoint_command = build_commands(
+        packet_id=packet_id,
+        launch_mode=launch_mode,
+        planner_profile=planner_profile,
+    )
+
+    immediate_actions = [str(line) for line in list(handoff_record.get("immediate_action_lines") or []) if str(line).strip()]
+    target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
+    mission_objective = build_mission_objective(handoff_record)
+    primary_action = immediate_actions[0] if immediate_actions else (target_lines[0] if target_lines else mission_objective)
+
+    expected_evidence_outputs = [
+        str(latest_packet_path.resolve()),
+        str(stamped_packet_path.resolve()),
+        str((WORKSPACE_ROOT / "planningops/runtime-artifacts/local/monday-local-operator-stack" / f"{packet_id}.json").resolve()),
+        str((WORKSPACE_ROOT / "planningops/runtime-artifacts/local/monday-local-operator-stack" / packet_id).resolve()),
+        str((validation_root / "monday-local-operator-stack-report.json").resolve()),
+        str((validation_root / f"{packet_id}-monday-local-operator-stack-report.json").resolve()),
+    ]
+
+    mission_packet = {
+        "version": "v1",
+        "packet_id": packet_id,
+        "mission_objective": mission_objective,
+        "mission_prompt": (
+            f"Use monday planner profile `{planner_profile}` via `{local_model_route}`. "
+            f"Start with `{primary_action}` and preserve the expected evidence outputs."
+        ),
+        "planner_profile": planner_profile,
+        "launch_mode": launch_mode,
+        "local_model_route": local_model_route,
+        "source_kind": str(handoff_record.get("source_kind") or "unknown"),
+        "attention_summary": str(handoff_record.get("attention_summary") or ""),
+        "newest_failing_summary": str(handoff_record.get("newest_failing_summary") or ""),
+        "local_runtime_summary": str(handoff_record.get("local_operator_summary") or ""),
+        "local_runtime_next_step": str(handoff_record.get("local_operator_next_step") or ""),
+        "primary_action": primary_action,
+        "immediate_actions": immediate_actions,
+        "target_lines": target_lines,
+        "preflight_command": preflight_command,
+        "monday_runtime_entrypoint_command": monday_runtime_entrypoint_command,
+        "rollback_command": rollback_command,
+        "expected_evidence_outputs": expected_evidence_outputs,
+        "source_artifacts": {
+            "handoff_report_path": str(handoff_report_path.resolve()),
+            "local_operator_report_path": str(local_operator_report_path.resolve()),
+        },
+    }
+
+    packet_doc = {
+        "generated_at_utc": now_utc(),
+        "packet_id": packet_id,
+        "contract_ref": CONTRACT_REF,
+        "artifact_paths": {
+            "latest_packet_path": str(latest_packet_path.resolve()),
+            "stamped_packet_path": str(stamped_packet_path.resolve()),
+            "output_path": None if output_path is None else str(output_path.resolve()),
+        },
+        "mission_packet": mission_packet,
+    }
+
+    for path in {latest_packet_path, stamped_packet_path}:
+        write_json(path, packet_doc)
+    if output_path is not None:
+        write_json(output_path, packet_doc)
+
+    print(json.dumps(packet_doc, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a monday local mission packet contract that freezes the promoted handoff-to-mission boundary
- add a deterministic writer that derives latest + stamped mission packet artifacts from the promoted handoff and local operator reports
- add regression coverage and rollout-plan updates for the new mission packet lane

## Scope
- `planningops/contracts/monday-local-mission-packet-contract.md`
- `planningops/scripts/write_monday_local_mission_packet.py`
- `planningops/scripts/test_write_monday_local_mission_packet.sh`
- `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #938

## Validation
- `bash planningops/scripts/test_write_monday_local_mission_packet.sh`
- `python3 -m py_compile planningops/scripts/write_monday_local_mission_packet.py`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- the packet currently points at the existing monday runtime smoke entrypoint because a richer packet-native mission executor does not exist yet
- latest mission packet artifacts are intentionally mutable, so downstream promotion flows should prefer the stamped packet path

## Review Checklist
- [ ] confirm the mission packet contract captures mission objective, planner profile, model route, evidence outputs, and rollback command
- [ ] confirm the writer derives latest + stamped packet artifacts deterministically from promoted inputs
- [ ] confirm the rollout plan now reflects the mission packet as a current deliverable

## Post-Deploy Monitoring & Validation
- inspect `planningops/artifacts/validation/monday-local-mission-packet.json` after the next mission packet write
- inspect `planningops/artifacts/validation/<packet-id>-monday-local-mission-packet.json` for the stamped mission input
- verify the next packet can consume the stamped mission packet without recomputing the handoff or local operator choice ad hoc
