### PR TITLE
feat(query-engine): fold monday inbox freshness into handoff report

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -171,6 +171,7 @@ Current deliverables:
 - `planningops/artifacts/validation/monday-local-inbox-consumer-report.json`
 - `planningops/artifacts/validation/<run-id>-monday-local-inbox-consumer-report.json`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now picks up the mirrored monday launch-request, runtime-report, and consumer-report families when they are present in planningops validation
+- `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries a local validation snapshot status/summary that folds the mirrored monday launch-request, runtime-report, and consumer-report families into the operator packet when present
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -232,6 +233,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether launch-request, runtime-report, and consumer-report freshness should also be folded into `handoff-report` local validation snapshots
-2. decide whether monday-owned schema validation verdicts should stay query-only or also be mirrored into planningops validation artifacts
+1. decide whether monday-owned schema validation verdicts should stay query-only or also be mirrored into planningops validation artifacts
+2. decide whether monday validation verdicts should also be folded into `handoff-report` or another cross-repo operator packet
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -308,6 +308,8 @@ class HandoffReportRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    local_validation_snapshot_status: str
+    local_validation_snapshot_summary: str
     local_validation_records: list[LocalValidationFreshnessRecord]
     local_validation_summary_lines: list[str]
     local_validation_action_lines: list[str]
@@ -2280,6 +2282,27 @@ def build_local_validation_action_line(record: LocalValidationFreshnessRecord) -
     )
 
 
+def build_local_validation_snapshot(records: list[LocalValidationFreshnessRecord]) -> tuple[str, str]:
+    if not records:
+        return "missing", "total=0 promotable=0 blocked=0 stale=0"
+
+    promotable_count = 0
+    stale_count = 0
+    for record in records:
+        if record.promotability_status == "promotable":
+            promotable_count += 1
+        if record.freshness_state != "fresh":
+            stale_count += 1
+
+    blocked_count = len(records) - promotable_count
+    snapshot_status = "fresh" if blocked_count == 0 and stale_count == 0 else "present"
+    snapshot_summary = (
+        f"total={len(records)} promotable={promotable_count} "
+        f"blocked={blocked_count} stale={stale_count}"
+    )
+    return snapshot_status, snapshot_summary
+
+
 def build_summary_health_fields(
     *,
     verdict: Any,
@@ -3453,6 +3476,9 @@ def build_handoff_report_record(
         target_limit=target_limit,
     )
     local_validation_records = discover_local_validation_freshness_records(validation_root=validation_root)
+    local_validation_snapshot_status, local_validation_snapshot_summary = build_local_validation_snapshot(
+        local_validation_records
+    )
     local_validation_summary_lines = [build_local_validation_summary_line(record) for record in local_validation_records]
     local_validation_action_lines = [
         action
@@ -3489,7 +3515,15 @@ def build_handoff_report_record(
         markdown_lines.append(f"- local operator: `{triage_report.local_operator_summary}`")
     if triage_report.local_operator_next_step is not None:
         markdown_lines.append(f"- local operator next step: {triage_report.local_operator_next_step}")
-    markdown_lines.extend(["", "### Local Validation", *[f"- {line}" for line in local_validation_summary_lines]])
+    markdown_lines.extend(
+        [
+            "",
+            "### Local Validation",
+            f"- snapshot status: `{local_validation_snapshot_status}`",
+            f"- snapshot summary: `{local_validation_snapshot_summary}`",
+            *[f"- {line}" for line in local_validation_summary_lines],
+        ]
+    )
     if local_validation_action_lines:
         markdown_lines.extend(["", "### Local Validation Actions", *[f"{index}. {line}" for index, line in enumerate(local_validation_action_lines, start=1)]])
     markdown_lines.extend(["", "### Queue", *[f"- {line}" for line in triage_report.queue_lines]])
@@ -3509,6 +3543,8 @@ def build_handoff_report_record(
         local_operator_record=triage_report.local_operator_record,
         local_operator_summary=triage_report.local_operator_summary,
         local_operator_next_step=triage_report.local_operator_next_step,
+        local_validation_snapshot_status=local_validation_snapshot_status,
+        local_validation_snapshot_summary=local_validation_snapshot_summary,
         local_validation_records=local_validation_records,
         local_validation_summary_lines=local_validation_summary_lines,
         local_validation_action_lines=local_validation_action_lines,
@@ -3533,6 +3569,8 @@ def render_handoff_report_table(record: HandoffReportRecord) -> str:
         sections.append(f"local_operator\t{record.local_operator_summary}")
     if record.local_operator_next_step is not None:
         sections.append(f"local_operator_next_step\t{record.local_operator_next_step}")
+    sections.append(f"local_validation_snapshot_status\t{record.local_validation_snapshot_status}")
+    sections.append(f"local_validation_snapshot_summary\t{record.local_validation_snapshot_summary}")
     sections.extend(["local_validation", *record.local_validation_summary_lines])
     if record.local_validation_action_lines:
         sections.extend(["local_validation_actions", *record.local_validation_action_lines])

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -2139,6 +2139,142 @@ path.write_text(payload, encoding="utf-8")
 )
 PY
 
+mkdir -p "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z"
+
+cat >"$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/launch-request.json" <<'JSON'
+{
+  "planner_profile": "local_ollama",
+  "launch_mode": "direct",
+  "local_model_route": "direct_local_ollama"
+}
+JSON
+
+cat >"$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/consumer-report.json" <<'JSON'
+{
+  "consumer_status": "blocked"
+}
+JSON
+
+cat >"$VALIDATION_DIR/monday-local-inbox-launch-request.json" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:31:00+00:00",
+  "run_id": "planningops-local-inbox-consumer-20260401T103000Z",
+  "artifact_family": "monday_local_inbox_launch_request",
+  "artifact_kind": "request",
+  "contract_ref": "planningops/contracts/monday-local-inbox-validation-mirror-contract.md",
+  "artifact_paths": {
+    "latest_mirror_path": "$VALIDATION_DIR/monday-local-inbox-launch-request.json",
+    "stamped_mirror_path": "$VALIDATION_DIR/planningops-local-inbox-consumer-20260401T103000Z-monday-local-inbox-launch-request.json",
+    "source_artifact_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/launch-request.json",
+    "source_launch_request_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/launch-request.json",
+    "source_runtime_report_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/local-runtime-smoke.json",
+    "source_consumer_report_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/consumer-report.json"
+  },
+  "mirror": {
+    "source_artifact_present": true,
+    "bridge_id": "monday-local-inbox-20260401T084500Z",
+    "mode": "apply",
+    "consumer_verdict": "blocked",
+    "consumer_status": "blocked",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "has_runtime_input_overrides": false,
+    "override_kinds": [],
+    "validation_dependency_paths": {
+      "monday_local_operator_inbox_payload": "$VALIDATION_DIR/monday-local-operator-inbox-payload.json"
+    },
+    "payload": {
+      "planner_profile": "local_ollama",
+      "launch_mode": "direct",
+      "local_model_route": "direct_local_ollama"
+    }
+  }
+}
+JSON
+
+cp "$VALIDATION_DIR/monday-local-inbox-launch-request.json" \
+  "$VALIDATION_DIR/planningops-local-inbox-consumer-20260401T103000Z-monday-local-inbox-launch-request.json"
+
+cat >"$VALIDATION_DIR/monday-local-inbox-runtime-report.json" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:32:00+00:00",
+  "run_id": "planningops-local-inbox-consumer-20260401T103000Z",
+  "artifact_family": "monday_local_inbox_runtime_report",
+  "artifact_kind": "report",
+  "contract_ref": "planningops/contracts/monday-local-inbox-validation-mirror-contract.md",
+  "artifact_paths": {
+    "latest_mirror_path": "$VALIDATION_DIR/monday-local-inbox-runtime-report.json",
+    "stamped_mirror_path": "$VALIDATION_DIR/planningops-local-inbox-consumer-20260401T103000Z-monday-local-inbox-runtime-report.json",
+    "source_artifact_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/local-runtime-smoke.json",
+    "source_launch_request_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/launch-request.json",
+    "source_runtime_report_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/local-runtime-smoke.json",
+    "source_consumer_report_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/consumer-report.json"
+  },
+  "mirror": {
+    "source_artifact_present": false,
+    "bridge_id": "monday-local-inbox-20260401T084500Z",
+    "mode": "apply",
+    "consumer_verdict": "blocked",
+    "consumer_status": "blocked",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "has_runtime_input_overrides": false,
+    "override_kinds": [],
+    "validation_dependency_paths": {
+      "monday_local_operator_inbox_payload": "$VALIDATION_DIR/monday-local-operator-inbox-payload.json",
+      "monday_local_inbox_launch_request": "$VALIDATION_DIR/monday-local-inbox-launch-request.json"
+    },
+    "payload": null
+  }
+}
+JSON
+
+cp "$VALIDATION_DIR/monday-local-inbox-runtime-report.json" \
+  "$VALIDATION_DIR/planningops-local-inbox-consumer-20260401T103000Z-monday-local-inbox-runtime-report.json"
+
+cat >"$VALIDATION_DIR/monday-local-inbox-consumer-report.json" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:33:00+00:00",
+  "run_id": "planningops-local-inbox-consumer-20260401T103000Z",
+  "artifact_family": "monday_local_inbox_consumer_report",
+  "artifact_kind": "report",
+  "contract_ref": "planningops/contracts/monday-local-inbox-validation-mirror-contract.md",
+  "artifact_paths": {
+    "latest_mirror_path": "$VALIDATION_DIR/monday-local-inbox-consumer-report.json",
+    "stamped_mirror_path": "$VALIDATION_DIR/planningops-local-inbox-consumer-20260401T103000Z-monday-local-inbox-consumer-report.json",
+    "source_artifact_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/consumer-report.json",
+    "source_launch_request_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/launch-request.json",
+    "source_runtime_report_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/local-runtime-smoke.json",
+    "source_consumer_report_path": "$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/consumer-report.json"
+  },
+  "mirror": {
+    "source_artifact_present": true,
+    "bridge_id": "monday-local-inbox-20260401T084500Z",
+    "mode": "apply",
+    "consumer_verdict": "blocked",
+    "consumer_status": "blocked",
+    "planner_profile": "local_ollama",
+    "launch_mode": "direct",
+    "local_model_route": "direct_local_ollama",
+    "has_runtime_input_overrides": false,
+    "override_kinds": [],
+    "validation_dependency_paths": {
+      "monday_local_operator_inbox_payload": "$VALIDATION_DIR/monday-local-operator-inbox-payload.json",
+      "monday_local_inbox_launch_request": "$VALIDATION_DIR/monday-local-inbox-launch-request.json",
+      "monday_local_inbox_runtime_report": "$VALIDATION_DIR/monday-local-inbox-runtime-report.json"
+    },
+    "payload": {
+      "consumer_status": "blocked"
+    }
+  }
+}
+JSON
+
+cp "$VALIDATION_DIR/monday-local-inbox-consumer-report.json" \
+  "$VALIDATION_DIR/planningops-local-inbox-consumer-20260401T103000Z-monday-local-inbox-consumer-report.json"
+
 python3 "$QUERY_PATH" handoff-report \
   --format json \
   --ci-root "$CI_DIR" \
@@ -2163,6 +2299,24 @@ assert record["local_operator_summary"] == (
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
 assert record["local_operator_next_step"] == "Expose Codex and add a direct local LLM profile.", record
+assert record["local_validation_snapshot_status"] == "present", record
+assert record["local_validation_snapshot_summary"] == "total=8 promotable=4 blocked=4 stale=1", record
+assert record["local_validation_summary_lines"] == [
+    "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
+    "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
+    "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
+    "monday_local_operator_day_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
+    "monday_local_operator_inbox_payload: freshness=fresh promotability=promotable dependencies=monday_local_operator_day_packet=current,monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
+    "monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+    "monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+], record
+assert record["local_validation_action_lines"] == [
+    "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
+    "local-validation: repair monday_local_mission_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)",
+    "local-validation: repair monday_local_operator_day_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)",
+    "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+], record
 assert record["queue_lines"] == [
     "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1",
     "lagging: targets=1 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint=1,readiness=1,reconcile=1",
@@ -2181,6 +2335,8 @@ assert "## Operator Handoff Report" in record["markdown"], record
 assert "### Snapshot" in record["markdown"], record
 assert "### Local Runtime" in record["markdown"], record
 assert "### Local Validation" in record["markdown"], record
+assert "snapshot status: `present`" in record["markdown"], record
+assert "snapshot summary: `total=8 promotable=4 blocked=4 stale=1`" in record["markdown"], record
 assert "### Local Validation Actions" in record["markdown"], record
 assert "### Queue" in record["markdown"], record
 assert "### Top Targets" in record["markdown"], record
@@ -2212,12 +2368,17 @@ assert record["local_operator_summary"] == (
     "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
+assert record["local_validation_snapshot_status"] == "present", record
+assert record["local_validation_snapshot_summary"] == "total=8 promotable=4 blocked=4 stale=1", record
 assert record["local_validation_summary_lines"] == [
     "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
     "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
     "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
     "monday_local_operator_day_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
     "monday_local_operator_inbox_payload: freshness=fresh promotability=promotable dependencies=monday_local_operator_day_packet=current,monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
+    "monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+    "monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
 ], record
 assert record["immediate_action_lines"] == [
     "local-runtime: Expose Codex and add a direct local LLM profile.",
@@ -2261,17 +2422,23 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
         "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
         "stack=skipped direct=skipped mode=both reason=readiness_blocked"
     ), doc
+    assert doc["record"]["local_validation_snapshot_status"] == "present", doc
+    assert doc["record"]["local_validation_snapshot_summary"] == "total=8 promotable=4 blocked=4 stale=1", doc
     assert doc["record"]["local_validation_summary_lines"] == [
         "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
         "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
         "monday_local_mission_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=operator_handoff_report=current,monday_local_operator_stack_report=current",
         "monday_local_operator_day_packet: freshness=fresh promotability=blocked reasons=missing_rollback_command dependencies=monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
         "monday_local_operator_inbox_payload: freshness=fresh promotability=promotable dependencies=monday_local_operator_day_packet=current,monday_local_mission_packet=current,operator_handoff_report=current,monday_local_operator_stack_report=current",
+        "monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+        "monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+        "monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
     ], doc
     assert doc["record"]["local_validation_action_lines"] == [
         "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
         "local-validation: repair monday_local_mission_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)",
         "local-validation: repair monday_local_operator_day_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)",
+        "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
     ], doc
     assert doc["record"]["immediate_action_lines"] == [
         "local-runtime: Expose Codex and add a direct local LLM profile.",
@@ -2721,9 +2888,12 @@ assert [record["artifact_family"] for record in records] == [
     "monday_local_mission_packet",
     "monday_local_operator_day_packet",
     "monday_local_operator_inbox_payload",
+    "monday_local_inbox_launch_request",
+    "monday_local_inbox_runtime_report",
+    "monday_local_inbox_consumer_report",
 ], records
 
-local_operator, handoff, mission, day_packet, inbox_payload = records
+local_operator, handoff, mission, day_packet, inbox_payload, launch_request, runtime_report, consumer_report = records
 
 assert local_operator["freshness_state"] == "fresh", local_operator
 assert local_operator["promotability_status"] == "promotable", local_operator
@@ -2764,6 +2934,33 @@ assert inbox_payload["dependency_states"] == {
     "monday_local_operator_stack_report": "current",
 }, inbox_payload
 assert inbox_payload["reasons"] == [], inbox_payload
+
+assert launch_request["freshness_state"] == "fresh", launch_request
+assert launch_request["promotability_status"] == "promotable", launch_request
+assert launch_request["promoted_id"] == "planningops-local-inbox-consumer-20260401T103000Z", launch_request
+assert launch_request["dependency_states"] == {
+    "monday_local_operator_inbox_payload": "current",
+}, launch_request
+assert launch_request["reasons"] == [], launch_request
+
+assert runtime_report["freshness_state"] == "fresh", runtime_report
+assert runtime_report["promotability_status"] == "blocked", runtime_report
+assert runtime_report["promoted_id"] == "planningops-local-inbox-consumer-20260401T103000Z", runtime_report
+assert runtime_report["dependency_states"] == {
+    "monday_local_operator_inbox_payload": "current",
+    "monday_local_inbox_launch_request": "current",
+}, runtime_report
+assert runtime_report["reasons"] == ["source_artifact_missing"], runtime_report
+
+assert consumer_report["freshness_state"] == "fresh", consumer_report
+assert consumer_report["promotability_status"] == "promotable", consumer_report
+assert consumer_report["promoted_id"] == "planningops-local-inbox-consumer-20260401T103000Z", consumer_report
+assert consumer_report["dependency_states"] == {
+    "monday_local_operator_inbox_payload": "current",
+    "monday_local_inbox_launch_request": "current",
+    "monday_local_inbox_runtime_report": "current",
+}, consumer_report
+assert consumer_report["reasons"] == [], consumer_report
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \
@@ -2782,6 +2979,7 @@ assert [record["artifact_family"] for record in records] == [
     "operator_handoff_report",
     "monday_local_mission_packet",
     "monday_local_operator_day_packet",
+    "monday_local_inbox_runtime_report",
 ], records
 PY
 


### PR DESCRIPTION
## Summary
- add `handoff-report` local validation snapshot status/summary fields
- fold mirrored monday launch-request, runtime-report, and consumer-report freshness into the operator handoff packet when present
- extend query-engine contract fixtures so the handoff packet exercises the monday inbox validation chain end to end

## Scope
- update `planningops/scripts/federation/query_federated_ci_artifacts.py`
- update `planningops/scripts/test_query_federated_ci_artifacts.sh`
- update `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #966
- Related #965

## Validation
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- handoff-report fixtures now create monday inbox validation mirrors earlier in the regression script, so ordering assumptions in nearby assertions matter more
- local validation snapshot counts are derived from promotability/freshness state and will need to stay aligned if we add more artifact families later

## Review Checklist
- [x] Query output includes monday inbox validation families inside `handoff-report` when mirrored artifacts are present
- [x] Snapshot status/summary stays consistent with detailed local validation lines
- [x] Existing docs/contract checks remain green
