### PR TITLE
feat(query-engine): add local validation freshness surface

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -122,6 +122,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report` now carry the latest local operator stack pointer
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` emits a handoff-ready operator packet
 - `planningops/scripts/federation/query_federated_ci_artifacts.py write-handoff-report`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness`
 - `planningops/artifacts/validation/operator-handoff-report.json`
 - `planningops/artifacts/validation/<report-id>-operator-handoff-report.json`
 - `planningops/contracts/monday-local-mission-packet-contract.md`
@@ -189,6 +190,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. add a validation freshness surface so local operator stamped/latest mirrors, handoff packets, and mission packets can be promoted with the same evidence-first rules as federated CI summaries
-2. decide whether mission packet promotion should also emit an inbox-ready day packet or stay as a reusable validation-sidecar primitive
+1. decide whether mission packet promotion should also emit an inbox-ready day packet or stay as a reusable validation-sidecar primitive
+2. surface local validation freshness directly inside `handoff-report` so the operator packet carries freshness + promotability in one document
 3. add a monday-native packet consumer once the repo exposes a mission executor richer than the current runtime smoke entrypoint

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -46,6 +46,13 @@ LATEST_GAP_CHOICES = (
 LOCAL_OPERATOR_VERDICT_CHOICES = ("pass", "fail", "planned")
 LOCAL_OPERATOR_READINESS_CHOICES = ("ready", "bootstrap_required", "blocked", "unknown")
 LOCAL_OPERATOR_STEP_STATUS_CHOICES = ("pass", "fail", "planned", "skipped", "report_only", "unknown", "missing")
+LOCAL_VALIDATION_FAMILY_CHOICES = (
+    "monday_local_operator_stack_report",
+    "operator_handoff_report",
+    "monday_local_mission_packet",
+)
+LOCAL_VALIDATION_FRESHNESS_CHOICES = ("fresh", "stale", "missing")
+LOCAL_VALIDATION_PROMOTABILITY_CHOICES = ("promotable", "blocked")
 
 
 @dataclass(frozen=True)
@@ -314,6 +321,20 @@ class LocalOperatorStackRecord:
     direct_status: str
     direct_report_path: str | None
     recommended_next_steps: list[str]
+
+
+@dataclass(frozen=True)
+class LocalValidationFreshnessRecord:
+    artifact_family: str
+    artifact_kind: str
+    promoted_id: str | None
+    generated_at_utc: str | None
+    freshness_state: str
+    promotability_status: str
+    latest_path: str
+    stamped_path: str | None
+    reasons: list[str]
+    dependency_states: dict[str, str]
 
 
 def resolve_root(path_text: str, default: Path) -> Path:
@@ -789,6 +810,371 @@ def build_local_operator_next_step(record: LocalOperatorStackRecord | None) -> s
     if record is None or not record.recommended_next_steps:
         return None
     return record.recommended_next_steps[0]
+
+
+def resolve_nested_value(doc: dict[str, Any], *keys: str) -> Any:
+    current: Any = doc
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def resolve_nested_artifact_path(doc: dict[str, Any], *keys: str) -> Path | None:
+    return resolve_artifact_path(resolve_nested_value(doc, *keys))
+
+
+def build_local_validation_dependency_state(
+    *,
+    raw_path: Any,
+    expected_path: Path,
+) -> tuple[str, str | None]:
+    resolved = resolve_artifact_path(raw_path)
+    if resolved is None:
+        return "missing", "dependency_path_missing"
+    if not resolved.exists():
+        return "missing", "dependency_missing"
+    if resolved != expected_path.resolve():
+        return "stale", "dependency_stale"
+    return "current", None
+
+
+def classify_local_validation_states(
+    *,
+    latest_path: Path,
+    latest_doc: dict[str, Any] | None,
+    stamped_path: Path | None,
+    freshness_reasons: list[str],
+    promotability_reasons: list[str],
+    dependency_states: dict[str, str],
+) -> tuple[str, str]:
+    if latest_doc is None:
+        if latest_path.exists():
+            freshness_reasons.insert(0, "latest_invalid_json")
+        else:
+            freshness_reasons.insert(0, "latest_missing")
+    elif stamped_path is None:
+        freshness_reasons.append("stamped_path_missing")
+    elif not stamped_path.exists():
+        freshness_reasons.append("stamped_missing")
+
+    freshness_state = "fresh"
+    if any(reason in {"latest_missing", "latest_invalid_json"} for reason in freshness_reasons):
+        freshness_state = "missing"
+    elif freshness_reasons:
+        freshness_state = "stale"
+
+    promotability_status = "promotable"
+    if freshness_state != "fresh" or promotability_reasons or any(
+        state != "current" for state in dependency_states.values()
+    ):
+        promotability_status = "blocked"
+    return freshness_state, promotability_status
+
+
+def build_local_operator_validation_freshness_record(*, validation_root: Path) -> LocalValidationFreshnessRecord:
+    latest_path = (validation_root / "monday-local-operator-stack-report.json").resolve()
+    latest_doc = load_optional_json(latest_path)
+    freshness_reasons: list[str] = []
+    promotability_reasons: list[str] = []
+    dependency_states: dict[str, str] = {}
+    stamped_path: Path | None = None
+    promoted_id: str | None = None
+    generated_at_utc: str | None = None
+
+    if latest_doc is not None:
+        promoted_id = str(latest_doc.get("run_id") or "").strip() or None
+        generated_at_utc = str(latest_doc.get("generated_at_utc") or "").strip() or None
+        if promoted_id is None:
+            promotability_reasons.append("missing_run_id")
+        latest_report_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "validation_latest_report_path")
+        stamped_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "validation_stamped_report_path")
+        if latest_report_path != latest_path:
+            freshness_reasons.append("latest_path_mismatch")
+        if not isinstance(latest_doc.get("readiness"), dict):
+            promotability_reasons.append("missing_readiness")
+        if not isinstance(latest_doc.get("stack_smoke"), dict):
+            promotability_reasons.append("missing_stack_smoke")
+        if not isinstance(latest_doc.get("direct_smoke"), dict):
+            promotability_reasons.append("missing_direct_smoke")
+        if not isinstance(latest_doc.get("verdict"), str) or not str(latest_doc.get("verdict")).strip():
+            promotability_reasons.append("missing_verdict")
+        if not isinstance(latest_doc.get("reason_code"), str) or not str(latest_doc.get("reason_code")).strip():
+            promotability_reasons.append("missing_reason_code")
+        if stamped_path is not None and stamped_path.exists():
+            stamped_doc = load_optional_json(stamped_path)
+            if stamped_doc is None:
+                freshness_reasons.append("stamped_invalid_json")
+            else:
+                if str(stamped_doc.get("run_id") or "").strip() != (promoted_id or ""):
+                    freshness_reasons.append("stamped_run_id_mismatch")
+                stamped_latest_path = resolve_nested_artifact_path(
+                    stamped_doc, "artifact_paths", "validation_latest_report_path"
+                )
+                stamped_stamped_path = resolve_nested_artifact_path(
+                    stamped_doc, "artifact_paths", "validation_stamped_report_path"
+                )
+                if stamped_latest_path != latest_path:
+                    freshness_reasons.append("stamped_latest_path_mismatch")
+                if stamped_stamped_path != stamped_path.resolve():
+                    freshness_reasons.append("stamped_path_mismatch")
+
+    freshness_state, promotability_status = classify_local_validation_states(
+        latest_path=latest_path,
+        latest_doc=latest_doc,
+        stamped_path=stamped_path,
+        freshness_reasons=freshness_reasons,
+        promotability_reasons=promotability_reasons,
+        dependency_states=dependency_states,
+    )
+    return LocalValidationFreshnessRecord(
+        artifact_family="monday_local_operator_stack_report",
+        artifact_kind="report",
+        promoted_id=promoted_id,
+        generated_at_utc=generated_at_utc,
+        freshness_state=freshness_state,
+        promotability_status=promotability_status,
+        latest_path=str(latest_path),
+        stamped_path=None if stamped_path is None else str(stamped_path.resolve()),
+        reasons=freshness_reasons + promotability_reasons,
+        dependency_states=dependency_states,
+    )
+
+
+def build_handoff_validation_freshness_record(*, validation_root: Path) -> LocalValidationFreshnessRecord:
+    latest_path = (validation_root / "operator-handoff-report.json").resolve()
+    latest_doc = load_optional_json(latest_path)
+    freshness_reasons: list[str] = []
+    promotability_reasons: list[str] = []
+    dependency_states: dict[str, str] = {}
+    stamped_path: Path | None = None
+    promoted_id: str | None = None
+    generated_at_utc: str | None = None
+
+    if latest_doc is not None:
+        promoted_id = str(latest_doc.get("report_id") or "").strip() or None
+        generated_at_utc = str(latest_doc.get("generated_at_utc") or "").strip() or None
+        if promoted_id is None:
+            promotability_reasons.append("missing_report_id")
+        latest_report_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "latest_report_path")
+        stamped_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "stamped_report_path")
+        if latest_report_path != latest_path:
+            freshness_reasons.append("latest_path_mismatch")
+        record_doc = resolve_nested_value(latest_doc, "record")
+        if not isinstance(record_doc, dict):
+            promotability_reasons.append("missing_record")
+        else:
+            if not isinstance(record_doc.get("headline"), str) or not str(record_doc.get("headline")).strip():
+                promotability_reasons.append("missing_headline")
+            if not isinstance(record_doc.get("attention_summary"), str) or not str(record_doc.get("attention_summary")).strip():
+                promotability_reasons.append("missing_attention_summary")
+            action_lines = [str(line) for line in list(record_doc.get("immediate_action_lines") or []) if str(line).strip()]
+            if not action_lines:
+                promotability_reasons.append("missing_immediate_action_lines")
+        if stamped_path is not None and stamped_path.exists():
+            stamped_doc = load_optional_json(stamped_path)
+            if stamped_doc is None:
+                freshness_reasons.append("stamped_invalid_json")
+            else:
+                if str(stamped_doc.get("report_id") or "").strip() != (promoted_id or ""):
+                    freshness_reasons.append("stamped_report_id_mismatch")
+                stamped_latest_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "latest_report_path")
+                stamped_stamped_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "stamped_report_path")
+                if stamped_latest_path != latest_path:
+                    freshness_reasons.append("stamped_latest_path_mismatch")
+                if stamped_stamped_path != stamped_path.resolve():
+                    freshness_reasons.append("stamped_path_mismatch")
+
+    freshness_state, promotability_status = classify_local_validation_states(
+        latest_path=latest_path,
+        latest_doc=latest_doc,
+        stamped_path=stamped_path,
+        freshness_reasons=freshness_reasons,
+        promotability_reasons=promotability_reasons,
+        dependency_states=dependency_states,
+    )
+    return LocalValidationFreshnessRecord(
+        artifact_family="operator_handoff_report",
+        artifact_kind="report",
+        promoted_id=promoted_id,
+        generated_at_utc=generated_at_utc,
+        freshness_state=freshness_state,
+        promotability_status=promotability_status,
+        latest_path=str(latest_path),
+        stamped_path=None if stamped_path is None else str(stamped_path.resolve()),
+        reasons=freshness_reasons + promotability_reasons,
+        dependency_states=dependency_states,
+    )
+
+
+def build_mission_packet_validation_freshness_record(*, validation_root: Path) -> LocalValidationFreshnessRecord:
+    latest_path = (validation_root / "monday-local-mission-packet.json").resolve()
+    latest_doc = load_optional_json(latest_path)
+    freshness_reasons: list[str] = []
+    promotability_reasons: list[str] = []
+    dependency_states: dict[str, str] = {}
+    stamped_path: Path | None = None
+    promoted_id: str | None = None
+    generated_at_utc: str | None = None
+
+    if latest_doc is not None:
+        promoted_id = str(latest_doc.get("packet_id") or "").strip() or None
+        generated_at_utc = str(latest_doc.get("generated_at_utc") or "").strip() or None
+        if promoted_id is None:
+            promotability_reasons.append("missing_packet_id")
+        if not isinstance(latest_doc.get("contract_ref"), str) or not str(latest_doc.get("contract_ref")).strip():
+            promotability_reasons.append("missing_contract_ref")
+        latest_packet_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "latest_packet_path")
+        stamped_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "stamped_packet_path")
+        if latest_packet_path != latest_path:
+            freshness_reasons.append("latest_path_mismatch")
+        mission_packet = resolve_nested_value(latest_doc, "mission_packet")
+        if not isinstance(mission_packet, dict):
+            promotability_reasons.append("missing_mission_packet")
+        else:
+            required_strings = {
+                "mission_objective": "missing_mission_objective",
+                "preflight_command": "missing_preflight_command",
+                "rollback_command": "missing_rollback_command",
+                "planner_profile": "missing_planner_profile",
+                "launch_mode": "missing_launch_mode",
+                "local_model_route": "missing_local_model_route",
+            }
+            for field_name, reason in required_strings.items():
+                value = mission_packet.get(field_name)
+                if not isinstance(value, str) or not value.strip():
+                    promotability_reasons.append(reason)
+            expected_outputs = [str(path) for path in list(mission_packet.get("expected_evidence_outputs") or []) if str(path).strip()]
+            if not expected_outputs:
+                promotability_reasons.append("missing_expected_evidence_outputs")
+            source_artifacts = mission_packet.get("source_artifacts")
+            if not isinstance(source_artifacts, dict):
+                promotability_reasons.append("missing_source_artifacts")
+            else:
+                handoff_state, handoff_reason = build_local_validation_dependency_state(
+                    raw_path=source_artifacts.get("handoff_report_path"),
+                    expected_path=validation_root / "operator-handoff-report.json",
+                )
+                local_state, local_reason = build_local_validation_dependency_state(
+                    raw_path=source_artifacts.get("local_operator_report_path"),
+                    expected_path=validation_root / "monday-local-operator-stack-report.json",
+                )
+                dependency_states["operator_handoff_report"] = handoff_state
+                dependency_states["monday_local_operator_stack_report"] = local_state
+                if handoff_reason == "dependency_path_missing":
+                    promotability_reasons.append("missing_handoff_report_path")
+                elif handoff_reason == "dependency_missing":
+                    promotability_reasons.append("handoff_dependency_missing")
+                elif handoff_reason == "dependency_stale":
+                    promotability_reasons.append("handoff_dependency_stale")
+                if local_reason == "dependency_path_missing":
+                    promotability_reasons.append("missing_local_operator_report_path")
+                elif local_reason == "dependency_missing":
+                    promotability_reasons.append("local_operator_dependency_missing")
+                elif local_reason == "dependency_stale":
+                    promotability_reasons.append("local_operator_dependency_stale")
+        if stamped_path is not None and stamped_path.exists():
+            stamped_doc = load_optional_json(stamped_path)
+            if stamped_doc is None:
+                freshness_reasons.append("stamped_invalid_json")
+            else:
+                if str(stamped_doc.get("packet_id") or "").strip() != (promoted_id or ""):
+                    freshness_reasons.append("stamped_packet_id_mismatch")
+                stamped_latest_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "latest_packet_path")
+                stamped_stamped_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "stamped_packet_path")
+                if stamped_latest_path != latest_path:
+                    freshness_reasons.append("stamped_latest_path_mismatch")
+                if stamped_stamped_path != stamped_path.resolve():
+                    freshness_reasons.append("stamped_path_mismatch")
+
+    freshness_state, promotability_status = classify_local_validation_states(
+        latest_path=latest_path,
+        latest_doc=latest_doc,
+        stamped_path=stamped_path,
+        freshness_reasons=freshness_reasons,
+        promotability_reasons=promotability_reasons,
+        dependency_states=dependency_states,
+    )
+    return LocalValidationFreshnessRecord(
+        artifact_family="monday_local_mission_packet",
+        artifact_kind="packet",
+        promoted_id=promoted_id,
+        generated_at_utc=generated_at_utc,
+        freshness_state=freshness_state,
+        promotability_status=promotability_status,
+        latest_path=str(latest_path),
+        stamped_path=None if stamped_path is None else str(stamped_path.resolve()),
+        reasons=freshness_reasons + promotability_reasons,
+        dependency_states=dependency_states,
+    )
+
+
+def discover_local_validation_freshness_records(*, validation_root: Path) -> list[LocalValidationFreshnessRecord]:
+    return [
+        build_local_operator_validation_freshness_record(validation_root=validation_root),
+        build_handoff_validation_freshness_record(validation_root=validation_root),
+        build_mission_packet_validation_freshness_record(validation_root=validation_root),
+    ]
+
+
+def filter_local_validation_freshness_records(
+    *,
+    records: list[LocalValidationFreshnessRecord],
+    artifact_family: str | None = None,
+    freshness_state: str | None = None,
+    promotability_status: str | None = None,
+    has_reason: str | None = None,
+) -> list[LocalValidationFreshnessRecord]:
+    filtered = records
+    if artifact_family:
+        filtered = [record for record in filtered if record.artifact_family == artifact_family]
+    if freshness_state:
+        filtered = [record for record in filtered if record.freshness_state == freshness_state]
+    if promotability_status:
+        filtered = [record for record in filtered if record.promotability_status == promotability_status]
+    if has_reason:
+        filtered = [record for record in filtered if has_reason in record.reasons]
+    return filtered
+
+
+def render_local_validation_freshness_table(records: list[LocalValidationFreshnessRecord]) -> str:
+    lines = [
+        "artifact_family\tartifact_kind\tpromoted_id\tfreshness\tpromotability\tdependency_states\treasons\tgenerated_at_utc\tlatest_path\tstamped_path",
+    ]
+    for record in records:
+        lines.append(
+            "\t".join(
+                [
+                    record.artifact_family,
+                    record.artifact_kind,
+                    str(record.promoted_id or ""),
+                    record.freshness_state,
+                    record.promotability_status,
+                    ",".join(f"{key}={value}" for key, value in record.dependency_states.items()),
+                    ",".join(record.reasons),
+                    str(record.generated_at_utc or ""),
+                    record.latest_path,
+                    str(record.stamped_path or ""),
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_local_validation_freshness_markdown(records: list[LocalValidationFreshnessRecord]) -> str:
+    lines = [
+        "| artifact_family | kind | promoted_id | freshness | promotability | dependency_states | reasons | generated_at_utc |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for record in records:
+        lines.append(
+            f"| {record.artifact_family} | {record.artifact_kind} | `{record.promoted_id or ''}` | "
+            f"{record.freshness_state} | {record.promotability_status} | "
+            f"{', '.join(f'{key}={value}' for key, value in record.dependency_states.items())} | "
+            f"{', '.join(record.reasons)} | {record.generated_at_utc or ''} |"
+        )
+    return "\n".join(lines)
 
 
 def build_summary_health_fields(
@@ -2874,6 +3260,22 @@ def parse_args() -> argparse.Namespace:
     write_handoff_report_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     write_handoff_report_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
 
+    local_validation_parser = subparsers.add_parser(
+        "local-validation-freshness",
+        help="show freshness and promotability for promoted monday local validation artifacts",
+    )
+    local_validation_parser.add_argument("--artifact-family", choices=LOCAL_VALIDATION_FAMILY_CHOICES, default=None)
+    local_validation_parser.add_argument("--freshness-state", choices=LOCAL_VALIDATION_FRESHNESS_CHOICES, default=None)
+    local_validation_parser.add_argument(
+        "--promotability-status",
+        choices=LOCAL_VALIDATION_PROMOTABILITY_CHOICES,
+        default=None,
+    )
+    local_validation_parser.add_argument("--has-reason", default=None)
+    local_validation_parser.add_argument("--limit", type=int, default=20)
+    local_validation_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    local_validation_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+
     local_operator_parser = subparsers.add_parser(
         "local-operator-stack",
         help="list planningops-owned monday local operator stack aggregate reports",
@@ -2897,6 +3299,26 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     local_root = resolve_root(getattr(args, "local_root", str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT)), DEFAULT_LOCAL_OPERATOR_STACK_ROOT)
+    validation_root = resolve_root(getattr(args, "validation_root", str(DEFAULT_VALIDATION_ROOT)), DEFAULT_VALIDATION_ROOT)
+    if args.command == "local-validation-freshness":
+        local_validation_records = discover_local_validation_freshness_records(validation_root=validation_root)
+        local_validation_records = filter_local_validation_freshness_records(
+            records=local_validation_records,
+            artifact_family=args.artifact_family,
+            freshness_state=args.freshness_state,
+            promotability_status=args.promotability_status,
+            has_reason=args.has_reason,
+        )
+        local_validation_records = local_validation_records[: args.limit]
+        if args.format == "json":
+            print(json.dumps({"records": [asdict(record) for record in local_validation_records]}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_local_validation_freshness_markdown(local_validation_records))
+            return 0
+        print(render_local_validation_freshness_table(local_validation_records))
+        return 0
+
     if args.command == "local-operator-stack":
         local_records = discover_local_operator_stack_records(local_root=local_root)
         local_records = filter_local_operator_stack_records(
@@ -2923,7 +3345,6 @@ def main() -> int:
         return 0
 
     ci_root = resolve_root(getattr(args, "ci_root", str(DEFAULT_CI_ROOT)), DEFAULT_CI_ROOT)
-    validation_root = resolve_root(getattr(args, "validation_root", str(DEFAULT_VALIDATION_ROOT)), DEFAULT_VALIDATION_ROOT)
     conformance_root = resolve_root(getattr(args, "conformance_root", str(DEFAULT_CONFORMANCE_ROOT)), DEFAULT_CONFORMANCE_ROOT)
     records = discover_summary_records(
         ci_root=ci_root,

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -649,6 +649,9 @@ TRIAGE_REPORT_ALL_OUTPUT="$TMP_DIR/triage-report-all.json"
 HANDOFF_REPORT_OUTPUT="$TMP_DIR/handoff-report.json"
 HANDOFF_REPORT_ALL_OUTPUT="$TMP_DIR/handoff-report-all.json"
 HANDOFF_WRITE_OUTPUT="$TMP_DIR/handoff-write.json"
+LOCAL_VALIDATION_OUTPUT="$TMP_DIR/local-validation-freshness.json"
+LOCAL_VALIDATION_BLOCKED_OUTPUT="$TMP_DIR/local-validation-freshness-blocked.json"
+LOCAL_VALIDATION_STALE_OUTPUT="$TMP_DIR/local-validation-freshness-stale.json"
 LOCAL_OPERATOR_OUTPUT="$TMP_DIR/local-operator-stack.json"
 LOCAL_OPERATOR_FILTERED_OUTPUT="$TMP_DIR/local-operator-stack-filtered.json"
 LOCAL_OPERATOR_DETAIL_OUTPUT="$TMP_DIR/local-operator-stack-detail.json"
@@ -2175,6 +2178,206 @@ record = records[0]
 assert record["run_id"] == "monday-local-operator-stack-20260401T060700Z", record
 assert record["has_detail_dir"] is False, record
 assert record["expected_detail_dir"].endswith("monday-local-operator-stack-20260401T060700Z"), record
+PY
+
+rm -f "$VALIDATION_DIR/operator-handoff-20260401T070000Z-operator-handoff-report.json"
+
+cat >"$VALIDATION_DIR/monday-local-operator-stack-report.json" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T06:05:24+00:00",
+  "run_id": "monday-local-operator-stack-20260401T060524Z",
+  "workspace_root": "/tmp/workspace",
+  "execution_mode": "both",
+  "direct_profile": "local_lmstudio",
+  "dry_run": false,
+  "verdict": "fail",
+  "reason_code": "readiness_blocked",
+  "readiness": {
+    "status": "blocked",
+    "report_path": "/tmp/readiness.json",
+    "report": {},
+    "step": {
+      "status": "report_only"
+    }
+  },
+  "stack_smoke": {
+    "status": "skipped",
+    "report_path": "/tmp/stack-smoke.json"
+  },
+  "direct_smoke": {
+    "status": "skipped",
+    "report_path": "/tmp/local_lmstudio.json"
+  },
+  "recommended_next_steps": [
+    "Expose Codex and add a direct local LLM profile."
+  ],
+  "artifact_paths": {
+    "detail_dir": "/tmp/monday-local-operator-stack-20260401T060524Z",
+    "runtime_report_path": "/tmp/monday-local-operator-stack-20260401T060524Z.json",
+    "validation_latest_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json",
+    "validation_stamped_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-20260401T060524Z-monday-local-operator-stack-report.json"
+  }
+}
+JSON
+
+python3 - <<'PY' "$VALIDATION_DIR/monday-local-operator-stack-report.json" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["validation_latest_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
+doc["artifact_paths"]["validation_stamped_report_path"] = str((validation_dir / "monday-local-operator-stack-20260401T060524Z-monday-local-operator-stack-report.json").resolve())
+path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+(validation_dir / "monday-local-operator-stack-20260401T060524Z-monday-local-operator-stack-report.json").write_text(
+    json.dumps(doc, ensure_ascii=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+cat >"$VALIDATION_DIR/monday-local-mission-packet.json" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T08:00:00+00:00",
+  "packet_id": "monday-local-mission-20260401T080000Z",
+  "contract_ref": "planningops/contracts/monday-local-mission-packet-contract.md",
+  "artifact_paths": {
+    "latest_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+    "stamped_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-20260401T080000Z-monday-local-mission-packet.json",
+    "output_path": null
+  },
+  "mission_packet": {
+    "version": "v1",
+    "packet_id": "monday-local-mission-20260401T080000Z",
+    "mission_objective": "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "mission_prompt": "Use monday planner profile `local_ollama` via `direct_local_ollama`.",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "source_kind": "stamped",
+    "attention_summary": "active=2, lagging=0, clear=0",
+    "newest_failing_summary": "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun26 / active",
+    "local_runtime_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
+    "local_runtime_next_step": "Expose Codex and add a direct local LLM profile.",
+    "primary_action": "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "immediate_actions": [
+      "local-runtime: Expose Codex and add a direct local LLM profile."
+    ],
+    "target_lines": [
+      "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "preflight_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id monday-local-mission-20260401T080000Z",
+    "expected_evidence_outputs": [
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-20260401T080000Z-monday-local-mission-packet.json"
+    ],
+    "source_artifacts": {
+      "handoff_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+      "local_operator_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json"
+    }
+  }
+}
+JSON
+
+python3 - <<'PY' "$VALIDATION_DIR/monday-local-mission-packet.json" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["latest_packet_path"] = str((validation_dir / "monday-local-mission-packet.json").resolve())
+doc["artifact_paths"]["stamped_packet_path"] = str((validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").resolve())
+doc["mission_packet"]["expected_evidence_outputs"] = [
+    str((validation_dir / "monday-local-mission-packet.json").resolve()),
+    str((validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").resolve()),
+]
+doc["mission_packet"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
+doc["mission_packet"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
+path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+(validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").write_text(
+    json.dumps(doc, ensure_ascii=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+python3 "$QUERY_PATH" local-validation-freshness \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_VALIDATION_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["artifact_family"] for record in records] == [
+    "monday_local_operator_stack_report",
+    "operator_handoff_report",
+    "monday_local_mission_packet",
+], records
+
+local_operator, handoff, mission = records
+
+assert local_operator["freshness_state"] == "fresh", local_operator
+assert local_operator["promotability_status"] == "promotable", local_operator
+assert local_operator["promoted_id"] == "monday-local-operator-stack-20260401T060524Z", local_operator
+assert local_operator["reasons"] == [], local_operator
+
+assert handoff["freshness_state"] == "stale", handoff
+assert handoff["promotability_status"] == "blocked", handoff
+assert handoff["promoted_id"] == "operator-handoff-20260401T070000Z", handoff
+assert handoff["reasons"] == ["stamped_missing"], handoff
+
+assert mission["freshness_state"] == "fresh", mission
+assert mission["promotability_status"] == "blocked", mission
+assert mission["promoted_id"] == "monday-local-mission-20260401T080000Z", mission
+assert mission["dependency_states"] == {
+    "operator_handoff_report": "current",
+    "monday_local_operator_stack_report": "current",
+}, mission
+assert mission["reasons"] == ["missing_rollback_command"], mission
+PY
+
+python3 "$QUERY_PATH" local-validation-freshness \
+  --promotability-status blocked \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_VALIDATION_BLOCKED_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_BLOCKED_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["artifact_family"] for record in records] == [
+    "operator_handoff_report",
+    "monday_local_mission_packet",
+], records
+PY
+
+python3 "$QUERY_PATH" local-validation-freshness \
+  --freshness-state stale \
+  --has-reason stamped_missing \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_VALIDATION_STALE_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_STALE_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["artifact_family"] == "operator_handoff_report", record
+assert record["freshness_state"] == "stale", record
+assert record["reasons"] == ["stamped_missing"], record
 PY
 
 echo "query federated ci artifacts ok"


### PR DESCRIPTION
## Summary
- add `local-validation-freshness` to the federated CI query engine
- surface freshness and promotability for local operator, handoff, and mission validation artifacts
- update the monday local codex rollout plan to reflect the new validation surface

## Scope
- extend `planningops/scripts/federation/query_federated_ci_artifacts.py` with new local validation discovery/filter/render logic
- expand `planningops/scripts/test_query_federated_ci_artifacts.sh` with fresh, stale, and blocked local validation fixtures
- refresh `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md` deliverables and next packets

## Linked Issues
- Closes #940

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- the new freshness surface classifies promotability from artifact shape and dependency linkage, so future schema changes in local runtime packets need matching query fixture updates

## Review Checklist
- [x] query surface covers local operator mirror, handoff report, and mission packet
- [x] tests exercise fresh/promotable, stale/blocked, and fresh/blocked states
- [x] rollout plan reflects the promoted local runtime lane

## Post-Deploy Monitoring & Validation
- re-run `local-validation-freshness` against real promoted artifacts after the next local operator/handoff/mission packet cycle
- confirm the handoff lane still reads cleanly with the new freshness signals available for follow-on integration
