### PR TITLE
docs(local-runtime): record ready apply regression

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -147,6 +147,11 @@ Current deliverables:
 - `monday/runtime-artifacts/integration/planningops-local-operator-inbox/<run-id>/mission.json`
 - `monday/runtime-artifacts/integration/planningops-local-operator-inbox/<run-id>/consumer-report.json`
 - monday now consumes the promoted inbox payload as structured input and materializes native runtime command argv without reparsing day-packet markdown
+- monday consumer regression now covers:
+  - ready dry-run packet materialization
+  - ready apply-time local runtime smoke through `scripts/run_local_runtime_smoke.py`
+  - blocked apply-time fail-closed behavior
+- explicit `--planner-runtime-config` and `--runtime-profile-file` passthrough can pin deterministic apply-time runtime inputs for local regression
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -209,5 +214,5 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. decide whether the inbox payload bridge and the monday-native consumer report should be schema-validated against monday-owned contracts
-2. add an apply-path regression for the monday consumer that exercises a `ready` launch through `scripts/run_local_runtime_smoke.py`
-3. add a dedicated query/report surface for the promoted inbox payload bridge or monday consumer report if operators need a payload-first view separate from `handoff-report`
+2. add a dedicated query/report surface for the promoted inbox payload bridge or monday consumer report if operators need a payload-first view separate from `handoff-report`
+3. decide whether the consumer's runtime input overrides should stay regression-only or be promoted into a reviewed operator-facing escape hatch


### PR DESCRIPTION
## Summary
- update the monday local Codex rollout plan after the monday inbox consumer gained a ready apply regression
- record that the consumer now covers ready dry-run, ready apply, and blocked apply behavior
- move the next packets to post-apply schema/query/operator-surface follow-up

## Scope
- rollout plan refresh only

## Linked Issues
- Closes #952

## Validation
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- this plan update assumes the sibling monday apply-regression branch merges alongside it

## Review Checklist
- [ ] Verify the deliverables list now mentions ready dry-run, ready apply, and blocked apply coverage
- [ ] Verify the next natural packets no longer include the ready apply regression as future work
- [ ] Verify no unrelated rollout phases changed

## Post-Deploy Monitoring & Validation
- Re-run `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- Re-run `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
