### PR TITLE
feat(query-engine): track cross-repo validation report freshness

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -2,7 +2,7 @@
 title: plan: Monday Local Codex Runtime Rollout
 type: plan
 date: 2026-04-01
-updated: 2026-04-01
+updated: 2026-04-02
 initiative: unified-personal-agent-platform
 lifecycle: workbench
 status: active
@@ -189,6 +189,7 @@ Current deliverables:
 - `planningops/artifacts/validation/cross-repo-validation-report.json`
 - `planningops/artifacts/validation/<report-id>-cross-repo-validation-report.json`
 - the dedicated cross-repo validation packet is now promotion-ready as a stamped validation artifact instead of staying query-only
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now tracks the promoted `cross_repo_validation_report` packet as its own validation family once the latest/stamped artifact pair exists
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -250,6 +251,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether the promoted `cross-repo-validation-report` should also be tracked in `local-validation-freshness` as its own validation family
-2. decide whether the same cross-repo validation snapshot should also surface in `triage-brief` or `triage-report`, not only `triage-feed`
+1. decide whether the same cross-repo validation snapshot should also surface in `triage-brief` or `triage-report`, not only `triage-feed`
+2. decide whether the dedicated `cross_repo_validation_report` family needs a first-class operator packet surface beyond `local-validation-freshness`
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/contracts/cross-repo-validation-report-contract.md
+++ b/planningops/contracts/cross-repo-validation-report-contract.md
@@ -57,8 +57,10 @@ Each promoted report must include:
 - write both latest and stamped copies on every invocation
 - preserve the full rendered record under `record`
 - allow an optional `--output` path for ad hoc export without skipping latest/stamped promotion
+- once the latest/stamped pair exists, `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` must expose the packet as `cross_repo_validation_report`
 
 ## Verification
 
 - `python3 planningops/scripts/federation/query_federated_ci_artifacts.py write-cross-repo-validation-report --validation-root <validation-root> --consumer-root <consumer-root> --monday-validation-root <monday-validation-root>`
+- `python3 planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness --artifact-family cross_repo_validation_report --validation-root <validation-root>`
 - `bash planningops/scripts/test_query_federated_ci_artifacts.sh`

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -67,6 +67,7 @@ LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_inbox_consumer_report",
     "monday_local_inbox_bridge_schema_validation",
     "monday_local_inbox_consumer_schema_validation",
+    "cross_repo_validation_report",
 )
 LOCAL_VALIDATION_FRESHNESS_CHOICES = ("fresh", "stale", "missing")
 LOCAL_VALIDATION_PROMOTABILITY_CHOICES = ("promotable", "blocked")
@@ -2488,6 +2489,139 @@ def build_monday_consumer_validation_mirror_freshness_record(
     )
 
 
+def build_cross_repo_validation_report_validation_freshness_record(
+    *,
+    validation_root: Path,
+) -> LocalValidationFreshnessRecord:
+    latest_path = (validation_root / "cross-repo-validation-report.json").resolve()
+    latest_doc = load_optional_json(latest_path)
+    freshness_reasons: list[str] = []
+    promotability_reasons: list[str] = []
+    dependency_states: dict[str, str] = {}
+    stamped_path: Path | None = None
+    promoted_id: str | None = None
+    generated_at_utc: str | None = None
+    dependency_filenames = {
+        "monday_local_inbox_launch_request": "monday-local-inbox-launch-request.json",
+        "monday_local_inbox_runtime_report": "monday-local-inbox-runtime-report.json",
+        "monday_local_inbox_consumer_report": "monday-local-inbox-consumer-report.json",
+        "monday_local_inbox_bridge_schema_validation": "monday-local-inbox-bridge-schema-validation.json",
+        "monday_local_inbox_consumer_schema_validation": "monday-local-inbox-consumer-schema-validation.json",
+    }
+
+    if latest_doc is not None:
+        promoted_id = normalize_optional_string(latest_doc.get("report_id"))
+        generated_at_utc = normalize_optional_string(latest_doc.get("generated_at_utc"))
+        if promoted_id is None:
+            promotability_reasons.append("missing_report_id")
+
+        contract_ref = normalize_optional_string(latest_doc.get("contract_ref"))
+        if contract_ref is None:
+            promotability_reasons.append("missing_contract_ref")
+        elif contract_ref != CROSS_REPO_VALIDATION_REPORT_CONTRACT_REF:
+            promotability_reasons.append("contract_ref_mismatch")
+
+        latest_report_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "latest_report_path")
+        stamped_path = resolve_nested_artifact_path(latest_doc, "artifact_paths", "stamped_report_path")
+        if latest_report_path != latest_path:
+            freshness_reasons.append("latest_path_mismatch")
+
+        record_doc = resolve_nested_value(latest_doc, "record")
+        if not isinstance(record_doc, dict):
+            promotability_reasons.append("missing_record")
+        else:
+            required_strings = {
+                "headline": "missing_headline",
+                "cross_repo_snapshot_status": "missing_cross_repo_snapshot_status",
+                "cross_repo_snapshot_summary": "missing_cross_repo_snapshot_summary",
+                "monday_source_validation_status": "missing_monday_source_validation_status",
+                "monday_source_validation_summary": "missing_monday_source_validation_summary",
+                "markdown": "missing_markdown",
+            }
+            for field_name, reason in required_strings.items():
+                value = record_doc.get(field_name)
+                if not isinstance(value, str) or not value.strip():
+                    promotability_reasons.append(reason)
+
+            cross_repo_validation_records = record_doc.get("cross_repo_validation_records")
+            if not isinstance(cross_repo_validation_records, list):
+                promotability_reasons.append("missing_cross_repo_validation_records")
+            else:
+                records_by_family: dict[str, dict[str, Any]] = {}
+                for item in cross_repo_validation_records:
+                    if not isinstance(item, dict):
+                        continue
+                    artifact_family = normalize_optional_string(item.get("artifact_family"))
+                    if artifact_family is None or artifact_family in records_by_family:
+                        continue
+                    records_by_family[artifact_family] = item
+
+                for dependency_family, dependency_filename in dependency_filenames.items():
+                    dependency_record = records_by_family.get(dependency_family)
+                    if dependency_record is None:
+                        dependency_states[dependency_family] = "missing"
+                        promotability_reasons.append(f"missing_{dependency_family}_record")
+                        continue
+
+                    dependency_state, dependency_reason = build_local_validation_dependency_state(
+                        raw_path=dependency_record.get("latest_path"),
+                        expected_path=validation_root / dependency_filename,
+                    )
+                    dependency_states[dependency_family] = dependency_state
+                    if dependency_reason == "dependency_path_missing":
+                        promotability_reasons.append(f"missing_{dependency_family}_path")
+                    elif dependency_reason == "dependency_missing":
+                        promotability_reasons.append(f"{dependency_family}_dependency_missing")
+                    elif dependency_reason == "dependency_stale":
+                        promotability_reasons.append(f"{dependency_family}_dependency_stale")
+
+            if not isinstance(record_doc.get("cross_repo_summary_lines"), list):
+                promotability_reasons.append("missing_cross_repo_summary_lines")
+            if not isinstance(record_doc.get("monday_validation_report_records"), list):
+                promotability_reasons.append("missing_monday_validation_report_records")
+            if not isinstance(record_doc.get("monday_validation_report_lines"), list):
+                promotability_reasons.append("missing_monday_validation_report_lines")
+
+        if stamped_path is not None and stamped_path.exists():
+            stamped_doc = load_optional_json(stamped_path)
+            if stamped_doc is None:
+                freshness_reasons.append("stamped_invalid_json")
+            else:
+                if normalize_optional_string(stamped_doc.get("report_id")) != promoted_id:
+                    freshness_reasons.append("stamped_report_id_mismatch")
+                stamped_latest_path = resolve_nested_artifact_path(stamped_doc, "artifact_paths", "latest_report_path")
+                stamped_stamped_path = resolve_nested_artifact_path(
+                    stamped_doc,
+                    "artifact_paths",
+                    "stamped_report_path",
+                )
+                if stamped_latest_path != latest_path:
+                    freshness_reasons.append("stamped_latest_path_mismatch")
+                if stamped_stamped_path != stamped_path.resolve():
+                    freshness_reasons.append("stamped_path_mismatch")
+
+    freshness_state, promotability_status = classify_local_validation_states(
+        latest_path=latest_path,
+        latest_doc=latest_doc,
+        stamped_path=stamped_path,
+        freshness_reasons=freshness_reasons,
+        promotability_reasons=promotability_reasons,
+        dependency_states=dependency_states,
+    )
+    return LocalValidationFreshnessRecord(
+        artifact_family="cross_repo_validation_report",
+        artifact_kind="report",
+        promoted_id=promoted_id,
+        generated_at_utc=generated_at_utc,
+        freshness_state=freshness_state,
+        promotability_status=promotability_status,
+        latest_path=str(latest_path),
+        stamped_path=None if stamped_path is None else str(stamped_path.resolve()),
+        reasons=freshness_reasons + promotability_reasons,
+        dependency_states=dependency_states,
+    )
+
+
 def resolve_monday_validation_bridge_id(
     *,
     validation_root: Path,
@@ -2656,6 +2790,12 @@ def discover_local_validation_freshness_records(*, validation_root: Path) -> lis
         stamped_glob="*-monday-local-inbox-consumer-schema-validation.json",
     ):
         records.append(build_monday_consumer_validation_mirror_freshness_record(validation_root=validation_root))
+    if has_promoted_local_validation_artifact(
+        validation_root=validation_root,
+        latest_filename="cross-repo-validation-report.json",
+        stamped_glob="*-cross-repo-validation-report.json",
+    ):
+        records.append(build_cross_repo_validation_report_validation_freshness_record(validation_root=validation_root))
     return records
 
 

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -660,6 +660,8 @@ LOCAL_VALIDATION_BLOCKED_OUTPUT="$TMP_DIR/local-validation-freshness-blocked.jso
 LOCAL_VALIDATION_STALE_OUTPUT="$TMP_DIR/local-validation-freshness-stale.json"
 LOCAL_VALIDATION_MIRROR_WRITE_OUTPUT="$TMP_DIR/local-validation-mirror-write.json"
 LOCAL_VALIDATION_WITH_CONSUMER_OUTPUT="$TMP_DIR/local-validation-freshness-with-consumer.json"
+LOCAL_VALIDATION_WITH_CROSS_REPO_REPORT_OUTPUT="$TMP_DIR/local-validation-freshness-with-cross-repo-report.json"
+LOCAL_VALIDATION_CROSS_REPO_REPORT_OUTPUT="$TMP_DIR/local-validation-cross-repo-report.json"
 LOCAL_VALIDATION_RUNTIME_BLOCKED_OUTPUT="$TMP_DIR/local-validation-runtime-blocked.json"
 LOCAL_INBOX_PAYLOAD_OUTPUT="$TMP_DIR/local-inbox-payload.json"
 LOCAL_INBOX_PAYLOAD_ALL_OUTPUT="$TMP_DIR/local-inbox-payload-all.json"
@@ -4003,6 +4005,66 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
         "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
         "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)",
     ], doc
+PY
+
+python3 "$QUERY_PATH" local-validation-freshness \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_VALIDATION_WITH_CROSS_REPO_REPORT_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_WITH_CROSS_REPO_REPORT_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert [record["artifact_family"] for record in records] == [
+    "monday_local_operator_stack_report",
+    "operator_handoff_report",
+    "monday_local_mission_packet",
+    "monday_local_operator_day_packet",
+    "monday_local_operator_inbox_payload",
+    "monday_local_inbox_launch_request",
+    "monday_local_inbox_runtime_report",
+    "monday_local_inbox_consumer_report",
+    "monday_local_inbox_bridge_schema_validation",
+    "monday_local_inbox_consumer_schema_validation",
+    "cross_repo_validation_report",
+], records
+
+cross_repo_report = records[10]
+assert cross_repo_report["freshness_state"] == "fresh", cross_repo_report
+assert cross_repo_report["promotability_status"] == "promotable", cross_repo_report
+assert cross_repo_report["promoted_id"] == "cross-repo-validation-20260401T110000Z", cross_repo_report
+assert cross_repo_report["dependency_states"] == {
+    "monday_local_inbox_launch_request": "current",
+    "monday_local_inbox_runtime_report": "current",
+    "monday_local_inbox_consumer_report": "current",
+    "monday_local_inbox_bridge_schema_validation": "current",
+    "monday_local_inbox_consumer_schema_validation": "current",
+}, cross_repo_report
+assert cross_repo_report["reasons"] == [], cross_repo_report
+PY
+
+python3 "$QUERY_PATH" local-validation-freshness \
+  --artifact-family cross_repo_validation_report \
+  --promotability-status promotable \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_VALIDATION_CROSS_REPO_REPORT_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_VALIDATION_CROSS_REPO_REPORT_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["artifact_family"] == "cross_repo_validation_report", record
+assert record["freshness_state"] == "fresh", record
+assert record["promotability_status"] == "promotable", record
+assert record["reasons"] == [], record
 PY
 
 python3 "$QUERY_PATH" triage-feed \


### PR DESCRIPTION
## Summary
- track the promoted `cross-repo-validation-report` packet in `local-validation-freshness` as its own validation family
- validate the promoted packet against its expected dependency artifacts and stamped/latest pair
- extend regressions and rollout docs to reflect the new validation-lane behavior

## Scope
- `planningops/scripts/federation/query_federated_ci_artifacts.py`
- `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `planningops/contracts/cross-repo-validation-report-contract.md`
- `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`

## Linked Issues
- Closes #982

## Validation
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- the new freshness family depends on the promoted cross-repo packet continuing to preserve the current record shape
- inherited CI failures outside this packet remain unchanged

## Review Checklist
- [x] `local-validation-freshness` exposes `cross_repo_validation_report` when the promoted latest/stamped pair exists
- [x] regression coverage verifies the new family is fresh/promotable and filterable by artifact family
- [x] rollout plan and contract reflect that the promoted packet now participates in the validation freshness lane