### PR TITLE
feat(local-runtime): add monday inbox payload bridge

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -135,6 +135,11 @@ Current deliverables:
 - `planningops/artifacts/validation/monday-local-operator-day-packet.json`
 - `planningops/artifacts/validation/<day-packet-id>-monday-local-operator-day-packet.json`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now includes the promoted day packet family in the same promotion lane
+- `planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md`
+- `planningops/scripts/write_monday_local_operator_inbox_payload.py`
+- `planningops/artifacts/validation/monday-local-operator-inbox-payload.json`
+- `planningops/artifacts/validation/<bridge-id>-monday-local-operator-inbox-payload.json`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now includes the promoted inbox payload bridge family in the same promotion lane
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -196,6 +201,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. add a monday-native packet consumer once the repo exposes a mission executor richer than the current runtime smoke entrypoint
-2. decide whether the day packet should stay PlanningOps-owned or also emit a monday-owned inbox payload bridge
-3. add a dedicated query/report surface for the promoted day packet if operators need a packet-first view separate from `handoff-report`
+1. add a monday-native consumer that accepts the promoted inbox payload bridge without reparsing day packet markdown
+2. decide whether the inbox payload bridge should be schema-validated against a monday-owned payload contract once that surface exists
+3. add a dedicated query/report surface for the promoted inbox payload bridge if operators need a payload-first view separate from `handoff-report`

--- a/planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md
+++ b/planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md
@@ -1,0 +1,133 @@
+# Monday Local Operator Inbox Payload Bridge Contract
+
+## Purpose
+Define the deterministic bridge from a promoted monday local operator day packet into a monday-friendly inbox payload artifact.
+
+This contract exists so:
+- `planningops` can promote one machine-readable payload that monday can consume without reparsing day-level markdown
+- the local launch context stays validation-first and reproducible
+- a future monday-native packet consumer can rely on one stable payload surface
+
+## Canonical Boundary
+
+PlanningOps owns:
+- the inbox payload bridge contract
+- deterministic bridge payload promotion into validation artifacts
+- deterministic derivation from:
+  - `planningops/artifacts/validation/monday-local-operator-day-packet.json`
+  - `planningops/artifacts/validation/monday-local-mission-packet.json`
+  - `planningops/artifacts/validation/operator-handoff-report.json`
+  - `planningops/artifacts/validation/monday-local-operator-stack-report.json`
+
+Monday owns:
+- any packet-native consumer that reads the promoted payload
+- runtime execution after the payload boundary
+- transport- or channel-specific delivery semantics beyond the payload shape
+
+PlanningOps must not:
+- re-infer launch commands from markdown when explicit command fields already exist
+- drop local validation context while translating the packet into an inbox payload
+- claim a monday-native consumer exists if only the bridge payload is implemented
+
+## Canonical Artifacts
+
+Every promoted inbox payload bridge must include:
+- latest payload: `planningops/artifacts/validation/monday-local-operator-inbox-payload.json`
+- stamped payload: `planningops/artifacts/validation/<bridge-id>-monday-local-operator-inbox-payload.json`
+
+The payload may also be written to one caller-specified extra output path.
+
+## Payload Document Shape
+
+Top-level required fields:
+1. `generated_at_utc`
+2. `bridge_id`
+3. `contract_ref`
+4. `artifact_paths.latest_payload_path`
+5. `artifact_paths.stamped_payload_path`
+6. `payload`
+
+`payload` required fields:
+1. `title`
+2. `status`
+3. `headline`
+4. `priority_headline`
+5. `operator_action`
+6. `recommended_wait_minutes`
+7. `retry_mode`
+8. `needs_human_attention`
+9. `message_class_hint`
+10. `planner_profile`
+11. `launch_mode`
+12. `local_model_route`
+13. `first_action_command`
+14. `monday_runtime_entrypoint_command`
+15. `rollback_command`
+16. `local_validation_snapshot_status`
+17. `local_validation_summary_lines`
+18. `local_validation_action_lines`
+19. `attachments`
+20. `body_markdown`
+21. `bridge_contract_ref`
+22. `source_artifacts.day_packet_path`
+23. `source_artifacts.mission_packet_path`
+24. `source_artifacts.handoff_report_path`
+25. `source_artifacts.local_operator_report_path`
+
+Optional fields:
+- `day_packet_id`
+- `mission_packet_id`
+- `mission_objective`
+- `queue_lines`
+- `target_lines`
+- `immediate_actions`
+
+## Deterministic Resolution Rules
+
+1. Identical promoted day packet inputs must produce the same bridge payload apart from timestamps.
+2. The bridge must reuse explicit launch fields from the day packet instead of recomputing them from `body_markdown`.
+3. `status` must be derived fail-closed:
+   - `blocked` when local validation actions are present or the carried runtime summary already indicates `verdict=fail` or `readiness=blocked`
+   - otherwise `ready`
+4. `needs_human_attention`, `message_class_hint`, `recommended_wait_minutes`, and `retry_mode` must be deterministically derived from `status`.
+5. local validation snapshot fields must be copied directly from the promoted day packet.
+6. `attachments` must include both bridge payload paths plus the source packet/report artifacts needed to reopen the launch context.
+
+## Status Mapping Rules
+
+- when `status=blocked`:
+  - `needs_human_attention=true`
+  - `message_class_hint=decision_request`
+  - `recommended_wait_minutes=5`
+  - `retry_mode=manual_recheck`
+- when `status=ready`:
+  - `needs_human_attention=false`
+  - `message_class_hint=status_update`
+  - `recommended_wait_minutes=0`
+  - `retry_mode=none`
+
+## Evidence Requirements
+
+Every bridge payload must preserve the source artifact references it was derived from:
+- promoted day packet path
+- promoted mission packet path
+- promoted handoff report path
+- promoted local operator report path
+
+Every bridge payload must also preserve the current local validation snapshot:
+- the snapshot status marker
+- summary lines
+- action lines
+
+## Failure Rules
+
+- missing promoted day packet is fail-fast
+- missing promoted mission packet, handoff report, or local operator report referenced by the day packet is fail-fast
+- empty `title`, `headline`, `first_action_command`, `monday_runtime_entrypoint_command`, `rollback_command`, or `body_markdown` is fail-fast
+- empty `attachments` is fail-fast
+
+## Validation
+
+- `planningops/scripts/write_monday_local_operator_inbox_payload.py`
+- `planningops/scripts/test_write_monday_local_operator_inbox_payload.sh`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness`

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -51,6 +51,7 @@ LOCAL_VALIDATION_FAMILY_CHOICES = (
     "operator_handoff_report",
     "monday_local_mission_packet",
     "monday_local_operator_day_packet",
+    "monday_local_operator_inbox_payload",
 )
 LOCAL_VALIDATION_FRESHNESS_CHOICES = ("fresh", "stale", "missing")
 LOCAL_VALIDATION_PROMOTABILITY_CHOICES = ("promotable", "blocked")
@@ -1231,12 +1232,151 @@ def build_day_packet_validation_freshness_record(*, validation_root: Path) -> Lo
     )
 
 
+def build_inbox_payload_validation_freshness_record(*, validation_root: Path) -> LocalValidationFreshnessRecord:
+    latest_path = (validation_root / "monday-local-operator-inbox-payload.json").resolve()
+    latest_doc = load_optional_json(latest_path)
+    freshness_reasons: list[str] = []
+    promotability_reasons: list[str] = []
+    dependency_states: dict[str, str] = {}
+    stamped_path: Path | None = None
+    promoted_id: str | None = None
+    generated_at_utc: str | None = None
+
+    if latest_doc is not None:
+        promoted_id = str(latest_doc.get("bridge_id") or "").strip() or None
+        generated_at_utc = str(latest_doc.get("generated_at_utc") or "").strip() or None
+        if promoted_id is None:
+            promotability_reasons.append("missing_bridge_id")
+        if not isinstance(latest_doc.get("contract_ref"), str) or not str(latest_doc.get("contract_ref")).strip():
+            promotability_reasons.append("missing_contract_ref")
+        latest_payload_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "latest_payload_path")
+        stamped_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "stamped_payload_path")
+        if latest_payload_path != latest_path:
+            freshness_reasons.append("latest_path_mismatch")
+        payload = resolve_nested_value(latest_doc, "payload")
+        if not isinstance(payload, dict):
+            promotability_reasons.append("missing_payload")
+        else:
+            required_strings = {
+                "title": "missing_title",
+                "status": "missing_status",
+                "headline": "missing_headline",
+                "priority_headline": "missing_priority_headline",
+                "operator_action": "missing_operator_action",
+                "retry_mode": "missing_retry_mode",
+                "message_class_hint": "missing_message_class_hint",
+                "planner_profile": "missing_planner_profile",
+                "launch_mode": "missing_launch_mode",
+                "local_model_route": "missing_local_model_route",
+                "first_action_command": "missing_first_action_command",
+                "monday_runtime_entrypoint_command": "missing_runtime_entrypoint_command",
+                "rollback_command": "missing_rollback_command",
+                "local_validation_snapshot_status": "missing_local_validation_snapshot_status",
+                "body_markdown": "missing_body_markdown",
+                "bridge_contract_ref": "missing_bridge_contract_ref",
+            }
+            for field_name, reason in required_strings.items():
+                value = payload.get(field_name)
+                if not isinstance(value, str) or not value.strip():
+                    promotability_reasons.append(reason)
+            if not isinstance(payload.get("recommended_wait_minutes"), int):
+                promotability_reasons.append("missing_recommended_wait_minutes")
+            if not isinstance(payload.get("needs_human_attention"), bool):
+                promotability_reasons.append("missing_needs_human_attention")
+            attachments = [str(path) for path in list(payload.get("attachments") or []) if str(path).strip()]
+            if not attachments:
+                promotability_reasons.append("missing_attachments")
+            source_artifacts = payload.get("source_artifacts")
+            if not isinstance(source_artifacts, dict):
+                promotability_reasons.append("missing_source_artifacts")
+            else:
+                day_state, day_reason = build_local_validation_dependency_state(
+                    raw_path=source_artifacts.get("day_packet_path"),
+                    expected_path=validation_root / "monday-local-operator-day-packet.json",
+                )
+                mission_state, mission_reason = build_local_validation_dependency_state(
+                    raw_path=source_artifacts.get("mission_packet_path"),
+                    expected_path=validation_root / "monday-local-mission-packet.json",
+                )
+                handoff_state, handoff_reason = build_local_validation_dependency_state(
+                    raw_path=source_artifacts.get("handoff_report_path"),
+                    expected_path=validation_root / "operator-handoff-report.json",
+                )
+                local_state, local_reason = build_local_validation_dependency_state(
+                    raw_path=source_artifacts.get("local_operator_report_path"),
+                    expected_path=validation_root / "monday-local-operator-stack-report.json",
+                )
+                dependency_states["monday_local_operator_day_packet"] = day_state
+                dependency_states["monday_local_mission_packet"] = mission_state
+                dependency_states["operator_handoff_report"] = handoff_state
+                dependency_states["monday_local_operator_stack_report"] = local_state
+                if day_reason == "dependency_path_missing":
+                    promotability_reasons.append("missing_day_packet_path")
+                elif day_reason == "dependency_missing":
+                    promotability_reasons.append("day_packet_dependency_missing")
+                elif day_reason == "dependency_stale":
+                    promotability_reasons.append("day_packet_dependency_stale")
+                if mission_reason == "dependency_path_missing":
+                    promotability_reasons.append("missing_mission_packet_path")
+                elif mission_reason == "dependency_missing":
+                    promotability_reasons.append("mission_packet_dependency_missing")
+                elif mission_reason == "dependency_stale":
+                    promotability_reasons.append("mission_packet_dependency_stale")
+                if handoff_reason == "dependency_path_missing":
+                    promotability_reasons.append("missing_handoff_report_path")
+                elif handoff_reason == "dependency_missing":
+                    promotability_reasons.append("handoff_dependency_missing")
+                elif handoff_reason == "dependency_stale":
+                    promotability_reasons.append("handoff_dependency_stale")
+                if local_reason == "dependency_path_missing":
+                    promotability_reasons.append("missing_local_operator_report_path")
+                elif local_reason == "dependency_missing":
+                    promotability_reasons.append("local_operator_dependency_missing")
+                elif local_reason == "dependency_stale":
+                    promotability_reasons.append("local_operator_dependency_stale")
+        if stamped_path is not None and stamped_path.exists():
+            stamped_doc = load_optional_json(stamped_path)
+            if stamped_doc is None:
+                freshness_reasons.append("stamped_invalid_json")
+            else:
+                if str(stamped_doc.get("bridge_id") or "").strip() != (promoted_id or ""):
+                    freshness_reasons.append("stamped_bridge_id_mismatch")
+                stamped_latest_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "latest_payload_path")
+                stamped_stamped_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "stamped_payload_path")
+                if stamped_latest_path != latest_path:
+                    freshness_reasons.append("stamped_latest_path_mismatch")
+                if stamped_stamped_path != stamped_path.resolve():
+                    freshness_reasons.append("stamped_path_mismatch")
+
+    freshness_state, promotability_status = classify_local_validation_states(
+        latest_path=latest_path,
+        latest_doc=latest_doc,
+        stamped_path=stamped_path,
+        freshness_reasons=freshness_reasons,
+        promotability_reasons=promotability_reasons,
+        dependency_states=dependency_states,
+    )
+    return LocalValidationFreshnessRecord(
+        artifact_family="monday_local_operator_inbox_payload",
+        artifact_kind="payload",
+        promoted_id=promoted_id,
+        generated_at_utc=generated_at_utc,
+        freshness_state=freshness_state,
+        promotability_status=promotability_status,
+        latest_path=str(latest_path),
+        stamped_path=None if stamped_path is None else str(stamped_path.resolve()),
+        reasons=freshness_reasons + promotability_reasons,
+        dependency_states=dependency_states,
+    )
+
+
 def discover_local_validation_freshness_records(*, validation_root: Path) -> list[LocalValidationFreshnessRecord]:
     return [
         build_local_operator_validation_freshness_record(validation_root=validation_root),
         build_handoff_validation_freshness_record(validation_root=validation_root),
         build_mission_packet_validation_freshness_record(validation_root=validation_root),
         build_day_packet_validation_freshness_record(validation_root=validation_root),
+        build_inbox_payload_validation_freshness_record(validation_root=validation_root),
     ]
 
 

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1996,6 +1996,92 @@ path.write_text(payload, encoding="utf-8")
 (validation_dir / "monday-local-day-20260401T083000Z-monday-local-operator-day-packet.json").write_text(payload, encoding="utf-8")
 PY
 
+cat >"$VALIDATION_DIR/monday-local-operator-inbox-payload.json" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T08:45:00+00:00",
+  "bridge_id": "monday-local-inbox-20260401T084500Z",
+  "contract_ref": "planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md",
+  "artifact_paths": {
+    "latest_payload_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-inbox-payload.json",
+    "stamped_payload_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-inbox-20260401T084500Z-monday-local-operator-inbox-payload.json",
+    "output_path": null
+  },
+  "payload": {
+    "title": "Monday local operator day packet: Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "status": "blocked",
+    "headline": "Monday local operator day packet: Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "priority_headline": "Monday local operator day packet: Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "operator_action": "launch_monday_local_runtime",
+    "recommended_wait_minutes": 5,
+    "retry_mode": "manual_recheck",
+    "needs_human_attention": true,
+    "message_class_hint": "decision_request",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "day_packet_id": "monday-local-day-20260401T083000Z",
+    "mission_packet_id": "monday-local-mission-20260401T080000Z",
+    "mission_objective": "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "first_action_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id monday-local-mission-20260401T080000Z",
+    "monday_runtime_entrypoint_command": "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local_ollama --run-id monday-local-mission-20260401T080000Z",
+    "rollback_command": "cd ../platform-provider-gateway && bash scripts/litellm_stack_launcher.sh --mode start",
+    "local_validation_snapshot_status": "present",
+    "local_validation_summary_lines": [
+      "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+      "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
+      "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
+      "monday_local_operator_day_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current"
+    ],
+    "local_validation_action_lines": [
+      "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
+      "local-validation: repair monday_local_mission_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)",
+      "local-validation: repair monday_local_operator_day_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)"
+    ],
+    "attachments": [
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-inbox-payload.json",
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-day-packet.json",
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+      "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json"
+    ],
+    "body_markdown": "## Monday Local Operator Day Packet",
+    "bridge_contract_ref": "planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md",
+    "source_artifacts": {
+      "day_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-day-packet.json",
+      "mission_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+      "handoff_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+      "local_operator_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json"
+    }
+  }
+}
+JSON
+
+python3 - <<'PY' "$VALIDATION_DIR/monday-local-operator-inbox-payload.json" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["latest_payload_path"] = str((validation_dir / "monday-local-operator-inbox-payload.json").resolve())
+doc["artifact_paths"]["stamped_payload_path"] = str((validation_dir / "monday-local-inbox-20260401T084500Z-monday-local-operator-inbox-payload.json").resolve())
+doc["payload"]["attachments"] = [
+    str((validation_dir / "monday-local-operator-inbox-payload.json").resolve()),
+    str((validation_dir / "monday-local-operator-day-packet.json").resolve()),
+    str((validation_dir / "monday-local-mission-packet.json").resolve()),
+    str((validation_dir / "operator-handoff-report.json").resolve()),
+    str((validation_dir / "monday-local-operator-stack-report.json").resolve()),
+]
+doc["payload"]["source_artifacts"]["day_packet_path"] = str((validation_dir / "monday-local-operator-day-packet.json").resolve())
+doc["payload"]["source_artifacts"]["mission_packet_path"] = str((validation_dir / "monday-local-mission-packet.json").resolve())
+doc["payload"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
+doc["payload"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
+payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
+path.write_text(payload, encoding="utf-8")
+(validation_dir / "monday-local-inbox-20260401T084500Z-monday-local-operator-inbox-payload.json").write_text(payload, encoding="utf-8")
+PY
+
 python3 "$QUERY_PATH" handoff-report \
   --format json \
   --ci-root "$CI_DIR" \
@@ -2074,6 +2160,7 @@ assert record["local_validation_summary_lines"] == [
     "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
     "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
     "monday_local_operator_day_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
+    "monday_local_operator_inbox_payload: freshness=fresh promotability=promotable dependencies=monday_local_operator_day_packet=current,monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
 ], record
 assert record["immediate_action_lines"] == [
     "local-runtime: Expose Codex and add a direct local LLM profile.",
@@ -2122,6 +2209,7 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
         "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
         "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
         "monday_local_operator_day_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
+        "monday_local_operator_inbox_payload: freshness=fresh promotability=promotable dependencies=monday_local_operator_day_packet=current,monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
     ], doc
     assert doc["record"]["local_validation_action_lines"] == [
         "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
@@ -2575,9 +2663,10 @@ assert [record["artifact_family"] for record in records] == [
     "operator_handoff_report",
     "monday_local_mission_packet",
     "monday_local_operator_day_packet",
+    "monday_local_operator_inbox_payload",
 ], records
 
-local_operator, handoff, mission, day_packet = records
+local_operator, handoff, mission, day_packet, inbox_payload = records
 
 assert local_operator["freshness_state"] == "fresh", local_operator
 assert local_operator["promotability_status"] == "promotable", local_operator
@@ -2607,6 +2696,17 @@ assert day_packet["dependency_states"] == {
     "monday_local_operator_stack_report": "current",
 }, day_packet
 assert day_packet["reasons"] == ["missing_rollback_command"], day_packet
+
+assert inbox_payload["freshness_state"] == "fresh", inbox_payload
+assert inbox_payload["promotability_status"] == "promotable", inbox_payload
+assert inbox_payload["promoted_id"] == "monday-local-inbox-20260401T084500Z", inbox_payload
+assert inbox_payload["dependency_states"] == {
+    "monday_local_operator_day_packet": "current",
+    "monday_local_mission_packet": "current",
+    "operator_handoff_report": "current",
+    "monday_local_operator_stack_report": "current",
+}, inbox_payload
+assert inbox_payload["reasons"] == [], inbox_payload
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \

--- a/planningops/scripts/test_write_monday_local_operator_inbox_payload.sh
+++ b/planningops/scripts/test_write_monday_local_operator_inbox_payload.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+VALIDATION_DIR="$TMP_DIR/validation"
+DAY_PACKET="$VALIDATION_DIR/monday-local-operator-day-packet.json"
+MISSION_PACKET="$VALIDATION_DIR/monday-local-mission-packet.json"
+HANDOFF_REPORT="$VALIDATION_DIR/operator-handoff-report.json"
+LOCAL_OPERATOR_REPORT="$VALIDATION_DIR/monday-local-operator-stack-report.json"
+OUTPUT_PATH="$TMP_DIR/inbox-payload-output.json"
+STDOUT_PATH="$TMP_DIR/inbox-payload-stdout.json"
+BRIDGE_ID="monday-local-inbox-20260401T084500Z"
+
+mkdir -p "$VALIDATION_DIR"
+
+cat >"$MISSION_PACKET" <<'JSON'
+{
+  "packet_id": "monday-local-mission-20260401T080000Z"
+}
+JSON
+
+cat >"$HANDOFF_REPORT" <<'JSON'
+{
+  "report_id": "operator-handoff-20260401T070000Z"
+}
+JSON
+
+cat >"$LOCAL_OPERATOR_REPORT" <<'JSON'
+{
+  "run_id": "monday-local-operator-stack-20260401T060524Z"
+}
+JSON
+
+cat >"$DAY_PACKET" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T08:30:00+00:00",
+  "day_packet_id": "monday-local-day-20260401T083000Z",
+  "contract_ref": "planningops/contracts/monday-local-operator-day-packet-contract.md",
+  "artifact_paths": {
+    "latest_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-day-packet.json",
+    "stamped_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-day-20260401T083000Z-monday-local-operator-day-packet.json",
+    "output_path": null
+  },
+  "day_packet": {
+    "version": "v1",
+    "day_packet_id": "monday-local-day-20260401T083000Z",
+    "mission_packet_id": "monday-local-mission-20260401T080000Z",
+    "headline": "Monday local operator day packet: Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "mission_objective": "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "mission_prompt": "Use monday planner profile `local_ollama` via `direct_local_ollama`.",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "first_action_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id monday-local-mission-20260401T080000Z",
+    "monday_runtime_entrypoint_command": "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local_ollama --run-id monday-local-mission-20260401T080000Z",
+    "rollback_command": "cd ../platform-provider-gateway && bash scripts/litellm_stack_launcher.sh --mode start",
+    "local_runtime_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
+    "local_validation_snapshot_status": "present",
+    "local_validation_summary_lines": [
+      "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+      "operator_handoff_report: freshness=blocked promotability=blocked reasons=stamped_missing"
+    ],
+    "local_validation_action_lines": [
+      "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)"
+    ],
+    "queue_lines": [
+      "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1"
+    ],
+    "target_lines": [
+      "[active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "immediate_actions": [
+      "local-runtime: Expose Codex and add a direct local LLM profile.",
+      "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
+    ],
+    "attachments": [
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-day-packet.json",
+      "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json"
+    ],
+    "body_markdown": "## Monday Local Operator Day Packet",
+    "source_artifacts": {
+      "mission_packet_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-mission-packet.json",
+      "handoff_report_path": "VALIDATION_ROOT_PLACEHOLDER/operator-handoff-report.json",
+      "local_operator_report_path": "VALIDATION_ROOT_PLACEHOLDER/monday-local-operator-stack-report.json"
+    }
+  }
+}
+JSON
+
+python3 - <<'PY' "$DAY_PACKET" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+validation_dir = Path(sys.argv[2]).resolve()
+doc = json.loads(path.read_text(encoding="utf-8"))
+doc["artifact_paths"]["latest_packet_path"] = str((validation_dir / "monday-local-operator-day-packet.json").resolve())
+doc["artifact_paths"]["stamped_packet_path"] = str((validation_dir / "monday-local-day-20260401T083000Z-monday-local-operator-day-packet.json").resolve())
+doc["day_packet"]["attachments"] = [
+    str((validation_dir / "monday-local-operator-day-packet.json").resolve()),
+    str((validation_dir / "monday-local-mission-packet.json").resolve()),
+]
+doc["day_packet"]["source_artifacts"]["mission_packet_path"] = str((validation_dir / "monday-local-mission-packet.json").resolve())
+doc["day_packet"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
+doc["day_packet"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
+payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
+path.write_text(payload, encoding="utf-8")
+(validation_dir / "monday-local-day-20260401T083000Z-monday-local-operator-day-packet.json").write_text(payload, encoding="utf-8")
+PY
+
+python3 planningops/scripts/write_monday_local_operator_inbox_payload.py \
+  --validation-root "$VALIDATION_DIR" \
+  --day-packet "$DAY_PACKET" \
+  --bridge-id "$BRIDGE_ID" \
+  --output "$OUTPUT_PATH" >"$STDOUT_PATH"
+
+python3 - <<'PY' "$STDOUT_PATH" "$OUTPUT_PATH" "$VALIDATION_DIR" "$BRIDGE_ID"
+import json
+import sys
+from pathlib import Path
+
+stdout_doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_doc = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+validation_dir = Path(sys.argv[3]).resolve()
+bridge_id = sys.argv[4]
+latest_path = validation_dir / "monday-local-operator-inbox-payload.json"
+stamped_path = validation_dir / f"{bridge_id}-monday-local-operator-inbox-payload.json"
+latest_doc = json.loads(latest_path.read_text(encoding="utf-8"))
+stamped_doc = json.loads(stamped_path.read_text(encoding="utf-8"))
+
+contract_text = Path("planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md").read_text(encoding="utf-8")
+assert "message_class_hint" in contract_text, contract_text
+assert "first_action_command" in contract_text, contract_text
+assert "bridge_contract_ref" in contract_text, contract_text
+
+for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
+    assert doc["bridge_id"] == bridge_id, doc
+    assert doc["contract_ref"] == "planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md", doc
+    assert doc["artifact_paths"]["latest_payload_path"] == str(latest_path), doc
+    assert doc["artifact_paths"]["stamped_payload_path"] == str(stamped_path), doc
+    payload = doc["payload"]
+    assert payload["status"] == "blocked", payload
+    assert payload["needs_human_attention"] is True, payload
+    assert payload["message_class_hint"] == "decision_request", payload
+    assert payload["recommended_wait_minutes"] == 5, payload
+    assert payload["retry_mode"] == "manual_recheck", payload
+    assert payload["planner_profile"] == "local_ollama", payload
+    assert payload["launch_mode"] == "direct", payload
+    assert payload["local_model_route"] == "direct_local_ollama", payload
+    assert payload["first_action_command"].startswith("python3 planningops/scripts/run_monday_local_operator_stack.py"), payload
+    assert payload["monday_runtime_entrypoint_command"].startswith("cd ../monday && python3 scripts/run_local_runtime_smoke.py"), payload
+    assert payload["rollback_command"] == "cd ../platform-provider-gateway && bash scripts/litellm_stack_launcher.sh --mode start", payload
+    assert payload["local_validation_snapshot_status"] == "present", payload
+    assert payload["local_validation_action_lines"] == [
+        "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)"
+    ], payload
+    assert payload["bridge_contract_ref"] == "planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md", payload
+    assert str(latest_path) in payload["attachments"], payload
+    assert str(stamped_path) in payload["attachments"], payload
+    assert str((validation_dir / "monday-local-operator-day-packet.json").resolve()) in payload["attachments"], payload
+    assert payload["source_artifacts"]["day_packet_path"] == str((validation_dir / "monday-local-operator-day-packet.json").resolve()), payload
+    assert payload["source_artifacts"]["mission_packet_path"] == str((validation_dir / "monday-local-mission-packet.json").resolve()), payload
+    assert payload["source_artifacts"]["handoff_report_path"] == str((validation_dir / "operator-handoff-report.json").resolve()), payload
+    assert payload["source_artifacts"]["local_operator_report_path"] == str((validation_dir / "monday-local-operator-stack-report.json").resolve()), payload
+    assert payload["body_markdown"] == "## Monday Local Operator Day Packet", payload
+
+assert stdout_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stdout_doc
+assert output_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), output_doc
+assert latest_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), latest_doc
+assert stamped_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stamped_doc
+PY
+
+echo "write monday local operator inbox payload ok"

--- a/planningops/scripts/write_monday_local_operator_inbox_payload.py
+++ b/planningops/scripts/write_monday_local_operator_inbox_payload.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_VALIDATION_ROOT = WORKSPACE_ROOT / "planningops/artifacts/validation"
+DEFAULT_DAY_PACKET = DEFAULT_VALIDATION_ROOT / "monday-local-operator-day-packet.json"
+CONTRACT_REF = "planningops/contracts/monday-local-operator-inbox-payload-bridge-contract.md"
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def utc_timestamp_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def resolve_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (WORKSPACE_ROOT / path).resolve()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def require_dict(doc: object, label: str) -> dict:
+    if not isinstance(doc, dict):
+        raise SystemExit(f"{label} must be a JSON object")
+    return doc
+
+
+def require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def normalize_string_list(raw_values: object) -> list[str]:
+    return [str(value) for value in list(raw_values or []) if str(value).strip()]
+
+
+def dedupe_preserve_order(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def require_existing_path(raw_path: object, label: str) -> Path:
+    path = require_string(raw_path, label)
+    resolved = resolve_path(path)
+    if not resolved.exists():
+        raise SystemExit(f"{label} missing: {resolved}")
+    return resolved
+
+
+def derive_status(*, local_runtime_summary: str, local_validation_action_lines: list[str]) -> tuple[str, bool, str, int, str]:
+    lowered_summary = local_runtime_summary.lower()
+    blocked = bool(local_validation_action_lines) or "verdict=fail" in lowered_summary or "readiness=blocked" in lowered_summary
+    if blocked:
+        return "blocked", True, "decision_request", 5, "manual_recheck"
+    return "ready", False, "status_update", 0, "none"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Write a monday-friendly inbox payload bridge from a promoted local operator day packet.")
+    parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    parser.add_argument("--day-packet", default=str(DEFAULT_DAY_PACKET))
+    parser.add_argument("--bridge-id", default=f"monday-local-inbox-{utc_timestamp_slug()}")
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    validation_root = resolve_path(args.validation_root)
+    day_packet_path = resolve_path(args.day_packet)
+    output_path = None if args.output is None else resolve_path(args.output)
+
+    if not day_packet_path.exists():
+        raise SystemExit(f"day packet missing: {day_packet_path}")
+    if not (WORKSPACE_ROOT / CONTRACT_REF).exists():
+        raise SystemExit(f"inbox payload bridge contract missing: {CONTRACT_REF}")
+
+    day_packet_doc = require_dict(load_json(day_packet_path), "day packet")
+    day_packet = require_dict(day_packet_doc.get("day_packet"), "day packet payload")
+    source_artifacts = require_dict(day_packet.get("source_artifacts"), "day packet source artifacts")
+
+    mission_packet_path = require_existing_path(source_artifacts.get("mission_packet_path"), "mission packet path")
+    handoff_report_path = require_existing_path(source_artifacts.get("handoff_report_path"), "handoff report path")
+    local_operator_report_path = require_existing_path(source_artifacts.get("local_operator_report_path"), "local operator report path")
+
+    bridge_id = args.bridge_id
+    latest_payload_path = validation_root / "monday-local-operator-inbox-payload.json"
+    stamped_payload_path = validation_root / f"{bridge_id}-monday-local-operator-inbox-payload.json"
+
+    headline = require_string(day_packet.get("headline"), "headline")
+    first_action_command = require_string(day_packet.get("first_action_command"), "first action command")
+    monday_runtime_entrypoint_command = require_string(
+        day_packet.get("monday_runtime_entrypoint_command"),
+        "monday runtime entrypoint command",
+    )
+    rollback_command = require_string(day_packet.get("rollback_command"), "rollback command")
+    body_markdown = require_string(day_packet.get("body_markdown"), "body markdown")
+    planner_profile = require_string(day_packet.get("planner_profile"), "planner profile")
+    launch_mode = require_string(day_packet.get("launch_mode"), "launch mode")
+    local_model_route = require_string(day_packet.get("local_model_route"), "local model route")
+    local_validation_snapshot_status = require_string(
+        day_packet.get("local_validation_snapshot_status"),
+        "local validation snapshot status",
+    )
+
+    local_validation_summary_lines = normalize_string_list(day_packet.get("local_validation_summary_lines"))
+    local_validation_action_lines = normalize_string_list(day_packet.get("local_validation_action_lines"))
+    queue_lines = normalize_string_list(day_packet.get("queue_lines"))
+    target_lines = normalize_string_list(day_packet.get("target_lines"))
+    immediate_actions = normalize_string_list(day_packet.get("immediate_actions"))
+    local_runtime_summary = str(day_packet.get("local_runtime_summary") or "").strip()
+
+    status, needs_human_attention, message_class_hint, recommended_wait_minutes, retry_mode = derive_status(
+        local_runtime_summary=local_runtime_summary,
+        local_validation_action_lines=local_validation_action_lines,
+    )
+
+    attachments = dedupe_preserve_order(
+        [
+            str(latest_payload_path.resolve()),
+            str(stamped_payload_path.resolve()),
+            str(day_packet_path.resolve()),
+            str(mission_packet_path.resolve()),
+            str(handoff_report_path.resolve()),
+            str(local_operator_report_path.resolve()),
+            *normalize_string_list(day_packet.get("attachments")),
+        ]
+    )
+    if not attachments:
+        raise SystemExit("attachments must not be empty")
+
+    payload = {
+        "title": headline,
+        "status": status,
+        "headline": headline,
+        "priority_headline": headline,
+        "operator_action": "launch_monday_local_runtime",
+        "recommended_wait_minutes": recommended_wait_minutes,
+        "retry_mode": retry_mode,
+        "needs_human_attention": needs_human_attention,
+        "message_class_hint": message_class_hint,
+        "planner_profile": planner_profile,
+        "launch_mode": launch_mode,
+        "local_model_route": local_model_route,
+        "day_packet_id": str(day_packet.get("day_packet_id") or ""),
+        "mission_packet_id": str(day_packet.get("mission_packet_id") or ""),
+        "mission_objective": str(day_packet.get("mission_objective") or ""),
+        "first_action_command": first_action_command,
+        "monday_runtime_entrypoint_command": monday_runtime_entrypoint_command,
+        "rollback_command": rollback_command,
+        "local_validation_snapshot_status": local_validation_snapshot_status,
+        "local_validation_summary_lines": local_validation_summary_lines,
+        "local_validation_action_lines": local_validation_action_lines,
+        "queue_lines": queue_lines,
+        "target_lines": target_lines,
+        "immediate_actions": immediate_actions,
+        "attachments": attachments,
+        "body_markdown": body_markdown,
+        "bridge_contract_ref": CONTRACT_REF,
+        "source_artifacts": {
+            "day_packet_path": str(day_packet_path.resolve()),
+            "mission_packet_path": str(mission_packet_path.resolve()),
+            "handoff_report_path": str(handoff_report_path.resolve()),
+            "local_operator_report_path": str(local_operator_report_path.resolve()),
+        },
+    }
+
+    bridge_doc = {
+        "generated_at_utc": now_utc(),
+        "bridge_id": bridge_id,
+        "contract_ref": CONTRACT_REF,
+        "artifact_paths": {
+            "latest_payload_path": str(latest_payload_path.resolve()),
+            "stamped_payload_path": str(stamped_payload_path.resolve()),
+            "output_path": None if output_path is None else str(output_path.resolve()),
+        },
+        "payload": payload,
+    }
+
+    write_json(latest_payload_path, bridge_doc)
+    write_json(stamped_payload_path, bridge_doc)
+    if output_path is not None:
+        write_json(output_path, bridge_doc)
+
+    print(json.dumps(bridge_doc, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- promote a monday-friendly inbox payload bridge from the local operator day packet
- extend local validation freshness so the inbox payload bridge joins the same promotion lane as operator, handoff, mission, and day artifacts
- update the local Codex runtime rollout plan to reflect the promoted inbox payload bridge layer

## Scope
- planningops inbox payload bridge contract, writer, and regression coverage
- local validation freshness query expansion
- rollout plan update

## Linked Issues
- Closes #948

## Validation
- python3 -m py_compile planningops/scripts/write_monday_local_operator_inbox_payload.py planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_write_monday_local_operator_inbox_payload.sh
- bash planningops/scripts/test_write_monday_local_operator_day_packet.sh
- bash planningops/scripts/test_write_monday_local_mission_packet.sh
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- local validation freshness ordering now includes an extra promoted inbox payload family, so downstream exact-string fixtures depend on the new family order
- the bridge payload is still planningops-owned until monday exposes a canonical native consumer

## Review Checklist
- [ ] Verify the promoted inbox payload paths are deterministic latest/stamped mirrors
- [ ] Verify the query surface now reports inbox payload freshness and promotability alongside the existing families
- [ ] Verify rollout documentation still matches the implemented packet ladder

## Post-Deploy Monitoring & Validation
- Re-run `bash planningops/scripts/test_query_federated_ci_artifacts.sh` after merge if local validation ordering changes again
- Confirm PR checks reach the usual steady state: template/docs/contract/federated/o11y pass and inherited runtime lanes remain unchanged
