### PR TITLE
feat(query-engine): add cross-repo details to handoff reports

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -197,6 +197,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report` now carry dedicated cross-repo detail lines and action lines alongside the immutable packet pointer so operators can read mirror/source specifics without immediately reopening the promoted packet
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-inbox-payload|monday-consumer-report` now point current blocking payload-first and apply/result-first records at the promoted `cross-repo-validation-packet` through explicit packet `report_id` and `path` fields instead of relying on snapshot-only linkage
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-inbox-payload|monday-consumer-report` now also carry the linked packet's dedicated cross-repo detail lines and action lines in their markdown/json surfaces so operators can stay in payload-first or apply/result-first views without reopening the promoted packet immediately
+- `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries the same linked packet snapshot, detail lines, monday source validation report lines, and action lines that triage surfaces already expose, while still keeping the immutable `cross-repo-validation-packet` pointer for deep-link evidence
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -258,5 +259,5 @@ bash scripts/litellm_stack_launcher.sh --mode start
 
 ## Next Natural Packets
 
-1. decide whether `handoff-report` should keep the immutable packet pointer only or also grow a dedicated cross-repo details/actions section to match triage surfaces
-2. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
+1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
+2. decide whether mission/day packet surfaces need a direct pointer to the promoted `cross-repo-validation-packet` or whether handoff, triage, payload-first, and apply/result-first entrypoints are sufficient

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -353,6 +353,14 @@ class HandoffReportRecord:
     monday_validation_records: list[LocalValidationFreshnessRecord]
     monday_validation_summary_lines: list[str]
     monday_validation_action_lines: list[str]
+    cross_repo_validation_snapshot_status: str
+    cross_repo_validation_snapshot_summary: str
+    monday_source_validation_status: str
+    monday_source_validation_summary: str
+    cross_repo_validation_action_line: str | None
+    cross_repo_validation_detail_lines: list[str]
+    monday_source_validation_report_lines: list[str]
+    cross_repo_validation_action_lines: list[str]
     cross_repo_validation_packet_report_id: str | None
     cross_repo_validation_packet_path: str | None
     queue_lines: list[str]
@@ -4605,13 +4613,30 @@ def build_handoff_report_record(
         for action in (build_local_validation_action_line(record) for record in monday_validation_records)
         if action is not None
     ]
-    cross_repo_validation_packet_report_id = None
-    cross_repo_validation_packet_path = None
     cross_repo_validation_record = build_cross_repo_validation_report_record(
         validation_root=validation_root,
         consumer_root=consumer_root,
         monday_validation_root=monday_validation_root,
     )
+    cross_repo_validation_snapshot_status = cross_repo_validation_record.cross_repo_snapshot_status
+    cross_repo_validation_snapshot_summary = cross_repo_validation_record.cross_repo_snapshot_summary
+    monday_source_validation_status = cross_repo_validation_record.monday_source_validation_status
+    monday_source_validation_summary = cross_repo_validation_record.monday_source_validation_summary
+    cross_repo_validation_action_line = None
+    cross_repo_validation_detail_lines = [
+        f"mirror: {line}" for line in cross_repo_validation_record.cross_repo_summary_lines
+    ]
+    monday_source_validation_report_lines = [
+        f"source: {line}" for line in cross_repo_validation_record.monday_validation_report_lines
+    ]
+    cross_repo_validation_action_lines = [
+        *cross_repo_validation_record.cross_repo_action_lines,
+        *cross_repo_validation_record.monday_validation_report_action_lines,
+    ]
+    if cross_repo_validation_record.cross_repo_action_lines:
+        cross_repo_validation_action_line = cross_repo_validation_record.cross_repo_action_lines[0]
+    cross_repo_validation_packet_report_id = None
+    cross_repo_validation_packet_path = None
     if (
         cross_repo_validation_record.cross_repo_action_lines
         or cross_repo_validation_record.monday_validation_report_action_lines
@@ -4681,6 +4706,18 @@ def build_handoff_report_record(
                 *[f"{index}. {line}" for index, line in enumerate(monday_validation_action_lines, start=1)],
             ]
         )
+    markdown_lines.extend(
+        [
+            "",
+            "### Cross-Repo Validation",
+            f"- snapshot status: `{cross_repo_validation_snapshot_status}`",
+            f"- snapshot summary: `{cross_repo_validation_snapshot_summary}`",
+            f"- monday source validation status: `{monday_source_validation_status}`",
+            f"- monday source validation summary: `{monday_source_validation_summary}`",
+        ]
+    )
+    if cross_repo_validation_action_line is not None:
+        markdown_lines.append(f"- next action: {cross_repo_validation_action_line}")
     cross_repo_validation_packet_lines: list[str] = []
     if cross_repo_validation_packet_report_id is not None:
         cross_repo_validation_packet_lines.append(
@@ -4690,6 +4727,26 @@ def build_handoff_report_record(
         cross_repo_validation_packet_lines.append(f"- detail packet path: `{cross_repo_validation_packet_path}`")
     if cross_repo_validation_packet_lines:
         markdown_lines.extend(["", "### Cross-Repo Validation Packet", *cross_repo_validation_packet_lines])
+    if cross_repo_validation_detail_lines or monday_source_validation_report_lines:
+        markdown_lines.extend(
+            [
+                "",
+                "### Cross-Repo Validation Details",
+                *[f"- {line}" for line in cross_repo_validation_detail_lines],
+                *[f"- {line}" for line in monday_source_validation_report_lines],
+            ]
+        )
+    if cross_repo_validation_action_lines:
+        markdown_lines.extend(
+            [
+                "",
+                "### Cross-Repo Validation Actions",
+                *[
+                    f"{index}. {line}"
+                    for index, line in enumerate(cross_repo_validation_action_lines, start=1)
+                ],
+            ]
+        )
     if local_validation_action_lines:
         markdown_lines.extend(["", "### Local Validation Actions", *[f"{index}. {line}" for index, line in enumerate(local_validation_action_lines, start=1)]])
     markdown_lines.extend(["", "### Queue", *[f"- {line}" for line in triage_report.queue_lines]])
@@ -4719,6 +4776,14 @@ def build_handoff_report_record(
         monday_validation_records=monday_validation_records,
         monday_validation_summary_lines=monday_validation_summary_lines,
         monday_validation_action_lines=monday_validation_action_lines,
+        cross_repo_validation_snapshot_status=cross_repo_validation_snapshot_status,
+        cross_repo_validation_snapshot_summary=cross_repo_validation_snapshot_summary,
+        monday_source_validation_status=monday_source_validation_status,
+        monday_source_validation_summary=monday_source_validation_summary,
+        cross_repo_validation_action_line=cross_repo_validation_action_line,
+        cross_repo_validation_detail_lines=cross_repo_validation_detail_lines,
+        monday_source_validation_report_lines=monday_source_validation_report_lines,
+        cross_repo_validation_action_lines=cross_repo_validation_action_lines,
         cross_repo_validation_packet_report_id=cross_repo_validation_packet_report_id,
         cross_repo_validation_packet_path=cross_repo_validation_packet_path,
         queue_lines=triage_report.queue_lines,
@@ -4751,6 +4816,22 @@ def render_handoff_report_table(record: HandoffReportRecord) -> str:
         sections.extend(["monday_validation", *record.monday_validation_summary_lines])
     if record.monday_validation_action_lines:
         sections.extend(["monday_validation_actions", *record.monday_validation_action_lines])
+    sections.extend(
+        [
+            f"cross_repo_validation_snapshot_status\t{record.cross_repo_validation_snapshot_status}",
+            f"cross_repo_validation_snapshot_summary\t{record.cross_repo_validation_snapshot_summary}",
+            f"monday_source_validation_status\t{record.monday_source_validation_status}",
+            f"monday_source_validation_summary\t{record.monday_source_validation_summary}",
+        ]
+    )
+    if record.cross_repo_validation_action_line is not None:
+        sections.append(f"cross_repo_validation_action\t{record.cross_repo_validation_action_line}")
+    if record.cross_repo_validation_detail_lines:
+        sections.extend(["cross_repo_validation_details", *record.cross_repo_validation_detail_lines])
+    if record.monday_source_validation_report_lines:
+        sections.extend(["monday_source_validation_reports", *record.monday_source_validation_report_lines])
+    if record.cross_repo_validation_action_lines:
+        sections.extend(["cross_repo_validation_actions", *record.cross_repo_validation_action_lines])
     if record.cross_repo_validation_packet_report_id is not None:
         sections.append(
             f"cross_repo_validation_packet_report_id\t{record.cross_repo_validation_packet_report_id}"

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -2383,6 +2383,23 @@ assert record["monday_validation_snapshot_status"] == "missing", record
 assert record["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
 assert record["monday_validation_summary_lines"] == [], record
 assert record["monday_validation_action_lines"] == [], record
+assert record["cross_repo_validation_snapshot_status"] == "present", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=3 promotable=2 blocked=1 stale=0", record
+assert record["monday_source_validation_status"] == "missing", record
+assert record["monday_source_validation_summary"] == "total=0 pass=0 fail=0 errors=0 warnings=0", record
+assert record["cross_repo_validation_action_line"] == (
+    "local-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+), record
+assert record["cross_repo_validation_detail_lines"] == [
+    "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+    "mirror: monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+], record
+assert record["monday_source_validation_report_lines"] == [], record
+assert record["cross_repo_validation_action_lines"] == [
+    "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+], record
 assert record["cross_repo_validation_packet_report_id"] is None, record
 assert record["cross_repo_validation_packet_path"] is None, record
 assert record["local_validation_summary_lines"] == [
@@ -2420,9 +2437,18 @@ assert "### Snapshot" in record["markdown"], record
 assert "### Local Runtime" in record["markdown"], record
 assert "### Local Validation" in record["markdown"], record
 assert "### Monday Schema Validation" not in record["markdown"], record
+assert "### Cross-Repo Validation" in record["markdown"], record
 assert "### Cross-Repo Validation Packet" not in record["markdown"], record
+assert "### Cross-Repo Validation Details" in record["markdown"], record
+assert "### Cross-Repo Validation Actions" in record["markdown"], record
 assert "snapshot status: `present`" in record["markdown"], record
 assert "snapshot summary: `total=8 promotable=4 blocked=4 stale=1`" in record["markdown"], record
+assert "### Cross-Repo Validation" in record["markdown"], record
+assert "snapshot summary: `total=3 promotable=2 blocked=1 stale=0`" in record["markdown"], record
+assert "monday source validation status: `missing`" in record["markdown"], record
+assert "monday source validation summary: `total=0 pass=0 fail=0 errors=0 warnings=0`" in record["markdown"], record
+assert "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing" in record["markdown"], record
+assert "1. local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)" in record["markdown"], record
 assert "### Local Validation Actions" in record["markdown"], record
 assert "### Queue" in record["markdown"], record
 assert "### Top Targets" in record["markdown"], record
@@ -2462,6 +2488,23 @@ assert record["monday_validation_snapshot_status"] == "missing", record
 assert record["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
 assert record["monday_validation_summary_lines"] == [], record
 assert record["monday_validation_action_lines"] == [], record
+assert record["cross_repo_validation_snapshot_status"] == "present", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=3 promotable=2 blocked=1 stale=0", record
+assert record["monday_source_validation_status"] == "missing", record
+assert record["monday_source_validation_summary"] == "total=0 pass=0 fail=0 errors=0 warnings=0", record
+assert record["cross_repo_validation_action_line"] == (
+    "local-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+), record
+assert record["cross_repo_validation_detail_lines"] == [
+    "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+    "mirror: monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+], record
+assert record["monday_source_validation_report_lines"] == [], record
+assert record["cross_repo_validation_action_lines"] == [
+    "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+], record
 assert record["cross_repo_validation_packet_report_id"] is None, record
 assert record["cross_repo_validation_packet_path"] is None, record
 assert record["local_validation_summary_lines"] == [
@@ -2481,6 +2524,7 @@ assert record["immediate_action_lines"] == [
 ], record
 assert "source_kind: `all`" in record["markdown"], record
 assert "### Local Validation" in record["markdown"], record
+assert "### Cross-Repo Validation" in record["markdown"], record
 assert "### Immediate Actions" in record["markdown"], record
 PY
 
@@ -2524,6 +2568,23 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert doc["record"]["monday_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", doc
     assert doc["record"]["monday_validation_summary_lines"] == [], doc
     assert doc["record"]["monday_validation_action_lines"] == [], doc
+    assert doc["record"]["cross_repo_validation_snapshot_status"] == "present", doc
+    assert doc["record"]["cross_repo_validation_snapshot_summary"] == "total=3 promotable=2 blocked=1 stale=0", doc
+    assert doc["record"]["monday_source_validation_status"] == "missing", doc
+    assert doc["record"]["monday_source_validation_summary"] == "total=0 pass=0 fail=0 errors=0 warnings=0", doc
+    assert doc["record"]["cross_repo_validation_action_line"] == (
+        "local-validation: repair monday_local_inbox_runtime_report "
+        "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+    ), doc
+    assert doc["record"]["cross_repo_validation_detail_lines"] == [
+        "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+        "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+        "mirror: monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+    ], doc
+    assert doc["record"]["monday_source_validation_report_lines"] == [], doc
+    assert doc["record"]["cross_repo_validation_action_lines"] == [
+        "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+    ], doc
     assert doc["record"]["cross_repo_validation_packet_report_id"] is None, doc
     assert doc["record"]["cross_repo_validation_packet_path"] is None, doc
     assert doc["record"]["local_validation_summary_lines"] == [
@@ -4136,11 +4197,43 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
+assert record["cross_repo_validation_snapshot_status"] == "present", record
+assert record["cross_repo_validation_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", record
+assert record["monday_source_validation_status"] == "attention", record
+assert record["monday_source_validation_summary"] == "total=2 pass=1 fail=1 errors=2 warnings=1", record
+assert record["cross_repo_validation_action_line"] == (
+    "local-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+), record
+assert record["cross_repo_validation_detail_lines"] == [
+    "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
+    "mirror: monday_local_inbox_consumer_report: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current,monday_local_inbox_runtime_report=current",
+    "mirror: monday_local_inbox_bridge_schema_validation: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
+    "mirror: monday_local_inbox_consumer_schema_validation: freshness=fresh promotability=blocked reasons=validation_verdict_fail,validation_errors_present dependencies=monday_local_inbox_consumer_report=current",
+], record
+assert record["monday_source_validation_report_lines"] == [
+    "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes",
+    "source: bridge: verdict=pass errors=0 warnings=0 artifact_exists=yes schema_exists=yes",
+], record
+assert record["cross_repo_validation_action_lines"] == [
+    "local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)",
+    "local-validation: repair monday_local_inbox_consumer_schema_validation (freshness=fresh, promotability=blocked, reasons=validation_verdict_fail,validation_errors_present)",
+    "monday-validation: inspect consumer-report source report (verdict=fail, errors=2, warnings=1)",
+], record
 assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
 assert record["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), record
+assert "### Cross-Repo Validation" in record["markdown"], record
+assert "snapshot summary: `total=5 promotable=3 blocked=2 stale=0`" in record["markdown"], record
+assert "monday source validation summary: `total=2 pass=1 fail=1 errors=2 warnings=1`" in record["markdown"], record
 assert "### Cross-Repo Validation Packet" in record["markdown"], record
+assert "### Cross-Repo Validation Details" in record["markdown"], record
+assert "### Cross-Repo Validation Actions" in record["markdown"], record
 assert "detail packet report id: `cross-repo-validation-20260401T110000Z`" in record["markdown"], record
 assert "detail packet path: `" in record["markdown"], record
+assert "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing" in record["markdown"], record
+assert "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes" in record["markdown"], record
+assert "1. local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)" in record["markdown"], record
 PY
 
 python3 "$QUERY_PATH" local-inbox-payload \


### PR DESCRIPTION
## Summary
- extend `handoff-report` with cross-repo snapshot, detail, monday source report, and action sections
- keep the promoted `cross-repo-validation-packet` pointer so handoff still links to immutable detail evidence
- lock the missing and present handoff cases with regression coverage so linked packet details only appear when the underlying snapshot supports them

## Scope
- Initiative docs: none
- Workbench docs: `docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md`
- `planningops/` scripts/contracts: `planningops/scripts/federation/query_federated_ci_artifacts.py`, `planningops/scripts/test_query_federated_ci_artifacts.sh`
- `.github/` workflows: none

## Linked Issues
- Closes #998
- Related #996

## Validation
- [x] `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`
- [x] Additional checks (if any):
  - `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
  - `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
  - `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`

## Risks
- Risk: `handoff-report` json/markdown/table outputs now expose cross-repo detail and action arrays whenever the mirrored monday inbox validation snapshot is present.
- Rollback: revert this PR.

## Review Checklist
- [x] No direct `main` edits; changes are from feature branch.
- [x] Canonical vs workbench boundary respected.
- [x] Path root rule respected (doc-relative links, repo-relative CLI paths).
- [x] If structure changed, `README` and `90-navigation` were updated together.
- [x] Evidence artifacts/logs are attached or linked.
