### PR TITLE
feat(local-runtime): mirror monday consumer artifacts into validation lane

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -161,6 +161,15 @@ Current deliverables:
   - blocked apply-time fail-closed behavior
 - explicit `--planner-runtime-config` and `--runtime-profile-file` passthrough can pin deterministic apply-time runtime inputs for local regression
 - `monday/scripts/run_local_runtime_smoke.py` now records the reviewed `--planner-runtime-config` override in smoke evidence instead of rejecting the consumer-produced argv
+- `planningops/contracts/monday-local-inbox-validation-mirror-contract.md`
+- `planningops/scripts/write_monday_local_inbox_validation_mirror.py`
+- `planningops/artifacts/validation/monday-local-inbox-launch-request.json`
+- `planningops/artifacts/validation/<run-id>-monday-local-inbox-launch-request.json`
+- `planningops/artifacts/validation/monday-local-inbox-runtime-report.json`
+- `planningops/artifacts/validation/<run-id>-monday-local-inbox-runtime-report.json`
+- `planningops/artifacts/validation/monday-local-inbox-consumer-report.json`
+- `planningops/artifacts/validation/<run-id>-monday-local-inbox-consumer-report.json`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now picks up the mirrored monday launch-request, runtime-report, and consumer-report families when they are present in planningops validation
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -222,6 +231,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether launch-request, runtime-report, or consumer-report freshness should be mirrored back into planningops-owned validation artifacts
-2. decide whether monday-owned schema validation reports should stay monday-side only or also surface through planningops query/report views
+1. decide whether monday-owned schema validation reports should stay monday-side only or also surface through planningops query/report views
+2. decide whether launch-request, runtime-report, and consumer-report freshness should also be folded into `handoff-report` local validation snapshots
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/contracts/monday-local-inbox-validation-mirror-contract.md
+++ b/planningops/contracts/monday-local-inbox-validation-mirror-contract.md
@@ -1,0 +1,63 @@
+# Monday Local Inbox Validation Mirror Contract
+
+## Purpose
+
+Promote monday-owned local inbox consumer evidence into planningops-owned validation artifacts so freshness and promotability can be judged without leaving the planningops validation lane.
+
+## Artifact Families
+
+- `monday_local_inbox_launch_request`
+- `monday_local_inbox_runtime_report`
+- `monday_local_inbox_consumer_report`
+
+Each family writes two mirrors:
+
+- latest: `planningops/artifacts/validation/<family-latest>.json`
+- stamped: `planningops/artifacts/validation/<run-id>-<family-latest>.json`
+
+## Required Top-Level Fields
+
+- `generated_at_utc`
+- `run_id`
+- `artifact_family`
+- `artifact_kind`
+- `contract_ref`
+- `artifact_paths.latest_mirror_path`
+- `artifact_paths.stamped_mirror_path`
+- `artifact_paths.source_artifact_path`
+- `artifact_paths.source_launch_request_path`
+- `artifact_paths.source_runtime_report_path`
+- `artifact_paths.source_consumer_report_path`
+- `mirror.source_artifact_present`
+- `mirror.bridge_id`
+- `mirror.mode`
+- `mirror.consumer_verdict`
+- `mirror.consumer_status`
+- `mirror.planner_profile`
+- `mirror.launch_mode`
+- `mirror.local_model_route`
+- `mirror.has_runtime_input_overrides`
+- `mirror.override_kinds`
+- `mirror.validation_dependency_paths`
+- `mirror.payload`
+
+## Contract Rules
+
+1. latest and stamped documents for the same family must carry the same `run_id`, `artifact_family`, `artifact_kind`, and `mirror` payload.
+2. `artifact_paths.latest_mirror_path` must point at the latest mirror written into planningops validation.
+3. `artifact_paths.stamped_mirror_path` must point at the stamped mirror written for the selected monday consumer `run_id`.
+4. `artifact_paths.source_artifact_path` must point at the monday-owned source artifact for the mirrored family, even when that source artifact is expected-but-missing.
+5. `mirror.validation_dependency_paths` must reference planningops-owned latest validation artifacts, not monday runtime-artifact paths.
+6. launch-request and consumer-report mirrors must carry a JSON object in `mirror.payload`.
+7. runtime-report mirrors may set `mirror.payload` to `null` only when `mirror.source_artifact_present=false`.
+
+## Dependency Expectations
+
+- `monday_local_inbox_launch_request` depends on `monday_local_operator_inbox_payload`
+- `monday_local_inbox_runtime_report` depends on:
+  - `monday_local_operator_inbox_payload`
+  - `monday_local_inbox_launch_request`
+- `monday_local_inbox_consumer_report` depends on:
+  - `monday_local_operator_inbox_payload`
+  - `monday_local_inbox_launch_request`
+  - `monday_local_inbox_runtime_report`

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -58,6 +58,9 @@ LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_mission_packet",
     "monday_local_operator_day_packet",
     "monday_local_operator_inbox_payload",
+    "monday_local_inbox_launch_request",
+    "monday_local_inbox_runtime_report",
+    "monday_local_inbox_consumer_report",
 )
 LOCAL_VALIDATION_FRESHNESS_CHOICES = ("fresh", "stale", "missing")
 LOCAL_VALIDATION_PROMOTABILITY_CHOICES = ("promotable", "blocked")
@@ -1835,14 +1838,203 @@ def build_inbox_payload_validation_freshness_record(*, validation_root: Path) ->
     )
 
 
+def has_promoted_local_validation_artifact(
+    *,
+    validation_root: Path,
+    latest_filename: str,
+    stamped_glob: str,
+) -> bool:
+    latest_path = validation_root / latest_filename
+    if latest_path.exists():
+        return True
+    return any(path.is_file() for path in validation_root.glob(stamped_glob))
+
+
+def build_monday_local_inbox_validation_freshness_record(
+    *,
+    validation_root: Path,
+    artifact_family: str,
+    artifact_kind: str,
+    latest_filename: str,
+    dependency_filenames: dict[str, str],
+) -> LocalValidationFreshnessRecord:
+    latest_path = (validation_root / latest_filename).resolve()
+    latest_doc = load_optional_json(latest_path)
+    freshness_reasons: list[str] = []
+    promotability_reasons: list[str] = []
+    dependency_states: dict[str, str] = {}
+    stamped_path: Path | None = None
+    promoted_id: str | None = None
+    generated_at_utc: str | None = None
+
+    if latest_doc is not None:
+        promoted_id = normalize_optional_string(latest_doc.get("run_id"))
+        generated_at_utc = normalize_optional_string(latest_doc.get("generated_at_utc"))
+        if promoted_id is None:
+            promotability_reasons.append("missing_run_id")
+        if normalize_optional_string(latest_doc.get("artifact_family")) != artifact_family:
+            promotability_reasons.append("artifact_family_mismatch")
+        if normalize_optional_string(latest_doc.get("artifact_kind")) != artifact_kind:
+            promotability_reasons.append("artifact_kind_mismatch")
+        if normalize_optional_string(latest_doc.get("contract_ref")) is None:
+            promotability_reasons.append("missing_contract_ref")
+
+        latest_mirror_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "latest_mirror_path")
+        stamped_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "stamped_mirror_path")
+        source_artifact_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "source_artifact_path")
+        if latest_mirror_path != latest_path:
+            freshness_reasons.append("latest_path_mismatch")
+
+        mirror = resolve_nested_value(latest_doc, "mirror")
+        if not isinstance(mirror, dict):
+            promotability_reasons.append("missing_mirror")
+        else:
+            source_artifact_present = mirror.get("source_artifact_present")
+            if not isinstance(source_artifact_present, bool):
+                promotability_reasons.append("missing_source_artifact_present")
+            else:
+                actual_source_exists = source_artifact_path.exists() if source_artifact_path is not None else False
+                if source_artifact_path is None:
+                    promotability_reasons.append("missing_source_artifact_path")
+                elif source_artifact_present != actual_source_exists:
+                    promotability_reasons.append("source_artifact_state_mismatch")
+                if not actual_source_exists:
+                    promotability_reasons.append("source_artifact_missing")
+                if source_artifact_present and not isinstance(mirror.get("payload"), dict):
+                    promotability_reasons.append("missing_payload")
+
+            validation_dependency_paths = mirror.get("validation_dependency_paths")
+            if dependency_filenames and not isinstance(validation_dependency_paths, dict):
+                promotability_reasons.append("missing_validation_dependency_paths")
+            elif isinstance(validation_dependency_paths, dict):
+                for dependency_family, dependency_filename in dependency_filenames.items():
+                    dependency_state, dependency_reason = build_local_validation_dependency_state(
+                        raw_path=validation_dependency_paths.get(dependency_family),
+                        expected_path=validation_root / dependency_filename,
+                    )
+                    dependency_states[dependency_family] = dependency_state
+                    if dependency_reason == "dependency_path_missing":
+                        promotability_reasons.append(f"missing_{dependency_family}_path")
+                    elif dependency_reason == "dependency_missing":
+                        promotability_reasons.append(f"{dependency_family}_dependency_missing")
+                    elif dependency_reason == "dependency_stale":
+                        promotability_reasons.append(f"{dependency_family}_dependency_stale")
+
+        if stamped_path is not None and stamped_path.exists():
+            stamped_doc = load_optional_json(stamped_path)
+            if stamped_doc is None:
+                freshness_reasons.append("stamped_invalid_json")
+            else:
+                if normalize_optional_string(stamped_doc.get("run_id")) != promoted_id:
+                    freshness_reasons.append("stamped_run_id_mismatch")
+                stamped_latest_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "latest_mirror_path")
+                stamped_stamped_path = resolve_nested_artifact_path(
+                    stamped_doc,
+                    "artifact_paths",
+                    "stamped_mirror_path",
+                )
+                if stamped_latest_path != latest_path:
+                    freshness_reasons.append("stamped_latest_path_mismatch")
+                if stamped_stamped_path != stamped_path.resolve():
+                    freshness_reasons.append("stamped_path_mismatch")
+
+    freshness_state, promotability_status = classify_local_validation_states(
+        latest_path=latest_path,
+        latest_doc=latest_doc,
+        stamped_path=stamped_path,
+        freshness_reasons=freshness_reasons,
+        promotability_reasons=promotability_reasons,
+        dependency_states=dependency_states,
+    )
+    return LocalValidationFreshnessRecord(
+        artifact_family=artifact_family,
+        artifact_kind=artifact_kind,
+        promoted_id=promoted_id,
+        generated_at_utc=generated_at_utc,
+        freshness_state=freshness_state,
+        promotability_status=promotability_status,
+        latest_path=str(latest_path),
+        stamped_path=None if stamped_path is None else str(stamped_path.resolve()),
+        reasons=freshness_reasons + promotability_reasons,
+        dependency_states=dependency_states,
+    )
+
+
+def build_monday_local_inbox_launch_request_validation_freshness_record(
+    *,
+    validation_root: Path,
+) -> LocalValidationFreshnessRecord:
+    return build_monday_local_inbox_validation_freshness_record(
+        validation_root=validation_root,
+        artifact_family="monday_local_inbox_launch_request",
+        artifact_kind="request",
+        latest_filename="monday-local-inbox-launch-request.json",
+        dependency_filenames={
+            "monday_local_operator_inbox_payload": "monday-local-operator-inbox-payload.json",
+        },
+    )
+
+
+def build_monday_local_inbox_runtime_report_validation_freshness_record(
+    *,
+    validation_root: Path,
+) -> LocalValidationFreshnessRecord:
+    return build_monday_local_inbox_validation_freshness_record(
+        validation_root=validation_root,
+        artifact_family="monday_local_inbox_runtime_report",
+        artifact_kind="report",
+        latest_filename="monday-local-inbox-runtime-report.json",
+        dependency_filenames={
+            "monday_local_operator_inbox_payload": "monday-local-operator-inbox-payload.json",
+            "monday_local_inbox_launch_request": "monday-local-inbox-launch-request.json",
+        },
+    )
+
+
+def build_monday_local_inbox_consumer_report_validation_freshness_record(
+    *,
+    validation_root: Path,
+) -> LocalValidationFreshnessRecord:
+    return build_monday_local_inbox_validation_freshness_record(
+        validation_root=validation_root,
+        artifact_family="monday_local_inbox_consumer_report",
+        artifact_kind="report",
+        latest_filename="monday-local-inbox-consumer-report.json",
+        dependency_filenames={
+            "monday_local_operator_inbox_payload": "monday-local-operator-inbox-payload.json",
+            "monday_local_inbox_launch_request": "monday-local-inbox-launch-request.json",
+            "monday_local_inbox_runtime_report": "monday-local-inbox-runtime-report.json",
+        },
+    )
+
+
 def discover_local_validation_freshness_records(*, validation_root: Path) -> list[LocalValidationFreshnessRecord]:
-    return [
+    records = [
         build_local_operator_validation_freshness_record(validation_root=validation_root),
         build_handoff_validation_freshness_record(validation_root=validation_root),
         build_mission_packet_validation_freshness_record(validation_root=validation_root),
         build_day_packet_validation_freshness_record(validation_root=validation_root),
         build_inbox_payload_validation_freshness_record(validation_root=validation_root),
     ]
+    if has_promoted_local_validation_artifact(
+        validation_root=validation_root,
+        latest_filename="monday-local-inbox-launch-request.json",
+        stamped_glob="*-monday-local-inbox-launch-request.json",
+    ):
+        records.append(build_monday_local_inbox_launch_request_validation_freshness_record(validation_root=validation_root))
+    if has_promoted_local_validation_artifact(
+        validation_root=validation_root,
+        latest_filename="monday-local-inbox-runtime-report.json",
+        stamped_glob="*-monday-local-inbox-runtime-report.json",
+    ):
+        records.append(build_monday_local_inbox_runtime_report_validation_freshness_record(validation_root=validation_root))
+    if has_promoted_local_validation_artifact(
+        validation_root=validation_root,
+        latest_filename="monday-local-inbox-consumer-report.json",
+        stamped_glob="*-monday-local-inbox-consumer-report.json",
+    ):
+        records.append(build_monday_local_inbox_consumer_report_validation_freshness_record(validation_root=validation_root))
+    return records
 
 
 def filter_local_validation_freshness_records(

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 QUERY_PATH="$ROOT_DIR/scripts/federation/query_federated_ci_artifacts.py"
+WRITE_LOCAL_INBOX_VALIDATION_MIRROR_PATH="$ROOT_DIR/scripts/write_monday_local_inbox_validation_mirror.py"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -653,6 +654,9 @@ HANDOFF_WRITE_OUTPUT="$TMP_DIR/handoff-write.json"
 LOCAL_VALIDATION_OUTPUT="$TMP_DIR/local-validation-freshness.json"
 LOCAL_VALIDATION_BLOCKED_OUTPUT="$TMP_DIR/local-validation-freshness-blocked.json"
 LOCAL_VALIDATION_STALE_OUTPUT="$TMP_DIR/local-validation-freshness-stale.json"
+LOCAL_VALIDATION_MIRROR_WRITE_OUTPUT="$TMP_DIR/local-validation-mirror-write.json"
+LOCAL_VALIDATION_WITH_CONSUMER_OUTPUT="$TMP_DIR/local-validation-freshness-with-consumer.json"
+LOCAL_VALIDATION_RUNTIME_BLOCKED_OUTPUT="$TMP_DIR/local-validation-runtime-blocked.json"
 LOCAL_INBOX_PAYLOAD_OUTPUT="$TMP_DIR/local-inbox-payload.json"
 LOCAL_INBOX_PAYLOAD_ALL_OUTPUT="$TMP_DIR/local-inbox-payload-all.json"
 LOCAL_INBOX_PAYLOAD_FILTERED_OUTPUT="$TMP_DIR/local-inbox-payload-filtered.json"
@@ -3235,6 +3239,100 @@ assert [record["run_id"] for record in records] == [
     "planningops-local-inbox-consumer-20260401T101000Z",
 ], records
 assert all(record["has_runtime_input_overrides"] is False for record in records), records
+PY
+
+python3 "$WRITE_LOCAL_INBOX_VALIDATION_MIRROR_PATH" \
+  --validation-root "$VALIDATION_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" >"$LOCAL_VALIDATION_MIRROR_WRITE_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_MIRROR_WRITE_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["run_id"] == "planningops-local-inbox-consumer-20260401T103000Z", doc
+assert [record["artifact_family"] for record in doc["records"]] == [
+    "monday_local_inbox_launch_request",
+    "monday_local_inbox_runtime_report",
+    "monday_local_inbox_consumer_report",
+], doc
+PY
+
+python3 "$QUERY_PATH" local-validation-freshness \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_VALIDATION_WITH_CONSUMER_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_WITH_CONSUMER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["artifact_family"] for record in records] == [
+    "monday_local_operator_stack_report",
+    "operator_handoff_report",
+    "monday_local_mission_packet",
+    "monday_local_operator_day_packet",
+    "monday_local_operator_inbox_payload",
+    "monday_local_inbox_launch_request",
+    "monday_local_inbox_runtime_report",
+    "monday_local_inbox_consumer_report",
+], records
+
+launch_request = records[5]
+runtime_report = records[6]
+consumer_report = records[7]
+
+assert launch_request["freshness_state"] == "fresh", launch_request
+assert launch_request["promotability_status"] == "promotable", launch_request
+assert launch_request["promoted_id"] == "planningops-local-inbox-consumer-20260401T103000Z", launch_request
+assert launch_request["dependency_states"] == {
+    "monday_local_operator_inbox_payload": "current",
+}, launch_request
+assert launch_request["reasons"] == [], launch_request
+
+assert runtime_report["freshness_state"] == "fresh", runtime_report
+assert runtime_report["promotability_status"] == "blocked", runtime_report
+assert runtime_report["promoted_id"] == "planningops-local-inbox-consumer-20260401T103000Z", runtime_report
+assert runtime_report["dependency_states"] == {
+    "monday_local_operator_inbox_payload": "current",
+    "monday_local_inbox_launch_request": "current",
+}, runtime_report
+assert runtime_report["reasons"] == ["source_artifact_missing"], runtime_report
+
+assert consumer_report["freshness_state"] == "fresh", consumer_report
+assert consumer_report["promotability_status"] == "promotable", consumer_report
+assert consumer_report["promoted_id"] == "planningops-local-inbox-consumer-20260401T103000Z", consumer_report
+assert consumer_report["dependency_states"] == {
+    "monday_local_operator_inbox_payload": "current",
+    "monday_local_inbox_launch_request": "current",
+    "monday_local_inbox_runtime_report": "current",
+}, consumer_report
+assert consumer_report["reasons"] == [], consumer_report
+PY
+
+python3 "$QUERY_PATH" local-validation-freshness \
+  --artifact-family monday_local_inbox_runtime_report \
+  --promotability-status blocked \
+  --has-reason source_artifact_missing \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_VALIDATION_RUNTIME_BLOCKED_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_RUNTIME_BLOCKED_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["artifact_family"] == "monday_local_inbox_runtime_report", record
+assert record["freshness_state"] == "fresh", record
+assert record["promotability_status"] == "blocked", record
+assert record["reasons"] == ["source_artifact_missing"], record
 PY
 
 echo "query federated ci artifacts ok"

--- a/planningops/scripts/test_write_monday_local_inbox_validation_mirror.sh
+++ b/planningops/scripts/test_write_monday_local_inbox_validation_mirror.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+VALIDATION_DIR="$TMP_DIR/validation"
+CONSUMER_DIR="$TMP_DIR/monday/runtime-artifacts/integration/planningops-local-operator-inbox"
+OUTPUT_PATH="$TMP_DIR/mirror-output.json"
+STDOUT_PATH="$TMP_DIR/mirror-stdout.json"
+PINNED_OUTPUT_PATH="$TMP_DIR/mirror-pinned-output.json"
+PINNED_STDOUT_PATH="$TMP_DIR/mirror-pinned-stdout.json"
+
+mkdir -p \
+  "$VALIDATION_DIR" \
+  "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z" \
+  "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z"
+
+cat >"$VALIDATION_DIR/monday-local-operator-inbox-payload.json" <<'JSON'
+{
+  "bridge_id": "monday-local-inbox-20260401T084500Z"
+}
+JSON
+
+cat >"$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/launch-request.json" <<'JSON'
+{
+  "planner_profile": "local_ollama",
+  "launch_mode": "direct",
+  "local_model_route": "direct_local_ollama",
+  "runtime_input_overrides": {
+    "planner_runtime_config": "/tmp/planner-runtime.json",
+    "runtime_profile_file": "/tmp/runtime-profiles.json"
+  }
+}
+JSON
+
+cat >"$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/local-runtime-smoke.json" <<'JSON'
+{
+  "verdict": "pass",
+  "reason_code": "ok"
+}
+JSON
+
+cat >"$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/consumer-report.json" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:20:00+00:00",
+  "run_id": "planningops-local-inbox-consumer-20260401T102000Z",
+  "bridge_id": "monday-local-inbox-20260401T084500Z",
+  "mode": "apply",
+  "verdict": "pass",
+  "consumer_status": "ready_to_launch",
+  "artifact_paths": {
+    "launch_request_path": "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/launch-request.json",
+    "runtime_report_path": "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/local-runtime-smoke.json",
+    "report_path": "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/consumer-report.json"
+  },
+  "launch_request": $(cat "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T102000Z/launch-request.json")
+}
+JSON
+
+cat >"$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/launch-request.json" <<'JSON'
+{
+  "planner_profile": "local_ollama",
+  "launch_mode": "direct",
+  "local_model_route": "direct_local_ollama"
+}
+JSON
+
+cat >"$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/consumer-report.json" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:30:00+00:00",
+  "run_id": "planningops-local-inbox-consumer-20260401T103000Z",
+  "bridge_id": "monday-local-inbox-20260401T084500Z",
+  "mode": "apply",
+  "verdict": "blocked",
+  "consumer_status": "blocked",
+  "artifact_paths": {
+    "launch_request_path": "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/launch-request.json",
+    "runtime_report_path": "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/local-runtime-smoke.json",
+    "report_path": "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/consumer-report.json"
+  },
+  "launch_request": $(cat "$CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/launch-request.json")
+}
+JSON
+
+python3 planningops/scripts/write_monday_local_inbox_validation_mirror.py \
+  --validation-root "$VALIDATION_DIR" \
+  --consumer-root "$CONSUMER_DIR" \
+  --output "$OUTPUT_PATH" >"$STDOUT_PATH"
+
+python3 - <<'PY' "$STDOUT_PATH" "$OUTPUT_PATH" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+stdout_doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_doc = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+validation_dir = Path(sys.argv[3]).resolve()
+
+assert stdout_doc["run_id"] == "planningops-local-inbox-consumer-20260401T103000Z", stdout_doc
+assert output_doc["run_id"] == "planningops-local-inbox-consumer-20260401T103000Z", output_doc
+assert Path("planningops/contracts/monday-local-inbox-validation-mirror-contract.md").exists()
+
+launch_latest = json.loads((validation_dir / "monday-local-inbox-launch-request.json").read_text(encoding="utf-8"))
+runtime_latest = json.loads((validation_dir / "monday-local-inbox-runtime-report.json").read_text(encoding="utf-8"))
+consumer_latest = json.loads((validation_dir / "monday-local-inbox-consumer-report.json").read_text(encoding="utf-8"))
+
+assert launch_latest["run_id"] == "planningops-local-inbox-consumer-20260401T103000Z", launch_latest
+assert launch_latest["artifact_family"] == "monday_local_inbox_launch_request", launch_latest
+assert launch_latest["mirror"]["source_artifact_present"] is True, launch_latest
+assert launch_latest["mirror"]["payload"]["planner_profile"] == "local_ollama", launch_latest
+assert launch_latest["mirror"]["validation_dependency_paths"] == {
+    "monday_local_operator_inbox_payload": str((validation_dir / "monday-local-operator-inbox-payload.json").resolve())
+}, launch_latest
+
+assert runtime_latest["run_id"] == "planningops-local-inbox-consumer-20260401T103000Z", runtime_latest
+assert runtime_latest["artifact_family"] == "monday_local_inbox_runtime_report", runtime_latest
+assert runtime_latest["mirror"]["source_artifact_present"] is False, runtime_latest
+assert runtime_latest["mirror"]["payload"] is None, runtime_latest
+assert runtime_latest["mirror"]["validation_dependency_paths"] == {
+    "monday_local_operator_inbox_payload": str((validation_dir / "monday-local-operator-inbox-payload.json").resolve()),
+    "monday_local_inbox_launch_request": str((validation_dir / "monday-local-inbox-launch-request.json").resolve()),
+}, runtime_latest
+
+assert consumer_latest["run_id"] == "planningops-local-inbox-consumer-20260401T103000Z", consumer_latest
+assert consumer_latest["artifact_family"] == "monday_local_inbox_consumer_report", consumer_latest
+assert consumer_latest["mirror"]["source_artifact_present"] is True, consumer_latest
+assert consumer_latest["mirror"]["payload"]["consumer_status"] == "blocked", consumer_latest
+assert consumer_latest["mirror"]["validation_dependency_paths"] == {
+    "monday_local_operator_inbox_payload": str((validation_dir / "monday-local-operator-inbox-payload.json").resolve()),
+    "monday_local_inbox_launch_request": str((validation_dir / "monday-local-inbox-launch-request.json").resolve()),
+    "monday_local_inbox_runtime_report": str((validation_dir / "monday-local-inbox-runtime-report.json").resolve()),
+}, consumer_latest
+PY
+
+python3 planningops/scripts/write_monday_local_inbox_validation_mirror.py \
+  --validation-root "$VALIDATION_DIR" \
+  --consumer-root "$CONSUMER_DIR" \
+  --run-id "planningops-local-inbox-consumer-20260401T102000Z" \
+  --output "$PINNED_OUTPUT_PATH" >"$PINNED_STDOUT_PATH"
+
+python3 - <<'PY' "$PINNED_STDOUT_PATH" "$PINNED_OUTPUT_PATH" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+stdout_doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_doc = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+validation_dir = Path(sys.argv[3]).resolve()
+
+assert stdout_doc["run_id"] == "planningops-local-inbox-consumer-20260401T102000Z", stdout_doc
+assert output_doc["run_id"] == "planningops-local-inbox-consumer-20260401T102000Z", output_doc
+
+runtime_latest = json.loads((validation_dir / "monday-local-inbox-runtime-report.json").read_text(encoding="utf-8"))
+consumer_latest = json.loads((validation_dir / "monday-local-inbox-consumer-report.json").read_text(encoding="utf-8"))
+
+assert runtime_latest["mirror"]["source_artifact_present"] is True, runtime_latest
+assert runtime_latest["mirror"]["payload"]["verdict"] == "pass", runtime_latest
+assert consumer_latest["mirror"]["has_runtime_input_overrides"] is True, consumer_latest
+assert consumer_latest["mirror"]["override_kinds"] == [
+    "planner_runtime_config",
+    "runtime_profile_file",
+], consumer_latest
+PY
+
+echo "write monday local inbox validation mirror ok"

--- a/planningops/scripts/write_monday_local_inbox_validation_mirror.py
+++ b/planningops/scripts/write_monday_local_inbox_validation_mirror.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_VALIDATION_ROOT = WORKSPACE_ROOT / "planningops/artifacts/validation"
+DEFAULT_CONSUMER_ROOT = WORKSPACE_ROOT.parent / "monday" / "runtime-artifacts/integration/planningops-local-operator-inbox"
+CONTRACT_REF = "planningops/contracts/monday-local-inbox-validation-mirror-contract.md"
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (WORKSPACE_ROOT / path).resolve()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def require_dict(value: object, label: str) -> dict:
+    if not isinstance(value, dict):
+        raise SystemExit(f"{label} must be a JSON object")
+    return value
+
+
+def require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def normalize_string_list(values: object) -> list[str]:
+    return [str(value) for value in list(values or []) if str(value).strip()]
+
+
+def resolve_optional_artifact_path(raw_path: object) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    return Path(raw_path).expanduser().resolve()
+
+
+def load_optional_json(path: Path | None) -> dict | None:
+    if path is None or not path.exists():
+        return None
+    try:
+        return load_json(path)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def discover_consumer_reports(consumer_root: Path) -> list[tuple[str, Path, dict]]:
+    records: list[tuple[str, Path, dict]] = []
+    if not consumer_root.exists():
+        return records
+    for path in sorted(consumer_root.glob("*/consumer-report.json")):
+        if any(part.startswith(".") or part.startswith("._") for part in path.parts):
+            continue
+        doc = load_optional_json(path)
+        if doc is None:
+            continue
+        run_id = str(doc.get("run_id") or "").strip()
+        generated_at_utc = str(doc.get("generated_at_utc") or "").strip()
+        if not run_id or not generated_at_utc:
+            continue
+        records.append((generated_at_utc, path.resolve(), doc))
+    records.sort(key=lambda item: (item[0], str(item[1])), reverse=True)
+    return records
+
+
+def select_consumer_report(*, consumer_root: Path, run_id: str | None) -> tuple[Path, dict]:
+    records = discover_consumer_reports(consumer_root)
+    if not records:
+        raise SystemExit(f"consumer reports not found under {consumer_root}")
+    if run_id is None:
+        return records[0][1], records[0][2]
+    for _, path, doc in records:
+        if str(doc.get("run_id") or "").strip() == run_id:
+            return path, doc
+    raise SystemExit(f"run_id not found under {consumer_root}: {run_id}")
+
+
+def build_override_kinds(launch_request: dict) -> list[str]:
+    runtime_input_overrides = (
+        launch_request.get("runtime_input_overrides")
+        if isinstance(launch_request.get("runtime_input_overrides"), dict)
+        else {}
+    )
+    override_kinds: list[str] = []
+    if isinstance(runtime_input_overrides.get("planner_runtime_config"), str) and runtime_input_overrides.get(
+        "planner_runtime_config"
+    ).strip():
+        override_kinds.append("planner_runtime_config")
+    if isinstance(runtime_input_overrides.get("runtime_profile_file"), str) and runtime_input_overrides.get(
+        "runtime_profile_file"
+    ).strip():
+        override_kinds.append("runtime_profile_file")
+    return override_kinds
+
+
+def build_mirror_doc(
+    *,
+    validation_root: Path,
+    run_id: str,
+    artifact_family: str,
+    artifact_kind: str,
+    latest_filename: str,
+    source_artifact_path: Path | None,
+    source_launch_request_path: Path | None,
+    source_runtime_report_path: Path | None,
+    source_consumer_report_path: Path,
+    bridge_id: str | None,
+    mode: str | None,
+    consumer_verdict: str | None,
+    consumer_status: str | None,
+    planner_profile: str | None,
+    launch_mode: str | None,
+    local_model_route: str | None,
+    has_runtime_input_overrides: bool,
+    override_kinds: list[str],
+    validation_dependency_paths: dict[str, str],
+    payload: dict | None,
+) -> tuple[dict, Path, Path]:
+    latest_mirror_path = validation_root / latest_filename
+    stamped_mirror_path = validation_root / f"{run_id}-{latest_filename}"
+    doc = {
+        "generated_at_utc": now_utc(),
+        "run_id": run_id,
+        "artifact_family": artifact_family,
+        "artifact_kind": artifact_kind,
+        "contract_ref": CONTRACT_REF,
+        "artifact_paths": {
+            "latest_mirror_path": str(latest_mirror_path.resolve()),
+            "stamped_mirror_path": str(stamped_mirror_path.resolve()),
+            "source_artifact_path": None if source_artifact_path is None else str(source_artifact_path.resolve()),
+            "source_launch_request_path": None
+            if source_launch_request_path is None
+            else str(source_launch_request_path.resolve()),
+            "source_runtime_report_path": None
+            if source_runtime_report_path is None
+            else str(source_runtime_report_path.resolve()),
+            "source_consumer_report_path": str(source_consumer_report_path.resolve()),
+        },
+        "mirror": {
+            "source_artifact_present": bool(source_artifact_path is not None and source_artifact_path.exists()),
+            "bridge_id": bridge_id,
+            "mode": mode,
+            "consumer_verdict": consumer_verdict,
+            "consumer_status": consumer_status,
+            "planner_profile": planner_profile,
+            "launch_mode": launch_mode,
+            "local_model_route": local_model_route,
+            "has_runtime_input_overrides": has_runtime_input_overrides,
+            "override_kinds": override_kinds,
+            "validation_dependency_paths": validation_dependency_paths,
+            "payload": payload,
+        },
+    }
+    return doc, latest_mirror_path, stamped_mirror_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Mirror monday local inbox launch/runtime/consumer artifacts into planningops validation."
+    )
+    parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    parser.add_argument("--consumer-root", default=str(DEFAULT_CONSUMER_ROOT))
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    validation_root = resolve_path(args.validation_root)
+    consumer_root = resolve_path(args.consumer_root)
+    output_path = None if args.output is None else resolve_path(args.output)
+
+    if not (WORKSPACE_ROOT / CONTRACT_REF).exists():
+        raise SystemExit(f"validation mirror contract missing: {CONTRACT_REF}")
+
+    consumer_report_path, consumer_report_doc = select_consumer_report(consumer_root=consumer_root, run_id=args.run_id)
+    artifact_paths = require_dict(consumer_report_doc.get("artifact_paths"), "consumer report artifact paths")
+    launch_request = require_dict(consumer_report_doc.get("launch_request"), "consumer launch request")
+
+    run_id = require_string(consumer_report_doc.get("run_id"), "consumer report run_id")
+    bridge_id = str(consumer_report_doc.get("bridge_id") or "").strip() or None
+    mode = str(consumer_report_doc.get("mode") or "").strip() or None
+    consumer_verdict = str(consumer_report_doc.get("verdict") or "").strip() or None
+    consumer_status = str(consumer_report_doc.get("consumer_status") or "").strip() or None
+    planner_profile = str(launch_request.get("planner_profile") or "").strip() or None
+    launch_mode = str(launch_request.get("launch_mode") or "").strip() or None
+    local_model_route = str(launch_request.get("local_model_route") or "").strip() or None
+    override_kinds = build_override_kinds(launch_request)
+    has_runtime_input_overrides = bool(override_kinds)
+
+    launch_request_path = resolve_optional_artifact_path(artifact_paths.get("launch_request_path"))
+    runtime_report_path = resolve_optional_artifact_path(artifact_paths.get("runtime_report_path"))
+    consumer_payload_path = consumer_report_path.resolve()
+    launch_request_payload = load_optional_json(launch_request_path)
+    runtime_report_payload = load_optional_json(runtime_report_path)
+
+    inbox_payload_latest_path = str((validation_root / "monday-local-operator-inbox-payload.json").resolve())
+    launch_request_latest_path = str((validation_root / "monday-local-inbox-launch-request.json").resolve())
+    runtime_report_latest_path = str((validation_root / "monday-local-inbox-runtime-report.json").resolve())
+
+    launch_request_doc, launch_request_latest, launch_request_stamped = build_mirror_doc(
+        validation_root=validation_root,
+        run_id=run_id,
+        artifact_family="monday_local_inbox_launch_request",
+        artifact_kind="request",
+        latest_filename="monday-local-inbox-launch-request.json",
+        source_artifact_path=launch_request_path,
+        source_launch_request_path=launch_request_path,
+        source_runtime_report_path=runtime_report_path,
+        source_consumer_report_path=consumer_payload_path,
+        bridge_id=bridge_id,
+        mode=mode,
+        consumer_verdict=consumer_verdict,
+        consumer_status=consumer_status,
+        planner_profile=planner_profile,
+        launch_mode=launch_mode,
+        local_model_route=local_model_route,
+        has_runtime_input_overrides=has_runtime_input_overrides,
+        override_kinds=override_kinds,
+        validation_dependency_paths={
+            "monday_local_operator_inbox_payload": inbox_payload_latest_path,
+        },
+        payload=launch_request_payload,
+    )
+    runtime_report_doc, runtime_report_latest, runtime_report_stamped = build_mirror_doc(
+        validation_root=validation_root,
+        run_id=run_id,
+        artifact_family="monday_local_inbox_runtime_report",
+        artifact_kind="report",
+        latest_filename="monday-local-inbox-runtime-report.json",
+        source_artifact_path=runtime_report_path,
+        source_launch_request_path=launch_request_path,
+        source_runtime_report_path=runtime_report_path,
+        source_consumer_report_path=consumer_payload_path,
+        bridge_id=bridge_id,
+        mode=mode,
+        consumer_verdict=consumer_verdict,
+        consumer_status=consumer_status,
+        planner_profile=planner_profile,
+        launch_mode=launch_mode,
+        local_model_route=local_model_route,
+        has_runtime_input_overrides=has_runtime_input_overrides,
+        override_kinds=override_kinds,
+        validation_dependency_paths={
+            "monday_local_operator_inbox_payload": inbox_payload_latest_path,
+            "monday_local_inbox_launch_request": launch_request_latest_path,
+        },
+        payload=runtime_report_payload,
+    )
+    consumer_report_doc_mirror, consumer_report_latest, consumer_report_stamped = build_mirror_doc(
+        validation_root=validation_root,
+        run_id=run_id,
+        artifact_family="monday_local_inbox_consumer_report",
+        artifact_kind="report",
+        latest_filename="monday-local-inbox-consumer-report.json",
+        source_artifact_path=consumer_payload_path,
+        source_launch_request_path=launch_request_path,
+        source_runtime_report_path=runtime_report_path,
+        source_consumer_report_path=consumer_payload_path,
+        bridge_id=bridge_id,
+        mode=mode,
+        consumer_verdict=consumer_verdict,
+        consumer_status=consumer_status,
+        planner_profile=planner_profile,
+        launch_mode=launch_mode,
+        local_model_route=local_model_route,
+        has_runtime_input_overrides=has_runtime_input_overrides,
+        override_kinds=override_kinds,
+        validation_dependency_paths={
+            "monday_local_operator_inbox_payload": inbox_payload_latest_path,
+            "monday_local_inbox_launch_request": launch_request_latest_path,
+            "monday_local_inbox_runtime_report": runtime_report_latest_path,
+        },
+        payload=consumer_report_doc,
+    )
+
+    for path, doc in (
+        (launch_request_latest, launch_request_doc),
+        (launch_request_stamped, launch_request_doc),
+        (runtime_report_latest, runtime_report_doc),
+        (runtime_report_stamped, runtime_report_doc),
+        (consumer_report_latest, consumer_report_doc_mirror),
+        (consumer_report_stamped, consumer_report_doc_mirror),
+    ):
+        write_json(path, doc)
+
+    result = {
+        "generated_at_utc": now_utc(),
+        "run_id": run_id,
+        "contract_ref": CONTRACT_REF,
+        "records": [
+            {
+                "artifact_family": "monday_local_inbox_launch_request",
+                "latest_mirror_path": str(launch_request_latest.resolve()),
+                "stamped_mirror_path": str(launch_request_stamped.resolve()),
+                "source_artifact_present": launch_request_doc["mirror"]["source_artifact_present"],
+            },
+            {
+                "artifact_family": "monday_local_inbox_runtime_report",
+                "latest_mirror_path": str(runtime_report_latest.resolve()),
+                "stamped_mirror_path": str(runtime_report_stamped.resolve()),
+                "source_artifact_present": runtime_report_doc["mirror"]["source_artifact_present"],
+            },
+            {
+                "artifact_family": "monday_local_inbox_consumer_report",
+                "latest_mirror_path": str(consumer_report_latest.resolve()),
+                "stamped_mirror_path": str(consumer_report_stamped.resolve()),
+                "source_artifact_present": consumer_report_doc_mirror["mirror"]["source_artifact_present"],
+            },
+        ],
+    }
+    if output_path is not None:
+        write_json(output_path, result)
+    print(json.dumps(result, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- mirror monday-owned launch-request, runtime-report, and consumer-report artifacts into planningops validation
- extend `local-validation-freshness` so those mirrored families participate in the same promotion lane
- cover fresh/promotable and fresh/blocked monday consumer mirror cases in regression tests

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`
- `planningops/` scripts/contracts: `planningops/contracts/monday-local-inbox-validation-mirror-contract.md`, `planningops/scripts/write_monday_local_inbox_validation_mirror.py`, `planningops/scripts/test_write_monday_local_inbox_validation_mirror.sh`, `planningops/scripts/federation/query_federated_ci_artifacts.py`, `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `.github/` workflows: none

## Linked Issues
- Closes #962
- Related #957

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `python3 -m py_compile planningops/scripts/write_monday_local_inbox_validation_mirror.py planningops/scripts/federation/query_federated_ci_artifacts.py`, `bash planningops/scripts/test_write_monday_local_inbox_validation_mirror.sh`, `bash planningops/scripts/test_query_federated_ci_artifacts.sh`, `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`

## Risks
- Risk: the new consumer mirror lane is validation-only and depends on monday consumer artifact shape staying compatible with the mirrored fields captured here.
- Rollback: revert this PR to remove the mirror writer/freshness families and fall back to monday-side consumer evidence only.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.