### PR TITLE
feat(query-engine): surface cross-repo validation in triage brief and report

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -190,6 +190,7 @@ Current deliverables:
 - `planningops/artifacts/validation/<report-id>-cross-repo-validation-report.json`
 - the dedicated cross-repo validation packet is now promotion-ready as a stamped validation artifact instead of staying query-only
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-validation-freshness` now tracks the promoted `cross_repo_validation_report` packet as its own validation family once the latest/stamped artifact pair exists
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief|triage-report` now carry the same cross-repo validation snapshot and monday source validation summary that `triage-feed` already exposes
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -251,6 +252,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether the same cross-repo validation snapshot should also surface in `triage-brief` or `triage-report`, not only `triage-feed`
-2. decide whether the dedicated `cross_repo_validation_report` family needs a first-class operator packet surface beyond `local-validation-freshness`
+1. decide whether the dedicated `cross_repo_validation_report` family needs a first-class operator packet surface beyond `local-validation-freshness`
+2. decide whether the cross-repo snapshot should stay summary-only in triage surfaces or grow a dedicated actions/details section outside `cross-repo-validation-report`
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -286,6 +286,11 @@ class TriageBriefRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    cross_repo_validation_snapshot_status: str | None
+    cross_repo_validation_snapshot_summary: str | None
+    monday_source_validation_status: str | None
+    monday_source_validation_summary: str | None
+    cross_repo_validation_action_line: str | None
     queue_lines: list[str]
     target_lines: list[str]
 
@@ -301,6 +306,11 @@ class TriageReportRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    cross_repo_validation_snapshot_status: str | None
+    cross_repo_validation_snapshot_summary: str | None
+    monday_source_validation_status: str | None
+    monday_source_validation_summary: str | None
+    cross_repo_validation_action_line: str | None
     queue_lines: list[str]
     target_lines: list[str]
     markdown: str
@@ -3992,6 +4002,11 @@ def build_triage_brief_record(
         local_operator_record=feed.local_operator_record,
         local_operator_summary=build_local_operator_summary(feed.local_operator_record),
         local_operator_next_step=build_local_operator_next_step(feed.local_operator_record),
+        cross_repo_validation_snapshot_status=feed.cross_repo_validation_snapshot_status,
+        cross_repo_validation_snapshot_summary=feed.cross_repo_validation_snapshot_summary,
+        monday_source_validation_status=feed.monday_source_validation_status,
+        monday_source_validation_summary=feed.monday_source_validation_summary,
+        cross_repo_validation_action_line=feed.cross_repo_validation_action_line,
         queue_lines=queue_lines,
         target_lines=target_lines,
     )
@@ -4014,6 +4029,17 @@ def render_triage_brief_table(record: TriageBriefRecord) -> str:
         sections.append(f"local_operator\t{record.local_operator_summary}")
     if record.local_operator_next_step is not None:
         sections.append(f"local_operator_next_step\t{record.local_operator_next_step}")
+    if record.cross_repo_validation_snapshot_status is not None:
+        sections.extend(
+            [
+                f"cross_repo_validation_snapshot_status\t{record.cross_repo_validation_snapshot_status}",
+                f"cross_repo_validation_snapshot_summary\t{record.cross_repo_validation_snapshot_summary or ''}",
+                f"monday_source_validation_status\t{record.monday_source_validation_status or ''}",
+                f"monday_source_validation_summary\t{record.monday_source_validation_summary or ''}",
+            ]
+        )
+        if record.cross_repo_validation_action_line is not None:
+            sections.append(f"cross_repo_validation_action\t{record.cross_repo_validation_action_line}")
     sections.extend(["queue", *record.queue_lines, "targets", *record.target_lines])
     return "\n".join(sections)
 
@@ -4040,6 +4066,19 @@ def render_triage_brief_markdown(record: TriageBriefRecord) -> str:
         lines.append(f"- local operator: `{record.local_operator_summary}`")
     if record.local_operator_next_step is not None:
         lines.append(f"- local operator next step: {record.local_operator_next_step}")
+    if record.cross_repo_validation_snapshot_status is not None:
+        lines.extend(
+            [
+                "",
+                "### Cross-Repo Validation",
+                f"- snapshot status: `{record.cross_repo_validation_snapshot_status}`",
+                f"- snapshot summary: `{record.cross_repo_validation_snapshot_summary or ''}`",
+                f"- monday source validation status: `{record.monday_source_validation_status or ''}`",
+                f"- monday source validation summary: `{record.monday_source_validation_summary or ''}`",
+            ]
+        )
+        if record.cross_repo_validation_action_line is not None:
+            lines.append(f"- next action: {record.cross_repo_validation_action_line}")
     lines.append("")
     lines.append("### Queue")
     lines.extend(f"- {line}" for line in record.queue_lines)
@@ -4100,6 +4139,19 @@ def build_triage_report_record(
         markdown_lines.append(f"- local operator: `{brief.local_operator_summary}`")
     if brief.local_operator_next_step is not None:
         markdown_lines.append(f"- local operator next step: {brief.local_operator_next_step}")
+    if brief.cross_repo_validation_snapshot_status is not None:
+        markdown_lines.extend(
+            [
+                "",
+                "### Cross-Repo Validation",
+                f"- snapshot status: `{brief.cross_repo_validation_snapshot_status}`",
+                f"- snapshot summary: `{brief.cross_repo_validation_snapshot_summary or ''}`",
+                f"- monday source validation status: `{brief.monday_source_validation_status or ''}`",
+                f"- monday source validation summary: `{brief.monday_source_validation_summary or ''}`",
+            ]
+        )
+        if brief.cross_repo_validation_action_line is not None:
+            markdown_lines.append(f"- next action: {brief.cross_repo_validation_action_line}")
     markdown_lines.extend(
         [
             "",
@@ -4120,6 +4172,11 @@ def build_triage_report_record(
         local_operator_record=brief.local_operator_record,
         local_operator_summary=brief.local_operator_summary,
         local_operator_next_step=brief.local_operator_next_step,
+        cross_repo_validation_snapshot_status=brief.cross_repo_validation_snapshot_status,
+        cross_repo_validation_snapshot_summary=brief.cross_repo_validation_snapshot_summary,
+        monday_source_validation_status=brief.monday_source_validation_status,
+        monday_source_validation_summary=brief.monday_source_validation_summary,
+        cross_repo_validation_action_line=brief.cross_repo_validation_action_line,
         queue_lines=brief.queue_lines,
         target_lines=brief.target_lines,
         markdown="\n".join(markdown_lines),
@@ -4140,6 +4197,17 @@ def render_triage_report_table(record: TriageReportRecord) -> str:
         sections.append(f"local_operator\t{record.local_operator_summary}")
     if record.local_operator_next_step is not None:
         sections.append(f"local_operator_next_step\t{record.local_operator_next_step}")
+    if record.cross_repo_validation_snapshot_status is not None:
+        sections.extend(
+            [
+                f"cross_repo_validation_snapshot_status\t{record.cross_repo_validation_snapshot_status}",
+                f"cross_repo_validation_snapshot_summary\t{record.cross_repo_validation_snapshot_summary or ''}",
+                f"monday_source_validation_status\t{record.monday_source_validation_status or ''}",
+                f"monday_source_validation_summary\t{record.monday_source_validation_summary or ''}",
+            ]
+        )
+        if record.cross_repo_validation_action_line is not None:
+            sections.append(f"cross_repo_validation_action\t{record.cross_repo_validation_action_line}")
     sections.extend(["queue", *record.queue_lines, "targets", *record.target_lines])
     return "\n".join(sections)
 

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -649,8 +649,10 @@ TRIAGE_FEED_ALL_OUTPUT="$TMP_DIR/triage-feed-all.json"
 TRIAGE_FEED_WITH_CROSS_REPO_VALIDATION_OUTPUT="$TMP_DIR/triage-feed-with-cross-repo-validation.json"
 TRIAGE_BRIEF_OUTPUT="$TMP_DIR/triage-brief.json"
 TRIAGE_BRIEF_ALL_OUTPUT="$TMP_DIR/triage-brief-all.json"
+TRIAGE_BRIEF_WITH_CROSS_REPO_VALIDATION_OUTPUT="$TMP_DIR/triage-brief-with-cross-repo-validation.json"
 TRIAGE_REPORT_OUTPUT="$TMP_DIR/triage-report.json"
 TRIAGE_REPORT_ALL_OUTPUT="$TMP_DIR/triage-report-all.json"
+TRIAGE_REPORT_WITH_CROSS_REPO_VALIDATION_OUTPUT="$TMP_DIR/triage-report-with-cross-repo-validation.json"
 HANDOFF_REPORT_OUTPUT="$TMP_DIR/handoff-report.json"
 HANDOFF_REPORT_ALL_OUTPUT="$TMP_DIR/handoff-report-all.json"
 HANDOFF_REPORT_WITH_MONDAY_VALIDATION_OUTPUT="$TMP_DIR/handoff-report-with-monday-validation.json"
@@ -1683,6 +1685,11 @@ assert record["local_operator_summary"] == (
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
 assert record["local_operator_next_step"] == "Expose Codex and add a direct local LLM profile.", record
+assert record["cross_repo_validation_snapshot_status"] == "missing", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
+assert record["monday_source_validation_status"] == "missing", record
+assert record["monday_source_validation_summary"] == "total=0 pass=0 fail=0 errors=0 warnings=0", record
+assert record["cross_repo_validation_action_line"] is None, record
 assert record["queue_lines"] == [
     "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1",
     "lagging: targets=1 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint=1,readiness=1,reconcile=1",
@@ -1724,6 +1731,11 @@ assert record["local_operator_summary"] == (
     "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
+assert record["cross_repo_validation_snapshot_status"] == "missing", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
+assert record["monday_source_validation_status"] == "missing", record
+assert record["monday_source_validation_summary"] == "total=0 pass=0 fail=0 errors=0 warnings=0", record
+assert record["cross_repo_validation_action_line"] is None, record
 assert record["queue_lines"] == [
     "active: targets=2 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun26 domains=checkpoint=1,readiness=2,reconcile=2",
 ], record
@@ -1760,6 +1772,11 @@ assert record["local_operator_summary"] == (
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
 assert record["local_operator_next_step"] == "Expose Codex and add a direct local LLM profile.", record
+assert record["cross_repo_validation_snapshot_status"] == "missing", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
+assert record["monday_source_validation_status"] == "missing", record
+assert record["monday_source_validation_summary"] == "total=0 pass=0 fail=0 errors=0 warnings=0", record
+assert record["cross_repo_validation_action_line"] is None, record
 assert record["queue_lines"] == [
     "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1",
     "lagging: targets=1 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint=1,readiness=1,reconcile=1",
@@ -1804,6 +1821,11 @@ assert record["local_operator_summary"] == (
     "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
+assert record["cross_repo_validation_snapshot_status"] == "missing", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
+assert record["monday_source_validation_status"] == "missing", record
+assert record["monday_source_validation_summary"] == "total=0 pass=0 fail=0 errors=0 warnings=0", record
+assert record["cross_repo_validation_action_line"] is None, record
 assert record["queue_lines"] == [
     "active: targets=2 newest=federated-ci-runtime-gates/federated-ci-runtime-gates-20260319-rerun26 domains=checkpoint=1,readiness=2,reconcile=2",
 ], record
@@ -4091,6 +4113,61 @@ assert record["cross_repo_validation_action_line"] == (
     "local-validation: repair monday_local_inbox_runtime_report "
     "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
 ), record
+PY
+
+python3 "$QUERY_PATH" triage-brief \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_BRIEF_WITH_CROSS_REPO_VALIDATION_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_BRIEF_WITH_CROSS_REPO_VALIDATION_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["cross_repo_validation_snapshot_status"] == "present", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", record
+assert record["monday_source_validation_status"] == "attention", record
+assert record["monday_source_validation_summary"] == "total=2 pass=1 fail=1 errors=2 warnings=1", record
+assert record["cross_repo_validation_action_line"] == (
+    "local-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+), record
+PY
+
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_REPORT_WITH_CROSS_REPO_VALIDATION_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_WITH_CROSS_REPO_VALIDATION_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["cross_repo_validation_snapshot_status"] == "present", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", record
+assert record["monday_source_validation_status"] == "attention", record
+assert record["monday_source_validation_summary"] == "total=2 pass=1 fail=1 errors=2 warnings=1", record
+assert record["cross_repo_validation_action_line"] == (
+    "local-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+), record
+assert "### Cross-Repo Validation" in record["markdown"], record
+assert "snapshot summary: `total=5 promotable=3 blocked=2 stale=0`" in record["markdown"], record
+assert "monday source validation summary: `total=2 pass=1 fail=1 errors=2 warnings=1`" in record["markdown"], record
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \


### PR DESCRIPTION
## Summary
- surface the cross-repo validation snapshot and monday source validation summary in `triage-brief` and `triage-report`
- extend the query regression to cover both missing and promoted cross-repo validation states in triage surfaces
- update the rollout plan to record triage-brief/report parity with triage-feed

## Scope
- planningops/scripts/federation/query_federated_ci_artifacts.py
- planningops/scripts/test_query_federated_ci_artifacts.sh
- docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md

## Linked Issues
- Closes #984

## Validation
- python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py
- bash planningops/scripts/test_query_federated_ci_artifacts.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Risks
- triage surfaces now depend on the same cross-repo snapshot composition used by triage-feed, so regressions would show up as mismatched summary-only operator views
- inherited CI red lanes remain outside this packet and are not addressed here

## Review Checklist
- [x] query output stays deterministic for missing and promoted cross-repo validation states
- [x] triage markdown and table outputs expose the same cross-repo summary fields
- [x] docs reflect the new current deliverable and next natural packets
