### PR TITLE
feat(query-engine): surface local validation in handoff report

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -120,7 +120,7 @@ Current deliverables:
 - `planningops/artifacts/validation/<run-id>-monday-local-operator-stack-report.json`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-operator-stack`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report` now carry the latest local operator stack pointer
-- `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` emits a handoff-ready operator packet
+- `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` emits a handoff-ready operator packet with local validation freshness/promotability
 - `planningops/scripts/federation/query_federated_ci_artifacts.py write-handoff-report`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness`
 - `planningops/artifacts/validation/operator-handoff-report.json`
@@ -191,5 +191,5 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. decide whether mission packet promotion should also emit an inbox-ready day packet or stay as a reusable validation-sidecar primitive
-2. surface local validation freshness directly inside `handoff-report` so the operator packet carries freshness + promotability in one document
-3. add a monday-native packet consumer once the repo exposes a mission executor richer than the current runtime smoke entrypoint
+2. add a monday-native packet consumer once the repo exposes a mission executor richer than the current runtime smoke entrypoint
+3. decide whether the local validation snapshot should also be mirrored into a day-level inbox or handoff digest artifact

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -294,6 +294,9 @@ class HandoffReportRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    local_validation_records: list[LocalValidationFreshnessRecord]
+    local_validation_summary_lines: list[str]
+    local_validation_action_lines: list[str]
     queue_lines: list[str]
     target_lines: list[str]
     immediate_action_lines: list[str]
@@ -1175,6 +1178,31 @@ def render_local_validation_freshness_markdown(records: list[LocalValidationFres
             f"{', '.join(record.reasons)} | {record.generated_at_utc or ''} |"
         )
     return "\n".join(lines)
+
+
+def build_local_validation_summary_line(record: LocalValidationFreshnessRecord) -> str:
+    line = (
+        f"{record.artifact_family}: freshness={record.freshness_state} "
+        f"promotability={record.promotability_status}"
+    )
+    if record.reasons:
+        line = f"{line} reasons={','.join(record.reasons)}"
+    if record.dependency_states:
+        line = (
+            f"{line} dependencies="
+            f"{','.join(f'{key}={value}' for key, value in record.dependency_states.items())}"
+        )
+    return line
+
+
+def build_local_validation_action_line(record: LocalValidationFreshnessRecord) -> str | None:
+    if record.promotability_status == "promotable" and record.freshness_state == "fresh":
+        return None
+    return (
+        f"local-validation: repair {record.artifact_family} "
+        f"(freshness={record.freshness_state}, promotability={record.promotability_status}, "
+        f"reasons={','.join(record.reasons) if record.reasons else 'none'})"
+    )
 
 
 def build_summary_health_fields(
@@ -2335,6 +2363,7 @@ def build_handoff_report_record(
     *,
     records: list[SummaryRecord],
     local_records: list[LocalOperatorStackRecord] | None,
+    validation_root: Path,
     family: str | None,
     run_id_prefix: str | None,
     source_kind: str,
@@ -2348,10 +2377,19 @@ def build_handoff_report_record(
         source_kind=source_kind,
         target_limit=target_limit,
     )
+    local_validation_records = discover_local_validation_freshness_records(validation_root=validation_root)
+    local_validation_summary_lines = [build_local_validation_summary_line(record) for record in local_validation_records]
+    local_validation_action_lines = [
+        action
+        for action in (build_local_validation_action_line(record) for record in local_validation_records)
+        if action is not None
+    ]
     headline = f"Operator handoff report: {triage_report.headline.removeprefix('Federated CI triage report: ')}"
     immediate_action_lines: list[str] = []
     if triage_report.local_operator_next_step is not None:
         immediate_action_lines.append(f"local-runtime: {triage_report.local_operator_next_step}")
+    if local_validation_action_lines:
+        immediate_action_lines.append(local_validation_action_lines[0])
     if triage_report.target_lines:
         immediate_action_lines.append(f"triage-target: {triage_report.target_lines[0]}")
     if len(triage_report.target_lines) > 1:
@@ -2376,6 +2414,9 @@ def build_handoff_report_record(
         markdown_lines.append(f"- local operator: `{triage_report.local_operator_summary}`")
     if triage_report.local_operator_next_step is not None:
         markdown_lines.append(f"- local operator next step: {triage_report.local_operator_next_step}")
+    markdown_lines.extend(["", "### Local Validation", *[f"- {line}" for line in local_validation_summary_lines]])
+    if local_validation_action_lines:
+        markdown_lines.extend(["", "### Local Validation Actions", *[f"{index}. {line}" for index, line in enumerate(local_validation_action_lines, start=1)]])
     markdown_lines.extend(["", "### Queue", *[f"- {line}" for line in triage_report.queue_lines]])
     markdown_lines.extend(
         ["", "### Top Targets", *[f"{index}. {line}" for index, line in enumerate(triage_report.target_lines, start=1)]]
@@ -2393,6 +2434,9 @@ def build_handoff_report_record(
         local_operator_record=triage_report.local_operator_record,
         local_operator_summary=triage_report.local_operator_summary,
         local_operator_next_step=triage_report.local_operator_next_step,
+        local_validation_records=local_validation_records,
+        local_validation_summary_lines=local_validation_summary_lines,
+        local_validation_action_lines=local_validation_action_lines,
         queue_lines=triage_report.queue_lines,
         target_lines=triage_report.target_lines,
         immediate_action_lines=immediate_action_lines,
@@ -2414,6 +2458,9 @@ def render_handoff_report_table(record: HandoffReportRecord) -> str:
         sections.append(f"local_operator\t{record.local_operator_summary}")
     if record.local_operator_next_step is not None:
         sections.append(f"local_operator_next_step\t{record.local_operator_next_step}")
+    sections.extend(["local_validation", *record.local_validation_summary_lines])
+    if record.local_validation_action_lines:
+        sections.extend(["local_validation_actions", *record.local_validation_action_lines])
     sections.extend(["queue", *record.queue_lines, "targets", *record.target_lines, "immediate_actions", *record.immediate_action_lines])
     return "\n".join(sections)
 
@@ -3631,6 +3678,7 @@ def main() -> int:
         record = build_handoff_report_record(
             records=records,
             local_records=local_records,
+            validation_root=validation_root,
             family=args.family,
             run_id_prefix=args.run_id_prefix,
             source_kind=args.source_kind,
@@ -3650,6 +3698,7 @@ def main() -> int:
         record = build_handoff_report_record(
             records=records,
             local_records=local_records,
+            validation_root=validation_root,
             family=args.family,
             run_id_prefix=args.run_id_prefix,
             source_kind=args.source_kind,

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1763,6 +1763,155 @@ assert "source_kind: `all`" in record["markdown"], record
 assert "local operator:" in record["markdown"], record
 PY
 
+cat >"$VALIDATION_DIR/monday-local-operator-stack-report.json" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T06:05:24+00:00",
+  "run_id": "monday-local-operator-stack-20260401T060524Z",
+  "workspace_root": "/tmp/workspace",
+  "execution_mode": "both",
+  "direct_profile": "local_lmstudio",
+  "dry_run": false,
+  "verdict": "fail",
+  "reason_code": "readiness_blocked",
+  "readiness": {
+    "status": "blocked",
+    "report_path": "/tmp/readiness.json",
+    "report": {},
+    "step": {
+      "status": "report_only"
+    }
+  },
+  "stack_smoke": {
+    "status": "skipped",
+    "report_path": "/tmp/stack-smoke.json"
+  },
+  "direct_smoke": {
+    "status": "skipped",
+    "report_path": "/tmp/local_lmstudio.json"
+  },
+  "recommended_next_steps": [
+    "Expose Codex and add a direct local LLM profile."
+  ],
+  "artifact_paths": {
+    "detail_dir": "/tmp/monday-local-operator-stack-20260401T060524Z",
+    "runtime_report_path": "/tmp/monday-local-operator-stack-20260401T060524Z.json",
+    "validation_latest_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json",
+    "validation_stamped_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-20260401T060524Z-monday-local-operator-stack-report.json"
+  }
+}
+JSON
+
+python3 - <<'PY' "$VALIDATION_DIR/monday-local-operator-stack-report.json" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["validation_latest_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
+doc["artifact_paths"]["validation_stamped_report_path"] = str((validation_dir / "monday-local-operator-stack-20260401T060524Z-monday-local-operator-stack-report.json").resolve())
+payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
+path.write_text(payload, encoding="utf-8")
+(validation_dir / "monday-local-operator-stack-20260401T060524Z-monday-local-operator-stack-report.json").write_text(payload, encoding="utf-8")
+PY
+
+cat >"$VALIDATION_DIR/operator-handoff-report.json" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T07:00:00+00:00",
+  "report_id": "operator-handoff-20260401T070000Z",
+  "artifact_paths": {
+    "latest_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+    "stamped_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-20260401T070000Z-operator-handoff-report.json",
+    "output_path": null
+  },
+  "record": {
+    "headline": "Operator handoff report: 2 attention families",
+    "attention_summary": "active=1, lagging=1, clear=0",
+    "immediate_action_lines": [
+      "local-runtime: Expose Codex and add a direct local LLM profile."
+    ]
+  }
+}
+JSON
+
+python3 - <<'PY' "$VALIDATION_DIR/operator-handoff-report.json" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["latest_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
+doc["artifact_paths"]["stamped_report_path"] = str((validation_dir / "operator-handoff-20260401T070000Z-operator-handoff-report.json").resolve())
+path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+cat >"$VALIDATION_DIR/monday-local-mission-packet.json" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T08:00:00+00:00",
+  "packet_id": "monday-local-mission-20260401T080000Z",
+  "contract_ref": "planningops/contracts/monday-local-mission-packet-contract.md",
+  "artifact_paths": {
+    "latest_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+    "stamped_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-20260401T080000Z-monday-local-mission-packet.json",
+    "output_path": null
+  },
+  "mission_packet": {
+    "version": "v1",
+    "packet_id": "monday-local-mission-20260401T080000Z",
+    "mission_objective": "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "mission_prompt": "Use monday planner profile `local_ollama` via `direct_local_ollama`.",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "source_kind": "stamped",
+    "attention_summary": "active=2, lagging=0, clear=0",
+    "newest_failing_summary": "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun26 / active",
+    "local_runtime_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
+    "local_runtime_next_step": "Expose Codex and add a direct local LLM profile.",
+    "primary_action": "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "immediate_actions": [
+      "local-runtime: Expose Codex and add a direct local LLM profile."
+    ],
+    "target_lines": [
+      "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "preflight_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id monday-local-mission-20260401T080000Z",
+    "expected_evidence_outputs": [
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-20260401T080000Z-monday-local-mission-packet.json"
+    ],
+    "source_artifacts": {
+      "handoff_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+      "local_operator_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json"
+    }
+  }
+}
+JSON
+
+python3 - <<'PY' "$VALIDATION_DIR/monday-local-mission-packet.json" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["latest_packet_path"] = str((validation_dir / "monday-local-mission-packet.json").resolve())
+doc["artifact_paths"]["stamped_packet_path"] = str((validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").resolve())
+doc["mission_packet"]["expected_evidence_outputs"] = [
+    str((validation_dir / "monday-local-mission-packet.json").resolve()),
+    str((validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").resolve()),
+]
+doc["mission_packet"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
+doc["mission_packet"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
+payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
+path.write_text(payload, encoding="utf-8")
+(validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").write_text(payload, encoding="utf-8")
+PY
+
 python3 "$QUERY_PATH" handoff-report \
   --format json \
   --ci-root "$CI_DIR" \
@@ -1797,12 +1946,15 @@ assert record["target_lines"] == [
 ], record
 assert record["immediate_action_lines"] == [
     "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
     "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
     "follow-up: [lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile",
 ], record
 assert "## Operator Handoff Report" in record["markdown"], record
 assert "### Snapshot" in record["markdown"], record
 assert "### Local Runtime" in record["markdown"], record
+assert "### Local Validation" in record["markdown"], record
+assert "### Local Validation Actions" in record["markdown"], record
 assert "### Queue" in record["markdown"], record
 assert "### Top Targets" in record["markdown"], record
 assert "### Immediate Actions" in record["markdown"], record
@@ -1833,11 +1985,18 @@ assert record["local_operator_summary"] == (
     "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
+assert record["local_validation_summary_lines"] == [
+    "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+    "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
+    "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
+], record
 assert record["immediate_action_lines"] == [
     "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
     "triage-target: [active/latest-gap] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun26 domains=readiness,reconcile",
 ], record
 assert "source_kind: `all`" in record["markdown"], record
+assert "### Local Validation" in record["markdown"], record
 assert "### Immediate Actions" in record["markdown"], record
 PY
 
@@ -1873,8 +2032,18 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
         "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
         "stack=skipped direct=skipped mode=both reason=readiness_blocked"
     ), doc
+    assert doc["record"]["local_validation_summary_lines"] == [
+        "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+        "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
+        "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
+    ], doc
+    assert doc["record"]["local_validation_action_lines"] == [
+        "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
+        "local-validation: repair monday_local_mission_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)",
+    ], doc
     assert doc["record"]["immediate_action_lines"] == [
         "local-runtime: Expose Codex and add a direct local LLM profile.",
+        "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
         "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
         "follow-up: [lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile",
     ], doc


### PR DESCRIPTION
## Summary
- surface local validation freshness and promotability directly in `handoff-report`
- carry local validation summary/action lines into promoted handoff artifacts
- update the monday local codex rollout plan to reflect the richer handoff surface

## Scope
- extend `planningops/scripts/federation/query_federated_ci_artifacts.py` handoff report records with local validation fields
- expand `planningops/scripts/test_query_federated_ci_artifacts.sh` to cover the new handoff output shape
- refresh `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md` deliverables and next packets

## Linked Issues
- Closes #942

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- the richer handoff packet now depends on local validation record expectations, so future schema changes in promoted local artifacts need matching handoff fixture updates

## Review Checklist
- [x] handoff report includes local validation summary and action lines
- [x] promoted handoff artifact keeps the new local validation fields
- [x] rollout plan reflects the expanded handoff packet

## Post-Deploy Monitoring & Validation
- re-run `handoff-report` and `write-handoff-report` after the next promoted local runtime cycle
- confirm local validation signals stay readable in the operator packet without opening a second query surface
