### PR TITLE
docs(local-runtime): record monday inbox bridge consumer

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -140,6 +140,13 @@ Current deliverables:
 - `planningops/artifacts/validation/monday-local-operator-inbox-payload.json`
 - `planningops/artifacts/validation/<bridge-id>-monday-local-operator-inbox-payload.json`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now includes the promoted inbox payload bridge family in the same promotion lane
+- `monday/contracts/planningops-local-operator-inbox-consumer-contract.md`
+- `monday/scripts/consume_planningops_local_operator_inbox_payload.py`
+- `monday/scripts/test_consume_planningops_local_operator_inbox_payload.sh`
+- `monday/runtime-artifacts/integration/planningops-local-operator-inbox/<run-id>/launch-request.json`
+- `monday/runtime-artifacts/integration/planningops-local-operator-inbox/<run-id>/mission.json`
+- `monday/runtime-artifacts/integration/planningops-local-operator-inbox/<run-id>/consumer-report.json`
+- monday now consumes the promoted inbox payload as structured input and materializes native runtime command argv without reparsing day-packet markdown
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -201,6 +208,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. add a monday-native consumer that accepts the promoted inbox payload bridge without reparsing day packet markdown
-2. decide whether the inbox payload bridge should be schema-validated against a monday-owned payload contract once that surface exists
-3. add a dedicated query/report surface for the promoted inbox payload bridge if operators need a payload-first view separate from `handoff-report`
+1. decide whether the inbox payload bridge and the monday-native consumer report should be schema-validated against monday-owned contracts
+2. add an apply-path regression for the monday consumer that exercises a `ready` launch through `scripts/run_local_runtime_smoke.py`
+3. add a dedicated query/report surface for the promoted inbox payload bridge or monday consumer report if operators need a payload-first view separate from `handoff-report`


### PR DESCRIPTION
## Summary
- update the monday local Codex rollout plan after the monday-native inbox payload consumer landed
- record the new monday contract, consumer script, and runtime-artifact surfaces
- move the next packets to post-consumer schema/apply/query follow-up

## Scope
- rollout plan refresh only

## Linked Issues
- Closes #950

## Validation
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- this plan update assumes the sibling monday consumer branch merges alongside it

## Review Checklist
- [ ] Verify the current deliverables list now includes the monday-native inbox consumer boundary
- [ ] Verify the next natural packets now start after the consumer exists
- [ ] Verify no other rollout phases were unintentionally changed

## Post-Deploy Monitoring & Validation
- Re-run `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- Re-run `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
