### PR TITLE
feat(query-engine): surface monday schema validation in handoff reports

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -179,6 +179,7 @@ Current deliverables:
 - `planningops/artifacts/validation/monday-local-inbox-consumer-schema-validation.json`
 - `planningops/artifacts/validation/<report-id>-monday-local-inbox-consumer-schema-validation.json`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now picks up mirrored monday-owned bridge and consumer schema validation verdicts when they are promoted into planningops validation
+- `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries a dedicated monday schema validation snapshot/summary/actions section when those mirrored verdicts are present
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -240,6 +241,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether mirrored monday schema validation verdicts should also be folded into `handoff-report` or another cross-repo operator packet
-2. decide whether monday validation verdicts need a payload-first or packet-first query/report surface beyond `local-validation-freshness`
+1. decide whether mirrored monday schema validation verdicts should also surface in `local-inbox-payload` or another payload-first operator packet
+2. decide whether monday validation verdicts need a dedicated cross-repo validation report surface beyond `handoff-report` and `local-validation-freshness`
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -315,6 +315,11 @@ class HandoffReportRecord:
     local_validation_records: list[LocalValidationFreshnessRecord]
     local_validation_summary_lines: list[str]
     local_validation_action_lines: list[str]
+    monday_validation_snapshot_status: str
+    monday_validation_snapshot_summary: str
+    monday_validation_records: list[LocalValidationFreshnessRecord]
+    monday_validation_summary_lines: list[str]
+    monday_validation_action_lines: list[str]
     queue_lines: list[str]
     target_lines: list[str]
     immediate_action_lines: list[str]
@@ -2485,6 +2490,20 @@ def build_local_validation_snapshot(records: list[LocalValidationFreshnessRecord
     return snapshot_status, snapshot_summary
 
 
+def select_monday_validation_records(
+    records: list[LocalValidationFreshnessRecord],
+) -> list[LocalValidationFreshnessRecord]:
+    return [
+        record
+        for record in records
+        if record.artifact_family
+        in {
+            "monday_local_inbox_bridge_schema_validation",
+            "monday_local_inbox_consumer_schema_validation",
+        }
+    ]
+
+
 def build_summary_health_fields(
     *,
     verdict: Any,
@@ -3667,6 +3686,16 @@ def build_handoff_report_record(
         for action in (build_local_validation_action_line(record) for record in local_validation_records)
         if action is not None
     ]
+    monday_validation_records = select_monday_validation_records(local_validation_records)
+    monday_validation_snapshot_status, monday_validation_snapshot_summary = build_local_validation_snapshot(
+        monday_validation_records
+    )
+    monday_validation_summary_lines = [build_local_validation_summary_line(record) for record in monday_validation_records]
+    monday_validation_action_lines = [
+        action
+        for action in (build_local_validation_action_line(record) for record in monday_validation_records)
+        if action is not None
+    ]
     headline = f"Operator handoff report: {triage_report.headline.removeprefix('Federated CI triage report: ')}"
     immediate_action_lines: list[str] = []
     if triage_report.local_operator_next_step is not None:
@@ -3706,6 +3735,24 @@ def build_handoff_report_record(
             *[f"- {line}" for line in local_validation_summary_lines],
         ]
     )
+    if monday_validation_records:
+        markdown_lines.extend(
+            [
+                "",
+                "### Monday Schema Validation",
+                f"- snapshot status: `{monday_validation_snapshot_status}`",
+                f"- snapshot summary: `{monday_validation_snapshot_summary}`",
+                *[f"- {line}" for line in monday_validation_summary_lines],
+            ]
+        )
+    if monday_validation_action_lines:
+        markdown_lines.extend(
+            [
+                "",
+                "### Monday Schema Validation Actions",
+                *[f"{index}. {line}" for index, line in enumerate(monday_validation_action_lines, start=1)],
+            ]
+        )
     if local_validation_action_lines:
         markdown_lines.extend(["", "### Local Validation Actions", *[f"{index}. {line}" for index, line in enumerate(local_validation_action_lines, start=1)]])
     markdown_lines.extend(["", "### Queue", *[f"- {line}" for line in triage_report.queue_lines]])
@@ -3730,6 +3777,11 @@ def build_handoff_report_record(
         local_validation_records=local_validation_records,
         local_validation_summary_lines=local_validation_summary_lines,
         local_validation_action_lines=local_validation_action_lines,
+        monday_validation_snapshot_status=monday_validation_snapshot_status,
+        monday_validation_snapshot_summary=monday_validation_snapshot_summary,
+        monday_validation_records=monday_validation_records,
+        monday_validation_summary_lines=monday_validation_summary_lines,
+        monday_validation_action_lines=monday_validation_action_lines,
         queue_lines=triage_report.queue_lines,
         target_lines=triage_report.target_lines,
         immediate_action_lines=immediate_action_lines,
@@ -3754,6 +3806,12 @@ def render_handoff_report_table(record: HandoffReportRecord) -> str:
     sections.append(f"local_validation_snapshot_status\t{record.local_validation_snapshot_status}")
     sections.append(f"local_validation_snapshot_summary\t{record.local_validation_snapshot_summary}")
     sections.extend(["local_validation", *record.local_validation_summary_lines])
+    sections.append(f"monday_validation_snapshot_status\t{record.monday_validation_snapshot_status}")
+    sections.append(f"monday_validation_snapshot_summary\t{record.monday_validation_snapshot_summary}")
+    if record.monday_validation_summary_lines:
+        sections.extend(["monday_validation", *record.monday_validation_summary_lines])
+    if record.monday_validation_action_lines:
+        sections.extend(["monday_validation_actions", *record.monday_validation_action_lines])
     if record.local_validation_action_lines:
         sections.extend(["local_validation_actions", *record.local_validation_action_lines])
     sections.extend(["queue", *record.queue_lines, "targets", *record.target_lines, "immediate_actions", *record.immediate_action_lines])

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -652,6 +652,7 @@ TRIAGE_REPORT_OUTPUT="$TMP_DIR/triage-report.json"
 TRIAGE_REPORT_ALL_OUTPUT="$TMP_DIR/triage-report-all.json"
 HANDOFF_REPORT_OUTPUT="$TMP_DIR/handoff-report.json"
 HANDOFF_REPORT_ALL_OUTPUT="$TMP_DIR/handoff-report-all.json"
+HANDOFF_REPORT_WITH_MONDAY_VALIDATION_OUTPUT="$TMP_DIR/handoff-report-with-monday-validation.json"
 HANDOFF_WRITE_OUTPUT="$TMP_DIR/handoff-write.json"
 LOCAL_VALIDATION_OUTPUT="$TMP_DIR/local-validation-freshness.json"
 LOCAL_VALIDATION_BLOCKED_OUTPUT="$TMP_DIR/local-validation-freshness-blocked.json"
@@ -2305,6 +2306,10 @@ assert record["local_operator_summary"] == (
 assert record["local_operator_next_step"] == "Expose Codex and add a direct local LLM profile.", record
 assert record["local_validation_snapshot_status"] == "present", record
 assert record["local_validation_snapshot_summary"] == "total=8 promotable=4 blocked=4 stale=1", record
+assert record["monday_validation_snapshot_status"] == "missing", record
+assert record["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
+assert record["monday_validation_summary_lines"] == [], record
+assert record["monday_validation_action_lines"] == [], record
 assert record["local_validation_summary_lines"] == [
     "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
     "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
@@ -2339,6 +2344,7 @@ assert "## Operator Handoff Report" in record["markdown"], record
 assert "### Snapshot" in record["markdown"], record
 assert "### Local Runtime" in record["markdown"], record
 assert "### Local Validation" in record["markdown"], record
+assert "### Monday Schema Validation" not in record["markdown"], record
 assert "snapshot status: `present`" in record["markdown"], record
 assert "snapshot summary: `total=8 promotable=4 blocked=4 stale=1`" in record["markdown"], record
 assert "### Local Validation Actions" in record["markdown"], record
@@ -2374,6 +2380,10 @@ assert record["local_operator_summary"] == (
 ), record
 assert record["local_validation_snapshot_status"] == "present", record
 assert record["local_validation_snapshot_summary"] == "total=8 promotable=4 blocked=4 stale=1", record
+assert record["monday_validation_snapshot_status"] == "missing", record
+assert record["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
+assert record["monday_validation_summary_lines"] == [], record
+assert record["monday_validation_action_lines"] == [], record
 assert record["local_validation_summary_lines"] == [
     "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
     "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
@@ -2428,6 +2438,10 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     ), doc
     assert doc["record"]["local_validation_snapshot_status"] == "present", doc
     assert doc["record"]["local_validation_snapshot_summary"] == "total=8 promotable=4 blocked=4 stale=1", doc
+    assert doc["record"]["monday_validation_snapshot_status"] == "missing", doc
+    assert doc["record"]["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", doc
+    assert doc["record"]["monday_validation_summary_lines"] == [], doc
+    assert doc["record"]["monday_validation_action_lines"] == [], doc
     assert doc["record"]["local_validation_summary_lines"] == [
         "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
         "operator_handoff_report: freshness=stale promotability=blocked reasons=stamped_missing",
@@ -3727,6 +3741,44 @@ assert record["reasons"] == [
     "validation_verdict_fail",
     "validation_errors_present",
 ], record
+PY
+
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" >"$HANDOFF_REPORT_WITH_MONDAY_VALIDATION_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_WITH_MONDAY_VALIDATION_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["local_validation_snapshot_status"] == "present", record
+assert record["local_validation_snapshot_summary"] == "total=10 promotable=5 blocked=5 stale=1", record
+assert record["monday_validation_snapshot_status"] == "present", record
+assert record["monday_validation_snapshot_summary"] == "total=2 promotable=1 blocked=1 stale=0", record
+assert record["monday_validation_summary_lines"] == [
+    "monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "monday_local_inbox_consumer_schema_validation: freshness=fresh promotability=blocked reasons=validation_verdict_fail,validation_errors_present dependencies=monday_local_inbox_consumer_report=current",
+], record
+assert record["monday_validation_action_lines"] == [
+    "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)",
+], record
+assert record["local_validation_summary_lines"][-2:] == [
+    "monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "monday_local_inbox_consumer_schema_validation: freshness=fresh promotability=blocked reasons=validation_verdict_fail,validation_errors_present dependencies=monday_local_inbox_consumer_report=current",
+], record
+assert record["local_validation_action_lines"][-1] == (
+    "local-validation: repair monday_local_inbox_consumer_schema_validation "
+    "(freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)"
+), record
+assert "### Monday Schema Validation" in record["markdown"], record
+assert "snapshot summary: `total=2 promotable=1 blocked=1 stale=0`" in record["markdown"], record
+assert "### Monday Schema Validation Actions" in record["markdown"], record
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \


### PR DESCRIPTION
## Summary
- Surface mirrored monday schema validation verdicts directly inside `handoff-report`.
- Add dedicated monday validation snapshot, summary lines, and action lines so operator packets show payload evidence and schema verdicts together.
- Extend the handoff/query regressions and rollout plan to lock the new cross-repo reporting shape.

## Scope
- Initiative docs:
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`
- `planningops/` scripts/contracts: `planningops/scripts/federation/query_federated_ci_artifacts.py`, `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `.github/` workflows:

## Linked Issues
- Closes #970
- Related #968

## Validation
- [x] `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- [x] `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): none

## Risks
- Risk: `handoff-report` JSON and markdown now carry monday-specific validation sections; downstream consumers that assumed only generic local validation summaries could need to tolerate extra fields/sections.
- Rollback: revert `feat(query-engine): surface monday schema validation in handoff`.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
