### PR TITLE
feat(query-engine): promote cross-repo validation report artifacts

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -184,6 +184,11 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py monday-consumer-report` now carries run-aware monday schema validation snapshot/summary/actions fields so apply/result-first triage sees the same cross-repo validation signal as payload-first and handoff surfaces
 - `planningops/scripts/federation/query_federated_ci_artifacts.py cross-repo-validation-report` now emits a dedicated fixed-format packet that combines mirrored monday inbox launch/runtime/consumer freshness with monday-owned schema validation verdicts in one operator view
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed` now carries the cross-repo validation snapshot/status summary so the top-level operator overview shows monday inbox mirror health and monday source validation verdicts without leaving the feed
+- `planningops/contracts/cross-repo-validation-report-contract.md`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py write-cross-repo-validation-report`
+- `planningops/artifacts/validation/cross-repo-validation-report.json`
+- `planningops/artifacts/validation/<report-id>-cross-repo-validation-report.json`
+- the dedicated cross-repo validation packet is now promotion-ready as a stamped validation artifact instead of staying query-only
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -245,6 +250,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether `cross-repo-validation-report` should stay query-only or also be promoted into stamped validation artifacts
+1. decide whether the promoted `cross-repo-validation-report` should also be tracked in `local-validation-freshness` as its own validation family
 2. decide whether the same cross-repo validation snapshot should also surface in `triage-brief` or `triage-report`, not only `triage-feed`
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/contracts/cross-repo-validation-report-contract.md
+++ b/planningops/contracts/cross-repo-validation-report-contract.md
@@ -1,0 +1,64 @@
+# Cross-Repo Validation Report Contract
+
+## Purpose
+
+Promote the fixed-format `cross-repo-validation-report` packet into `planningops/artifacts/validation` so operators can reuse one stamped report without recomputing cross-repo monday inbox freshness and monday-owned schema verdicts on demand.
+
+## Source Inputs
+
+- `planningops/scripts/federation/query_federated_ci_artifacts.py cross-repo-validation-report`
+- `planningops/artifacts/validation/monday-local-inbox-launch-request.json`
+- `planningops/artifacts/validation/monday-local-inbox-runtime-report.json`
+- `planningops/artifacts/validation/monday-local-inbox-consumer-report.json`
+- `planningops/artifacts/validation/monday-local-inbox-bridge-schema-validation.json`
+- `planningops/artifacts/validation/monday-local-inbox-consumer-schema-validation.json`
+- `monday/runtime-artifacts/validation/planningops-local-operator-inbox-payload-validation-report.json`
+- `monday/runtime-artifacts/validation/planningops-local-operator-inbox-consumer-report-validation-report.json`
+
+## Promoted Outputs
+
+- latest: `planningops/artifacts/validation/cross-repo-validation-report.json`
+- stamped: `planningops/artifacts/validation/<report-id>-cross-repo-validation-report.json`
+
+## Document Shape
+
+Each promoted report must include:
+
+- `generated_at_utc`
+- `report_id`
+- `contract_ref`
+- `artifact_paths.latest_report_path`
+- `artifact_paths.stamped_report_path`
+- `artifact_paths.output_path`
+- `record.headline`
+- `record.cross_repo_snapshot_status`
+- `record.cross_repo_snapshot_summary`
+- `record.cross_repo_validation_records`
+- `record.cross_repo_summary_lines`
+- `record.cross_repo_action_lines`
+- `record.monday_source_validation_status`
+- `record.monday_source_validation_summary`
+- `record.monday_validation_report_records`
+- `record.monday_validation_report_lines`
+- `record.monday_validation_report_action_lines`
+- `record.latest_payload_bridge_id`
+- `record.latest_payload_status`
+- `record.latest_payload_monday_validation_snapshot_status`
+- `record.latest_consumer_run_id`
+- `record.latest_consumer_mode`
+- `record.latest_consumer_verdict`
+- `record.latest_consumer_status`
+- `record.latest_consumer_monday_validation_snapshot_status`
+- `record.markdown`
+
+## Promotion Rules
+
+- always materialize the report from the same record shape returned by the query surface
+- write both latest and stamped copies on every invocation
+- preserve the full rendered record under `record`
+- allow an optional `--output` path for ad hoc export without skipping latest/stamped promotion
+
+## Verification
+
+- `python3 planningops/scripts/federation/query_federated_ci_artifacts.py write-cross-repo-validation-report --validation-root <validation-root> --consumer-root <consumer-root> --monday-validation-root <monday-validation-root>`
+- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -29,6 +29,7 @@ DEFAULT_CONFORMANCE_ROOT = WORKSPACE_ROOT / "planningops/artifacts/conformance"
 DEFAULT_LOCAL_OPERATOR_STACK_ROOT = WORKSPACE_ROOT / "planningops/runtime-artifacts/local/monday-local-operator-stack"
 DEFAULT_MONDAY_CONSUMER_ROOT = WORKSPACE_ROOT.parent / "monday" / "runtime-artifacts/integration/planningops-local-operator-inbox"
 DEFAULT_MONDAY_VALIDATION_ROOT = WORKSPACE_ROOT.parent / "monday" / "runtime-artifacts/validation"
+CROSS_REPO_VALIDATION_REPORT_CONTRACT_REF = "planningops/contracts/cross-repo-validation-report-contract.md"
 
 LATEST_GAP_CHOICES = (
     "readiness_missing",
@@ -4388,6 +4389,27 @@ def build_handoff_artifact_document(
     }
 
 
+def build_cross_repo_validation_artifact_document(
+    *,
+    record: CrossRepoValidationReportRecord,
+    report_id: str,
+    latest_report_path: Path,
+    stamped_report_path: Path,
+    output_path: Path | None,
+) -> dict[str, Any]:
+    return {
+        "generated_at_utc": now_utc(),
+        "report_id": report_id,
+        "contract_ref": CROSS_REPO_VALIDATION_REPORT_CONTRACT_REF,
+        "artifact_paths": {
+            "latest_report_path": str(latest_report_path.resolve()),
+            "stamped_report_path": str(stamped_report_path.resolve()),
+            "output_path": None if output_path is None else str(output_path.resolve()),
+        },
+        "record": asdict(record),
+    }
+
+
 def select_record(
     *,
     records: list[SummaryRecord],
@@ -5299,6 +5321,17 @@ def parse_args() -> argparse.Namespace:
     cross_repo_validation_parser.add_argument("--consumer-root", default=str(DEFAULT_MONDAY_CONSUMER_ROOT))
     cross_repo_validation_parser.add_argument("--monday-validation-root", default=str(DEFAULT_MONDAY_VALIDATION_ROOT))
 
+    write_cross_repo_validation_parser = subparsers.add_parser(
+        "write-cross-repo-validation-report",
+        help="write the cross-repo monday inbox validation report into latest + stamped validation artifacts",
+    )
+    write_cross_repo_validation_parser.add_argument("--report-id", default=None)
+    write_cross_repo_validation_parser.add_argument("--output", default=None)
+    write_cross_repo_validation_parser.add_argument("--format", choices=["table", "json", "markdown"], default="json")
+    write_cross_repo_validation_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+    write_cross_repo_validation_parser.add_argument("--consumer-root", default=str(DEFAULT_MONDAY_CONSUMER_ROOT))
+    write_cross_repo_validation_parser.add_argument("--monday-validation-root", default=str(DEFAULT_MONDAY_VALIDATION_ROOT))
+
     local_operator_parser = subparsers.add_parser(
         "local-operator-stack",
         help="list planningops-owned monday local operator stack aggregate reports",
@@ -5432,6 +5465,36 @@ def main() -> int:
         )
         if args.format == "json":
             print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_cross_repo_validation_report_markdown(record))
+            return 0
+        print(render_cross_repo_validation_report_table(record))
+        return 0
+
+    if args.command == "write-cross-repo-validation-report":
+        record = build_cross_repo_validation_report_record(
+            validation_root=validation_root,
+            consumer_root=consumer_root,
+            monday_validation_root=monday_validation_root,
+        )
+        report_id = args.report_id or f"cross-repo-validation-{utc_timestamp_slug()}"
+        latest_report_path = validation_root / "cross-repo-validation-report.json"
+        stamped_report_path = validation_root / f"{report_id}-cross-repo-validation-report.json"
+        output_path = resolve_optional_path(args.output)
+        doc = build_cross_repo_validation_artifact_document(
+            record=record,
+            report_id=report_id,
+            latest_report_path=latest_report_path,
+            stamped_report_path=stamped_report_path,
+            output_path=output_path,
+        )
+        write_json(latest_report_path, doc)
+        write_json(stamped_report_path, doc)
+        if output_path is not None:
+            write_json(output_path, doc)
+        if args.format == "json":
+            print(json.dumps(doc, ensure_ascii=True, indent=2))
             return 0
         if args.format == "markdown":
             print(render_cross_repo_validation_report_markdown(record))

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -675,6 +675,8 @@ MONDAY_VALIDATION_FAIL_OUTPUT="$TMP_DIR/monday-validation-report-fail.json"
 MONDAY_VALIDATION_BRIDGE_OUTPUT="$TMP_DIR/monday-validation-report-bridge.json"
 MONDAY_VALIDATION_MIRROR_WRITE_OUTPUT="$TMP_DIR/monday-validation-report-mirror-write.json"
 CROSS_REPO_VALIDATION_REPORT_OUTPUT="$TMP_DIR/cross-repo-validation-report.json"
+CROSS_REPO_VALIDATION_WRITE_OUTPUT="$TMP_DIR/cross-repo-validation-write.json"
+CROSS_REPO_VALIDATION_WRITE_STDOUT="$TMP_DIR/cross-repo-validation-write-stdout.json"
 LOCAL_VALIDATION_WITH_MONDAY_VALIDATION_OUTPUT="$TMP_DIR/local-validation-freshness-with-monday-validation.json"
 LOCAL_VALIDATION_MONDAY_VALIDATION_BLOCKED_OUTPUT="$TMP_DIR/local-validation-monday-validation-blocked.json"
 LOCAL_OPERATOR_OUTPUT="$TMP_DIR/local-operator-stack.json"
@@ -3963,6 +3965,44 @@ assert record["latest_consumer_monday_validation_snapshot_status"] == "present",
 assert "### Cross-Repo Mirror Validation" in record["markdown"], record
 assert "### Monday Source Validation Reports" in record["markdown"], record
 assert "### Monday Source Validation Actions" in record["markdown"], record
+PY
+
+python3 "$QUERY_PATH" write-cross-repo-validation-report \
+  --report-id cross-repo-validation-20260401T110000Z \
+  --output "$CROSS_REPO_VALIDATION_WRITE_OUTPUT" \
+  --format json \
+  --validation-root "$VALIDATION_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$CROSS_REPO_VALIDATION_WRITE_STDOUT"
+
+python3 - <<'PY' "$CROSS_REPO_VALIDATION_WRITE_STDOUT" "$CROSS_REPO_VALIDATION_WRITE_OUTPUT" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+stdout_doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_doc = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+validation_dir = Path(sys.argv[3]).resolve()
+latest_path = validation_dir / "cross-repo-validation-report.json"
+stamped_path = validation_dir / "cross-repo-validation-20260401T110000Z-cross-repo-validation-report.json"
+latest_doc = json.loads(latest_path.read_text(encoding="utf-8"))
+stamped_doc = json.loads(stamped_path.read_text(encoding="utf-8"))
+
+for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
+    assert doc["report_id"] == "cross-repo-validation-20260401T110000Z", doc
+    assert doc["contract_ref"] == "planningops/contracts/cross-repo-validation-report-contract.md", doc
+    assert doc["artifact_paths"]["latest_report_path"] == str(latest_path.resolve()), doc
+    assert doc["artifact_paths"]["stamped_report_path"] == str(stamped_path.resolve()), doc
+    assert doc["record"]["cross_repo_snapshot_status"] == "present", doc
+    assert doc["record"]["cross_repo_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", doc
+    assert doc["record"]["monday_source_validation_status"] == "attention", doc
+    assert doc["record"]["monday_source_validation_summary"] == "total=2 pass=1 fail=1 errors=2 warnings=1", doc
+    assert doc["record"]["latest_payload_bridge_id"] == "monday-local-inbox-20260401T084500Z", doc
+    assert doc["record"]["latest_consumer_run_id"] == "planningops-local-inbox-consumer-20260401T103000Z", doc
+    assert doc["record"]["cross_repo_action_lines"] == [
+        "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+        "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)",
+    ], doc
 PY
 
 python3 "$QUERY_PATH" triage-feed \


### PR DESCRIPTION
## Summary
- promote `cross-repo-validation-report` into latest and stamped validation artifacts
- add a contract for the promoted cross-repo validation packet
- extend query regressions to verify the write path as well as the read path

## Scope
- `planningops/scripts/federation/query_federated_ci_artifacts.py`
- `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `planningops/contracts/cross-repo-validation-report-contract.md`
- `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #980

## Validation
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- the promoted packet now becomes another validation artifact contract, so the write path must stay in sync with the read-only `cross-repo-validation-report` record shape
- inherited CI failures outside this packet remain unchanged

## Review Checklist
- [x] latest and stamped cross-repo validation artifacts are written together
- [x] regression coverage verifies stdout, output, latest, and stamped documents agree
- [x] rollout plan reflects that the packet is no longer query-only