### PR TITLE
feat(query-engine): add cross-repo details to triage surfaces

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -194,6 +194,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py cross-repo-validation-packet` now exposes the promoted latest/stamped packet directly from `planningops/artifacts/validation` so operators can read immutable evidence without recomputing source roots
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report` now point summary-first triage surfaces at the promoted `cross-repo-validation-packet` through explicit packet `report_id` and `path` fields so operators can jump to the immutable detail packet without re-expanding source roots
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now points blocking cross-repo validation states at the promoted `cross-repo-validation-packet` through explicit packet `report_id` and `path` fields so operator handoff can jump straight to immutable detail evidence
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report` now carry dedicated cross-repo detail lines and action lines alongside the immutable packet pointer so operators can read mirror/source specifics without immediately reopening the promoted packet
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -255,6 +256,6 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether the summary-only cross-repo section should stay pointer-only or grow a dedicated actions/details section beyond `cross-repo-validation-packet`
-2. decide whether payload-first and apply/result-first operator blockers should also carry the promoted `cross-repo-validation-packet` pointer explicitly instead of relying on snapshot-only linkage
+1. decide whether payload-first and apply/result-first operator blockers should also carry the promoted `cross-repo-validation-packet` pointer explicitly instead of relying on snapshot-only linkage
+2. decide whether `handoff-report` should keep the immutable packet pointer only or also grow a dedicated cross-repo details/actions section to match triage surfaces
 3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -269,6 +269,9 @@ class TriageFeedRecord:
     monday_source_validation_status: str | None
     monday_source_validation_summary: str | None
     cross_repo_validation_action_line: str | None
+    cross_repo_validation_detail_lines: list[str]
+    monday_source_validation_report_lines: list[str]
+    cross_repo_validation_action_lines: list[str]
     cross_repo_validation_packet_report_id: str | None
     cross_repo_validation_packet_path: str | None
 
@@ -294,6 +297,9 @@ class TriageBriefRecord:
     monday_source_validation_status: str | None
     monday_source_validation_summary: str | None
     cross_repo_validation_action_line: str | None
+    cross_repo_validation_detail_lines: list[str]
+    monday_source_validation_report_lines: list[str]
+    cross_repo_validation_action_lines: list[str]
     cross_repo_validation_packet_report_id: str | None
     cross_repo_validation_packet_path: str | None
     queue_lines: list[str]
@@ -316,6 +322,9 @@ class TriageReportRecord:
     monday_source_validation_status: str | None
     monday_source_validation_summary: str | None
     cross_repo_validation_action_line: str | None
+    cross_repo_validation_detail_lines: list[str]
+    monday_source_validation_report_lines: list[str]
+    cross_repo_validation_action_lines: list[str]
     cross_repo_validation_packet_report_id: str | None
     cross_repo_validation_packet_path: str | None
     queue_lines: list[str]
@@ -3886,6 +3895,9 @@ def build_triage_feed_record(
     monday_source_validation_status = None
     monday_source_validation_summary = None
     cross_repo_validation_action_line = None
+    cross_repo_validation_detail_lines: list[str] = []
+    monday_source_validation_report_lines: list[str] = []
+    cross_repo_validation_action_lines: list[str] = []
     cross_repo_validation_packet_report_id = None
     cross_repo_validation_packet_path = None
     if family is None and run_id_prefix is None and local_records is not None:
@@ -3899,6 +3911,16 @@ def build_triage_feed_record(
         cross_repo_validation_snapshot_summary = cross_repo_validation_record.cross_repo_snapshot_summary
         monday_source_validation_status = cross_repo_validation_record.monday_source_validation_status
         monday_source_validation_summary = cross_repo_validation_record.monday_source_validation_summary
+        cross_repo_validation_detail_lines = [
+            f"mirror: {line}" for line in cross_repo_validation_record.cross_repo_summary_lines
+        ]
+        monday_source_validation_report_lines = [
+            f"source: {line}" for line in cross_repo_validation_record.monday_validation_report_lines
+        ]
+        cross_repo_validation_action_lines = [
+            *cross_repo_validation_record.cross_repo_action_lines,
+            *cross_repo_validation_record.monday_validation_report_action_lines,
+        ]
         if cross_repo_validation_record.cross_repo_action_lines:
             cross_repo_validation_action_line = cross_repo_validation_record.cross_repo_action_lines[0]
         packet_record = select_cross_repo_validation_packet_record(
@@ -3921,6 +3943,9 @@ def build_triage_feed_record(
         monday_source_validation_status=monday_source_validation_status,
         monday_source_validation_summary=monday_source_validation_summary,
         cross_repo_validation_action_line=cross_repo_validation_action_line,
+        cross_repo_validation_detail_lines=cross_repo_validation_detail_lines,
+        monday_source_validation_report_lines=monday_source_validation_report_lines,
+        cross_repo_validation_action_lines=cross_repo_validation_action_lines,
         cross_repo_validation_packet_report_id=cross_repo_validation_packet_report_id,
         cross_repo_validation_packet_path=cross_repo_validation_packet_path,
     )
@@ -3944,6 +3969,12 @@ def render_triage_feed_table(record: TriageFeedRecord) -> str:
         )
         if record.cross_repo_validation_action_line is not None:
             sections.append(f"cross_repo_validation_action\t{record.cross_repo_validation_action_line}")
+        if record.cross_repo_validation_detail_lines:
+            sections.extend(["cross_repo_validation_details", *record.cross_repo_validation_detail_lines])
+        if record.monday_source_validation_report_lines:
+            sections.extend(["monday_source_validation_reports", *record.monday_source_validation_report_lines])
+        if record.cross_repo_validation_action_lines:
+            sections.extend(["cross_repo_validation_actions", *record.cross_repo_validation_action_lines])
         if record.cross_repo_validation_packet_report_id is not None:
             sections.append(
                 f"cross_repo_validation_packet_report_id\t{record.cross_repo_validation_packet_report_id}"
@@ -3998,6 +4029,30 @@ def render_triage_feed_markdown(record: TriageFeedRecord) -> str:
         if record.cross_repo_validation_packet_path is not None:
             cross_repo_lines.append(f"- detail packet path: `{record.cross_repo_validation_packet_path}`")
         sections.append("\n".join(cross_repo_lines))
+        if record.cross_repo_validation_detail_lines or record.monday_source_validation_report_lines:
+            sections.append(
+                "\n".join(
+                    [
+                        "### Cross-Repo Validation Details",
+                        "",
+                        *[f"- {line}" for line in record.cross_repo_validation_detail_lines],
+                        *[f"- {line}" for line in record.monday_source_validation_report_lines],
+                    ]
+                )
+            )
+        if record.cross_repo_validation_action_lines:
+            sections.append(
+                "\n".join(
+                    [
+                        "### Cross-Repo Validation Actions",
+                        "",
+                        *[
+                            f"{index}. {line}"
+                            for index, line in enumerate(record.cross_repo_validation_action_lines, start=1)
+                        ],
+                    ]
+                )
+            )
     if record.local_operator_record is not None:
         local_record = record.local_operator_record
         local_lines = [
@@ -4082,6 +4137,9 @@ def build_triage_brief_record(
         monday_source_validation_status=feed.monday_source_validation_status,
         monday_source_validation_summary=feed.monday_source_validation_summary,
         cross_repo_validation_action_line=feed.cross_repo_validation_action_line,
+        cross_repo_validation_detail_lines=feed.cross_repo_validation_detail_lines,
+        monday_source_validation_report_lines=feed.monday_source_validation_report_lines,
+        cross_repo_validation_action_lines=feed.cross_repo_validation_action_lines,
         cross_repo_validation_packet_report_id=feed.cross_repo_validation_packet_report_id,
         cross_repo_validation_packet_path=feed.cross_repo_validation_packet_path,
         queue_lines=queue_lines,
@@ -4117,6 +4175,12 @@ def render_triage_brief_table(record: TriageBriefRecord) -> str:
         )
         if record.cross_repo_validation_action_line is not None:
             sections.append(f"cross_repo_validation_action\t{record.cross_repo_validation_action_line}")
+        if record.cross_repo_validation_detail_lines:
+            sections.extend(["cross_repo_validation_details", *record.cross_repo_validation_detail_lines])
+        if record.monday_source_validation_report_lines:
+            sections.extend(["monday_source_validation_reports", *record.monday_source_validation_report_lines])
+        if record.cross_repo_validation_action_lines:
+            sections.extend(["cross_repo_validation_actions", *record.cross_repo_validation_action_lines])
         if record.cross_repo_validation_packet_report_id is not None:
             sections.append(
                 f"cross_repo_validation_packet_report_id\t{record.cross_repo_validation_packet_report_id}"
@@ -4166,6 +4230,26 @@ def render_triage_brief_markdown(record: TriageBriefRecord) -> str:
             lines.append(f"- detail packet report id: `{record.cross_repo_validation_packet_report_id}`")
         if record.cross_repo_validation_packet_path is not None:
             lines.append(f"- detail packet path: `{record.cross_repo_validation_packet_path}`")
+        if record.cross_repo_validation_detail_lines or record.monday_source_validation_report_lines:
+            lines.extend(
+                [
+                    "",
+                    "### Cross-Repo Validation Details",
+                    *[f"- {line}" for line in record.cross_repo_validation_detail_lines],
+                    *[f"- {line}" for line in record.monday_source_validation_report_lines],
+                ]
+            )
+        if record.cross_repo_validation_action_lines:
+            lines.extend(
+                [
+                    "",
+                    "### Cross-Repo Validation Actions",
+                    *[
+                        f"{index}. {line}"
+                        for index, line in enumerate(record.cross_repo_validation_action_lines, start=1)
+                    ],
+                ]
+            )
     lines.append("")
     lines.append("### Queue")
     lines.extend(f"- {line}" for line in record.queue_lines)
@@ -4245,6 +4329,26 @@ def build_triage_report_record(
             )
         if brief.cross_repo_validation_packet_path is not None:
             markdown_lines.append(f"- detail packet path: `{brief.cross_repo_validation_packet_path}`")
+        if brief.cross_repo_validation_detail_lines or brief.monday_source_validation_report_lines:
+            markdown_lines.extend(
+                [
+                    "",
+                    "### Cross-Repo Validation Details",
+                    *[f"- {line}" for line in brief.cross_repo_validation_detail_lines],
+                    *[f"- {line}" for line in brief.monday_source_validation_report_lines],
+                ]
+            )
+        if brief.cross_repo_validation_action_lines:
+            markdown_lines.extend(
+                [
+                    "",
+                    "### Cross-Repo Validation Actions",
+                    *[
+                        f"{index}. {line}"
+                        for index, line in enumerate(brief.cross_repo_validation_action_lines, start=1)
+                    ],
+                ]
+            )
     markdown_lines.extend(
         [
             "",
@@ -4270,6 +4374,9 @@ def build_triage_report_record(
         monday_source_validation_status=brief.monday_source_validation_status,
         monday_source_validation_summary=brief.monday_source_validation_summary,
         cross_repo_validation_action_line=brief.cross_repo_validation_action_line,
+        cross_repo_validation_detail_lines=brief.cross_repo_validation_detail_lines,
+        monday_source_validation_report_lines=brief.monday_source_validation_report_lines,
+        cross_repo_validation_action_lines=brief.cross_repo_validation_action_lines,
         cross_repo_validation_packet_report_id=brief.cross_repo_validation_packet_report_id,
         cross_repo_validation_packet_path=brief.cross_repo_validation_packet_path,
         queue_lines=brief.queue_lines,
@@ -4303,6 +4410,12 @@ def render_triage_report_table(record: TriageReportRecord) -> str:
         )
         if record.cross_repo_validation_action_line is not None:
             sections.append(f"cross_repo_validation_action\t{record.cross_repo_validation_action_line}")
+        if record.cross_repo_validation_detail_lines:
+            sections.extend(["cross_repo_validation_details", *record.cross_repo_validation_detail_lines])
+        if record.monday_source_validation_report_lines:
+            sections.extend(["monday_source_validation_reports", *record.monday_source_validation_report_lines])
+        if record.cross_repo_validation_action_lines:
+            sections.extend(["cross_repo_validation_actions", *record.cross_repo_validation_action_lines])
         if record.cross_repo_validation_packet_report_id is not None:
             sections.append(
                 f"cross_repo_validation_packet_report_id\t{record.cross_repo_validation_packet_report_id}"

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -4215,6 +4215,22 @@ assert record["cross_repo_validation_action_line"] == (
     "local-validation: repair monday_local_inbox_runtime_report "
     "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
 ), record
+assert record["cross_repo_validation_detail_lines"] == [
+    "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+    "mirror: monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+    "mirror: monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_consumer_schema_validation: freshness=fresh promotability=blocked reasons=validation_verdict_fail,validation_errors_present dependencies=monday_local_inbox_consumer_report=current",
+], record
+assert record["monday_source_validation_report_lines"] == [
+    "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes",
+    "source: bridge: verdict=pass errors=0 warnings=0 artifact_exists=yes schema_exists=yes",
+], record
+assert record["cross_repo_validation_action_lines"] == [
+    "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+    "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)",
+    "monday-validation: inspect consumer-report source report (verdict=fail, errors=2, warnings=1)",
+], record
 assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
 assert record["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), record
 PY
@@ -4243,6 +4259,22 @@ assert record["cross_repo_validation_action_line"] == (
     "local-validation: repair monday_local_inbox_runtime_report "
     "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
 ), record
+assert record["cross_repo_validation_detail_lines"] == [
+    "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+    "mirror: monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+    "mirror: monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_consumer_schema_validation: freshness=fresh promotability=blocked reasons=validation_verdict_fail,validation_errors_present dependencies=monday_local_inbox_consumer_report=current",
+], record
+assert record["monday_source_validation_report_lines"] == [
+    "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes",
+    "source: bridge: verdict=pass errors=0 warnings=0 artifact_exists=yes schema_exists=yes",
+], record
+assert record["cross_repo_validation_action_lines"] == [
+    "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+    "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)",
+    "monday-validation: inspect consumer-report source report (verdict=fail, errors=2, warnings=1)",
+], record
 assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
 assert record["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), record
 PY
@@ -4271,11 +4303,32 @@ assert record["cross_repo_validation_action_line"] == (
     "local-validation: repair monday_local_inbox_runtime_report "
     "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
 ), record
+assert record["cross_repo_validation_detail_lines"] == [
+    "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+    "mirror: monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+    "mirror: monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_consumer_schema_validation: freshness=fresh promotability=blocked reasons=validation_verdict_fail,validation_errors_present dependencies=monday_local_inbox_consumer_report=current",
+], record
+assert record["monday_source_validation_report_lines"] == [
+    "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes",
+    "source: bridge: verdict=pass errors=0 warnings=0 artifact_exists=yes schema_exists=yes",
+], record
+assert record["cross_repo_validation_action_lines"] == [
+    "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+    "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)",
+    "monday-validation: inspect consumer-report source report (verdict=fail, errors=2, warnings=1)",
+], record
 assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
 assert record["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), record
 assert "### Cross-Repo Validation" in record["markdown"], record
 assert "snapshot summary: `total=5 promotable=3 blocked=2 stale=0`" in record["markdown"], record
 assert "monday source validation summary: `total=2 pass=1 fail=1 errors=2 warnings=1`" in record["markdown"], record
+assert "### Cross-Repo Validation Details" in record["markdown"], record
+assert "### Cross-Repo Validation Actions" in record["markdown"], record
+assert "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing" in record["markdown"], record
+assert "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes" in record["markdown"], record
+assert "1. local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)" in record["markdown"], record
 assert "detail packet report id: `cross-repo-validation-20260401T110000Z`" in record["markdown"], record
 assert "detail packet path: `" in record["markdown"], record
 PY


### PR DESCRIPTION
## Summary
- grow triage cross-repo sections beyond snapshot plus packet pointer only
- add mirror detail lines, monday source validation report lines, and full action lines to `triage-feed`, `triage-brief`, and `triage-report`
- keep the promoted `cross-repo-validation-packet` pointer as the immutable deep link and refresh the rollout plan

## Scope
- extend triage record shapes with dedicated cross-repo detail/action arrays
- render dedicated details/actions sections in triage markdown and table outputs
- lock the promoted cross-repo triage regressions to the new fields and sections

## Linked Issues
Closes #992

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Risks
- triage surfaces now duplicate a condensed subset of packet detail lines, so future packet contract changes need triage regression updates too
- this patch intentionally does not yet add the same details/actions expansion to `handoff-report`

## Review Checklist
- [ ] confirm triage cross-repo details show both mirror and monday source report lines
- [ ] confirm triage cross-repo actions include both local validation repairs and monday source validation follow-up
- [ ] confirm promoted packet pointer still resolves to the same latest immutable packet
