### PR TITLE
feat(query-engine): surface monday schema validation in consumer reports

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -181,6 +181,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now picks up mirrored monday-owned bridge and consumer schema validation verdicts when they are promoted into planningops validation
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries a dedicated monday schema validation snapshot/summary/actions section when those mirrored verdicts are present
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-inbox-payload` now carries a bridge-aware monday schema validation snapshot/summary/actions view for the current inbox payload without routing through `handoff-report`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py monday-consumer-report` now carries run-aware monday schema validation snapshot/summary/actions fields so apply/result-first triage sees the same cross-repo validation signal as payload-first and handoff surfaces
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -242,6 +243,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether monday validation verdicts need a dedicated cross-repo validation report surface beyond `handoff-report`, `local-inbox-payload`, and `local-validation-freshness`
-2. decide whether `monday-consumer-report` should also fold mirrored schema validation status into its apply/result-first surface
+1. decide whether monday validation verdicts need a dedicated cross-repo validation report surface beyond `handoff-report`, `local-inbox-payload`, `monday-consumer-report`, and `local-validation-freshness`
+2. decide whether cross-repo validation snapshot/status should surface in `triage-feed` or a separate operator packet instead of only per-surface query commands
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -412,8 +412,12 @@ class MondayConsumerReportRecord:
     launch_mode: str | None
     local_model_route: str | None
     local_validation_snapshot_status: str | None
+    monday_validation_snapshot_status: str
+    monday_validation_snapshot_summary: str
     block_reasons: list[str]
     command_args: list[str]
+    monday_validation_summary_lines: list[str]
+    monday_validation_action_lines: list[str]
     has_runtime_input_overrides: bool
     override_kinds: list[str]
     planner_runtime_config_path: str | None
@@ -1292,6 +1296,7 @@ def render_local_inbox_payload_markdown(records: list[LocalInboxPayloadRecord]) 
 
 def build_monday_consumer_report_record(
     *,
+    validation_root: Path,
     report_path: Path,
     report_doc: dict[str, Any],
 ) -> MondayConsumerReportRecord:
@@ -1316,11 +1321,28 @@ def build_monday_consumer_report_record(
         override_kinds.append("planner_runtime_config")
     if runtime_profile_file_path is not None:
         override_kinds.append("runtime_profile_file")
+    bridge_id = normalize_optional_string(report_doc.get("bridge_id"))
+    monday_validation_records = discover_monday_validation_records_for_consumer_report(
+        validation_root=validation_root,
+        report_path=report_path,
+        bridge_id=bridge_id,
+    )
+    monday_validation_snapshot_status, monday_validation_snapshot_summary = build_local_validation_snapshot(
+        monday_validation_records
+    )
+    monday_validation_summary_lines = [
+        build_local_validation_summary_line(record) for record in monday_validation_records
+    ]
+    monday_validation_action_lines = [
+        action
+        for action in (build_local_validation_action_line(record) for record in monday_validation_records)
+        if action is not None
+    ]
     return MondayConsumerReportRecord(
         run_id=str(report_doc.get("run_id")),
         report_path=str(report_path.resolve()),
         generated_at_utc=str(report_doc.get("generated_at_utc") or ""),
-        bridge_id=normalize_optional_string(report_doc.get("bridge_id")),
+        bridge_id=bridge_id,
         mode=normalize_optional_string(report_doc.get("mode")),
         verdict=normalize_optional_string(report_doc.get("verdict")),
         reason_code=normalize_optional_string(report_doc.get("reason_code")),
@@ -1330,8 +1352,12 @@ def build_monday_consumer_report_record(
         launch_mode=normalize_optional_string(launch_request.get("launch_mode")),
         local_model_route=normalize_optional_string(launch_request.get("local_model_route")),
         local_validation_snapshot_status=normalize_optional_string(launch_request.get("local_validation_snapshot_status")),
+        monday_validation_snapshot_status=monday_validation_snapshot_status,
+        monday_validation_snapshot_summary=monday_validation_snapshot_summary,
         block_reasons=normalize_string_list(launch_request.get("block_reasons")),
         command_args=normalize_string_list(launch_request.get("runtime_command_args")),
+        monday_validation_summary_lines=monday_validation_summary_lines,
+        monday_validation_action_lines=monday_validation_action_lines,
         has_runtime_input_overrides=bool(override_kinds),
         override_kinds=override_kinds,
         planner_runtime_config_path=planner_runtime_config_path,
@@ -1346,7 +1372,7 @@ def build_monday_consumer_report_record(
     )
 
 
-def discover_monday_consumer_report_records(*, consumer_root: Path) -> list[MondayConsumerReportRecord]:
+def discover_monday_consumer_report_records(*, consumer_root: Path, validation_root: Path) -> list[MondayConsumerReportRecord]:
     if not consumer_root.exists():
         return []
     records: list[MondayConsumerReportRecord] = []
@@ -1359,7 +1385,13 @@ def discover_monday_consumer_report_records(*, consumer_root: Path) -> list[Mond
             continue
         if not is_monday_consumer_report_document(doc):
             continue
-        records.append(build_monday_consumer_report_record(report_path=path, report_doc=doc))
+        records.append(
+            build_monday_consumer_report_record(
+                validation_root=validation_root,
+                report_path=path,
+                report_doc=doc,
+            )
+        )
     records.sort(
         key=lambda record: (
             record.generated_at_utc,
@@ -1424,7 +1456,7 @@ def filter_monday_consumer_report_records(
 
 def render_monday_consumer_report_table(records: list[MondayConsumerReportRecord]) -> str:
     lines = [
-        "run_id\tmode\tverdict\treason_code\tconsumer_status\tcan_launch\tplanner_profile\tlaunch_mode\tlocal_model_route\thas_runtime_overrides\toverride_kinds\texecution_attempted\texecution_exit_code\truntime_report_verdict\thas_runtime_report\tblock_reasons\tgenerated_at_utc",
+        "run_id\tmode\tverdict\treason_code\tconsumer_status\tcan_launch\tplanner_profile\tlaunch_mode\tlocal_model_route\tmonday_validation_snapshot\thas_runtime_overrides\toverride_kinds\texecution_attempted\texecution_exit_code\truntime_report_verdict\thas_runtime_report\tblock_reasons\tgenerated_at_utc",
     ]
     for record in records:
         lines.append(
@@ -1439,6 +1471,7 @@ def render_monday_consumer_report_table(records: list[MondayConsumerReportRecord
                     str(record.planner_profile or ""),
                     str(record.launch_mode or ""),
                     str(record.local_model_route or ""),
+                    record.monday_validation_snapshot_status,
                     "yes" if record.has_runtime_input_overrides else "no",
                     ",".join(record.override_kinds),
                     (
@@ -1459,8 +1492,8 @@ def render_monday_consumer_report_table(records: list[MondayConsumerReportRecord
 
 def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRecord]) -> str:
     lines = [
-        "| run_id | mode | verdict | reason_code | consumer_status | can_launch | planner_profile | launch_mode | local_model_route | has_runtime_overrides | override_kinds | execution_attempted | execution_exit_code | runtime_report_verdict | has_runtime_report | block_reasons | generated_at_utc |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
+        "| run_id | mode | verdict | reason_code | consumer_status | can_launch | planner_profile | launch_mode | local_model_route | monday_validation_snapshot | has_runtime_overrides | override_kinds | execution_attempted | execution_exit_code | runtime_report_verdict | has_runtime_report | block_reasons | generated_at_utc |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
     ]
     for record in records:
         lines.append(
@@ -1468,6 +1501,7 @@ def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRec
             f"{record.consumer_status or ''} | "
             f"{'' if record.can_launch is None else ('yes' if record.can_launch else 'no')} | "
             f"{record.planner_profile or ''} | {record.launch_mode or ''} | {record.local_model_route or ''} | "
+            f"{record.monday_validation_snapshot_status} | "
             f"{'yes' if record.has_runtime_input_overrides else 'no'} | "
             f"{', '.join(record.override_kinds)} | "
             f"{'' if record.execution_attempted is None else ('yes' if record.execution_attempted else 'no')} | "
@@ -2439,6 +2473,64 @@ def discover_monday_validation_records_for_bridge(
         ) != bridge_id:
             continue
         records.append(builder(validation_root=validation_root))
+    return records
+
+
+def resolve_monday_validation_artifact_path(
+    *,
+    validation_root: Path,
+    artifact_family: str,
+) -> Path | None:
+    latest_filename_by_family = {
+        "monday_local_inbox_bridge_schema_validation": "monday-local-inbox-bridge-schema-validation.json",
+        "monday_local_inbox_consumer_schema_validation": "monday-local-inbox-consumer-schema-validation.json",
+    }
+    latest_filename = latest_filename_by_family.get(artifact_family)
+    if latest_filename is None:
+        return None
+
+    latest_doc = load_optional_json((validation_root / latest_filename).resolve())
+    if latest_doc is None:
+        return None
+    source_report_doc = resolve_nested_value(latest_doc, "mirror", "payload")
+    if not isinstance(source_report_doc, dict):
+        return None
+    return resolve_artifact_path(source_report_doc.get("artifact_path"))
+
+
+def discover_monday_validation_records_for_consumer_report(
+    *,
+    validation_root: Path,
+    report_path: Path,
+    bridge_id: str | None,
+) -> list[LocalValidationFreshnessRecord]:
+    records: list[LocalValidationFreshnessRecord] = []
+    resolved_report_path = report_path.resolve()
+
+    if bridge_id is not None and has_promoted_local_validation_artifact(
+        validation_root=validation_root,
+        latest_filename="monday-local-inbox-bridge-schema-validation.json",
+        stamped_glob="*-monday-local-inbox-bridge-schema-validation.json",
+    ):
+        if resolve_monday_validation_bridge_id(
+            validation_root=validation_root,
+            artifact_family="monday_local_inbox_bridge_schema_validation",
+        ) == bridge_id:
+            records.append(build_monday_bridge_validation_mirror_freshness_record(validation_root=validation_root))
+
+    artifact_family = "monday_local_inbox_consumer_schema_validation"
+    if has_promoted_local_validation_artifact(
+        validation_root=validation_root,
+        latest_filename="monday-local-inbox-consumer-schema-validation.json",
+        stamped_glob="*-monday-local-inbox-consumer-schema-validation.json",
+    ):
+        artifact_path = resolve_monday_validation_artifact_path(
+            validation_root=validation_root,
+            artifact_family=artifact_family,
+        )
+        if artifact_path == resolved_report_path:
+            records.append(build_monday_consumer_validation_mirror_freshness_record(validation_root=validation_root))
+
     return records
 
 
@@ -4814,6 +4906,7 @@ def parse_args() -> argparse.Namespace:
     monday_consumer_parser.add_argument("--execution-attempted", choices=["yes", "no"], default=None)
     monday_consumer_parser.add_argument("--limit", type=int, default=20)
     monday_consumer_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    monday_consumer_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     monday_consumer_parser.add_argument("--consumer-root", default=str(DEFAULT_MONDAY_CONSUMER_ROOT))
 
     monday_validation_parser = subparsers.add_parser(
@@ -4904,7 +4997,10 @@ def main() -> int:
         return 0
 
     if args.command == "monday-consumer-report":
-        consumer_records = discover_monday_consumer_report_records(consumer_root=consumer_root)
+        consumer_records = discover_monday_consumer_report_records(
+            consumer_root=consumer_root,
+            validation_root=validation_root,
+        )
         consumer_records = filter_monday_consumer_report_records(
             records=consumer_records,
             run_id_prefix=args.run_id_prefix,

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -668,6 +668,7 @@ MONDAY_CONSUMER_OUTPUT="$TMP_DIR/monday-consumer-report.json"
 MONDAY_CONSUMER_FILTERED_OUTPUT="$TMP_DIR/monday-consumer-report-filtered.json"
 MONDAY_CONSUMER_BLOCKED_OUTPUT="$TMP_DIR/monday-consumer-report-blocked.json"
 MONDAY_CONSUMER_OVERRIDE_OUTPUT="$TMP_DIR/monday-consumer-report-override.json"
+MONDAY_CONSUMER_WITH_MONDAY_VALIDATION_OUTPUT="$TMP_DIR/monday-consumer-report-with-monday-validation.json"
 MONDAY_VALIDATION_OUTPUT="$TMP_DIR/monday-validation-report.json"
 MONDAY_VALIDATION_FAIL_OUTPUT="$TMP_DIR/monday-validation-report-fail.json"
 MONDAY_VALIDATION_BRIDGE_OUTPUT="$TMP_DIR/monday-validation-report-bridge.json"
@@ -3379,6 +3380,10 @@ assert blocked["block_reasons"] == [
     "needs_human_attention",
     "local_validation_actions_present",
 ], blocked
+assert blocked["monday_validation_snapshot_status"] == "missing", blocked
+assert blocked["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", blocked
+assert blocked["monday_validation_summary_lines"] == [], blocked
+assert blocked["monday_validation_action_lines"] == [], blocked
 
 assert passed_apply["verdict"] == "pass", passed_apply
 assert passed_apply["mode"] == "apply", passed_apply
@@ -3394,6 +3399,10 @@ assert passed_apply["override_kinds"] == [
 ], passed_apply
 assert passed_apply["planner_runtime_config_path"].endswith("/planner-runtime.json"), passed_apply
 assert passed_apply["runtime_profile_file_path"].endswith("/runtime-profiles.json"), passed_apply
+assert passed_apply["monday_validation_snapshot_status"] == "missing", passed_apply
+assert passed_apply["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", passed_apply
+assert passed_apply["monday_validation_summary_lines"] == [], passed_apply
+assert passed_apply["monday_validation_action_lines"] == [], passed_apply
 
 assert dry_run["mode"] == "dry-run", dry_run
 assert dry_run["verdict"] == "pass", dry_run
@@ -3404,6 +3413,10 @@ assert dry_run["has_launch_request"] is True, dry_run
 assert dry_run["has_mission_file"] is True, dry_run
 assert dry_run["has_runtime_report"] is False, dry_run
 assert dry_run["has_runtime_input_overrides"] is False, dry_run
+assert dry_run["monday_validation_snapshot_status"] == "missing", dry_run
+assert dry_run["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", dry_run
+assert dry_run["monday_validation_summary_lines"] == [], dry_run
+assert dry_run["monday_validation_action_lines"] == [], dry_run
 PY
 
 python3 "$QUERY_PATH" monday-consumer-report \
@@ -3786,6 +3799,45 @@ assert stamped_old["monday_validation_snapshot_status"] == "missing", stamped_ol
 assert stamped_old["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", stamped_old
 assert stamped_old["monday_validation_summary_lines"] == [], stamped_old
 assert stamped_old["monday_validation_action_lines"] == [], stamped_old
+PY
+
+python3 "$QUERY_PATH" monday-consumer-report \
+  --format json \
+  --validation-root "$VALIDATION_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" >"$MONDAY_CONSUMER_WITH_MONDAY_VALIDATION_OUTPUT"
+
+python3 - <<'PY' "$MONDAY_CONSUMER_WITH_MONDAY_VALIDATION_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["run_id"] for record in records] == [
+    "planningops-local-inbox-consumer-20260401T103000Z",
+    "planningops-local-inbox-consumer-20260401T102000Z",
+    "planningops-local-inbox-consumer-20260401T101000Z",
+], records
+
+blocked, passed_apply, dry_run = records
+
+assert blocked["monday_validation_snapshot_status"] == "present", blocked
+assert blocked["monday_validation_snapshot_summary"] == "total=2 promotable=1 blocked=1 stale=0", blocked
+assert blocked["monday_validation_summary_lines"] == [
+    "monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "monday_local_inbox_consumer_schema_validation: freshness=fresh promotability=blocked reasons=validation_verdict_fail,validation_errors_present dependencies=monday_local_inbox_consumer_report=current",
+], blocked
+assert blocked["monday_validation_action_lines"] == [
+    "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)"
+], blocked
+
+for record in (passed_apply, dry_run):
+    assert record["monday_validation_snapshot_status"] == "fresh", record
+    assert record["monday_validation_snapshot_summary"] == "total=1 promotable=1 blocked=0 stale=0", record
+    assert record["monday_validation_summary_lines"] == [
+        "monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current"
+    ], record
+    assert record["monday_validation_action_lines"] == [], record
 PY
 
 python3 "$QUERY_PATH" handoff-report \


### PR DESCRIPTION
## Summary
- Surface mirrored monday schema validation verdicts directly in `monday-consumer-report`.
- Keep bridge validation bridge-aware and consumer validation report-path-aware so apply/result rows inherit only matching cross-repo validation state.
- Extend query regressions and rollout planning for the apply/result-first operator surface.

## Scope
- Initiative docs:
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`
- `planningops/` scripts/contracts: `planningops/scripts/federation/query_federated_ci_artifacts.py`, `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `.github/` workflows:

## Linked Issues
- Closes #974
- Related #972

## Validation
- [x] `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- [x] `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any): none

## Risks
- Risk: `monday-consumer-report` rows now include monday validation snapshot fields, so downstream parsers need to tolerate extra JSON fields and one more summary column in table/markdown views.
- Rollback: revert `feat(query-engine): surface monday schema validation in consumer reports`.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
