### PR TITLE
feat(query-engine): surface cross-repo packet details on payload and consumer views

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -196,6 +196,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now points blocking cross-repo validation states at the promoted `cross-repo-validation-packet` through explicit packet `report_id` and `path` fields so operator handoff can jump straight to immutable detail evidence
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report` now carry dedicated cross-repo detail lines and action lines alongside the immutable packet pointer so operators can read mirror/source specifics without immediately reopening the promoted packet
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-inbox-payload|monday-consumer-report` now point current blocking payload-first and apply/result-first records at the promoted `cross-repo-validation-packet` through explicit packet `report_id` and `path` fields instead of relying on snapshot-only linkage
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-inbox-payload|monday-consumer-report` now also carry the linked packet's dedicated cross-repo detail lines and action lines in their markdown/json surfaces so operators can stay in payload-first or apply/result-first views without reopening the promoted packet immediately
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -258,5 +259,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. decide whether `handoff-report` should keep the immutable packet pointer only or also grow a dedicated cross-repo details/actions section to match triage surfaces
-2. decide whether payload-first and apply/result-first surfaces should stay pointer-only or also grow dedicated cross-repo details/actions sections when the linked packet is blocking
-3. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
+2. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -481,6 +481,9 @@ class LocalInboxPayloadRecord:
     monday_validation_action_lines: list[str]
     cross_repo_validation_packet_report_id: str | None
     cross_repo_validation_packet_path: str | None
+    cross_repo_validation_detail_lines: list[str]
+    monday_source_validation_report_lines: list[str]
+    cross_repo_validation_action_lines: list[str]
     local_validation_action_lines: list[str]
     immediate_actions: list[str]
     queue_lines: list[str]
@@ -511,6 +514,9 @@ class MondayConsumerReportRecord:
     monday_validation_action_lines: list[str]
     cross_repo_validation_packet_report_id: str | None
     cross_repo_validation_packet_path: str | None
+    cross_repo_validation_detail_lines: list[str]
+    monday_source_validation_report_lines: list[str]
+    cross_repo_validation_action_lines: list[str]
     has_runtime_input_overrides: bool
     override_kinds: list[str]
     planner_runtime_config_path: str | None
@@ -1237,6 +1243,9 @@ def build_local_inbox_payload_record(
     ]
     cross_repo_validation_packet_report_id = None
     cross_repo_validation_packet_path = None
+    cross_repo_validation_detail_lines: list[str] = []
+    monday_source_validation_report_lines: list[str] = []
+    cross_repo_validation_action_lines: list[str] = []
     packet_record = select_current_cross_repo_validation_packet_record(
         validation_root=validation_root,
         bridge_id=bridge_id,
@@ -1244,6 +1253,11 @@ def build_local_inbox_payload_record(
     if packet_record is not None:
         cross_repo_validation_packet_report_id = packet_record.report_id
         cross_repo_validation_packet_path = packet_record.report_path
+        (
+            cross_repo_validation_detail_lines,
+            monday_source_validation_report_lines,
+            cross_repo_validation_action_lines,
+        ) = build_cross_repo_validation_packet_lines(packet_record)
     return LocalInboxPayloadRecord(
         bridge_id=bridge_id,
         source_kind=source_kind_for_local_inbox_payload_path(payload_path),
@@ -1274,6 +1288,9 @@ def build_local_inbox_payload_record(
         monday_validation_action_lines=monday_validation_action_lines,
         cross_repo_validation_packet_report_id=cross_repo_validation_packet_report_id,
         cross_repo_validation_packet_path=cross_repo_validation_packet_path,
+        cross_repo_validation_detail_lines=cross_repo_validation_detail_lines,
+        monday_source_validation_report_lines=monday_source_validation_report_lines,
+        cross_repo_validation_action_lines=cross_repo_validation_action_lines,
         local_validation_action_lines=normalize_string_list(payload.get("local_validation_action_lines")),
         immediate_actions=normalize_string_list(payload.get("immediate_actions")),
         queue_lines=normalize_string_list(payload.get("queue_lines")),
@@ -1397,6 +1414,7 @@ def render_local_inbox_payload_markdown(records: list[LocalInboxPayloadRecord]) 
         "| bridge_id | source | status | attention | message_class | retry_mode | planner_profile | launch_mode | local_model_route | validation_snapshot | monday_validation_snapshot | cross_repo_packet_report_id | cross_repo_packet_path | dependencies | immediate_actions | targets | attachments | generated_at_utc |",
         "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- |",
     ]
+    sections: list[str] = []
     for record in records:
         lines.append(
             f"| `{record.bridge_id}` | {record.source_kind} | {record.status or ''} | "
@@ -1411,7 +1429,41 @@ def render_local_inbox_payload_markdown(records: list[LocalInboxPayloadRecord]) 
             f"{len(record.immediate_actions)} | {len(record.target_lines)} | {record.attachment_count} | "
             f"{record.generated_at_utc} |"
         )
-    return "\n".join(lines)
+        detail_lines: list[str] = []
+        if record.cross_repo_validation_packet_report_id is not None:
+            detail_lines.append(
+                f"- detail packet report id: `{record.cross_repo_validation_packet_report_id}`"
+            )
+        if record.cross_repo_validation_packet_path is not None:
+            detail_lines.append(f"- detail packet path: `{record.cross_repo_validation_packet_path}`")
+        detail_lines.extend(f"- {line}" for line in record.cross_repo_validation_detail_lines)
+        detail_lines.extend(f"- {line}" for line in record.monday_source_validation_report_lines)
+        if detail_lines:
+            sections.append(
+                "\n".join(
+                    [
+                        f"### Cross-Repo Validation Details: `{record.bridge_id}`",
+                        "",
+                        *detail_lines,
+                    ]
+                )
+            )
+        if record.cross_repo_validation_action_lines:
+            sections.append(
+                "\n".join(
+                    [
+                        f"### Cross-Repo Validation Actions: `{record.bridge_id}`",
+                        "",
+                        *[
+                            f"{index}. {line}"
+                            for index, line in enumerate(record.cross_repo_validation_action_lines, start=1)
+                        ],
+                    ]
+                )
+            )
+    if not sections:
+        return "\n".join(lines)
+    return "\n".join(lines) + "\n\n" + "\n\n".join(sections)
 
 
 def build_monday_consumer_report_record(
@@ -1460,6 +1512,9 @@ def build_monday_consumer_report_record(
     ]
     cross_repo_validation_packet_report_id = None
     cross_repo_validation_packet_path = None
+    cross_repo_validation_detail_lines: list[str] = []
+    monday_source_validation_report_lines: list[str] = []
+    cross_repo_validation_action_lines: list[str] = []
     packet_record = select_current_cross_repo_validation_packet_record(
         validation_root=validation_root,
         consumer_run_id=str(report_doc.get("run_id")),
@@ -1467,6 +1522,11 @@ def build_monday_consumer_report_record(
     if packet_record is not None:
         cross_repo_validation_packet_report_id = packet_record.report_id
         cross_repo_validation_packet_path = packet_record.report_path
+        (
+            cross_repo_validation_detail_lines,
+            monday_source_validation_report_lines,
+            cross_repo_validation_action_lines,
+        ) = build_cross_repo_validation_packet_lines(packet_record)
     return MondayConsumerReportRecord(
         run_id=str(report_doc.get("run_id")),
         report_path=str(report_path.resolve()),
@@ -1489,6 +1549,9 @@ def build_monday_consumer_report_record(
         monday_validation_action_lines=monday_validation_action_lines,
         cross_repo_validation_packet_report_id=cross_repo_validation_packet_report_id,
         cross_repo_validation_packet_path=cross_repo_validation_packet_path,
+        cross_repo_validation_detail_lines=cross_repo_validation_detail_lines,
+        monday_source_validation_report_lines=monday_source_validation_report_lines,
+        cross_repo_validation_action_lines=cross_repo_validation_action_lines,
         has_runtime_input_overrides=bool(override_kinds),
         override_kinds=override_kinds,
         planner_runtime_config_path=planner_runtime_config_path,
@@ -1628,6 +1691,7 @@ def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRec
         "| run_id | mode | verdict | reason_code | consumer_status | can_launch | planner_profile | launch_mode | local_model_route | monday_validation_snapshot | cross_repo_packet_report_id | cross_repo_packet_path | has_runtime_overrides | override_kinds | execution_attempted | execution_exit_code | runtime_report_verdict | has_runtime_report | block_reasons | generated_at_utc |",
         "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
     ]
+    sections: list[str] = []
     for record in records:
         lines.append(
             f"| `{record.run_id}` | {record.mode or ''} | {record.verdict or ''} | {record.reason_code or ''} | "
@@ -1645,7 +1709,41 @@ def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRec
             f"{'yes' if record.has_runtime_report else 'no'} | "
             f"{', '.join(record.block_reasons)} | {record.generated_at_utc} |"
         )
-    return "\n".join(lines)
+        detail_lines: list[str] = []
+        if record.cross_repo_validation_packet_report_id is not None:
+            detail_lines.append(
+                f"- detail packet report id: `{record.cross_repo_validation_packet_report_id}`"
+            )
+        if record.cross_repo_validation_packet_path is not None:
+            detail_lines.append(f"- detail packet path: `{record.cross_repo_validation_packet_path}`")
+        detail_lines.extend(f"- {line}" for line in record.cross_repo_validation_detail_lines)
+        detail_lines.extend(f"- {line}" for line in record.monday_source_validation_report_lines)
+        if detail_lines:
+            sections.append(
+                "\n".join(
+                    [
+                        f"### Cross-Repo Validation Details: `{record.run_id}`",
+                        "",
+                        *detail_lines,
+                    ]
+                )
+            )
+        if record.cross_repo_validation_action_lines:
+            sections.append(
+                "\n".join(
+                    [
+                        f"### Cross-Repo Validation Actions: `{record.run_id}`",
+                        "",
+                        *[
+                            f"{index}. {line}"
+                            for index, line in enumerate(record.cross_repo_validation_action_lines, start=1)
+                        ],
+                    ]
+                )
+            )
+    if not sections:
+        return "\n".join(lines)
+    return "\n".join(lines) + "\n\n" + "\n\n".join(sections)
 
 
 def build_monday_validation_report_record(
@@ -4970,6 +5068,21 @@ def select_current_cross_repo_validation_packet_record(
     if consumer_run_id is not None and packet_record.latest_consumer_run_id == consumer_run_id:
         return packet_record
     return None
+
+
+def build_cross_repo_validation_packet_lines(
+    packet_record: CrossRepoValidationPacketRecord | None,
+) -> tuple[list[str], list[str], list[str]]:
+    if packet_record is None:
+        return [], [], []
+    return (
+        [f"mirror: {line}" for line in packet_record.cross_repo_summary_lines],
+        [f"source: {line}" for line in packet_record.monday_validation_report_lines],
+        [
+            *packet_record.cross_repo_action_lines,
+            *packet_record.monday_validation_report_action_lines,
+        ],
+    )
 
 
 def render_cross_repo_validation_packet_table(record: CrossRepoValidationPacketRecord) -> str:

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -683,7 +683,9 @@ CROSS_REPO_VALIDATION_REPORT_OUTPUT="$TMP_DIR/cross-repo-validation-report.json"
 CROSS_REPO_VALIDATION_PACKET_OUTPUT="$TMP_DIR/cross-repo-validation-packet.json"
 CROSS_REPO_VALIDATION_PACKET_STAMPED_OUTPUT="$TMP_DIR/cross-repo-validation-packet-stamped.json"
 LOCAL_INBOX_PAYLOAD_WITH_CROSS_REPO_PACKET_OUTPUT="$TMP_DIR/local-inbox-payload-with-cross-repo-packet.json"
+LOCAL_INBOX_PAYLOAD_WITH_CROSS_REPO_PACKET_MARKDOWN_OUTPUT="$TMP_DIR/local-inbox-payload-with-cross-repo-packet.md"
 MONDAY_CONSUMER_WITH_CROSS_REPO_PACKET_OUTPUT="$TMP_DIR/monday-consumer-report-with-cross-repo-packet.json"
+MONDAY_CONSUMER_WITH_CROSS_REPO_PACKET_MARKDOWN_OUTPUT="$TMP_DIR/monday-consumer-report-with-cross-repo-packet.md"
 CROSS_REPO_VALIDATION_WRITE_OUTPUT="$TMP_DIR/cross-repo-validation-write.json"
 CROSS_REPO_VALIDATION_WRITE_STDOUT="$TMP_DIR/cross-repo-validation-write-stdout.json"
 LOCAL_VALIDATION_WITH_MONDAY_VALIDATION_OUTPUT="$TMP_DIR/local-validation-freshness-with-monday-validation.json"
@@ -4158,9 +4160,47 @@ latest, stamped_current, stamped_old = records
 for record in (latest, stamped_current):
     assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
     assert record["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), record
+    assert record["cross_repo_validation_detail_lines"] == [
+        "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+        "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+        "mirror: monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+        "mirror: monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+        "mirror: monday_local_inbox_consumer_schema_validation: freshness=fresh promotability=blocked reasons=validation_verdict_fail,validation_errors_present dependencies=monday_local_inbox_consumer_report=current",
+    ], record
+    assert record["monday_source_validation_report_lines"] == [
+        "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes",
+        "source: bridge: verdict=pass errors=0 warnings=0 artifact_exists=yes schema_exists=yes",
+    ], record
+    assert record["cross_repo_validation_action_lines"] == [
+        "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+        "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)",
+        "monday-validation: inspect consumer-report source report (verdict=fail, errors=2, warnings=1)",
+    ], record
 
 assert stamped_old["cross_repo_validation_packet_report_id"] is None, stamped_old
 assert stamped_old["cross_repo_validation_packet_path"] is None, stamped_old
+assert stamped_old["cross_repo_validation_detail_lines"] == [], stamped_old
+assert stamped_old["monday_source_validation_report_lines"] == [], stamped_old
+assert stamped_old["cross_repo_validation_action_lines"] == [], stamped_old
+PY
+
+python3 "$QUERY_PATH" local-inbox-payload \
+  --source-kind latest \
+  --limit 1 \
+  --format markdown \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_INBOX_PAYLOAD_WITH_CROSS_REPO_PACKET_MARKDOWN_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_INBOX_PAYLOAD_WITH_CROSS_REPO_PACKET_MARKDOWN_OUTPUT"
+from pathlib import Path
+import sys
+
+markdown = Path(sys.argv[1]).read_text(encoding="utf-8")
+assert "### Cross-Repo Validation Details: `monday-local-inbox-20260401T084500Z`" in markdown, markdown
+assert "detail packet report id: `cross-repo-validation-20260401T110000Z`" in markdown, markdown
+assert "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing" in markdown, markdown
+assert "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes" in markdown, markdown
+assert "### Cross-Repo Validation Actions: `monday-local-inbox-20260401T084500Z`" in markdown, markdown
+assert "1. local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)" in markdown, markdown
 PY
 
 python3 "$QUERY_PATH" monday-consumer-report \
@@ -4179,10 +4219,49 @@ blocked, passed_apply, dry_run = records
 
 assert blocked["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", blocked
 assert blocked["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), blocked
+assert blocked["cross_repo_validation_detail_lines"] == [
+    "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+    "mirror: monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+    "mirror: monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_consumer_schema_validation: freshness=fresh promotability=blocked reasons=validation_verdict_fail,validation_errors_present dependencies=monday_local_inbox_consumer_report=current",
+], blocked
+assert blocked["monday_source_validation_report_lines"] == [
+    "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes",
+    "source: bridge: verdict=pass errors=0 warnings=0 artifact_exists=yes schema_exists=yes",
+], blocked
+assert blocked["cross_repo_validation_action_lines"] == [
+    "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+    "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)",
+    "monday-validation: inspect consumer-report source report (verdict=fail, errors=2, warnings=1)",
+], blocked
 
 for record in (passed_apply, dry_run):
     assert record["cross_repo_validation_packet_report_id"] is None, record
     assert record["cross_repo_validation_packet_path"] is None, record
+    assert record["cross_repo_validation_detail_lines"] == [], record
+    assert record["monday_source_validation_report_lines"] == [], record
+    assert record["cross_repo_validation_action_lines"] == [], record
+PY
+
+python3 "$QUERY_PATH" monday-consumer-report \
+  --verdict blocked \
+  --limit 1 \
+  --format markdown \
+  --validation-root "$VALIDATION_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" >"$MONDAY_CONSUMER_WITH_CROSS_REPO_PACKET_MARKDOWN_OUTPUT"
+
+python3 - <<'PY' "$MONDAY_CONSUMER_WITH_CROSS_REPO_PACKET_MARKDOWN_OUTPUT"
+from pathlib import Path
+import sys
+
+markdown = Path(sys.argv[1]).read_text(encoding="utf-8")
+assert "### Cross-Repo Validation Details: `planningops-local-inbox-consumer-20260401T103000Z`" in markdown, markdown
+assert "detail packet report id: `cross-repo-validation-20260401T110000Z`" in markdown, markdown
+assert "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing" in markdown, markdown
+assert "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes" in markdown, markdown
+assert "### Cross-Repo Validation Actions: `planningops-local-inbox-consumer-20260401T103000Z`" in markdown, markdown
+assert "1. local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)" in markdown, markdown
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \


### PR DESCRIPTION
## Summary
- extend `local-inbox-payload` blocking records with linked cross-repo packet detail and action lines
- extend `monday-consumer-report` blocking runs with the same linked packet detail and action lines
- keep historical and non-blocking records empty so packet details do not leak onto unrelated views

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`
- `planningops/` scripts/contracts: `planningops/scripts/federation/query_federated_ci_artifacts.py`, `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `.github/` workflows: none

## Linked Issues
- Closes #996
- Related #994

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
  - `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
  - `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`

## Risks
- Risk: payload and consumer query surfaces now expose packet-derived cross-repo detail and action sections for linked blocking records only.
- Rollback: revert this PR.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
