### PR TITLE
feat(local-runtime): add monday operator day packet

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -130,6 +130,11 @@ Current deliverables:
 - `planningops/artifacts/validation/monday-local-mission-packet.json`
 - `planningops/artifacts/validation/<packet-id>-monday-local-mission-packet.json`
 - mission packets now carry forward local validation freshness/promotability snapshot fields from promoted handoff packets
+- `planningops/contracts/monday-local-operator-day-packet-contract.md`
+- `planningops/scripts/write_monday_local_operator_day_packet.py`
+- `planningops/artifacts/validation/monday-local-operator-day-packet.json`
+- `planningops/artifacts/validation/<day-packet-id>-monday-local-operator-day-packet.json`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now includes the promoted day packet family in the same promotion lane
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -191,6 +196,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether mission packet promotion should also emit an inbox-ready day packet or stay as a reusable validation-sidecar primitive
-2. add a monday-native packet consumer once the repo exposes a mission executor richer than the current runtime smoke entrypoint
-3. decide whether the carried local validation snapshot should also be mirrored into a day-level inbox or handoff digest artifact
+1. add a monday-native packet consumer once the repo exposes a mission executor richer than the current runtime smoke entrypoint
+2. decide whether the day packet should stay PlanningOps-owned or also emit a monday-owned inbox payload bridge
+3. add a dedicated query/report surface for the promoted day packet if operators need a packet-first view separate from `handoff-report`

--- a/planningops/contracts/monday-local-operator-day-packet-contract.md
+++ b/planningops/contracts/monday-local-operator-day-packet-contract.md
@@ -1,0 +1,121 @@
+# Monday Local Operator Day Packet Contract
+
+## Purpose
+Define the deterministic boundary for the inbox-ready day-level packet that PlanningOps promotes after the monday local mission packet exists.
+
+This contract exists so:
+- Codex can hand one reusable day packet to the next operator step without reopening multiple artifacts
+- `planningops` remains the owner of promotion, evidence, and rollback guidance
+- `monday` local launch work can start from one deterministic packet instead of ad hoc note assembly
+
+## Canonical Boundary
+
+PlanningOps owns:
+- the day packet contract
+- day packet promotion into validation artifacts
+- deterministic derivation from:
+  - `planningops/artifacts/validation/monday-local-mission-packet.json`
+  - `planningops/artifacts/validation/operator-handoff-report.json`
+  - `planningops/artifacts/validation/monday-local-operator-stack-report.json`
+
+Monday owns:
+- runtime execution after the packet boundary
+- planner semantics beyond the packet
+- future monday-native consumers for this packet
+
+PlanningOps must not:
+- invent monday-private runtime state
+- hide launch commands inside prompt-local prose
+- drop local validation context while compressing the packet into a day-level artifact
+
+## Canonical Artifacts
+
+Every promoted day packet must include:
+- latest packet: `planningops/artifacts/validation/monday-local-operator-day-packet.json`
+- stamped packet: `planningops/artifacts/validation/<day-packet-id>-monday-local-operator-day-packet.json`
+
+The packet may also be written to one caller-specified extra output path.
+
+## Packet Document Shape
+
+Top-level required fields:
+1. `generated_at_utc`
+2. `day_packet_id`
+3. `contract_ref`
+4. `artifact_paths.latest_packet_path`
+5. `artifact_paths.stamped_packet_path`
+6. `day_packet`
+
+`day_packet` required fields:
+1. `version` (`v1`)
+2. `day_packet_id`
+3. `mission_packet_id`
+4. `headline`
+5. `mission_objective`
+6. `mission_prompt`
+7. `planner_profile`
+8. `launch_mode`
+9. `local_model_route`
+10. `first_action_command`
+11. `monday_runtime_entrypoint_command`
+12. `rollback_command`
+13. `queue_lines`
+14. `target_lines`
+15. `immediate_actions`
+16. `local_validation_snapshot_status`
+17. `local_validation_records`
+18. `local_validation_summary_lines`
+19. `local_validation_action_lines`
+20. `attachments`
+21. `body_markdown`
+22. `source_artifacts.mission_packet_path`
+23. `source_artifacts.handoff_report_path`
+24. `source_artifacts.local_operator_report_path`
+
+Optional fields:
+- `attention_summary`
+- `newest_failing_summary`
+- `local_runtime_summary`
+- `local_runtime_next_step`
+
+## Deterministic Resolution Rules
+
+1. Identical promoted mission packet, handoff report, and local operator report must produce the same day packet apart from timestamps.
+2. The day packet must reuse mission-launch fields from the promoted mission packet instead of recomputing them.
+3. `headline` must be derivable from the promoted mission objective and remain operator-readable.
+4. `attachments` must include the latest + stamped day packet paths and the source artifact references needed to reopen the launch context.
+5. local validation snapshot fields must be copied from the mission packet when present; otherwise the writer may fall back to the promoted handoff snapshot and must mark that fallback explicitly; otherwise it must emit `missing` with empty collections.
+
+## Command Rules
+
+- `first_action_command` must remain PlanningOps-owned and come from the mission packet `preflight_command`.
+- `monday_runtime_entrypoint_command` must remain explicit and deterministic.
+- `rollback_command` must remain explicit and deterministic.
+- the day packet must never require the next operator to infer launch commands from `body_markdown`
+
+## Evidence Requirements
+
+Every day packet must preserve the source artifact references it was derived from:
+- mission packet path
+- promoted handoff report path
+- promoted local operator report path
+
+Every day packet must also preserve the current local validation snapshot:
+- machine-readable local validation records
+- operator-facing local validation summary lines
+- operator-facing local validation action lines
+- an explicit snapshot status marker
+
+## Failure Rules
+
+- missing promoted mission packet is fail-fast
+- missing promoted handoff report is fail-fast
+- missing promoted local operator report is fail-fast
+- empty `headline`, `mission_objective`, `first_action_command`, `monday_runtime_entrypoint_command`, or `rollback_command` is fail-fast
+- empty `attachments` is fail-fast
+
+## Validation
+
+- `planningops/scripts/write_monday_local_operator_day_packet.py`
+- `planningops/scripts/test_write_monday_local_operator_day_packet.sh`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness`

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -50,6 +50,7 @@ LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_operator_stack_report",
     "operator_handoff_report",
     "monday_local_mission_packet",
+    "monday_local_operator_day_packet",
 )
 LOCAL_VALIDATION_FRESHNESS_CHOICES = ("fresh", "stale", "missing")
 LOCAL_VALIDATION_PROMOTABILITY_CHOICES = ("promotable", "blocked")
@@ -1113,11 +1114,129 @@ def build_mission_packet_validation_freshness_record(*, validation_root: Path) -
     )
 
 
+def build_day_packet_validation_freshness_record(*, validation_root: Path) -> LocalValidationFreshnessRecord:
+    latest_path = (validation_root / "monday-local-operator-day-packet.json").resolve()
+    latest_doc = load_optional_json(latest_path)
+    freshness_reasons: list[str] = []
+    promotability_reasons: list[str] = []
+    dependency_states: dict[str, str] = {}
+    stamped_path: Path | None = None
+    promoted_id: str | None = None
+    generated_at_utc: str | None = None
+
+    if latest_doc is not None:
+        promoted_id = str(latest_doc.get("day_packet_id") or "").strip() or None
+        generated_at_utc = str(latest_doc.get("generated_at_utc") or "").strip() or None
+        if promoted_id is None:
+            promotability_reasons.append("missing_day_packet_id")
+        if not isinstance(latest_doc.get("contract_ref"), str) or not str(latest_doc.get("contract_ref")).strip():
+            promotability_reasons.append("missing_contract_ref")
+        latest_packet_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "latest_packet_path")
+        stamped_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "stamped_packet_path")
+        if latest_packet_path != latest_path:
+            freshness_reasons.append("latest_path_mismatch")
+        day_packet = resolve_nested_value(latest_doc, "day_packet")
+        if not isinstance(day_packet, dict):
+            promotability_reasons.append("missing_day_packet")
+        else:
+            required_strings = {
+                "headline": "missing_headline",
+                "mission_objective": "missing_mission_objective",
+                "planner_profile": "missing_planner_profile",
+                "launch_mode": "missing_launch_mode",
+                "local_model_route": "missing_local_model_route",
+                "first_action_command": "missing_first_action_command",
+                "monday_runtime_entrypoint_command": "missing_runtime_entrypoint_command",
+                "rollback_command": "missing_rollback_command",
+                "body_markdown": "missing_body_markdown",
+                "local_validation_snapshot_status": "missing_local_validation_snapshot_status",
+            }
+            for field_name, reason in required_strings.items():
+                value = day_packet.get(field_name)
+                if not isinstance(value, str) or not value.strip():
+                    promotability_reasons.append(reason)
+            attachments = [str(path) for path in list(day_packet.get("attachments") or []) if str(path).strip()]
+            if not attachments:
+                promotability_reasons.append("missing_attachments")
+            source_artifacts = day_packet.get("source_artifacts")
+            if not isinstance(source_artifacts, dict):
+                promotability_reasons.append("missing_source_artifacts")
+            else:
+                mission_state, mission_reason = build_local_validation_dependency_state(
+                    raw_path=source_artifacts.get("mission_packet_path"),
+                    expected_path=validation_root / "monday-local-mission-packet.json",
+                )
+                handoff_state, handoff_reason = build_local_validation_dependency_state(
+                    raw_path=source_artifacts.get("handoff_report_path"),
+                    expected_path=validation_root / "operator-handoff-report.json",
+                )
+                local_state, local_reason = build_local_validation_dependency_state(
+                    raw_path=source_artifacts.get("local_operator_report_path"),
+                    expected_path=validation_root / "monday-local-operator-stack-report.json",
+                )
+                dependency_states["monday_local_mission_packet"] = mission_state
+                dependency_states["operator_handoff_report"] = handoff_state
+                dependency_states["monday_local_operator_stack_report"] = local_state
+                if mission_reason == "dependency_path_missing":
+                    promotability_reasons.append("missing_mission_packet_path")
+                elif mission_reason == "dependency_missing":
+                    promotability_reasons.append("mission_packet_dependency_missing")
+                elif mission_reason == "dependency_stale":
+                    promotability_reasons.append("mission_packet_dependency_stale")
+                if handoff_reason == "dependency_path_missing":
+                    promotability_reasons.append("missing_handoff_report_path")
+                elif handoff_reason == "dependency_missing":
+                    promotability_reasons.append("handoff_dependency_missing")
+                elif handoff_reason == "dependency_stale":
+                    promotability_reasons.append("handoff_dependency_stale")
+                if local_reason == "dependency_path_missing":
+                    promotability_reasons.append("missing_local_operator_report_path")
+                elif local_reason == "dependency_missing":
+                    promotability_reasons.append("local_operator_dependency_missing")
+                elif local_reason == "dependency_stale":
+                    promotability_reasons.append("local_operator_dependency_stale")
+        if stamped_path is not None and stamped_path.exists():
+            stamped_doc = load_optional_json(stamped_path)
+            if stamped_doc is None:
+                freshness_reasons.append("stamped_invalid_json")
+            else:
+                if str(stamped_doc.get("day_packet_id") or "").strip() != (promoted_id or ""):
+                    freshness_reasons.append("stamped_day_packet_id_mismatch")
+                stamped_latest_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "latest_packet_path")
+                stamped_stamped_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "stamped_packet_path")
+                if stamped_latest_path != latest_path:
+                    freshness_reasons.append("stamped_latest_path_mismatch")
+                if stamped_stamped_path != stamped_path.resolve():
+                    freshness_reasons.append("stamped_path_mismatch")
+
+    freshness_state, promotability_status = classify_local_validation_states(
+        latest_path=latest_path,
+        latest_doc=latest_doc,
+        stamped_path=stamped_path,
+        freshness_reasons=freshness_reasons,
+        promotability_reasons=promotability_reasons,
+        dependency_states=dependency_states,
+    )
+    return LocalValidationFreshnessRecord(
+        artifact_family="monday_local_operator_day_packet",
+        artifact_kind="packet",
+        promoted_id=promoted_id,
+        generated_at_utc=generated_at_utc,
+        freshness_state=freshness_state,
+        promotability_status=promotability_status,
+        latest_path=str(latest_path),
+        stamped_path=None if stamped_path is None else str(stamped_path.resolve()),
+        reasons=freshness_reasons + promotability_reasons,
+        dependency_states=dependency_states,
+    )
+
+
 def discover_local_validation_freshness_records(*, validation_root: Path) -> list[LocalValidationFreshnessRecord]:
     return [
         build_local_operator_validation_freshness_record(validation_root=validation_root),
         build_handoff_validation_freshness_record(validation_root=validation_root),
         build_mission_packet_validation_freshness_record(validation_root=validation_root),
+        build_day_packet_validation_freshness_record(validation_root=validation_root),
     ]
 
 

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1912,6 +1912,90 @@ path.write_text(payload, encoding="utf-8")
 (validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").write_text(payload, encoding="utf-8")
 PY
 
+cat >"$VALIDATION_DIR/monday-local-operator-day-packet.json" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T08:30:00+00:00",
+  "day_packet_id": "monday-local-day-20260401T083000Z",
+  "contract_ref": "planningops/contracts/monday-local-operator-day-packet-contract.md",
+  "artifact_paths": {
+    "latest_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-day-packet.json",
+    "stamped_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-day-20260401T083000Z-monday-local-operator-day-packet.json",
+    "output_path": null
+  },
+  "day_packet": {
+    "version": "v1",
+    "day_packet_id": "monday-local-day-20260401T083000Z",
+    "mission_packet_id": "monday-local-mission-20260401T080000Z",
+    "headline": "Monday local operator day packet: Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "mission_objective": "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "mission_prompt": "Use monday planner profile `local_ollama` via `direct_local_ollama`.",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "first_action_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id monday-local-mission-20260401T080000Z",
+    "monday_runtime_entrypoint_command": "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local_ollama --run-id monday-local-mission-20260401T080000Z",
+    "rollback_command": "",
+    "local_runtime_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
+    "local_runtime_next_step": "Expose Codex and add a direct local LLM profile.",
+    "local_validation_snapshot_status": "present",
+    "local_validation_records": [],
+    "local_validation_summary_lines": [
+      "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+      "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
+      "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current"
+    ],
+    "local_validation_action_lines": [
+      "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
+      "local-validation: repair monday_local_mission_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)"
+    ],
+    "queue_lines": [
+      "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1"
+    ],
+    "target_lines": [
+      "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "immediate_actions": [
+      "local-runtime: Expose Codex and add a direct local LLM profile.",
+      "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "attachments": [
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+      "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json"
+    ],
+    "body_markdown": "## Monday Local Operator Day Packet",
+    "source_artifacts": {
+      "mission_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+      "handoff_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+      "local_operator_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json"
+    }
+  }
+}
+JSON
+
+python3 - <<'PY' "$VALIDATION_DIR/monday-local-operator-day-packet.json" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["latest_packet_path"] = str((validation_dir / "monday-local-operator-day-packet.json").resolve())
+doc["artifact_paths"]["stamped_packet_path"] = str((validation_dir / "monday-local-day-20260401T083000Z-monday-local-operator-day-packet.json").resolve())
+doc["day_packet"]["attachments"] = [
+    str((validation_dir / "monday-local-mission-packet.json").resolve()),
+    str((validation_dir / "operator-handoff-report.json").resolve()),
+    str((validation_dir / "monday-local-operator-stack-report.json").resolve()),
+]
+doc["day_packet"]["source_artifacts"]["mission_packet_path"] = str((validation_dir / "monday-local-mission-packet.json").resolve())
+doc["day_packet"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
+doc["day_packet"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
+payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
+path.write_text(payload, encoding="utf-8")
+(validation_dir / "monday-local-day-20260401T083000Z-monday-local-operator-day-packet.json").write_text(payload, encoding="utf-8")
+PY
+
 python3 "$QUERY_PATH" handoff-report \
   --format json \
   --ci-root "$CI_DIR" \
@@ -1989,6 +2073,7 @@ assert record["local_validation_summary_lines"] == [
     "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
     "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
     "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
+    "monday_local_operator_day_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
 ], record
 assert record["immediate_action_lines"] == [
     "local-runtime: Expose Codex and add a direct local LLM profile.",
@@ -2036,10 +2121,12 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
         "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
         "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
         "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
+        "monday_local_operator_day_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
     ], doc
     assert doc["record"]["local_validation_action_lines"] == [
         "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
         "local-validation: repair monday_local_mission_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)",
+        "local-validation: repair monday_local_operator_day_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)",
     ], doc
     assert doc["record"]["immediate_action_lines"] == [
         "local-runtime: Expose Codex and add a direct local LLM profile.",
@@ -2487,9 +2574,10 @@ assert [record["artifact_family"] for record in records] == [
     "monday_local_operator_stack_report",
     "operator_handoff_report",
     "monday_local_mission_packet",
+    "monday_local_operator_day_packet",
 ], records
 
-local_operator, handoff, mission = records
+local_operator, handoff, mission, day_packet = records
 
 assert local_operator["freshness_state"] == "fresh", local_operator
 assert local_operator["promotability_status"] == "promotable", local_operator
@@ -2509,6 +2597,16 @@ assert mission["dependency_states"] == {
     "monday_local_operator_stack_report": "current",
 }, mission
 assert mission["reasons"] == ["missing_rollback_command"], mission
+
+assert day_packet["freshness_state"] == "fresh", day_packet
+assert day_packet["promotability_status"] == "blocked", day_packet
+assert day_packet["promoted_id"] == "monday-local-day-20260401T083000Z", day_packet
+assert day_packet["dependency_states"] == {
+    "monday_local_mission_packet": "current",
+    "operator_handoff_report": "current",
+    "monday_local_operator_stack_report": "current",
+}, day_packet
+assert day_packet["reasons"] == ["missing_rollback_command"], day_packet
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \
@@ -2526,6 +2624,7 @@ records = doc["records"]
 assert [record["artifact_family"] for record in records] == [
     "operator_handoff_report",
     "monday_local_mission_packet",
+    "monday_local_operator_day_packet",
 ], records
 PY
 

--- a/planningops/scripts/test_write_monday_local_operator_day_packet.sh
+++ b/planningops/scripts/test_write_monday_local_operator_day_packet.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+VALIDATION_DIR="$TMP_DIR/validation"
+MISSION_PACKET="$VALIDATION_DIR/monday-local-mission-packet.json"
+HANDOFF_REPORT="$VALIDATION_DIR/operator-handoff-report.json"
+LOCAL_OPERATOR_REPORT="$VALIDATION_DIR/monday-local-operator-stack-report.json"
+OUTPUT_PATH="$TMP_DIR/day-packet-output.json"
+STDOUT_PATH="$TMP_DIR/day-packet-stdout.json"
+DAY_PACKET_ID="monday-local-day-20260401T083000Z"
+
+mkdir -p "$VALIDATION_DIR"
+
+cat >"$MISSION_PACKET" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T08:00:00+00:00",
+  "packet_id": "monday-local-mission-20260401T080000Z",
+  "contract_ref": "planningops/contracts/monday-local-mission-packet-contract.md",
+  "artifact_paths": {
+    "latest_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+    "stamped_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-20260401T080000Z-monday-local-mission-packet.json",
+    "output_path": null
+  },
+  "mission_packet": {
+    "version": "v1",
+    "packet_id": "monday-local-mission-20260401T080000Z",
+    "mission_objective": "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "mission_prompt": "Use monday planner profile `local_ollama` via `direct_local_ollama`.",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "source_kind": "stamped",
+    "attention_summary": "active=1, lagging=1, clear=0",
+    "newest_failing_summary": "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun29 / lagging",
+    "local_runtime_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
+    "local_runtime_next_step": "Expose Codex and add a direct local LLM profile.",
+    "local_validation_snapshot_status": "present",
+    "local_validation_records": [
+      {
+        "artifact_family": "monday_local_operator_stack_report",
+        "artifact_kind": "report",
+        "promoted_id": "monday-local-operator-stack-20260401T060524Z",
+        "freshness_state": "fresh",
+        "promotability_status": "promotable",
+        "reasons": [],
+        "dependency_states": {}
+      }
+    ],
+    "local_validation_summary_lines": [
+      "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+      "operator_handoff_report: freshness=fresh promotability=promotable"
+    ],
+    "local_validation_action_lines": [],
+    "primary_action": "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "immediate_actions": [
+      "local-runtime: Expose Codex and add a direct local LLM profile."
+    ],
+    "target_lines": [
+      "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "preflight_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id monday-local-mission-20260401T080000Z",
+    "monday_runtime_entrypoint_command": "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local_ollama --run-id monday-local-mission-20260401T080000Z",
+    "rollback_command": "cd ../platform-provider-gateway && bash scripts/litellm_stack_launcher.sh --mode start",
+    "expected_evidence_outputs": [
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-20260401T080000Z-monday-local-mission-packet.json"
+    ],
+    "source_artifacts": {
+      "handoff_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+      "local_operator_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json"
+    }
+  }
+}
+JSON
+
+python3 - <<'PY' "$MISSION_PACKET" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["latest_packet_path"] = str((validation_dir / "monday-local-mission-packet.json").resolve())
+doc["artifact_paths"]["stamped_packet_path"] = str((validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").resolve())
+doc["mission_packet"]["expected_evidence_outputs"] = [
+    str((validation_dir / "monday-local-mission-packet.json").resolve()),
+    str((validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").resolve()),
+]
+doc["mission_packet"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
+doc["mission_packet"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
+payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
+path.write_text(payload, encoding="utf-8")
+(validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").write_text(payload, encoding="utf-8")
+PY
+
+cat >"$HANDOFF_REPORT" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T07:00:00+00:00",
+  "report_id": "operator-handoff-20260401T070000Z",
+  "artifact_paths": {
+    "latest_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+    "stamped_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-20260401T070000Z-operator-handoff-report.json",
+    "output_path": null
+  },
+  "record": {
+    "source_kind": "stamped",
+    "target_limit": 3,
+    "headline": "Operator handoff report: 2 attention families",
+    "attention_summary": "active=1, lagging=1, clear=0",
+    "newest_failing_summary": "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun29 / lagging",
+    "local_operator_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
+    "local_operator_next_step": "Expose Codex and add a direct local LLM profile.",
+    "queue_lines": [
+      "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1"
+    ],
+    "target_lines": [
+      "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "immediate_action_lines": [
+      "local-runtime: Expose Codex and add a direct local LLM profile.",
+      "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "local_validation_records": [
+      {
+        "artifact_family": "monday_local_operator_stack_report",
+        "artifact_kind": "report",
+        "promoted_id": "monday-local-operator-stack-20260401T060524Z",
+        "freshness_state": "fresh",
+        "promotability_status": "promotable",
+        "reasons": [],
+        "dependency_states": {}
+      }
+    ],
+    "local_validation_summary_lines": [
+      "monday_local_operator_stack_report: freshness=fresh promotability=promotable"
+    ],
+    "local_validation_action_lines": [],
+    "markdown": "## Operator Handoff Report"
+  }
+}
+JSON
+
+python3 - <<'PY' "$HANDOFF_REPORT" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["latest_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
+doc["artifact_paths"]["stamped_report_path"] = str((validation_dir / "operator-handoff-20260401T070000Z-operator-handoff-report.json").resolve())
+payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
+path.write_text(payload, encoding="utf-8")
+(validation_dir / "operator-handoff-20260401T070000Z-operator-handoff-report.json").write_text(payload, encoding="utf-8")
+PY
+
+cat >"$LOCAL_OPERATOR_REPORT" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T06:05:24+00:00",
+  "run_id": "monday-local-operator-stack-20260401T060524Z",
+  "workspace_root": "/tmp/workspace",
+  "execution_mode": "both",
+  "direct_profile": "local_ollama",
+  "dry_run": false,
+  "verdict": "fail",
+  "reason_code": "readiness_blocked",
+  "readiness": {
+    "status": "blocked",
+    "report_path": "/tmp/readiness.json",
+    "report": {},
+    "step": {
+      "status": "report_only"
+    }
+  },
+  "stack_smoke": {
+    "status": "skipped",
+    "report_path": "/tmp/stack-smoke.json"
+  },
+  "direct_smoke": {
+    "status": "skipped",
+    "report_path": "/tmp/local_ollama.json"
+  },
+  "recommended_next_steps": [
+    "Expose Codex and add a direct local LLM profile."
+  ],
+  "artifact_paths": {
+    "detail_dir": "/tmp/monday-local-operator-stack-20260401T060524Z",
+    "runtime_report_path": "/tmp/monday-local-operator-stack-20260401T060524Z.json",
+    "validation_latest_report_path": "/tmp/monday-local-operator-stack-report.json",
+    "validation_stamped_report_path": "/tmp/monday-local-operator-stack-20260401T060524Z-monday-local-operator-stack-report.json"
+  }
+}
+JSON
+
+python3 planningops/scripts/write_monday_local_operator_day_packet.py \
+  --validation-root "$VALIDATION_DIR" \
+  --mission-packet "$MISSION_PACKET" \
+  --handoff-report "$HANDOFF_REPORT" \
+  --local-operator-report "$LOCAL_OPERATOR_REPORT" \
+  --day-packet-id "$DAY_PACKET_ID" \
+  --output "$OUTPUT_PATH" >"$STDOUT_PATH"
+
+python3 - <<'PY' "$STDOUT_PATH" "$OUTPUT_PATH" "$VALIDATION_DIR" "$DAY_PACKET_ID"
+import json
+import sys
+from pathlib import Path
+
+stdout_doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_doc = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+validation_dir = Path(sys.argv[3]).resolve()
+day_packet_id = sys.argv[4]
+latest_path = validation_dir / "monday-local-operator-day-packet.json"
+stamped_path = validation_dir / f"{day_packet_id}-monday-local-operator-day-packet.json"
+latest_doc = json.loads(latest_path.read_text(encoding="utf-8"))
+stamped_doc = json.loads(stamped_path.read_text(encoding="utf-8"))
+
+contract_text = Path("planningops/contracts/monday-local-operator-day-packet-contract.md").read_text(encoding="utf-8")
+assert "mission_packet_id" in contract_text, contract_text
+assert "first_action_command" in contract_text, contract_text
+assert "attachments" in contract_text, contract_text
+assert "local_validation_snapshot_status" in contract_text, contract_text
+assert "body_markdown" in contract_text, contract_text
+
+for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
+    assert doc["day_packet_id"] == day_packet_id, doc
+    assert doc["contract_ref"] == "planningops/contracts/monday-local-operator-day-packet-contract.md", doc
+    assert doc["artifact_paths"]["latest_packet_path"] == str(latest_path), doc
+    assert doc["artifact_paths"]["stamped_packet_path"] == str(stamped_path), doc
+    packet = doc["day_packet"]
+    assert packet["version"] == "v1", packet
+    assert packet["day_packet_id"] == day_packet_id, packet
+    assert packet["mission_packet_id"] == "monday-local-mission-20260401T080000Z", packet
+    assert packet["headline"].startswith("Monday local operator day packet: Resolve [active/latest-gap]"), packet
+    assert packet["mission_objective"] == (
+        "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ), packet
+    assert packet["planner_profile"] == "local_ollama", packet
+    assert packet["launch_mode"] == "direct", packet
+    assert packet["local_model_route"] == "direct_local_ollama", packet
+    assert packet["first_action_command"] == (
+        "python3 planningops/scripts/run_monday_local_operator_stack.py "
+        "--execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id "
+        "monday-local-mission-20260401T080000Z"
+    ), packet
+    assert packet["monday_runtime_entrypoint_command"] == (
+        "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local_ollama "
+        "--run-id monday-local-mission-20260401T080000Z"
+    ), packet
+    assert packet["rollback_command"] == "cd ../platform-provider-gateway && bash scripts/litellm_stack_launcher.sh --mode start", packet
+    assert packet["local_validation_snapshot_status"] == "present", packet
+    assert packet["local_validation_summary_lines"] == [
+        "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+        "operator_handoff_report: freshness=fresh promotability=promotable",
+    ], packet
+    assert packet["queue_lines"] == [
+        "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1"
+    ], packet
+    assert packet["target_lines"] == [
+        "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ], packet
+    assert packet["immediate_actions"] == [
+        "local-runtime: Expose Codex and add a direct local LLM profile.",
+        "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    ], packet
+    assert str(latest_path) in packet["attachments"], packet
+    assert str(stamped_path) in packet["attachments"], packet
+    assert str((validation_dir / "monday-local-mission-packet.json").resolve()) in packet["attachments"], packet
+    assert str((validation_dir / "operator-handoff-report.json").resolve()) in packet["attachments"], packet
+    assert str((validation_dir / "monday-local-operator-stack-report.json").resolve()) in packet["attachments"], packet
+    assert packet["source_artifacts"]["mission_packet_path"] == str((validation_dir / "monday-local-mission-packet.json").resolve()), packet
+    assert packet["source_artifacts"]["handoff_report_path"] == str((validation_dir / "operator-handoff-report.json").resolve()), packet
+    assert packet["source_artifacts"]["local_operator_report_path"] == str((validation_dir / "monday-local-operator-stack-report.json").resolve()), packet
+    assert "## Monday Local Operator Day Packet" in packet["body_markdown"], packet
+    assert "### Commands" in packet["body_markdown"], packet
+    assert "### Local Validation" in packet["body_markdown"], packet
+    assert "### Attachments" in packet["body_markdown"], packet
+
+assert stdout_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stdout_doc
+assert output_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), output_doc
+assert latest_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), latest_doc
+assert stamped_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stamped_doc
+PY
+
+echo "write monday local operator day packet ok"

--- a/planningops/scripts/write_monday_local_operator_day_packet.py
+++ b/planningops/scripts/write_monday_local_operator_day_packet.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_VALIDATION_ROOT = WORKSPACE_ROOT / "planningops/artifacts/validation"
+DEFAULT_MISSION_PACKET = DEFAULT_VALIDATION_ROOT / "monday-local-mission-packet.json"
+DEFAULT_HANDOFF_REPORT = DEFAULT_VALIDATION_ROOT / "operator-handoff-report.json"
+DEFAULT_LOCAL_OPERATOR_REPORT = DEFAULT_VALIDATION_ROOT / "monday-local-operator-stack-report.json"
+CONTRACT_REF = "planningops/contracts/monday-local-operator-day-packet-contract.md"
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def utc_timestamp_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def resolve_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (WORKSPACE_ROOT / path).resolve()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def require_dict(doc: object, label: str) -> dict:
+    if not isinstance(doc, dict):
+        raise SystemExit(f"{label} must be a JSON object")
+    return doc
+
+
+def require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def normalize_string_list(raw_values: object) -> list[str]:
+    return [str(value) for value in list(raw_values or []) if str(value).strip()]
+
+
+def normalize_local_validation_records(raw_values: object) -> list[dict]:
+    records: list[dict] = []
+    for value in list(raw_values or []):
+        if isinstance(value, dict):
+            records.append(value)
+    return records
+
+
+def dedupe_preserve_order(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def build_local_validation_snapshot(*, mission_packet: dict, handoff_record: dict) -> tuple[str, list[dict], list[str], list[str]]:
+    snapshot_status = str(mission_packet.get("local_validation_snapshot_status") or "").strip()
+    records = normalize_local_validation_records(mission_packet.get("local_validation_records"))
+    summary_lines = normalize_string_list(mission_packet.get("local_validation_summary_lines"))
+    action_lines = normalize_string_list(mission_packet.get("local_validation_action_lines"))
+    if snapshot_status:
+        return snapshot_status, records, summary_lines, action_lines
+
+    fallback_records = normalize_local_validation_records(handoff_record.get("local_validation_records"))
+    fallback_summary_lines = normalize_string_list(handoff_record.get("local_validation_summary_lines"))
+    fallback_action_lines = normalize_string_list(handoff_record.get("local_validation_action_lines"))
+    if fallback_records or fallback_summary_lines or fallback_action_lines:
+        return "carried_from_handoff", fallback_records, fallback_summary_lines, fallback_action_lines
+    return "missing", [], [], []
+
+
+def build_body_markdown(
+    *,
+    headline: str,
+    mission_objective: str,
+    planner_profile: str,
+    launch_mode: str,
+    local_model_route: str,
+    first_action_command: str,
+    monday_runtime_entrypoint_command: str,
+    rollback_command: str,
+    local_runtime_summary: str | None,
+    local_runtime_next_step: str | None,
+    local_validation_summary_lines: list[str],
+    local_validation_action_lines: list[str],
+    queue_lines: list[str],
+    target_lines: list[str],
+    immediate_actions: list[str],
+    attachments: list[str],
+) -> str:
+    lines = [
+        "## Monday Local Operator Day Packet",
+        "",
+        "### Snapshot",
+        f"- headline: {headline}",
+        f"- mission objective: {mission_objective}",
+        f"- planner profile: `{planner_profile}`",
+        f"- launch mode: `{launch_mode}`",
+        f"- local model route: `{local_model_route}`",
+        "",
+        "### Commands",
+        f"1. preflight: `{first_action_command}`",
+        f"2. monday runtime: `{monday_runtime_entrypoint_command}`",
+        f"3. rollback: `{rollback_command}`",
+    ]
+    lines.extend(["", "### Local Runtime"])
+    lines.append(f"- local runtime summary: {local_runtime_summary or 'unavailable'}")
+    if local_runtime_next_step:
+        lines.append(f"- local runtime next step: {local_runtime_next_step}")
+    lines.extend(["", "### Local Validation", *[f"- {line}" for line in local_validation_summary_lines]])
+    if local_validation_action_lines:
+        lines.extend(["", "### Local Validation Actions", *[f"{index}. {line}" for index, line in enumerate(local_validation_action_lines, start=1)]])
+    lines.extend(["", "### Queue", *[f"- {line}" for line in queue_lines]])
+    lines.extend(["", "### Top Targets", *[f"{index}. {line}" for index, line in enumerate(target_lines, start=1)]])
+    lines.extend(["", "### Immediate Actions", *[f"{index}. {line}" for index, line in enumerate(immediate_actions, start=1)]])
+    lines.extend(["", "### Attachments", *[f"- {path}" for path in attachments]])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Write an inbox-ready monday local operator day packet from promoted mission and handoff artifacts.")
+    parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    parser.add_argument("--mission-packet", default=str(DEFAULT_MISSION_PACKET))
+    parser.add_argument("--handoff-report", default=str(DEFAULT_HANDOFF_REPORT))
+    parser.add_argument("--local-operator-report", default=str(DEFAULT_LOCAL_OPERATOR_REPORT))
+    parser.add_argument("--day-packet-id", default=f"monday-local-day-{utc_timestamp_slug()}")
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    validation_root = resolve_path(args.validation_root)
+    mission_packet_path = resolve_path(args.mission_packet)
+    handoff_report_path = resolve_path(args.handoff_report)
+    local_operator_report_path = resolve_path(args.local_operator_report)
+    output_path = None if args.output is None else resolve_path(args.output)
+
+    if not mission_packet_path.exists():
+        raise SystemExit(f"mission packet missing: {mission_packet_path}")
+    if not handoff_report_path.exists():
+        raise SystemExit(f"handoff report missing: {handoff_report_path}")
+    if not local_operator_report_path.exists():
+        raise SystemExit(f"local operator report missing: {local_operator_report_path}")
+    if not (WORKSPACE_ROOT / CONTRACT_REF).exists():
+        raise SystemExit(f"day packet contract missing: {CONTRACT_REF}")
+
+    mission_doc = require_dict(load_json(mission_packet_path), "mission packet")
+    handoff_doc = require_dict(load_json(handoff_report_path), "handoff report")
+    local_operator_doc = require_dict(load_json(local_operator_report_path), "local operator report")
+    mission_packet = require_dict(mission_doc.get("mission_packet"), "mission packet payload")
+    handoff_record = require_dict(handoff_doc.get("record"), "handoff report record")
+
+    day_packet_id = args.day_packet_id
+    latest_packet_path = validation_root / "monday-local-operator-day-packet.json"
+    stamped_packet_path = validation_root / f"{day_packet_id}-monday-local-operator-day-packet.json"
+
+    mission_packet_id = require_string(mission_doc.get("packet_id"), "mission packet id")
+    mission_objective = require_string(mission_packet.get("mission_objective"), "mission objective")
+    mission_prompt = require_string(mission_packet.get("mission_prompt"), "mission prompt")
+    planner_profile = require_string(mission_packet.get("planner_profile"), "planner profile")
+    launch_mode = require_string(mission_packet.get("launch_mode"), "launch mode")
+    local_model_route = require_string(mission_packet.get("local_model_route"), "local model route")
+    first_action_command = require_string(mission_packet.get("preflight_command"), "first action command")
+    monday_runtime_entrypoint_command = require_string(
+        mission_packet.get("monday_runtime_entrypoint_command"),
+        "monday runtime entrypoint command",
+    )
+    rollback_command = require_string(mission_packet.get("rollback_command"), "rollback command")
+    headline = f"Monday local operator day packet: {mission_objective}"
+
+    queue_lines = normalize_string_list(handoff_record.get("queue_lines"))
+    target_lines = normalize_string_list(handoff_record.get("target_lines"))
+    immediate_actions = dedupe_preserve_order(
+        normalize_string_list(mission_packet.get("immediate_actions"))
+        + normalize_string_list(handoff_record.get("immediate_action_lines"))
+    )
+    local_validation_snapshot_status, local_validation_records, local_validation_summary_lines, local_validation_action_lines = (
+        build_local_validation_snapshot(mission_packet=mission_packet, handoff_record=handoff_record)
+    )
+
+    attachment_candidates = [
+        str(latest_packet_path.resolve()),
+        str(stamped_packet_path.resolve()),
+        str(mission_packet_path.resolve()),
+        str(handoff_report_path.resolve()),
+        str(local_operator_report_path.resolve()),
+        str((validation_root / f"{mission_packet_id}-monday-local-mission-packet.json").resolve()),
+    ]
+    handoff_artifacts = require_dict(handoff_doc.get("artifact_paths"), "handoff artifact paths")
+    for key in ("latest_report_path", "stamped_report_path"):
+        raw_value = handoff_artifacts.get(key)
+        if isinstance(raw_value, str) and raw_value.strip():
+            attachment_candidates.append(str(resolve_path(raw_value).resolve()))
+    local_operator_artifacts = require_dict(local_operator_doc.get("artifact_paths"), "local operator artifact paths")
+    for key in ("runtime_report_path", "detail_dir", "validation_latest_report_path", "validation_stamped_report_path"):
+        raw_value = local_operator_artifacts.get(key)
+        if isinstance(raw_value, str) and raw_value.strip():
+            attachment_candidates.append(str(resolve_path(raw_value).resolve()))
+    attachments = dedupe_preserve_order(attachment_candidates)
+    if not attachments:
+        raise SystemExit("attachments must not be empty")
+
+    local_runtime_summary = str(mission_packet.get("local_runtime_summary") or handoff_record.get("local_operator_summary") or "").strip()
+    local_runtime_next_step = str(mission_packet.get("local_runtime_next_step") or handoff_record.get("local_operator_next_step") or "").strip()
+
+    day_packet = {
+        "version": "v1",
+        "day_packet_id": day_packet_id,
+        "mission_packet_id": mission_packet_id,
+        "headline": headline,
+        "mission_objective": mission_objective,
+        "mission_prompt": mission_prompt,
+        "attention_summary": str(mission_packet.get("attention_summary") or handoff_record.get("attention_summary") or ""),
+        "newest_failing_summary": str(mission_packet.get("newest_failing_summary") or handoff_record.get("newest_failing_summary") or ""),
+        "planner_profile": planner_profile,
+        "launch_mode": launch_mode,
+        "local_model_route": local_model_route,
+        "first_action_command": first_action_command,
+        "monday_runtime_entrypoint_command": monday_runtime_entrypoint_command,
+        "rollback_command": rollback_command,
+        "local_runtime_summary": local_runtime_summary,
+        "local_runtime_next_step": local_runtime_next_step,
+        "local_validation_snapshot_status": local_validation_snapshot_status,
+        "local_validation_records": local_validation_records,
+        "local_validation_summary_lines": local_validation_summary_lines,
+        "local_validation_action_lines": local_validation_action_lines,
+        "queue_lines": queue_lines,
+        "target_lines": target_lines,
+        "immediate_actions": immediate_actions,
+        "attachments": attachments,
+        "body_markdown": build_body_markdown(
+            headline=headline,
+            mission_objective=mission_objective,
+            planner_profile=planner_profile,
+            launch_mode=launch_mode,
+            local_model_route=local_model_route,
+            first_action_command=first_action_command,
+            monday_runtime_entrypoint_command=monday_runtime_entrypoint_command,
+            rollback_command=rollback_command,
+            local_runtime_summary=local_runtime_summary or None,
+            local_runtime_next_step=local_runtime_next_step or None,
+            local_validation_summary_lines=local_validation_summary_lines,
+            local_validation_action_lines=local_validation_action_lines,
+            queue_lines=queue_lines,
+            target_lines=target_lines,
+            immediate_actions=immediate_actions,
+            attachments=attachments,
+        ),
+        "source_artifacts": {
+            "mission_packet_path": str(mission_packet_path.resolve()),
+            "handoff_report_path": str(handoff_report_path.resolve()),
+            "local_operator_report_path": str(local_operator_report_path.resolve()),
+        },
+    }
+
+    packet_doc = {
+        "generated_at_utc": now_utc(),
+        "day_packet_id": day_packet_id,
+        "contract_ref": CONTRACT_REF,
+        "artifact_paths": {
+            "latest_packet_path": str(latest_packet_path.resolve()),
+            "stamped_packet_path": str(stamped_packet_path.resolve()),
+            "output_path": None if output_path is None else str(output_path.resolve()),
+        },
+        "day_packet": day_packet,
+    }
+
+    write_json(latest_packet_path, packet_doc)
+    write_json(stamped_packet_path, packet_doc)
+    if output_path is not None:
+        write_json(output_path, packet_doc)
+
+    print(json.dumps(packet_doc, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- promote an inbox-ready monday local operator day packet into validation artifacts
- extend local validation freshness so the day packet joins the same promotion lane as operator, handoff, and mission artifacts
- update the local Codex runtime rollout plan to reflect the promoted day packet layer

## Scope
- planningops day packet contract, writer, and regression coverage
- local validation freshness query expansion
- rollout plan update

## Linked Issues
- Closes #946

## Validation
- python3 -m py_compile planningops/scripts/write_monday_local_operator_day_packet.py planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_write_monday_local_operator_day_packet.sh
- bash planningops/scripts/test_write_monday_local_mission_packet.sh
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- local validation freshness ordering now includes an extra promoted artifact family, so downstream exact-string fixtures depend on the new family order
- the day packet remains planningops-owned until monday exposes a packet-native consumer

## Review Checklist
- [ ] Verify the promoted day packet paths are deterministic latest/stamped mirrors
- [ ] Verify the query surface now reports day packet freshness and promotability alongside the existing families
- [ ] Verify rollout documentation still matches the implemented packet ladder

## Post-Deploy Monitoring & Validation
- Re-run `bash planningops/scripts/test_query_federated_ci_artifacts.sh` after merge if local validation ordering changes again
- Confirm PR checks reach the usual steady state: template/docs/contract/federated/o11y pass and inherited runtime lanes remain unchanged
