### PR TITLE
feat(query-engine): surface cross-repo validation in triage feed

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -183,6 +183,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-inbox-payload` now carries a bridge-aware monday schema validation snapshot/summary/actions view for the current inbox payload without routing through `handoff-report`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py monday-consumer-report` now carries run-aware monday schema validation snapshot/summary/actions fields so apply/result-first triage sees the same cross-repo validation signal as payload-first and handoff surfaces
 - `planningops/scripts/federation/query_federated_ci_artifacts.py cross-repo-validation-report` now emits a dedicated fixed-format packet that combines mirrored monday inbox launch/runtime/consumer freshness with monday-owned schema validation verdicts in one operator view
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed` now carries the cross-repo validation snapshot/status summary so the top-level operator overview shows monday inbox mirror health and monday source validation verdicts without leaving the feed
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -244,6 +245,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether cross-repo validation snapshot/status should surface in `triage-feed` or a separate operator packet instead of only `handoff-report`, `local-inbox-payload`, `monday-consumer-report`, `local-validation-freshness`, and `cross-repo-validation-report`
-2. decide whether `cross-repo-validation-report` should stay query-only or also be promoted into stamped validation artifacts
+1. decide whether `cross-repo-validation-report` should stay query-only or also be promoted into stamped validation artifacts
+2. decide whether the same cross-repo validation snapshot should also surface in `triage-brief` or `triage-report`, not only `triage-feed`
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -261,6 +261,11 @@ class TriageFeedRecord:
     queue_records: list[TriageQueueRecord]
     target_records: list[TriageTargetRecord]
     local_operator_record: LocalOperatorStackRecord | None
+    cross_repo_validation_snapshot_status: str | None
+    cross_repo_validation_snapshot_summary: str | None
+    monday_source_validation_status: str | None
+    monday_source_validation_summary: str | None
+    cross_repo_validation_action_line: str | None
 
 
 @dataclass(frozen=True)
@@ -3647,6 +3652,9 @@ def build_triage_feed_record(
     *,
     records: list[SummaryRecord],
     local_records: list[LocalOperatorStackRecord] | None,
+    validation_root: Path,
+    consumer_root: Path,
+    monday_validation_root: Path,
     family: str | None,
     run_id_prefix: str | None,
     source_kind: str,
@@ -3671,8 +3679,24 @@ def build_triage_feed_record(
         source_kind=source_kind,
     )[:target_limit]
     local_operator_record = None
+    cross_repo_validation_snapshot_status = None
+    cross_repo_validation_snapshot_summary = None
+    monday_source_validation_status = None
+    monday_source_validation_summary = None
+    cross_repo_validation_action_line = None
     if family is None and run_id_prefix is None and local_records is not None:
         local_operator_record = select_latest_local_operator_stack_record(local_records)
+        cross_repo_validation_record = build_cross_repo_validation_report_record(
+            validation_root=validation_root,
+            consumer_root=consumer_root,
+            monday_validation_root=monday_validation_root,
+        )
+        cross_repo_validation_snapshot_status = cross_repo_validation_record.cross_repo_snapshot_status
+        cross_repo_validation_snapshot_summary = cross_repo_validation_record.cross_repo_snapshot_summary
+        monday_source_validation_status = cross_repo_validation_record.monday_source_validation_status
+        monday_source_validation_summary = cross_repo_validation_record.monday_source_validation_summary
+        if cross_repo_validation_record.cross_repo_action_lines:
+            cross_repo_validation_action_line = cross_repo_validation_record.cross_repo_action_lines[0]
     return TriageFeedRecord(
         source_kind=source_kind,
         target_limit=target_limit,
@@ -3680,6 +3704,11 @@ def build_triage_feed_record(
         queue_records=queue_records,
         target_records=target_records,
         local_operator_record=local_operator_record,
+        cross_repo_validation_snapshot_status=cross_repo_validation_snapshot_status,
+        cross_repo_validation_snapshot_summary=cross_repo_validation_snapshot_summary,
+        monday_source_validation_status=monday_source_validation_status,
+        monday_source_validation_summary=monday_source_validation_summary,
+        cross_repo_validation_action_line=cross_repo_validation_action_line,
     )
 
 
@@ -3690,6 +3719,17 @@ def render_triage_feed_table(record: TriageFeedRecord) -> str:
         "overview",
         render_triage_overview_table(record.overview),
     ]
+    if record.cross_repo_validation_snapshot_status is not None:
+        sections.extend(
+            [
+                f"cross_repo_validation_snapshot_status\t{record.cross_repo_validation_snapshot_status}",
+                f"cross_repo_validation_snapshot_summary\t{record.cross_repo_validation_snapshot_summary or ''}",
+                f"monday_source_validation_status\t{record.monday_source_validation_status or ''}",
+                f"monday_source_validation_summary\t{record.monday_source_validation_summary or ''}",
+            ]
+        )
+        if record.cross_repo_validation_action_line is not None:
+            sections.append(f"cross_repo_validation_action\t{record.cross_repo_validation_action_line}")
     if record.local_operator_record is not None:
         local_record = record.local_operator_record
         sections.extend(
@@ -3720,6 +3760,18 @@ def render_triage_feed_markdown(record: TriageFeedRecord) -> str:
         f"## Triage Feed\n\n- source_kind: `{record.source_kind}`\n- target_limit: `{record.target_limit}`",
         "### Overview\n\n" + render_triage_overview_markdown(record.overview),
     ]
+    if record.cross_repo_validation_snapshot_status is not None:
+        cross_repo_lines = [
+            "### Cross-Repo Validation",
+            "",
+            f"- snapshot status: `{record.cross_repo_validation_snapshot_status}`",
+            f"- snapshot summary: `{record.cross_repo_validation_snapshot_summary or ''}`",
+            f"- monday source validation status: `{record.monday_source_validation_status or ''}`",
+            f"- monday source validation summary: `{record.monday_source_validation_summary or ''}`",
+        ]
+        if record.cross_repo_validation_action_line is not None:
+            cross_repo_lines.append(f"- next action: {record.cross_repo_validation_action_line}")
+        sections.append("\n".join(cross_repo_lines))
     if record.local_operator_record is not None:
         local_record = record.local_operator_record
         local_lines = [
@@ -3748,6 +3800,9 @@ def build_triage_brief_record(
     *,
     records: list[SummaryRecord],
     local_records: list[LocalOperatorStackRecord] | None,
+    validation_root: Path,
+    consumer_root: Path,
+    monday_validation_root: Path,
     family: str | None,
     run_id_prefix: str | None,
     source_kind: str,
@@ -3756,6 +3811,9 @@ def build_triage_brief_record(
     feed = build_triage_feed_record(
         records=records,
         local_records=local_records,
+        validation_root=validation_root,
+        consumer_root=consumer_root,
+        monday_validation_root=monday_validation_root,
         family=family,
         run_id_prefix=run_id_prefix,
         source_kind=source_kind,
@@ -3854,6 +3912,9 @@ def build_triage_report_record(
     *,
     records: list[SummaryRecord],
     local_records: list[LocalOperatorStackRecord] | None,
+    validation_root: Path,
+    consumer_root: Path,
+    monday_validation_root: Path,
     family: str | None,
     run_id_prefix: str | None,
     source_kind: str,
@@ -3862,6 +3923,9 @@ def build_triage_report_record(
     brief = build_triage_brief_record(
         records=records,
         local_records=local_records,
+        validation_root=validation_root,
+        consumer_root=consumer_root,
+        monday_validation_root=monday_validation_root,
         family=family,
         run_id_prefix=run_id_prefix,
         source_kind=source_kind,
@@ -3948,6 +4012,8 @@ def build_handoff_report_record(
     records: list[SummaryRecord],
     local_records: list[LocalOperatorStackRecord] | None,
     validation_root: Path,
+    consumer_root: Path,
+    monday_validation_root: Path,
     family: str | None,
     run_id_prefix: str | None,
     source_kind: str,
@@ -3956,6 +4022,9 @@ def build_handoff_report_record(
     triage_report = build_triage_report_record(
         records=records,
         local_records=local_records,
+        validation_root=validation_root,
+        consumer_root=consumer_root,
+        monday_validation_root=monday_validation_root,
         family=family,
         run_id_prefix=run_id_prefix,
         source_kind=source_kind,
@@ -5078,6 +5147,8 @@ def parse_args() -> argparse.Namespace:
     triage_feed_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     triage_feed_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     triage_feed_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
+    triage_feed_parser.add_argument("--consumer-root", default=str(DEFAULT_MONDAY_CONSUMER_ROOT))
+    triage_feed_parser.add_argument("--monday-validation-root", default=str(DEFAULT_MONDAY_VALIDATION_ROOT))
 
     triage_brief_parser = subparsers.add_parser(
         "triage-brief",
@@ -5092,6 +5163,8 @@ def parse_args() -> argparse.Namespace:
     triage_brief_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     triage_brief_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     triage_brief_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
+    triage_brief_parser.add_argument("--consumer-root", default=str(DEFAULT_MONDAY_CONSUMER_ROOT))
+    triage_brief_parser.add_argument("--monday-validation-root", default=str(DEFAULT_MONDAY_VALIDATION_ROOT))
 
     triage_report_parser = subparsers.add_parser(
         "triage-report",
@@ -5106,6 +5179,8 @@ def parse_args() -> argparse.Namespace:
     triage_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     triage_report_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     triage_report_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
+    triage_report_parser.add_argument("--consumer-root", default=str(DEFAULT_MONDAY_CONSUMER_ROOT))
+    triage_report_parser.add_argument("--monday-validation-root", default=str(DEFAULT_MONDAY_VALIDATION_ROOT))
 
     handoff_report_parser = subparsers.add_parser(
         "handoff-report",
@@ -5120,6 +5195,8 @@ def parse_args() -> argparse.Namespace:
     handoff_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     handoff_report_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     handoff_report_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
+    handoff_report_parser.add_argument("--consumer-root", default=str(DEFAULT_MONDAY_CONSUMER_ROOT))
+    handoff_report_parser.add_argument("--monday-validation-root", default=str(DEFAULT_MONDAY_VALIDATION_ROOT))
 
     write_handoff_report_parser = subparsers.add_parser(
         "write-handoff-report",
@@ -5136,6 +5213,8 @@ def parse_args() -> argparse.Namespace:
     write_handoff_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
     write_handoff_report_parser.add_argument("--conformance-root", default=str(DEFAULT_CONFORMANCE_ROOT))
     write_handoff_report_parser.add_argument("--local-root", default=str(DEFAULT_LOCAL_OPERATOR_STACK_ROOT))
+    write_handoff_report_parser.add_argument("--consumer-root", default=str(DEFAULT_MONDAY_CONSUMER_ROOT))
+    write_handoff_report_parser.add_argument("--monday-validation-root", default=str(DEFAULT_MONDAY_VALIDATION_ROOT))
 
     local_validation_parser = subparsers.add_parser(
         "local-validation-freshness",
@@ -5615,6 +5694,9 @@ def main() -> int:
         record = build_triage_feed_record(
             records=records,
             local_records=local_records,
+            validation_root=validation_root,
+            consumer_root=consumer_root,
+            monday_validation_root=monday_validation_root,
             family=args.family,
             run_id_prefix=args.run_id_prefix,
             source_kind=args.source_kind,
@@ -5634,6 +5716,9 @@ def main() -> int:
         record = build_triage_brief_record(
             records=records,
             local_records=local_records,
+            validation_root=validation_root,
+            consumer_root=consumer_root,
+            monday_validation_root=monday_validation_root,
             family=args.family,
             run_id_prefix=args.run_id_prefix,
             source_kind=args.source_kind,
@@ -5653,6 +5738,9 @@ def main() -> int:
         record = build_triage_report_record(
             records=records,
             local_records=local_records,
+            validation_root=validation_root,
+            consumer_root=consumer_root,
+            monday_validation_root=monday_validation_root,
             family=args.family,
             run_id_prefix=args.run_id_prefix,
             source_kind=args.source_kind,
@@ -5673,6 +5761,8 @@ def main() -> int:
             records=records,
             local_records=local_records,
             validation_root=validation_root,
+            consumer_root=consumer_root,
+            monday_validation_root=monday_validation_root,
             family=args.family,
             run_id_prefix=args.run_id_prefix,
             source_kind=args.source_kind,
@@ -5693,6 +5783,8 @@ def main() -> int:
             records=records,
             local_records=local_records,
             validation_root=validation_root,
+            consumer_root=consumer_root,
+            monday_validation_root=monday_validation_root,
             family=args.family,
             run_id_prefix=args.run_id_prefix,
             source_kind=args.source_kind,

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -646,6 +646,7 @@ TRIAGE_QUEUE_LAGGING_OUTPUT="$TMP_DIR/triage-queue-lagging.json"
 TRIAGE_QUEUE_ALL_OUTPUT="$TMP_DIR/triage-queue-all.json"
 TRIAGE_FEED_OUTPUT="$TMP_DIR/triage-feed.json"
 TRIAGE_FEED_ALL_OUTPUT="$TMP_DIR/triage-feed-all.json"
+TRIAGE_FEED_WITH_CROSS_REPO_VALIDATION_OUTPUT="$TMP_DIR/triage-feed-with-cross-repo-validation.json"
 TRIAGE_BRIEF_OUTPUT="$TMP_DIR/triage-brief.json"
 TRIAGE_BRIEF_ALL_OUTPUT="$TMP_DIR/triage-brief-all.json"
 TRIAGE_REPORT_OUTPUT="$TMP_DIR/triage-report.json"
@@ -1575,7 +1576,9 @@ python3 "$QUERY_PATH" triage-feed \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$TRIAGE_FEED_OUTPUT"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_FEED_OUTPUT"
 
 python3 - <<'PY' "$TRIAGE_FEED_OUTPUT"
 import json
@@ -1597,6 +1600,11 @@ assert record["local_operator_record"]["verdict"] == "fail", record
 assert record["local_operator_record"]["readiness_status"] == "blocked", record
 assert record["local_operator_record"]["stack_status"] == "skipped", record
 assert record["local_operator_record"]["direct_status"] == "skipped", record
+assert record["cross_repo_validation_snapshot_status"] == "missing", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
+assert record["monday_source_validation_status"] == "missing", record
+assert record["monday_source_validation_summary"] == "total=0 pass=0 fail=0 errors=0 warnings=0", record
+assert record["cross_repo_validation_action_line"] is None, record
 assert record["target_records"][0]["priority_bucket"] == "active", record
 assert record["target_records"][1]["priority_bucket"] == "lagging", record
 PY
@@ -1608,7 +1616,9 @@ python3 "$QUERY_PATH" triage-feed \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$TRIAGE_FEED_ALL_OUTPUT"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_FEED_ALL_OUTPUT"
 
 python3 - <<'PY' "$TRIAGE_FEED_ALL_OUTPUT"
 import json
@@ -1631,6 +1641,11 @@ assert target["family"] == "federated-ci-runtime-gates", target
 assert target["priority_bucket"] == "active", target
 assert target["target_source_kind"] == "latest", target
 assert record["local_operator_record"]["run_id"] == "monday-local-operator-stack-20260401T060524Z", record
+assert record["cross_repo_validation_snapshot_status"] == "missing", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
+assert record["monday_source_validation_status"] == "missing", record
+assert record["monday_source_validation_summary"] == "total=0 pass=0 fail=0 errors=0 warnings=0", record
+assert record["cross_repo_validation_action_line"] is None, record
 PY
 
 python3 "$QUERY_PATH" triage-brief \
@@ -1638,7 +1653,9 @@ python3 "$QUERY_PATH" triage-brief \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$TRIAGE_BRIEF_OUTPUT"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_BRIEF_OUTPUT"
 
 python3 - <<'PY' "$TRIAGE_BRIEF_OUTPUT"
 import json
@@ -1679,7 +1696,9 @@ python3 "$QUERY_PATH" triage-brief \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$TRIAGE_BRIEF_ALL_OUTPUT"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_BRIEF_ALL_OUTPUT"
 
 python3 - <<'PY' "$TRIAGE_BRIEF_ALL_OUTPUT"
 import json
@@ -1714,7 +1733,9 @@ python3 "$QUERY_PATH" triage-report \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$TRIAGE_REPORT_OUTPUT"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_REPORT_OUTPUT"
 
 python3 - <<'PY' "$TRIAGE_REPORT_OUTPUT"
 import json
@@ -1758,7 +1779,9 @@ python3 "$QUERY_PATH" triage-report \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$TRIAGE_REPORT_ALL_OUTPUT"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_REPORT_ALL_OUTPUT"
 
 python3 - <<'PY' "$TRIAGE_REPORT_ALL_OUTPUT"
 import json
@@ -2288,7 +2311,9 @@ python3 "$QUERY_PATH" handoff-report \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$HANDOFF_REPORT_OUTPUT"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$HANDOFF_REPORT_OUTPUT"
 
 python3 - <<'PY' "$HANDOFF_REPORT_OUTPUT"
 import json
@@ -2363,7 +2388,9 @@ python3 "$QUERY_PATH" handoff-report \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$HANDOFF_REPORT_ALL_OUTPUT"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$HANDOFF_REPORT_ALL_OUTPUT"
 
 python3 - <<'PY' "$HANDOFF_REPORT_ALL_OUTPUT"
 import json
@@ -2414,7 +2441,9 @@ python3 "$QUERY_PATH" write-handoff-report \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$HANDOFF_WRITE_OUTPUT.stdout"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$HANDOFF_WRITE_OUTPUT.stdout"
 
 python3 - <<'PY' "$HANDOFF_WRITE_OUTPUT.stdout" "$HANDOFF_WRITE_OUTPUT" "$VALIDATION_DIR"
 import json
@@ -3846,7 +3875,9 @@ python3 "$QUERY_PATH" handoff-report \
   --ci-root "$CI_DIR" \
   --validation-root "$VALIDATION_DIR" \
   --conformance-root "$CONFORMANCE_DIR" \
-  --local-root "$LOCAL_OPERATOR_DIR" >"$HANDOFF_REPORT_WITH_MONDAY_VALIDATION_OUTPUT"
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$HANDOFF_REPORT_WITH_MONDAY_VALIDATION_OUTPUT"
 
 python3 - <<'PY' "$HANDOFF_REPORT_WITH_MONDAY_VALIDATION_OUTPUT"
 import json
@@ -3932,6 +3963,32 @@ assert record["latest_consumer_monday_validation_snapshot_status"] == "present",
 assert "### Cross-Repo Mirror Validation" in record["markdown"], record
 assert "### Monday Source Validation Reports" in record["markdown"], record
 assert "### Monday Source Validation Actions" in record["markdown"], record
+PY
+
+python3 "$QUERY_PATH" triage-feed \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_FEED_WITH_CROSS_REPO_VALIDATION_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_FEED_WITH_CROSS_REPO_VALIDATION_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["cross_repo_validation_snapshot_status"] == "present", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", record
+assert record["monday_source_validation_status"] == "attention", record
+assert record["monday_source_validation_summary"] == "total=2 pass=1 fail=1 errors=2 warnings=1", record
+assert record["cross_repo_validation_action_line"] == (
+    "local-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+), record
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \


### PR DESCRIPTION
## Summary
- surface the cross-repo validation snapshot directly in `triage-feed`
- expose monday consumer and monday validation roots on the triage and handoff CLI surfaces
- keep triage and handoff regressions deterministic by pointing them at the tmp monday fixture roots

## Scope
- `planningops/scripts/federation/query_federated_ci_artifacts.py`
- `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #978

## Validation
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- `triage-feed`, `triage-brief`, `triage-report`, and `handoff-report` now expose monday consumer and validation roots; regression coverage was extended to keep these code paths deterministic.
- Existing inherited CI failures outside this packet remain unchanged.

## Review Checklist
- [x] Query regression updated for cross-repo validation snapshot in `triage-feed`
- [x] CLI parser accepts the monday consumer and validation roots on affected surfaces
- [x] Workbench docs updated for the new current deliverable