### PR TITLE
feat(query-engine): surface consumer override usage

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -148,6 +148,7 @@ Current deliverables:
 - `monday/runtime-artifacts/integration/planningops-local-operator-inbox/<run-id>/mission.json`
 - `monday/runtime-artifacts/integration/planningops-local-operator-inbox/<run-id>/consumer-report.json`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py monday-consumer-report` exposes a monday-native apply/result view over dry-run, apply-pass, and blocked consumer reports
+- `planningops/scripts/federation/query_federated_ci_artifacts.py monday-consumer-report` now also exposes `runtime_input_overrides` usage for audit; overrides remain regression-only and are not yet promoted to an operator-facing escape hatch
 - monday now consumes the promoted inbox payload as structured input and materializes native runtime command argv without reparsing day-packet markdown
 - monday consumer regression now covers:
   - ready dry-run packet materialization
@@ -216,5 +217,5 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. decide whether the inbox payload bridge and the monday-native consumer report should be schema-validated against monday-owned contracts
-2. decide whether the consumer's runtime input overrides should stay regression-only or be promoted into a reviewed operator-facing escape hatch
-3. decide whether launch-request, runtime-report, or consumer-report freshness should be mirrored back into planningops-owned validation artifacts
+2. decide whether launch-request, runtime-report, or consumer-report freshness should be mirrored back into planningops-owned validation artifacts
+3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -395,6 +395,10 @@ class MondayConsumerReportRecord:
     local_validation_snapshot_status: str | None
     block_reasons: list[str]
     command_args: list[str]
+    has_runtime_input_overrides: bool
+    override_kinds: list[str]
+    planner_runtime_config_path: str | None
+    runtime_profile_file_path: str | None
     execution_attempted: bool | None
     execution_exit_code: int | None
     runtime_report_verdict: str | None
@@ -1226,6 +1230,9 @@ def build_monday_consumer_report_record(
 ) -> MondayConsumerReportRecord:
     artifact_paths = report_doc.get("artifact_paths") if isinstance(report_doc.get("artifact_paths"), dict) else {}
     launch_request = report_doc.get("launch_request") if isinstance(report_doc.get("launch_request"), dict) else {}
+    runtime_input_overrides = (
+        launch_request.get("runtime_input_overrides") if isinstance(launch_request.get("runtime_input_overrides"), dict) else {}
+    )
     execution = report_doc.get("execution") if isinstance(report_doc.get("execution"), dict) else {}
     runtime_report_summary = (
         report_doc.get("runtime_report_summary") if isinstance(report_doc.get("runtime_report_summary"), dict) else {}
@@ -1235,6 +1242,13 @@ def build_monday_consumer_report_record(
     runtime_report_path = resolve_artifact_path(artifact_paths.get("runtime_report_path"))
     execution_attempted = execution.get("attempted") if isinstance(execution.get("attempted"), bool) else None
     execution_exit_code = execution.get("exit_code") if isinstance(execution.get("exit_code"), int) else None
+    planner_runtime_config_path = normalize_optional_string(runtime_input_overrides.get("planner_runtime_config"))
+    runtime_profile_file_path = normalize_optional_string(runtime_input_overrides.get("runtime_profile_file"))
+    override_kinds: list[str] = []
+    if planner_runtime_config_path is not None:
+        override_kinds.append("planner_runtime_config")
+    if runtime_profile_file_path is not None:
+        override_kinds.append("runtime_profile_file")
     return MondayConsumerReportRecord(
         run_id=str(report_doc.get("run_id")),
         report_path=str(report_path.resolve()),
@@ -1251,6 +1265,10 @@ def build_monday_consumer_report_record(
         local_validation_snapshot_status=normalize_optional_string(launch_request.get("local_validation_snapshot_status")),
         block_reasons=normalize_string_list(launch_request.get("block_reasons")),
         command_args=normalize_string_list(launch_request.get("runtime_command_args")),
+        has_runtime_input_overrides=bool(override_kinds),
+        override_kinds=override_kinds,
+        planner_runtime_config_path=planner_runtime_config_path,
+        runtime_profile_file_path=runtime_profile_file_path,
         execution_attempted=execution_attempted,
         execution_exit_code=execution_exit_code,
         runtime_report_verdict=normalize_optional_string(runtime_report_summary.get("verdict")),
@@ -1298,6 +1316,8 @@ def filter_monday_consumer_report_records(
     planner_profile: str | None = None,
     launch_mode: str | None = None,
     local_model_route: str | None = None,
+    has_runtime_input_overrides: str | None = None,
+    override_kind: str | None = None,
     has_runtime_report: str | None = None,
     execution_attempted: str | None = None,
 ) -> list[MondayConsumerReportRecord]:
@@ -1321,6 +1341,11 @@ def filter_monday_consumer_report_records(
         filtered = [record for record in filtered if record.launch_mode == launch_mode]
     if local_model_route:
         filtered = [record for record in filtered if record.local_model_route == local_model_route]
+    if has_runtime_input_overrides is not None:
+        expected = has_runtime_input_overrides == "yes"
+        filtered = [record for record in filtered if record.has_runtime_input_overrides is expected]
+    if override_kind:
+        filtered = [record for record in filtered if override_kind in record.override_kinds]
     if has_runtime_report is not None:
         expected = has_runtime_report == "yes"
         filtered = [record for record in filtered if record.has_runtime_report is expected]
@@ -1332,7 +1357,7 @@ def filter_monday_consumer_report_records(
 
 def render_monday_consumer_report_table(records: list[MondayConsumerReportRecord]) -> str:
     lines = [
-        "run_id\tmode\tverdict\treason_code\tconsumer_status\tcan_launch\tplanner_profile\tlaunch_mode\tlocal_model_route\texecution_attempted\texecution_exit_code\truntime_report_verdict\thas_runtime_report\tblock_reasons\tgenerated_at_utc",
+        "run_id\tmode\tverdict\treason_code\tconsumer_status\tcan_launch\tplanner_profile\tlaunch_mode\tlocal_model_route\thas_runtime_overrides\toverride_kinds\texecution_attempted\texecution_exit_code\truntime_report_verdict\thas_runtime_report\tblock_reasons\tgenerated_at_utc",
     ]
     for record in records:
         lines.append(
@@ -1347,6 +1372,8 @@ def render_monday_consumer_report_table(records: list[MondayConsumerReportRecord
                     str(record.planner_profile or ""),
                     str(record.launch_mode or ""),
                     str(record.local_model_route or ""),
+                    "yes" if record.has_runtime_input_overrides else "no",
+                    ",".join(record.override_kinds),
                     (
                         ""
                         if record.execution_attempted is None
@@ -1365,8 +1392,8 @@ def render_monday_consumer_report_table(records: list[MondayConsumerReportRecord
 
 def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRecord]) -> str:
     lines = [
-        "| run_id | mode | verdict | reason_code | consumer_status | can_launch | planner_profile | launch_mode | local_model_route | execution_attempted | execution_exit_code | runtime_report_verdict | has_runtime_report | block_reasons | generated_at_utc |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
+        "| run_id | mode | verdict | reason_code | consumer_status | can_launch | planner_profile | launch_mode | local_model_route | has_runtime_overrides | override_kinds | execution_attempted | execution_exit_code | runtime_report_verdict | has_runtime_report | block_reasons | generated_at_utc |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
     ]
     for record in records:
         lines.append(
@@ -1374,6 +1401,8 @@ def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRec
             f"{record.consumer_status or ''} | "
             f"{'' if record.can_launch is None else ('yes' if record.can_launch else 'no')} | "
             f"{record.planner_profile or ''} | {record.launch_mode or ''} | {record.local_model_route or ''} | "
+            f"{'yes' if record.has_runtime_input_overrides else 'no'} | "
+            f"{', '.join(record.override_kinds)} | "
             f"{'' if record.execution_attempted is None else ('yes' if record.execution_attempted else 'no')} | "
             f"{'' if record.execution_exit_code is None else record.execution_exit_code} | "
             f"{record.runtime_report_verdict or ''} | "
@@ -4052,6 +4081,8 @@ def parse_args() -> argparse.Namespace:
     monday_consumer_parser.add_argument("--planner-profile", default=None)
     monday_consumer_parser.add_argument("--launch-mode", default=None)
     monday_consumer_parser.add_argument("--local-model-route", default=None)
+    monday_consumer_parser.add_argument("--has-runtime-overrides", choices=["yes", "no"], default=None)
+    monday_consumer_parser.add_argument("--override-kind", choices=["planner_runtime_config", "runtime_profile_file"], default=None)
     monday_consumer_parser.add_argument("--has-runtime-report", choices=["yes", "no"], default=None)
     monday_consumer_parser.add_argument("--execution-attempted", choices=["yes", "no"], default=None)
     monday_consumer_parser.add_argument("--limit", type=int, default=20)
@@ -4139,6 +4170,8 @@ def main() -> int:
             planner_profile=args.planner_profile,
             launch_mode=args.launch_mode,
             local_model_route=args.local_model_route,
+            has_runtime_input_overrides=args.has_runtime_overrides,
+            override_kind=args.override_kind,
             has_runtime_report=args.has_runtime_report,
             execution_attempted=args.execution_attempted,
         )

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -659,6 +659,7 @@ LOCAL_INBOX_PAYLOAD_FILTERED_OUTPUT="$TMP_DIR/local-inbox-payload-filtered.json"
 MONDAY_CONSUMER_OUTPUT="$TMP_DIR/monday-consumer-report.json"
 MONDAY_CONSUMER_FILTERED_OUTPUT="$TMP_DIR/monday-consumer-report-filtered.json"
 MONDAY_CONSUMER_BLOCKED_OUTPUT="$TMP_DIR/monday-consumer-report-blocked.json"
+MONDAY_CONSUMER_OVERRIDE_OUTPUT="$TMP_DIR/monday-consumer-report-override.json"
 LOCAL_OPERATOR_OUTPUT="$TMP_DIR/local-operator-stack.json"
 LOCAL_OPERATOR_FILTERED_OUTPUT="$TMP_DIR/local-operator-stack-filtered.json"
 LOCAL_OPERATOR_DETAIL_OUTPUT="$TMP_DIR/local-operator-stack-detail.json"
@@ -2963,6 +2964,46 @@ cat >"$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/loc
 }
 JSON
 
+cat >"$TMP_DIR/planner-runtime.json" <<'JSON'
+{
+  "profile": "local_ollama"
+}
+JSON
+
+cat >"$TMP_DIR/runtime-profiles.json" <<'JSON'
+{
+  "profiles": [
+    "local_ollama"
+  ]
+}
+JSON
+
+python3 - <<'PY' "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/launch-request.json" "$TMP_DIR/planner-runtime.json" "$TMP_DIR/runtime-profiles.json"
+import json
+import sys
+from pathlib import Path
+
+launch_request_path = Path(sys.argv[1])
+planner_runtime_path = Path(sys.argv[2]).resolve()
+runtime_profiles_path = Path(sys.argv[3]).resolve()
+doc = json.loads(launch_request_path.read_text(encoding="utf-8"))
+doc["runtime_command_args"] = [
+    "python3",
+    "scripts/run_local_runtime_smoke.py",
+    "--profile",
+    "local_ollama",
+    "--planner-runtime-config",
+    str(planner_runtime_path),
+    "--runtime-profile-file",
+    str(runtime_profiles_path),
+]
+doc["runtime_input_overrides"] = {
+    "planner_runtime_config": str(planner_runtime_path),
+    "runtime_profile_file": str(runtime_profiles_path),
+}
+launch_request_path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
 cat >"$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/consumer-report.json" <<JSON
 {
   "generated_at_utc": "2026-04-01T10:20:00+00:00",
@@ -2983,12 +3024,14 @@ cat >"$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/con
   "launch_request": $(cat "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/launch-request.json"),
   "execution": {
     "attempted": true,
-    "command_args": [
-      "python3",
-      "scripts/run_local_runtime_smoke.py",
-      "--profile",
-      "local_ollama"
-    ],
+    "command_args": $(python3 - <<'PY' "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/launch-request.json"
+import json
+import sys
+from pathlib import Path
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(json.dumps(doc["runtime_command_args"]))
+PY
+),
     "exit_code": 0,
     "stdout": "runtime ok",
     "stderr": ""
@@ -3111,6 +3154,13 @@ assert passed_apply["execution_exit_code"] == 0, passed_apply
 assert passed_apply["has_runtime_report"] is True, passed_apply
 assert passed_apply["runtime_report_verdict"] == "pass", passed_apply
 assert passed_apply["runtime_report_reason_code"] == "ok", passed_apply
+assert passed_apply["has_runtime_input_overrides"] is True, passed_apply
+assert passed_apply["override_kinds"] == [
+    "planner_runtime_config",
+    "runtime_profile_file",
+], passed_apply
+assert passed_apply["planner_runtime_config_path"].endswith("/planner-runtime.json"), passed_apply
+assert passed_apply["runtime_profile_file_path"].endswith("/runtime-profiles.json"), passed_apply
 
 assert dry_run["mode"] == "dry-run", dry_run
 assert dry_run["verdict"] == "pass", dry_run
@@ -3120,11 +3170,14 @@ assert dry_run["execution_attempted"] is None, dry_run
 assert dry_run["has_launch_request"] is True, dry_run
 assert dry_run["has_mission_file"] is True, dry_run
 assert dry_run["has_runtime_report"] is False, dry_run
+assert dry_run["has_runtime_input_overrides"] is False, dry_run
 PY
 
 python3 "$QUERY_PATH" monday-consumer-report \
   --mode apply \
   --verdict pass \
+  --has-runtime-overrides yes \
+  --override-kind runtime_profile_file \
   --has-runtime-report yes \
   --execution-attempted yes \
   --format json \
@@ -3142,6 +3195,7 @@ record = records[0]
 assert record["run_id"] == "planningops-local-inbox-consumer-20260401T102000Z", record
 assert record["runtime_report_verdict"] == "pass", record
 assert record["reason_code"] == "ok", record
+assert record["has_runtime_input_overrides"] is True, record
 PY
 
 python3 "$QUERY_PATH" monday-consumer-report \
@@ -3162,6 +3216,25 @@ record = records[0]
 assert record["run_id"] == "planningops-local-inbox-consumer-20260401T103000Z", record
 assert record["verdict"] == "blocked", record
 assert record["execution_attempted"] is False, record
+PY
+
+python3 "$QUERY_PATH" monday-consumer-report \
+  --has-runtime-overrides no \
+  --format json \
+  --consumer-root "$MONDAY_CONSUMER_DIR" >"$MONDAY_CONSUMER_OVERRIDE_OUTPUT"
+
+python3 - <<'PY' "$MONDAY_CONSUMER_OVERRIDE_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["run_id"] for record in records] == [
+    "planningops-local-inbox-consumer-20260401T103000Z",
+    "planningops-local-inbox-consumer-20260401T101000Z",
+], records
+assert all(record["has_runtime_input_overrides"] is False for record in records), records
 PY
 
 echo "query federated ci artifacts ok"


### PR DESCRIPTION
## Summary
- surface runtime input override usage in `monday-consumer-report`
- keep overrides regression-only while making them auditable from planningops
- update the monday local codex rollout plan with the current policy and next packets

## Scope
- add override fields and filters to `planningops/scripts/federation/query_federated_ci_artifacts.py`
- extend `planningops/scripts/test_query_federated_ci_artifacts.sh`
- update `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #958

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- query/reporting only; no monday runtime behavior changes
- override visibility stays audit-only and does not promote an operator escape hatch

## Review Checklist
- [ ] override usage is visible in monday consumer records
- [ ] filters cover `--has-runtime-overrides` and `--override-kind`
- [ ] rollout plan records the regression-only override policy

## Post-Deploy Monitoring & Validation
- confirm `template-and-link-check` stays green
- verify inherited red lanes remain unchanged
