### PR TITLE
feat(local-runtime): carry local validation snapshot into mission packet

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -129,6 +129,7 @@ Current deliverables:
 - `planningops/scripts/write_monday_local_mission_packet.py`
 - `planningops/artifacts/validation/monday-local-mission-packet.json`
 - `planningops/artifacts/validation/<packet-id>-monday-local-mission-packet.json`
+- mission packets now carry forward local validation freshness/promotability snapshot fields from promoted handoff packets
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -192,4 +193,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 1. decide whether mission packet promotion should also emit an inbox-ready day packet or stay as a reusable validation-sidecar primitive
 2. add a monday-native packet consumer once the repo exposes a mission executor richer than the current runtime smoke entrypoint
-3. decide whether the local validation snapshot should also be mirrored into a day-level inbox or handoff digest artifact
+3. decide whether the carried local validation snapshot should also be mirrored into a day-level inbox or handoff digest artifact

--- a/planningops/contracts/monday-local-mission-packet-contract.md
+++ b/planningops/contracts/monday-local-mission-packet-contract.md
@@ -62,6 +62,10 @@ Top-level required fields:
 14. `target_lines`
 15. `source_artifacts.handoff_report_path`
 16. `source_artifacts.local_operator_report_path`
+17. `local_validation_snapshot_status`
+18. `local_validation_records`
+19. `local_validation_summary_lines`
+20. `local_validation_action_lines`
 
 Optional fields:
 - `attention_summary`
@@ -79,6 +83,7 @@ Optional fields:
    - if no direct profile is present, fall back to `local_ollama`
 3. `mission_objective` must come from the promoted handoff surface, not from prompt-local inference.
 4. `expected_evidence_outputs` must point at deterministic artifact paths that the chosen launch path is expected to refresh.
+5. local validation snapshot fields must be carried forward from the promoted handoff packet when present; otherwise the mission packet must emit `local_validation_snapshot_status=missing` with empty local validation collections.
 
 ## Command Rules
 
@@ -104,6 +109,11 @@ Every packet must also name the mission-run evidence it expects next:
 - latest + stamped mission packet paths
 - the local operator runtime aggregate path keyed by `packet_id`
 - the stamped local operator validation mirror keyed by `packet_id`
+
+Every packet must also preserve the current local validation snapshot:
+- machine-readable local validation records when the promoted handoff packet already has them
+- operator-facing local validation summary/action lines
+- an explicit missing marker when the upstream handoff packet does not yet provide the snapshot
 
 ## Failure Rules
 

--- a/planningops/scripts/test_write_monday_local_mission_packet.sh
+++ b/planningops/scripts/test_write_monday_local_mission_packet.sh
@@ -13,6 +13,10 @@ LOCAL_OPERATOR_REPORT="$VALIDATION_DIR/monday-local-operator-stack-report.json"
 OUTPUT_PATH="$TMP_DIR/mission-packet-output.json"
 STDOUT_PATH="$TMP_DIR/mission-packet-stdout.json"
 PACKET_ID="monday-local-mission-20260401T080000Z"
+LEGACY_HANDOFF_REPORT="$VALIDATION_DIR/operator-handoff-report-legacy.json"
+LEGACY_OUTPUT_PATH="$TMP_DIR/mission-packet-legacy-output.json"
+LEGACY_STDOUT_PATH="$TMP_DIR/mission-packet-legacy-stdout.json"
+LEGACY_PACKET_ID="monday-local-mission-20260401T080100Z"
 
 mkdir -p "$VALIDATION_DIR"
 
@@ -47,6 +51,33 @@ cat >"$HANDOFF_REPORT" <<'JSON'
       "local-runtime: Expose Codex and add a direct local LLM profile.",
       "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
       "follow-up: [lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile"
+    ],
+    "local_validation_records": [
+      {
+        "artifact_family": "monday_local_operator_stack_report",
+        "artifact_kind": "report",
+        "promoted_id": "monday-local-operator-stack-20260401T060524Z",
+        "freshness_state": "fresh",
+        "promotability_status": "promotable",
+        "reasons": [],
+        "dependency_states": {}
+      },
+      {
+        "artifact_family": "operator_handoff_report",
+        "artifact_kind": "report",
+        "promoted_id": "operator-handoff-20260401T070000Z",
+        "freshness_state": "stale",
+        "promotability_status": "blocked",
+        "reasons": ["stamped_missing"],
+        "dependency_states": {}
+      }
+    ],
+    "local_validation_summary_lines": [
+      "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+      "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing"
+    ],
+    "local_validation_action_lines": [
+      "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)"
     ],
     "markdown": "## Operator Handoff Report"
   }
@@ -120,6 +151,10 @@ assert "planner_profile" in contract_text, contract_text
 assert "local_model_route" in contract_text, contract_text
 assert "expected_evidence_outputs" in contract_text, contract_text
 assert "rollback_command" in contract_text, contract_text
+assert "local_validation_snapshot_status" in contract_text, contract_text
+assert "local_validation_records" in contract_text, contract_text
+assert "local_validation_summary_lines" in contract_text, contract_text
+assert "local_validation_action_lines" in contract_text, contract_text
 
 for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert doc["packet_id"] == packet_id, doc
@@ -148,6 +183,18 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert mission["source_artifacts"]["local_operator_report_path"] == str((validation_dir / "monday-local-operator-stack-report.json").resolve()), mission
     assert mission["immediate_actions"][0] == "local-runtime: Expose Codex and add a direct local LLM profile.", mission
     assert mission["target_lines"][0].startswith("[active/latest-gap] federated-ci-local"), mission
+    assert mission["local_validation_snapshot_status"] == "present", mission
+    assert [record["artifact_family"] for record in mission["local_validation_records"]] == [
+        "monday_local_operator_stack_report",
+        "operator_handoff_report",
+    ], mission
+    assert mission["local_validation_summary_lines"] == [
+        "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+        "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
+    ], mission
+    assert mission["local_validation_action_lines"] == [
+        "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)"
+    ], mission
     assert str(latest_path) in mission["expected_evidence_outputs"], mission
     assert str(stamped_path) in mission["expected_evidence_outputs"], mission
     assert any(path.endswith(f"{packet_id}.json") for path in mission["expected_evidence_outputs"]), mission
@@ -157,6 +204,57 @@ assert stdout_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).reso
 assert output_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), output_doc
 assert latest_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), latest_doc
 assert stamped_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stamped_doc
+PY
+
+cat >"$LEGACY_HANDOFF_REPORT" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T07:01:00+00:00",
+  "report_id": "operator-handoff-20260401T070100Z",
+  "artifact_paths": {
+    "latest_report_path": "/tmp/operator-handoff-report.json",
+    "stamped_report_path": "/tmp/operator-handoff-20260401T070100Z-report.json",
+    "output_path": null
+  },
+  "record": {
+    "source_kind": "stamped",
+    "target_limit": 1,
+    "headline": "Operator handoff report: 1 attention family",
+    "attention_summary": "active=1, lagging=0, clear=0",
+    "newest_failing_summary": "federated-ci-local / federated-ci-local-20260301 / active",
+    "newest_recovered_summary": null,
+    "local_operator_record": null,
+    "local_operator_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
+    "local_operator_next_step": "Expose Codex and add a direct local LLM profile.",
+    "queue_lines": [],
+    "target_lines": [
+      "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "immediate_action_lines": [
+      "local-runtime: Expose Codex and add a direct local LLM profile."
+    ],
+    "markdown": "## Operator Handoff Report"
+  }
+}
+JSON
+
+python3 planningops/scripts/write_monday_local_mission_packet.py \
+  --validation-root "$VALIDATION_DIR" \
+  --handoff-report "$LEGACY_HANDOFF_REPORT" \
+  --local-operator-report "$LOCAL_OPERATOR_REPORT" \
+  --packet-id "$LEGACY_PACKET_ID" \
+  --output "$LEGACY_OUTPUT_PATH" >"$LEGACY_STDOUT_PATH"
+
+python3 - <<'PY' "$LEGACY_STDOUT_PATH"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+mission = doc["mission_packet"]
+assert mission["local_validation_snapshot_status"] == "missing", mission
+assert mission["local_validation_records"] == [], mission
+assert mission["local_validation_summary_lines"] == [], mission
+assert mission["local_validation_action_lines"] == [], mission
 PY
 
 echo "write monday local mission packet ok"

--- a/planningops/scripts/write_monday_local_mission_packet.py
+++ b/planningops/scripts/write_monday_local_mission_packet.py
@@ -49,6 +49,26 @@ def require_dict(doc: object, label: str) -> dict:
     return doc
 
 
+def normalize_string_list(raw_values: object) -> list[str]:
+    return [str(value) for value in list(raw_values or []) if str(value).strip()]
+
+
+def normalize_local_validation_records(raw_values: object) -> list[dict]:
+    records: list[dict] = []
+    for value in list(raw_values or []):
+        if isinstance(value, dict):
+            records.append(value)
+    return records
+
+
+def build_local_validation_snapshot(handoff_record: dict) -> tuple[str, list[dict], list[str], list[str]]:
+    records = normalize_local_validation_records(handoff_record.get("local_validation_records"))
+    summary_lines = normalize_string_list(handoff_record.get("local_validation_summary_lines"))
+    action_lines = normalize_string_list(handoff_record.get("local_validation_action_lines"))
+    snapshot_status = "present" if records or summary_lines or action_lines else "missing"
+    return snapshot_status, records, summary_lines, action_lines
+
+
 def build_mission_objective(handoff_record: dict) -> str:
     target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
     if target_lines:
@@ -172,6 +192,12 @@ def main() -> int:
     target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
     mission_objective = build_mission_objective(handoff_record)
     primary_action = immediate_actions[0] if immediate_actions else (target_lines[0] if target_lines else mission_objective)
+    (
+        local_validation_snapshot_status,
+        local_validation_records,
+        local_validation_summary_lines,
+        local_validation_action_lines,
+    ) = build_local_validation_snapshot(handoff_record)
 
     expected_evidence_outputs = [
         str(latest_packet_path.resolve()),
@@ -201,6 +227,10 @@ def main() -> int:
         "primary_action": primary_action,
         "immediate_actions": immediate_actions,
         "target_lines": target_lines,
+        "local_validation_snapshot_status": local_validation_snapshot_status,
+        "local_validation_records": local_validation_records,
+        "local_validation_summary_lines": local_validation_summary_lines,
+        "local_validation_action_lines": local_validation_action_lines,
         "preflight_command": preflight_command,
         "monday_runtime_entrypoint_command": monday_runtime_entrypoint_command,
         "rollback_command": rollback_command,


### PR DESCRIPTION
## Summary
- carry local validation snapshot fields into monday local mission packets
- extend the mission packet contract to document the richer mission boundary
- expand regression coverage for present and missing local validation snapshot cases

## Scope
- update `planningops/scripts/write_monday_local_mission_packet.py` to preserve local validation snapshot state from promoted handoff packets
- extend `planningops/scripts/test_write_monday_local_mission_packet.sh` with present/missing snapshot coverage
- refresh `planningops/contracts/monday-local-mission-packet-contract.md` and the rollout plan

## Linked Issues
- Closes #944

## Validation
- `python3 -m py_compile planningops/scripts/write_monday_local_mission_packet.py`
- `bash planningops/scripts/test_write_monday_local_mission_packet.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- mission packet consumers now see additional local validation fields, so any downstream assumptions about the packet shape should continue to tolerate additive fields

## Review Checklist
- [x] mission packet carries local validation snapshot fields when present
- [x] legacy handoff inputs degrade to `missing` with empty local validation collections
- [x] contract and rollout plan reflect the richer mission boundary

## Post-Deploy Monitoring & Validation
- re-run mission packet promotion after the next real promoted handoff cycle
- confirm the promoted mission packet preserves local validation snapshot data in validation artifacts
