### PR TITLE
feat(local-runtime): mirror monday schema validation reports

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -172,6 +172,13 @@ Current deliverables:
 - `planningops/artifacts/validation/<run-id>-monday-local-inbox-consumer-report.json`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now picks up the mirrored monday launch-request, runtime-report, and consumer-report families when they are present in planningops validation
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries a local validation snapshot status/summary that folds the mirrored monday launch-request, runtime-report, and consumer-report families into the operator packet when present
+- `planningops/contracts/monday-validation-report-mirror-contract.md`
+- `planningops/scripts/write_monday_validation_report_mirror.py`
+- `planningops/artifacts/validation/monday-local-inbox-bridge-schema-validation.json`
+- `planningops/artifacts/validation/<report-id>-monday-local-inbox-bridge-schema-validation.json`
+- `planningops/artifacts/validation/monday-local-inbox-consumer-schema-validation.json`
+- `planningops/artifacts/validation/<report-id>-monday-local-inbox-consumer-schema-validation.json`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now picks up mirrored monday-owned bridge and consumer schema validation verdicts when they are promoted into planningops validation
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -233,6 +240,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether monday-owned schema validation verdicts should stay query-only or also be mirrored into planningops validation artifacts
-2. decide whether monday validation verdicts should also be folded into `handoff-report` or another cross-repo operator packet
+1. decide whether mirrored monday schema validation verdicts should also be folded into `handoff-report` or another cross-repo operator packet
+2. decide whether monday validation verdicts need a payload-first or packet-first query/report surface beyond `local-validation-freshness`
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/contracts/monday-validation-report-mirror-contract.md
+++ b/planningops/contracts/monday-validation-report-mirror-contract.md
@@ -1,0 +1,79 @@
+# Monday Validation Report Mirror Contract
+
+## Purpose
+
+Promote monday-owned inbox schema validation verdicts into `planningops/artifacts/validation` so planningops can reason about those verdicts without rereading sibling runtime artifacts directly.
+
+## Source Inputs
+
+- `monday/runtime-artifacts/validation/planningops-local-operator-inbox-payload-validation-report.json`
+- `monday/runtime-artifacts/validation/planningops-local-operator-inbox-consumer-report-validation-report.json`
+
+Each source report is expected to carry:
+
+- `generated_at_utc`
+- `kind`
+- `artifact_path`
+- `schema_path`
+- `error_count`
+- `warning_count`
+- `errors`
+- `warnings`
+- `verdict`
+
+## Promoted Outputs
+
+### Bridge Validation
+
+- latest: `planningops/artifacts/validation/monday-local-inbox-bridge-schema-validation.json`
+- stamped: `planningops/artifacts/validation/<report-id>-monday-local-inbox-bridge-schema-validation.json`
+
+### Consumer Validation
+
+- latest: `planningops/artifacts/validation/monday-local-inbox-consumer-schema-validation.json`
+- stamped: `planningops/artifacts/validation/<report-id>-monday-local-inbox-consumer-schema-validation.json`
+
+## Document Shape
+
+Each promoted mirror must include:
+
+- `generated_at_utc`
+- `report_id`
+- `artifact_family`
+- `artifact_kind`
+- `contract_ref`
+- `artifact_paths.latest_mirror_path`
+- `artifact_paths.stamped_mirror_path`
+- `artifact_paths.source_report_path`
+- `mirror.source_report_present`
+- `mirror.report_kind`
+- `mirror.report_verdict`
+- `mirror.error_count`
+- `mirror.warning_count`
+- `mirror.artifact_exists`
+- `mirror.schema_exists`
+- `mirror.validation_dependency_paths`
+- `mirror.payload`
+
+## Family Mapping
+
+- `kind=bridge` -> `artifact_family=monday_local_inbox_bridge_schema_validation`
+- `kind=consumer-report` -> `artifact_family=monday_local_inbox_consumer_schema_validation`
+
+## Dependency Mapping
+
+- bridge validation depends on `planningops/artifacts/validation/monday-local-operator-inbox-payload.json`
+- consumer validation depends on `planningops/artifacts/validation/monday-local-inbox-consumer-report.json`
+
+## Promotion Rules
+
+- mirror whichever validation kinds are present; do not fail if one kind is absent
+- fail only when no promotable source validation report documents are discovered
+- preserve source payload verbatim under `mirror.payload`
+- generate deterministic latest and stamped paths for each mirrored kind
+
+## Verification
+
+- `python3 planningops/scripts/write_monday_validation_report_mirror.py --validation-root <validation-root> --monday-validation-root <monday-validation-root>`
+- `bash planningops/scripts/test_write_monday_validation_report_mirror.sh`
+- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -64,6 +64,8 @@ LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_inbox_launch_request",
     "monday_local_inbox_runtime_report",
     "monday_local_inbox_consumer_report",
+    "monday_local_inbox_bridge_schema_validation",
+    "monday_local_inbox_consumer_schema_validation",
 )
 LOCAL_VALIDATION_FRESHNESS_CHOICES = ("fresh", "stale", "missing")
 LOCAL_VALIDATION_PROMOTABILITY_CHOICES = ("promotable", "blocked")
@@ -2169,6 +2171,174 @@ def build_monday_local_inbox_consumer_report_validation_freshness_record(
     )
 
 
+def build_monday_validation_report_mirror_freshness_record(
+    *,
+    validation_root: Path,
+    artifact_family: str,
+    latest_filename: str,
+    expected_report_kind: str,
+    dependency_filenames: dict[str, str],
+) -> LocalValidationFreshnessRecord:
+    latest_path = (validation_root / latest_filename).resolve()
+    latest_doc = load_optional_json(latest_path)
+    freshness_reasons: list[str] = []
+    promotability_reasons: list[str] = []
+    dependency_states: dict[str, str] = {}
+    stamped_path: Path | None = None
+    promoted_id: str | None = None
+    generated_at_utc: str | None = None
+
+    if latest_doc is not None:
+        promoted_id = normalize_optional_string(latest_doc.get("report_id"))
+        generated_at_utc = normalize_optional_string(latest_doc.get("generated_at_utc"))
+        if promoted_id is None:
+            promotability_reasons.append("missing_report_id")
+        if normalize_optional_string(latest_doc.get("artifact_family")) != artifact_family:
+            promotability_reasons.append("artifact_family_mismatch")
+        if normalize_optional_string(latest_doc.get("artifact_kind")) != "validation":
+            promotability_reasons.append("artifact_kind_mismatch")
+        if normalize_optional_string(latest_doc.get("contract_ref")) is None:
+            promotability_reasons.append("missing_contract_ref")
+
+        latest_mirror_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "latest_mirror_path")
+        stamped_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "stamped_mirror_path")
+        source_report_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "source_report_path")
+        if latest_mirror_path != latest_path:
+            freshness_reasons.append("latest_path_mismatch")
+
+        mirror = resolve_nested_value(latest_doc, "mirror")
+        if not isinstance(mirror, dict):
+            promotability_reasons.append("missing_mirror")
+        else:
+            source_report_present = mirror.get("source_report_present")
+            if not isinstance(source_report_present, bool):
+                promotability_reasons.append("missing_source_report_present")
+            else:
+                actual_source_exists = source_report_path.exists() if source_report_path is not None else False
+                if source_report_path is None:
+                    promotability_reasons.append("missing_source_report_path")
+                elif source_report_present != actual_source_exists:
+                    promotability_reasons.append("source_report_state_mismatch")
+                if not actual_source_exists:
+                    promotability_reasons.append("source_report_missing")
+
+            if normalize_optional_string(mirror.get("report_kind")) != expected_report_kind:
+                promotability_reasons.append("report_kind_mismatch")
+
+            report_verdict = normalize_optional_string(mirror.get("report_verdict"))
+            if report_verdict is None:
+                promotability_reasons.append("missing_report_verdict")
+            elif report_verdict != "pass":
+                promotability_reasons.append("validation_verdict_fail")
+
+            error_count = mirror.get("error_count")
+            if not isinstance(error_count, int):
+                promotability_reasons.append("missing_error_count")
+            elif error_count > 0:
+                promotability_reasons.append("validation_errors_present")
+
+            warning_count = mirror.get("warning_count")
+            if not isinstance(warning_count, int):
+                promotability_reasons.append("missing_warning_count")
+
+            artifact_exists = mirror.get("artifact_exists")
+            if not isinstance(artifact_exists, bool):
+                promotability_reasons.append("missing_artifact_exists")
+            elif not artifact_exists:
+                promotability_reasons.append("validated_artifact_missing")
+
+            schema_exists = mirror.get("schema_exists")
+            if not isinstance(schema_exists, bool):
+                promotability_reasons.append("missing_schema_exists")
+            elif not schema_exists:
+                promotability_reasons.append("validation_schema_missing")
+
+            if source_report_present and not isinstance(mirror.get("payload"), dict):
+                promotability_reasons.append("missing_payload")
+
+            validation_dependency_paths = mirror.get("validation_dependency_paths")
+            if dependency_filenames and not isinstance(validation_dependency_paths, dict):
+                promotability_reasons.append("missing_validation_dependency_paths")
+            elif isinstance(validation_dependency_paths, dict):
+                for dependency_family, dependency_filename in dependency_filenames.items():
+                    dependency_state, dependency_reason = build_local_validation_dependency_state(
+                        raw_path=validation_dependency_paths.get(dependency_family),
+                        expected_path=validation_root / dependency_filename,
+                    )
+                    dependency_states[dependency_family] = dependency_state
+                    if dependency_reason == "dependency_path_missing":
+                        promotability_reasons.append(f"missing_{dependency_family}_path")
+                    elif dependency_reason == "dependency_missing":
+                        promotability_reasons.append(f"{dependency_family}_dependency_missing")
+                    elif dependency_reason == "dependency_stale":
+                        promotability_reasons.append(f"{dependency_family}_dependency_stale")
+
+        if stamped_path is not None and stamped_path.exists():
+            stamped_doc = load_optional_json(stamped_path)
+            if stamped_doc is None:
+                freshness_reasons.append("stamped_invalid_json")
+            else:
+                if normalize_optional_string(stamped_doc.get("report_id")) != promoted_id:
+                    freshness_reasons.append("stamped_report_id_mismatch")
+                stamped_latest_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "latest_mirror_path")
+                stamped_stamped_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "stamped_mirror_path")
+                if stamped_latest_path != latest_path:
+                    freshness_reasons.append("stamped_latest_path_mismatch")
+                if stamped_stamped_path != stamped_path.resolve():
+                    freshness_reasons.append("stamped_path_mismatch")
+
+    freshness_state, promotability_status = classify_local_validation_states(
+        latest_path=latest_path,
+        latest_doc=latest_doc,
+        stamped_path=stamped_path,
+        freshness_reasons=freshness_reasons,
+        promotability_reasons=promotability_reasons,
+        dependency_states=dependency_states,
+    )
+    return LocalValidationFreshnessRecord(
+        artifact_family=artifact_family,
+        artifact_kind="validation",
+        promoted_id=promoted_id,
+        generated_at_utc=generated_at_utc,
+        freshness_state=freshness_state,
+        promotability_status=promotability_status,
+        latest_path=str(latest_path),
+        stamped_path=None if stamped_path is None else str(stamped_path.resolve()),
+        reasons=freshness_reasons + promotability_reasons,
+        dependency_states=dependency_states,
+    )
+
+
+def build_monday_bridge_validation_mirror_freshness_record(
+    *,
+    validation_root: Path,
+) -> LocalValidationFreshnessRecord:
+    return build_monday_validation_report_mirror_freshness_record(
+        validation_root=validation_root,
+        artifact_family="monday_local_inbox_bridge_schema_validation",
+        latest_filename="monday-local-inbox-bridge-schema-validation.json",
+        expected_report_kind="bridge",
+        dependency_filenames={
+            "monday_local_operator_inbox_payload": "monday-local-operator-inbox-payload.json",
+        },
+    )
+
+
+def build_monday_consumer_validation_mirror_freshness_record(
+    *,
+    validation_root: Path,
+) -> LocalValidationFreshnessRecord:
+    return build_monday_validation_report_mirror_freshness_record(
+        validation_root=validation_root,
+        artifact_family="monday_local_inbox_consumer_schema_validation",
+        latest_filename="monday-local-inbox-consumer-schema-validation.json",
+        expected_report_kind="consumer-report",
+        dependency_filenames={
+            "monday_local_inbox_consumer_report": "monday-local-inbox-consumer-report.json",
+        },
+    )
+
+
 def discover_local_validation_freshness_records(*, validation_root: Path) -> list[LocalValidationFreshnessRecord]:
     records = [
         build_local_operator_validation_freshness_record(validation_root=validation_root),
@@ -2195,6 +2365,18 @@ def discover_local_validation_freshness_records(*, validation_root: Path) -> lis
         stamped_glob="*-monday-local-inbox-consumer-report.json",
     ):
         records.append(build_monday_local_inbox_consumer_report_validation_freshness_record(validation_root=validation_root))
+    if has_promoted_local_validation_artifact(
+        validation_root=validation_root,
+        latest_filename="monday-local-inbox-bridge-schema-validation.json",
+        stamped_glob="*-monday-local-inbox-bridge-schema-validation.json",
+    ):
+        records.append(build_monday_bridge_validation_mirror_freshness_record(validation_root=validation_root))
+    if has_promoted_local_validation_artifact(
+        validation_root=validation_root,
+        latest_filename="monday-local-inbox-consumer-schema-validation.json",
+        stamped_glob="*-monday-local-inbox-consumer-schema-validation.json",
+    ):
+        records.append(build_monday_consumer_validation_mirror_freshness_record(validation_root=validation_root))
     return records
 
 

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 QUERY_PATH="$ROOT_DIR/scripts/federation/query_federated_ci_artifacts.py"
 WRITE_LOCAL_INBOX_VALIDATION_MIRROR_PATH="$ROOT_DIR/scripts/write_monday_local_inbox_validation_mirror.py"
+WRITE_MONDAY_VALIDATION_REPORT_MIRROR_PATH="$ROOT_DIR/scripts/write_monday_validation_report_mirror.py"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -668,6 +669,9 @@ MONDAY_CONSUMER_OVERRIDE_OUTPUT="$TMP_DIR/monday-consumer-report-override.json"
 MONDAY_VALIDATION_OUTPUT="$TMP_DIR/monday-validation-report.json"
 MONDAY_VALIDATION_FAIL_OUTPUT="$TMP_DIR/monday-validation-report-fail.json"
 MONDAY_VALIDATION_BRIDGE_OUTPUT="$TMP_DIR/monday-validation-report-bridge.json"
+MONDAY_VALIDATION_MIRROR_WRITE_OUTPUT="$TMP_DIR/monday-validation-report-mirror-write.json"
+LOCAL_VALIDATION_WITH_MONDAY_VALIDATION_OUTPUT="$TMP_DIR/local-validation-freshness-with-monday-validation.json"
+LOCAL_VALIDATION_MONDAY_VALIDATION_BLOCKED_OUTPUT="$TMP_DIR/local-validation-monday-validation-blocked.json"
 LOCAL_OPERATOR_OUTPUT="$TMP_DIR/local-operator-stack.json"
 LOCAL_OPERATOR_FILTERED_OUTPUT="$TMP_DIR/local-operator-stack-filtered.json"
 LOCAL_OPERATOR_DETAIL_OUTPUT="$TMP_DIR/local-operator-stack-detail.json"
@@ -3563,6 +3567,24 @@ assert record["verdict"] == "pass", record
 assert record["warning_count"] == 0, record
 PY
 
+python3 "$WRITE_MONDAY_VALIDATION_REPORT_MIRROR_PATH" \
+  --validation-root "$VALIDATION_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$MONDAY_VALIDATION_MIRROR_WRITE_OUTPUT"
+
+python3 - <<'PY' "$MONDAY_VALIDATION_MIRROR_WRITE_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert [record["artifact_family"] for record in doc["records"]] == [
+    "monday_local_inbox_bridge_schema_validation",
+    "monday_local_inbox_consumer_schema_validation",
+], doc
+assert doc["records"][0]["report_verdict"] == "pass", doc
+assert doc["records"][1]["report_verdict"] == "fail", doc
+PY
+
 python3 "$WRITE_LOCAL_INBOX_VALIDATION_MIRROR_PATH" \
   --validation-root "$VALIDATION_DIR" \
   --consumer-root "$MONDAY_CONSUMER_DIR" >"$LOCAL_VALIDATION_MIRROR_WRITE_OUTPUT"
@@ -3601,6 +3623,8 @@ assert [record["artifact_family"] for record in records] == [
     "monday_local_inbox_launch_request",
     "monday_local_inbox_runtime_report",
     "monday_local_inbox_consumer_report",
+    "monday_local_inbox_bridge_schema_validation",
+    "monday_local_inbox_consumer_schema_validation",
 ], records
 
 launch_request = records[5]
@@ -3633,6 +3657,76 @@ assert consumer_report["dependency_states"] == {
     "monday_local_inbox_runtime_report": "current",
 }, consumer_report
 assert consumer_report["reasons"] == [], consumer_report
+PY
+
+python3 "$QUERY_PATH" local-validation-freshness \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_VALIDATION_WITH_MONDAY_VALIDATION_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_WITH_MONDAY_VALIDATION_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["artifact_family"] for record in records] == [
+    "monday_local_operator_stack_report",
+    "operator_handoff_report",
+    "monday_local_mission_packet",
+    "monday_local_operator_day_packet",
+    "monday_local_operator_inbox_payload",
+    "monday_local_inbox_launch_request",
+    "monday_local_inbox_runtime_report",
+    "monday_local_inbox_consumer_report",
+    "monday_local_inbox_bridge_schema_validation",
+    "monday_local_inbox_consumer_schema_validation",
+], records
+
+bridge_validation = records[8]
+consumer_validation = records[9]
+
+assert bridge_validation["freshness_state"] == "fresh", bridge_validation
+assert bridge_validation["promotability_status"] == "promotable", bridge_validation
+assert bridge_validation["dependency_states"] == {
+    "monday_local_operator_inbox_payload": "current",
+}, bridge_validation
+assert bridge_validation["reasons"] == [], bridge_validation
+
+assert consumer_validation["freshness_state"] == "fresh", consumer_validation
+assert consumer_validation["promotability_status"] == "blocked", consumer_validation
+assert consumer_validation["dependency_states"] == {
+    "monday_local_inbox_consumer_report": "current",
+}, consumer_validation
+assert consumer_validation["reasons"] == [
+    "validation_verdict_fail",
+    "validation_errors_present",
+], consumer_validation
+PY
+
+python3 "$QUERY_PATH" local-validation-freshness \
+  --artifact-family monday_local_inbox_consumer_schema_validation \
+  --promotability-status blocked \
+  --has-reason validation_verdict_fail \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_VALIDATION_MONDAY_VALIDATION_BLOCKED_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_MONDAY_VALIDATION_BLOCKED_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["artifact_family"] == "monday_local_inbox_consumer_schema_validation", record
+assert record["freshness_state"] == "fresh", record
+assert record["promotability_status"] == "blocked", record
+assert record["reasons"] == [
+    "validation_verdict_fail",
+    "validation_errors_present",
+], record
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \

--- a/planningops/scripts/test_write_monday_validation_report_mirror.sh
+++ b/planningops/scripts/test_write_monday_validation_report_mirror.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+VALIDATION_DIR="$TMP_DIR/validation"
+MONDAY_VALIDATION_DIR="$TMP_DIR/monday/runtime-artifacts/validation"
+OUTPUT_PATH="$TMP_DIR/monday-validation-mirror-output.json"
+STDOUT_PATH="$TMP_DIR/monday-validation-mirror-stdout.json"
+
+mkdir -p "$VALIDATION_DIR" "$MONDAY_VALIDATION_DIR"
+
+cat >"$VALIDATION_DIR/monday-local-operator-inbox-payload.json" <<'JSON'
+{
+  "bridge_id": "monday-local-inbox-20260401T084500Z"
+}
+JSON
+
+cat >"$VALIDATION_DIR/monday-local-inbox-consumer-report.json" <<'JSON'
+{
+  "run_id": "planningops-local-inbox-consumer-20260401T103000Z"
+}
+JSON
+
+cat >"$MONDAY_VALIDATION_DIR/source-bridge-artifact.json" <<'JSON'
+{
+  "bridge_id": "monday-local-inbox-20260401T084500Z"
+}
+JSON
+
+cat >"$MONDAY_VALIDATION_DIR/source-consumer-report.json" <<'JSON'
+{
+  "run_id": "planningops-local-inbox-consumer-20260401T103000Z"
+}
+JSON
+
+cat >"$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-payload-bridge.schema.json" <<'JSON'
+{
+  "title": "bridge schema"
+}
+JSON
+
+cat >"$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-consumer-report.schema.json" <<'JSON'
+{
+  "title": "consumer schema"
+}
+JSON
+
+cat >"$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-payload-validation-report.json" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:40:00+00:00",
+  "kind": "bridge",
+  "artifact_path": "$MONDAY_VALIDATION_DIR/source-bridge-artifact.json",
+  "schema_path": "$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-payload-bridge.schema.json",
+  "error_count": 0,
+  "warning_count": 0,
+  "errors": [],
+  "warnings": [],
+  "verdict": "pass"
+}
+JSON
+
+cat >"$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-consumer-report-validation-report.json" <<JSON
+{
+  "generated_at_utc": "2026-04-01T10:50:00+00:00",
+  "kind": "consumer-report",
+  "artifact_path": "$MONDAY_VALIDATION_DIR/source-consumer-report.json",
+  "schema_path": "$MONDAY_VALIDATION_DIR/planningops-local-operator-inbox-consumer-report.schema.json",
+  "error_count": 2,
+  "warning_count": 1,
+  "errors": [
+    "consumer contract ref mismatch",
+    "schema validation failed"
+  ],
+  "warnings": [
+    "runtime report path missing"
+  ],
+  "verdict": "fail"
+}
+JSON
+
+python3 planningops/scripts/write_monday_validation_report_mirror.py \
+  --validation-root "$VALIDATION_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --output "$OUTPUT_PATH" >"$STDOUT_PATH"
+
+python3 - <<'PY' "$STDOUT_PATH" "$OUTPUT_PATH" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+stdout_doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_doc = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+validation_dir = Path(sys.argv[3]).resolve()
+
+for doc in (stdout_doc, output_doc):
+    assert [record["artifact_family"] for record in doc["records"]] == [
+        "monday_local_inbox_bridge_schema_validation",
+        "monday_local_inbox_consumer_schema_validation",
+    ], doc
+
+bridge_latest = json.loads((validation_dir / "monday-local-inbox-bridge-schema-validation.json").read_text(encoding="utf-8"))
+consumer_latest = json.loads((validation_dir / "monday-local-inbox-consumer-schema-validation.json").read_text(encoding="utf-8"))
+
+assert bridge_latest["artifact_family"] == "monday_local_inbox_bridge_schema_validation", bridge_latest
+assert bridge_latest["artifact_kind"] == "validation", bridge_latest
+assert bridge_latest["mirror"]["report_kind"] == "bridge", bridge_latest
+assert bridge_latest["mirror"]["report_verdict"] == "pass", bridge_latest
+assert bridge_latest["mirror"]["error_count"] == 0, bridge_latest
+assert bridge_latest["mirror"]["artifact_exists"] is True, bridge_latest
+assert bridge_latest["mirror"]["schema_exists"] is True, bridge_latest
+assert bridge_latest["mirror"]["validation_dependency_paths"] == {
+    "monday_local_operator_inbox_payload": str((validation_dir / "monday-local-operator-inbox-payload.json").resolve())
+}, bridge_latest
+
+assert consumer_latest["artifact_family"] == "monday_local_inbox_consumer_schema_validation", consumer_latest
+assert consumer_latest["artifact_kind"] == "validation", consumer_latest
+assert consumer_latest["mirror"]["report_kind"] == "consumer-report", consumer_latest
+assert consumer_latest["mirror"]["report_verdict"] == "fail", consumer_latest
+assert consumer_latest["mirror"]["error_count"] == 2, consumer_latest
+assert consumer_latest["mirror"]["warning_count"] == 1, consumer_latest
+assert consumer_latest["mirror"]["artifact_exists"] is True, consumer_latest
+assert consumer_latest["mirror"]["schema_exists"] is True, consumer_latest
+assert consumer_latest["mirror"]["validation_dependency_paths"] == {
+    "monday_local_inbox_consumer_report": str((validation_dir / "monday-local-inbox-consumer-report.json").resolve())
+}, consumer_latest
+PY
+
+echo "write monday validation report mirror ok"

--- a/planningops/scripts/write_monday_validation_report_mirror.py
+++ b/planningops/scripts/write_monday_validation_report_mirror.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_VALIDATION_ROOT = WORKSPACE_ROOT / "planningops/artifacts/validation"
+DEFAULT_MONDAY_VALIDATION_ROOT = WORKSPACE_ROOT.parent / "monday" / "runtime-artifacts/validation"
+CONTRACT_REF = "planningops/contracts/monday-validation-report-mirror-contract.md"
+
+MIRROR_CONFIGS = {
+    "bridge": {
+        "artifact_family": "monday_local_inbox_bridge_schema_validation",
+        "latest_filename": "monday-local-inbox-bridge-schema-validation.json",
+        "dependency_paths": {
+            "monday_local_operator_inbox_payload": "monday-local-operator-inbox-payload.json",
+        },
+    },
+    "consumer-report": {
+        "artifact_family": "monday_local_inbox_consumer_schema_validation",
+        "latest_filename": "monday-local-inbox-consumer-schema-validation.json",
+        "dependency_paths": {
+            "monday_local_inbox_consumer_report": "monday-local-inbox-consumer-report.json",
+        },
+    },
+}
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (WORKSPACE_ROOT / path).resolve()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_optional_json(path: Path) -> dict | None:
+    try:
+        return load_json(path)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def write_json(path: Path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def is_validation_report_document(doc: dict) -> bool:
+    return (
+        isinstance(doc.get("generated_at_utc"), str)
+        and doc.get("kind") in MIRROR_CONFIGS
+        and isinstance(doc.get("artifact_path"), str)
+        and isinstance(doc.get("schema_path"), str)
+        and isinstance(doc.get("error_count"), int)
+        and isinstance(doc.get("warning_count"), int)
+        and isinstance(doc.get("errors"), list)
+        and isinstance(doc.get("warnings"), list)
+        and isinstance(doc.get("verdict"), str)
+    )
+
+
+def timestamp_slug(raw_timestamp: str) -> str:
+    text = raw_timestamp.strip()
+    if not text:
+        return "unknown"
+    cleaned = text.replace("-", "").replace(":", "").replace("+00:00", "Z").replace("+0000", "Z")
+    cleaned = cleaned.replace(".", "").replace("T", "T")
+    return "".join(ch for ch in cleaned if ch.isalnum())
+
+
+def discover_latest_reports_by_kind(monday_validation_root: Path) -> dict[str, tuple[Path, dict]]:
+    candidates: dict[str, list[tuple[str, str, Path, dict]]] = {kind: [] for kind in MIRROR_CONFIGS}
+    if not monday_validation_root.exists():
+        return {}
+    for path in monday_validation_root.glob("*.json"):
+        if any(part.startswith(".") or part.startswith("._") for part in path.parts):
+            continue
+        doc = load_optional_json(path)
+        if doc is None or not is_validation_report_document(doc):
+            continue
+        kind = str(doc.get("kind"))
+        generated_at_utc = str(doc.get("generated_at_utc") or "").strip()
+        candidates[kind].append((generated_at_utc, str(path.resolve()), path.resolve(), doc))
+
+    latest_by_kind: dict[str, tuple[Path, dict]] = {}
+    for kind, items in candidates.items():
+        if not items:
+            continue
+        items.sort(key=lambda item: (item[0], item[1]), reverse=True)
+        latest_by_kind[kind] = (items[0][2], items[0][3])
+    return latest_by_kind
+
+
+def build_mirror_doc(
+    *,
+    validation_root: Path,
+    kind: str,
+    source_report_path: Path,
+    source_report_doc: dict,
+) -> tuple[dict, Path, Path]:
+    config = MIRROR_CONFIGS[kind]
+    generated_at_utc = str(source_report_doc.get("generated_at_utc") or "").strip()
+    report_id = f"monday-validation-{kind.replace('-', '-')}-{timestamp_slug(generated_at_utc)}"
+    latest_mirror_path = validation_root / config["latest_filename"]
+    stamped_mirror_path = validation_root / f"{report_id}-{config['latest_filename']}"
+
+    source_artifact_path = resolve_path(str(source_report_doc.get("artifact_path")))
+    source_schema_path = resolve_path(str(source_report_doc.get("schema_path")))
+    dependency_paths = {
+        family: str((validation_root / filename).resolve())
+        for family, filename in config["dependency_paths"].items()
+    }
+    doc = {
+        "generated_at_utc": now_utc(),
+        "report_id": report_id,
+        "artifact_family": config["artifact_family"],
+        "artifact_kind": "validation",
+        "contract_ref": CONTRACT_REF,
+        "artifact_paths": {
+            "latest_mirror_path": str(latest_mirror_path.resolve()),
+            "stamped_mirror_path": str(stamped_mirror_path.resolve()),
+            "source_report_path": str(source_report_path.resolve()),
+        },
+        "mirror": {
+            "source_report_present": bool(source_report_path.exists()),
+            "report_kind": kind,
+            "report_verdict": str(source_report_doc.get("verdict") or "").strip() or None,
+            "error_count": int(source_report_doc.get("error_count") or 0),
+            "warning_count": int(source_report_doc.get("warning_count") or 0),
+            "artifact_exists": source_artifact_path.exists(),
+            "schema_exists": source_schema_path.exists(),
+            "validation_dependency_paths": dependency_paths,
+            "payload": source_report_doc,
+        },
+    }
+    return doc, latest_mirror_path, stamped_mirror_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Mirror monday-owned inbox schema validation reports into planningops validation."
+    )
+    parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    parser.add_argument("--monday-validation-root", default=str(DEFAULT_MONDAY_VALIDATION_ROOT))
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    validation_root = resolve_path(args.validation_root)
+    monday_validation_root = resolve_path(args.monday_validation_root)
+    output_path = None if args.output is None else resolve_path(args.output)
+
+    if not (WORKSPACE_ROOT / CONTRACT_REF).exists():
+        raise SystemExit(f"validation mirror contract missing: {CONTRACT_REF}")
+
+    latest_by_kind = discover_latest_reports_by_kind(monday_validation_root)
+    if not latest_by_kind:
+        raise SystemExit(f"monday validation reports not found under {monday_validation_root}")
+
+    result_records: list[dict] = []
+    for kind in ("bridge", "consumer-report"):
+        selected = latest_by_kind.get(kind)
+        if selected is None:
+            continue
+        source_report_path, source_report_doc = selected
+        doc, latest_mirror_path, stamped_mirror_path = build_mirror_doc(
+            validation_root=validation_root,
+            kind=kind,
+            source_report_path=source_report_path,
+            source_report_doc=source_report_doc,
+        )
+        write_json(latest_mirror_path, doc)
+        write_json(stamped_mirror_path, doc)
+        result_records.append(
+            {
+                "artifact_family": doc["artifact_family"],
+                "report_id": doc["report_id"],
+                "latest_mirror_path": str(latest_mirror_path.resolve()),
+                "stamped_mirror_path": str(stamped_mirror_path.resolve()),
+                "report_kind": kind,
+                "report_verdict": doc["mirror"]["report_verdict"],
+                "error_count": doc["mirror"]["error_count"],
+                "warning_count": doc["mirror"]["warning_count"],
+            }
+        )
+
+    if not result_records:
+        raise SystemExit(f"no mirrorable monday validation reports found under {monday_validation_root}")
+
+    result = {
+        "generated_at_utc": now_utc(),
+        "contract_ref": CONTRACT_REF,
+        "records": result_records,
+    }
+    if output_path is not None:
+        write_json(output_path, result)
+    print(json.dumps(result, ensure_ascii=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Mirror monday-owned inbox schema validation reports into `planningops/artifacts/validation` as latest/stamped artifacts.
- Extend `local-validation-freshness` so the mirrored bridge and consumer schema validation families are evaluated in the same promotion lane.
- Record the new mirror lane in the monday local Codex rollout plan.

## Scope
- Initiative docs:
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`
- `planningops/` scripts/contracts: `planningops/contracts/monday-validation-report-mirror-contract.md`, `planningops/scripts/write_monday_validation_report_mirror.py`, `planningops/scripts/test_write_monday_validation_report_mirror.sh`, `planningops/scripts/federation/query_federated_ci_artifacts.py`, `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `.github/` workflows:

## Linked Issues
- Closes #968
- Related #964

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): `python3 -m py_compile planningops/scripts/write_monday_validation_report_mirror.py planningops/scripts/federation/query_federated_ci_artifacts.py`, `bash planningops/scripts/test_write_monday_validation_report_mirror.sh`, `bash planningops/scripts/test_query_federated_ci_artifacts.sh`, `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`

## Risks
- Risk: cross-repo validation verdicts can drift if monday-owned report shapes change without updating the mirror contract.
- Rollback: revert this PR to remove the mirror writer and query-engine integration.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.