### PR TITLE
feat(query-engine): add monday validation report surface

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -154,6 +154,7 @@ Current deliverables:
 - `monday/scripts/validate_planningops_local_operator_inbox_artifacts.py`
 - `monday/scripts/test_validate_planningops_local_operator_inbox_artifacts.sh`
 - monday local CI now validates the promoted inbox payload bridge and monday-native consumer report against monday-owned schemas before merge
+- `planningops/scripts/federation/query_federated_ci_artifacts.py monday-validation-report` now exposes monday-owned bridge/consumer-report schema validation verdicts from `monday/runtime-artifacts/validation`
 - monday now consumes the promoted inbox payload as structured input and materializes native runtime command argv without reparsing day-packet markdown
 - monday consumer regression now covers:
   - ready dry-run packet materialization
@@ -231,6 +232,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether monday-owned schema validation reports should stay monday-side only or also surface through planningops query/report views
-2. decide whether launch-request, runtime-report, and consumer-report freshness should also be folded into `handoff-report` local validation snapshots
+1. decide whether launch-request, runtime-report, and consumer-report freshness should also be folded into `handoff-report` local validation snapshots
+2. decide whether monday-owned schema validation verdicts should stay query-only or also be mirrored into planningops validation artifacts
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -28,6 +28,7 @@ DEFAULT_VALIDATION_ROOT = WORKSPACE_ROOT / "planningops/artifacts/validation"
 DEFAULT_CONFORMANCE_ROOT = WORKSPACE_ROOT / "planningops/artifacts/conformance"
 DEFAULT_LOCAL_OPERATOR_STACK_ROOT = WORKSPACE_ROOT / "planningops/runtime-artifacts/local/monday-local-operator-stack"
 DEFAULT_MONDAY_CONSUMER_ROOT = WORKSPACE_ROOT.parent / "monday" / "runtime-artifacts/integration/planningops-local-operator-inbox"
+DEFAULT_MONDAY_VALIDATION_ROOT = WORKSPACE_ROOT.parent / "monday" / "runtime-artifacts/validation"
 
 LATEST_GAP_CHOICES = (
     "readiness_missing",
@@ -52,6 +53,8 @@ LOCAL_INBOX_PAYLOAD_STATUS_CHOICES = ("ready", "blocked")
 MONDAY_CONSUMER_MODE_CHOICES = ("dry-run", "apply")
 MONDAY_CONSUMER_VERDICT_CHOICES = ("pass", "fail", "blocked")
 MONDAY_CONSUMER_STATUS_CHOICES = ("ready_to_launch", "blocked")
+MONDAY_VALIDATION_KIND_CHOICES = ("bridge", "consumer-report")
+MONDAY_VALIDATION_VERDICT_CHOICES = ("pass", "fail")
 LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_operator_stack_report",
     "operator_handoff_report",
@@ -409,6 +412,22 @@ class MondayConsumerReportRecord:
     has_launch_request: bool
     has_mission_file: bool
     has_runtime_report: bool
+
+
+@dataclass(frozen=True)
+class MondayValidationReportRecord:
+    kind: str
+    report_path: str
+    generated_at_utc: str
+    verdict: str | None
+    error_count: int
+    warning_count: int
+    artifact_path: str | None
+    schema_path: str | None
+    artifact_exists: bool
+    schema_exists: bool
+    errors: list[str]
+    warnings: list[str]
 
 
 def resolve_root(path_text: str, default: Path) -> Path:
@@ -926,6 +945,16 @@ def is_monday_consumer_report_document(doc: dict[str, Any]) -> bool:
     )
 
 
+def is_monday_validation_report_document(doc: dict[str, Any]) -> bool:
+    return (
+        doc.get("kind") in MONDAY_VALIDATION_KIND_CHOICES
+        and isinstance(doc.get("artifact_path"), str)
+        and isinstance(doc.get("schema_path"), str)
+        and isinstance(doc.get("errors"), list)
+        and isinstance(doc.get("warnings"), list)
+    )
+
+
 def build_local_validation_dependency_state(
     *,
     raw_path: Any,
@@ -1411,6 +1440,136 @@ def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRec
             f"{record.runtime_report_verdict or ''} | "
             f"{'yes' if record.has_runtime_report else 'no'} | "
             f"{', '.join(record.block_reasons)} | {record.generated_at_utc} |"
+        )
+    return "\n".join(lines)
+
+
+def build_monday_validation_report_record(
+    *,
+    report_path: Path,
+    report_doc: dict[str, Any],
+) -> MondayValidationReportRecord:
+    artifact_path = resolve_artifact_path(report_doc.get("artifact_path"))
+    schema_path = resolve_artifact_path(report_doc.get("schema_path"))
+    errors = normalize_string_list(report_doc.get("errors"))
+    warnings = normalize_string_list(report_doc.get("warnings"))
+    raw_error_count = report_doc.get("error_count")
+    raw_warning_count = report_doc.get("warning_count")
+    error_count = raw_error_count if isinstance(raw_error_count, int) else len(errors)
+    warning_count = raw_warning_count if isinstance(raw_warning_count, int) else len(warnings)
+    return MondayValidationReportRecord(
+        kind=str(report_doc.get("kind")),
+        report_path=str(report_path.resolve()),
+        generated_at_utc=str(report_doc.get("generated_at_utc") or ""),
+        verdict=normalize_optional_string(report_doc.get("verdict")),
+        error_count=error_count,
+        warning_count=warning_count,
+        artifact_path=None if artifact_path is None else str(artifact_path),
+        schema_path=None if schema_path is None else str(schema_path),
+        artifact_exists=artifact_path.exists() if artifact_path is not None else False,
+        schema_exists=schema_path.exists() if schema_path is not None else False,
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+def discover_monday_validation_report_records(*, validation_root: Path) -> list[MondayValidationReportRecord]:
+    if not validation_root.exists():
+        return []
+    records: list[MondayValidationReportRecord] = []
+    for path in sorted(validation_root.glob("planningops-local-operator-inbox*-validation-report.json")):
+        if any(part.startswith(".") or part.startswith("._") for part in path.parts):
+            continue
+        try:
+            doc = load_json(path)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if not is_monday_validation_report_document(doc):
+            continue
+        records.append(build_monday_validation_report_record(report_path=path, report_doc=doc))
+    records.sort(
+        key=lambda record: (
+            record.generated_at_utc,
+            record.kind,
+            record.report_path,
+        ),
+        reverse=True,
+    )
+    return records
+
+
+def filter_monday_validation_report_records(
+    *,
+    records: list[MondayValidationReportRecord],
+    kind: str | None = None,
+    verdict: str | None = None,
+    has_errors: str | None = None,
+    has_warnings: str | None = None,
+    artifact_exists: str | None = None,
+    schema_exists: str | None = None,
+    has_message: str | None = None,
+) -> list[MondayValidationReportRecord]:
+    filtered = records
+    if kind:
+        filtered = [record for record in filtered if record.kind == kind]
+    if verdict:
+        filtered = [record for record in filtered if record.verdict == verdict]
+    if has_errors is not None:
+        expected = has_errors == "yes"
+        filtered = [record for record in filtered if (record.error_count > 0) is expected]
+    if has_warnings is not None:
+        expected = has_warnings == "yes"
+        filtered = [record for record in filtered if (record.warning_count > 0) is expected]
+    if artifact_exists is not None:
+        expected = artifact_exists == "yes"
+        filtered = [record for record in filtered if record.artifact_exists is expected]
+    if schema_exists is not None:
+        expected = schema_exists == "yes"
+        filtered = [record for record in filtered if record.schema_exists is expected]
+    if has_message:
+        needle = has_message.lower()
+        filtered = [
+            record
+            for record in filtered
+            if any(needle in message.lower() for message in [*record.errors, *record.warnings])
+        ]
+    return filtered
+
+
+def render_monday_validation_report_table(records: list[MondayValidationReportRecord]) -> str:
+    lines = [
+        "kind\tverdict\terror_count\twarning_count\tartifact_exists\tschema_exists\treport_path\tartifact_path\tschema_path\tgenerated_at_utc",
+    ]
+    for record in records:
+        lines.append(
+            "\t".join(
+                [
+                    record.kind,
+                    str(record.verdict or ""),
+                    str(record.error_count),
+                    str(record.warning_count),
+                    "yes" if record.artifact_exists else "no",
+                    "yes" if record.schema_exists else "no",
+                    record.report_path,
+                    str(record.artifact_path or ""),
+                    str(record.schema_path or ""),
+                    record.generated_at_utc,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_monday_validation_report_markdown(records: list[MondayValidationReportRecord]) -> str:
+    lines = [
+        "| kind | verdict | error_count | warning_count | artifact_exists | schema_exists | report_path | artifact_path | schema_path | generated_at_utc |",
+        "| --- | --- | ---: | ---: | --- | --- | --- | --- | --- | --- |",
+    ]
+    for record in records:
+        lines.append(
+            f"| {record.kind} | {record.verdict or ''} | {record.error_count} | {record.warning_count} | "
+            f"{'yes' if record.artifact_exists else 'no'} | {'yes' if record.schema_exists else 'no'} | "
+            f"`{record.report_path}` | `{record.artifact_path or ''}` | `{record.schema_path or ''}` | {record.generated_at_utc} |"
         )
     return "\n".join(lines)
 
@@ -4281,6 +4440,21 @@ def parse_args() -> argparse.Namespace:
     monday_consumer_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
     monday_consumer_parser.add_argument("--consumer-root", default=str(DEFAULT_MONDAY_CONSUMER_ROOT))
 
+    monday_validation_parser = subparsers.add_parser(
+        "monday-validation-report",
+        help="list monday-owned inbox schema validation reports",
+    )
+    monday_validation_parser.add_argument("--kind", choices=MONDAY_VALIDATION_KIND_CHOICES, default=None)
+    monday_validation_parser.add_argument("--verdict", choices=MONDAY_VALIDATION_VERDICT_CHOICES, default=None)
+    monday_validation_parser.add_argument("--has-errors", choices=["yes", "no"], default=None)
+    monday_validation_parser.add_argument("--has-warnings", choices=["yes", "no"], default=None)
+    monday_validation_parser.add_argument("--artifact-exists", choices=["yes", "no"], default=None)
+    monday_validation_parser.add_argument("--schema-exists", choices=["yes", "no"], default=None)
+    monday_validation_parser.add_argument("--has-message", default=None)
+    monday_validation_parser.add_argument("--limit", type=int, default=20)
+    monday_validation_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    monday_validation_parser.add_argument("--monday-validation-root", default=str(DEFAULT_MONDAY_VALIDATION_ROOT))
+
     local_operator_parser = subparsers.add_parser(
         "local-operator-stack",
         help="list planningops-owned monday local operator stack aggregate reports",
@@ -4306,6 +4480,10 @@ def main() -> int:
     local_root = resolve_root(getattr(args, "local_root", str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT)), DEFAULT_LOCAL_OPERATOR_STACK_ROOT)
     validation_root = resolve_root(getattr(args, "validation_root", str(DEFAULT_VALIDATION_ROOT)), DEFAULT_VALIDATION_ROOT)
     consumer_root = resolve_root(getattr(args, "consumer_root", str(DEFAULT_MONDAY_CONSUMER_ROOT)), DEFAULT_MONDAY_CONSUMER_ROOT)
+    monday_validation_root = resolve_root(
+        getattr(args, "monday_validation_root", str(DEFAULT_MONDAY_VALIDATION_ROOT)),
+        DEFAULT_MONDAY_VALIDATION_ROOT,
+    )
     if args.command == "local-validation-freshness":
         local_validation_records = discover_local_validation_freshness_records(validation_root=validation_root)
         local_validation_records = filter_local_validation_freshness_records(
@@ -4375,6 +4553,28 @@ def main() -> int:
             print(render_monday_consumer_report_markdown(consumer_records))
             return 0
         print(render_monday_consumer_report_table(consumer_records))
+        return 0
+
+    if args.command == "monday-validation-report":
+        validation_records = discover_monday_validation_report_records(validation_root=monday_validation_root)
+        validation_records = filter_monday_validation_report_records(
+            records=validation_records,
+            kind=args.kind,
+            verdict=args.verdict,
+            has_errors=args.has_errors,
+            has_warnings=args.has_warnings,
+            artifact_exists=args.artifact_exists,
+            schema_exists=args.schema_exists,
+            has_message=args.has_message,
+        )
+        validation_records = validation_records[: args.limit]
+        if args.format == "json":
+            print(json.dumps({"records": [asdict(record) for record in validation_records]}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_monday_validation_report_markdown(validation_records))
+            return 0
+        print(render_monday_validation_report_table(validation_records))
         return 0
 
     if args.command == "local-operator-stack":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -31,8 +31,9 @@ VALIDATION_DIR="$TMP_DIR/validation"
 CONFORMANCE_DIR="$TMP_DIR/conformance"
 LOCAL_OPERATOR_DIR="$TMP_DIR/local-operator-stack"
 MONDAY_CONSUMER_DIR="$TMP_DIR/monday/runtime-artifacts/integration/planningops-local-operator-inbox"
+MONDAY_VALIDATION_DIR="$TMP_DIR/monday/runtime-artifacts/validation"
 mkdir -p "$CI_DIR" "$VALIDATION_DIR" "$CONFORMANCE_DIR"
-mkdir -p "$LOCAL_OPERATOR_DIR" "$MONDAY_CONSUMER_DIR"
+mkdir -p "$LOCAL_OPERATOR_DIR" "$MONDAY_CONSUMER_DIR" "$MONDAY_VALIDATION_DIR"
 
 cat >"$CI_DIR/federated-ci-runtime-gates-20260319-rerun26.json" <<'JSON'
 {
@@ -664,6 +665,9 @@ MONDAY_CONSUMER_OUTPUT="$TMP_DIR/monday-consumer-report.json"
 MONDAY_CONSUMER_FILTERED_OUTPUT="$TMP_DIR/monday-consumer-report-filtered.json"
 MONDAY_CONSUMER_BLOCKED_OUTPUT="$TMP_DIR/monday-consumer-report-blocked.json"
 MONDAY_CONSUMER_OVERRIDE_OUTPUT="$TMP_DIR/monday-consumer-report-override.json"
+MONDAY_VALIDATION_OUTPUT="$TMP_DIR/monday-validation-report.json"
+MONDAY_VALIDATION_FAIL_OUTPUT="$TMP_DIR/monday-validation-report-fail.json"
+MONDAY_VALIDATION_BRIDGE_OUTPUT="$TMP_DIR/monday-validation-report-bridge.json"
 LOCAL_OPERATOR_OUTPUT="$TMP_DIR/local-operator-stack.json"
 LOCAL_OPERATOR_FILTERED_OUTPUT="$TMP_DIR/local-operator-stack-filtered.json"
 LOCAL_OPERATOR_DETAIL_OUTPUT="$TMP_DIR/local-operator-stack-detail.json"
@@ -3239,6 +3243,126 @@ assert [record["run_id"] for record in records] == [
     "planningops-local-inbox-consumer-20260401T101000Z",
 ], records
 assert all(record["has_runtime_input_overrides"] is False for record in records), records
+PY
+
+cat >"$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-payload-bridge.schema.json" <<'JSON'
+{
+  "type": "object"
+}
+JSON
+
+cat >"$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-consumer-report.schema.json" <<'JSON'
+{
+  "type": "object"
+}
+JSON
+
+cat >"$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-payload-validation-report.json" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:40:00+00:00",
+  "kind": "bridge",
+  "artifact_path": "$VALIDATION_DIR/monday-local-operator-inbox-payload.json",
+  "schema_path": "$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-payload-bridge.schema.json",
+  "error_count": 0,
+  "warning_count": 0,
+  "errors": [],
+  "warnings": [],
+  "verdict": "pass"
+}
+JSON
+
+cat >"$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-consumer-report-validation-report.json" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:50:00+00:00",
+  "kind": "consumer-report",
+  "artifact_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/consumer-report.json",
+  "schema_path": "$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-consumer-report.schema.json",
+  "error_count": 2,
+  "warning_count": 1,
+  "errors": [
+    "consumer contract ref mismatch",
+    "schema validation failed: launch_request.source_bridge_id must match bridge_id"
+  ],
+  "warnings": [
+    "runtime report path missing"
+  ],
+  "verdict": "fail"
+}
+JSON
+
+python3 "$QUERY_PATH" monday-validation-report \
+  --format json \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$MONDAY_VALIDATION_OUTPUT"
+
+python3 - <<'PY' "$MONDAY_VALIDATION_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["kind"] for record in records] == [
+    "consumer-report",
+    "bridge",
+], records
+consumer_report, bridge = records
+assert consumer_report["verdict"] == "fail", consumer_report
+assert consumer_report["error_count"] == 2, consumer_report
+assert consumer_report["warning_count"] == 1, consumer_report
+assert consumer_report["artifact_exists"] is True, consumer_report
+assert consumer_report["schema_exists"] is True, consumer_report
+assert "consumer contract ref mismatch" in consumer_report["errors"], consumer_report
+assert bridge["verdict"] == "pass", bridge
+assert bridge["error_count"] == 0, bridge
+assert bridge["warning_count"] == 0, bridge
+assert bridge["artifact_exists"] is True, bridge
+assert bridge["schema_exists"] is True, bridge
+PY
+
+python3 "$QUERY_PATH" monday-validation-report \
+  --kind consumer-report \
+  --verdict fail \
+  --has-errors yes \
+  --has-message contract \
+  --format json \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$MONDAY_VALIDATION_FAIL_OUTPUT"
+
+python3 - <<'PY' "$MONDAY_VALIDATION_FAIL_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["kind"] == "consumer-report", record
+assert record["verdict"] == "fail", record
+assert record["error_count"] == 2, record
+PY
+
+python3 "$QUERY_PATH" monday-validation-report \
+  --kind bridge \
+  --verdict pass \
+  --has-errors no \
+  --has-warnings no \
+  --artifact-exists yes \
+  --schema-exists yes \
+  --format json \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$MONDAY_VALIDATION_BRIDGE_OUTPUT"
+
+python3 - <<'PY' "$MONDAY_VALIDATION_BRIDGE_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["kind"] == "bridge", record
+assert record["verdict"] == "pass", record
+assert record["warning_count"] == 0, record
 PY
 
 python3 "$WRITE_LOCAL_INBOX_VALIDATION_MIRROR_PATH" \


### PR DESCRIPTION
## Summary
- add a planningops query surface for monday-owned bridge and consumer-report schema validation reports
- cover pass/fail monday validation report cases in the query regression fixture
- update the monday local Codex rollout plan

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`
- `planningops/` scripts/contracts: `planningops/scripts/federation/query_federated_ci_artifacts.py`, `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `.github/` workflows: none

## Linked Issues
- Closes #964
- Related #963

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`, `bash planningops/scripts/test_query_federated_ci_artifacts.sh`, `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`

## Risks
- Risk: this surface reads monday-owned validation report shape directly, so future monday schema-validator field changes will need coordinated query updates here.
- Rollback: revert this PR to remove the monday validation report surface and fall back to monday-side inspection only.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.