### PR TITLE
feat(local-runtime): point mission and day packets at cross-repo validation packets

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -198,6 +198,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-inbox-payload|monday-consumer-report` now point current blocking payload-first and apply/result-first records at the promoted `cross-repo-validation-packet` through explicit packet `report_id` and `path` fields instead of relying on snapshot-only linkage
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-inbox-payload|monday-consumer-report` now also carry the linked packet's dedicated cross-repo detail lines and action lines in their markdown/json surfaces so operators can stay in payload-first or apply/result-first views without reopening the promoted packet immediately
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries the same linked packet snapshot, detail lines, monday source validation report lines, and action lines that triage surfaces already expose, while still keeping the immutable `cross-repo-validation-packet` pointer for deep-link evidence
+- `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now preserve the promoted `cross-repo-validation-packet` pointer inside mission/day packet surfaces so packet-only operator flows can reopen immutable cross-repo evidence without routing back through `handoff-report`
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -260,4 +261,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether mission/day packet surfaces need a direct pointer to the promoted `cross-repo-validation-packet` or whether handoff, triage, payload-first, and apply/result-first entrypoints are sufficient
+2. decide whether mission/day packet surfaces should stay pointer-only for promoted `cross-repo-validation-packet` evidence or also inline packet detail/action sections the way triage, payload-first, apply/result-first, and handoff now do

--- a/planningops/contracts/monday-local-mission-packet-contract.md
+++ b/planningops/contracts/monday-local-mission-packet-contract.md
@@ -66,6 +66,8 @@ Top-level required fields:
 18. `local_validation_records`
 19. `local_validation_summary_lines`
 20. `local_validation_action_lines`
+21. `cross_repo_validation_packet_report_id`
+22. `cross_repo_validation_packet_path`
 
 Optional fields:
 - `attention_summary`
@@ -84,6 +86,7 @@ Optional fields:
 3. `mission_objective` must come from the promoted handoff surface, not from prompt-local inference.
 4. `expected_evidence_outputs` must point at deterministic artifact paths that the chosen launch path is expected to refresh.
 5. local validation snapshot fields must be carried forward from the promoted handoff packet when present; otherwise the mission packet must emit `local_validation_snapshot_status=missing` with empty local validation collections.
+6. when the promoted handoff already points at a promoted `cross-repo-validation-packet`, the mission packet must preserve that immutable `report_id`/`path` pair instead of recomputing or rewriting it.
 
 ## Command Rules
 
@@ -114,6 +117,11 @@ Every packet must also preserve the current local validation snapshot:
 - machine-readable local validation records when the promoted handoff packet already has them
 - operator-facing local validation summary/action lines
 - an explicit missing marker when the upstream handoff packet does not yet provide the snapshot
+
+When present upstream, every packet must also preserve the promoted cross-repo validation packet pointer:
+- immutable `cross_repo_validation_packet_report_id`
+- immutable `cross_repo_validation_packet_path`
+- the packet path must stay reusable as downstream evidence instead of being collapsed into prompt-local prose
 
 ## Failure Rules
 

--- a/planningops/contracts/monday-local-operator-day-packet-contract.md
+++ b/planningops/contracts/monday-local-operator-day-packet-contract.md
@@ -67,10 +67,12 @@ Top-level required fields:
 18. `local_validation_summary_lines`
 19. `local_validation_action_lines`
 20. `attachments`
-21. `body_markdown`
-22. `source_artifacts.mission_packet_path`
-23. `source_artifacts.handoff_report_path`
-24. `source_artifacts.local_operator_report_path`
+21. `cross_repo_validation_packet_report_id`
+22. `cross_repo_validation_packet_path`
+23. `body_markdown`
+24. `source_artifacts.mission_packet_path`
+25. `source_artifacts.handoff_report_path`
+26. `source_artifacts.local_operator_report_path`
 
 Optional fields:
 - `attention_summary`
@@ -85,6 +87,7 @@ Optional fields:
 3. `headline` must be derivable from the promoted mission objective and remain operator-readable.
 4. `attachments` must include the latest + stamped day packet paths and the source artifact references needed to reopen the launch context.
 5. local validation snapshot fields must be copied from the mission packet when present; otherwise the writer may fall back to the promoted handoff snapshot and must mark that fallback explicitly; otherwise it must emit `missing` with empty collections.
+6. when the promoted mission packet already carries a promoted `cross-repo-validation-packet` pointer, the day packet must preserve that immutable `report_id`/`path` pair; only legacy mission packets may fall back to the handoff pointer.
 
 ## Command Rules
 
@@ -105,6 +108,12 @@ Every day packet must also preserve the current local validation snapshot:
 - operator-facing local validation summary lines
 - operator-facing local validation action lines
 - an explicit snapshot status marker
+
+When present, every day packet must also preserve the promoted cross-repo validation packet pointer:
+- immutable `cross_repo_validation_packet_report_id`
+- immutable `cross_repo_validation_packet_path`
+- attachment reuse of the packet path so operators can reopen the promoted evidence directly from the day packet
+- body-level visibility of the pointer so the deep link survives packet-only handoff flows
 
 ## Failure Rules
 

--- a/planningops/scripts/test_write_monday_local_mission_packet.sh
+++ b/planningops/scripts/test_write_monday_local_mission_packet.sh
@@ -79,6 +79,8 @@ cat >"$HANDOFF_REPORT" <<'JSON'
     "local_validation_action_lines": [
       "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)"
     ],
+    "cross_repo_validation_packet_report_id": "cross-repo-validation-20260401T110000Z",
+    "cross_repo_validation_packet_path": "/tmp/cross-repo-validation-report.json",
     "markdown": "## Operator Handoff Report"
   }
 }
@@ -195,8 +197,11 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert mission["local_validation_action_lines"] == [
         "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)"
     ], mission
+    assert mission["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", mission
+    assert mission["cross_repo_validation_packet_path"] == "/tmp/cross-repo-validation-report.json", mission
     assert str(latest_path) in mission["expected_evidence_outputs"], mission
     assert str(stamped_path) in mission["expected_evidence_outputs"], mission
+    assert "/tmp/cross-repo-validation-report.json" in mission["expected_evidence_outputs"], mission
     assert any(path.endswith(f"{packet_id}.json") for path in mission["expected_evidence_outputs"]), mission
     assert any(path.endswith(f"{packet_id}-monday-local-operator-stack-report.json") for path in mission["expected_evidence_outputs"]), mission
 
@@ -255,6 +260,8 @@ assert mission["local_validation_snapshot_status"] == "missing", mission
 assert mission["local_validation_records"] == [], mission
 assert mission["local_validation_summary_lines"] == [], mission
 assert mission["local_validation_action_lines"] == [], mission
+assert mission["cross_repo_validation_packet_report_id"] is None, mission
+assert mission["cross_repo_validation_packet_path"] is None, mission
 PY
 
 echo "write monday local mission packet ok"

--- a/planningops/scripts/test_write_monday_local_operator_day_packet.sh
+++ b/planningops/scripts/test_write_monday_local_operator_day_packet.sh
@@ -57,6 +57,8 @@ cat >"$MISSION_PACKET" <<'JSON'
       "operator_handoff_report: freshness=fresh promotability=promotable"
     ],
     "local_validation_action_lines": [],
+    "cross_repo_validation_packet_report_id": "cross-repo-validation-20260401T110000Z",
+    "cross_repo_validation_packet_path": "VALIDATION_ROOT_PLACEHOLDER/cross-repo-validation-report.json",
     "primary_action": "local-runtime: Expose Codex and add a direct local LLM profile.",
     "immediate_actions": [
       "local-runtime: Expose Codex and add a direct local LLM profile."
@@ -93,11 +95,13 @@ doc["mission_packet"]["expected_evidence_outputs"] = [
     str((validation_dir / "monday-local-mission-packet.json").resolve()),
     str((validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").resolve()),
 ]
+doc["mission_packet"]["cross_repo_validation_packet_path"] = str((validation_dir / "cross-repo-validation-report.json").resolve())
 doc["mission_packet"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
 doc["mission_packet"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
 payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
 path.write_text(payload, encoding="utf-8")
 (validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").write_text(payload, encoding="utf-8")
+(validation_dir / "cross-repo-validation-report.json").write_text("{}\n", encoding="utf-8")
 PY
 
 cat >"$HANDOFF_REPORT" <<'JSON'
@@ -260,6 +264,8 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
         "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
         "operator_handoff_report: freshness=fresh promotability=promotable",
     ], packet
+    assert packet["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", packet
+    assert packet["cross_repo_validation_packet_path"] == str((validation_dir / "cross-repo-validation-report.json").resolve()), packet
     assert packet["queue_lines"] == [
         "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1"
     ], packet
@@ -275,11 +281,15 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert str((validation_dir / "monday-local-mission-packet.json").resolve()) in packet["attachments"], packet
     assert str((validation_dir / "operator-handoff-report.json").resolve()) in packet["attachments"], packet
     assert str((validation_dir / "monday-local-operator-stack-report.json").resolve()) in packet["attachments"], packet
+    assert str((validation_dir / "cross-repo-validation-report.json").resolve()) in packet["attachments"], packet
     assert packet["source_artifacts"]["mission_packet_path"] == str((validation_dir / "monday-local-mission-packet.json").resolve()), packet
     assert packet["source_artifacts"]["handoff_report_path"] == str((validation_dir / "operator-handoff-report.json").resolve()), packet
     assert packet["source_artifacts"]["local_operator_report_path"] == str((validation_dir / "monday-local-operator-stack-report.json").resolve()), packet
     assert "## Monday Local Operator Day Packet" in packet["body_markdown"], packet
     assert "### Commands" in packet["body_markdown"], packet
+    assert "### Cross-Repo Validation Packet" in packet["body_markdown"], packet
+    assert "detail packet report id: `cross-repo-validation-20260401T110000Z`" in packet["body_markdown"], packet
+    assert str((validation_dir / "cross-repo-validation-report.json").resolve()) in packet["body_markdown"], packet
     assert "### Local Validation" in packet["body_markdown"], packet
     assert "### Attachments" in packet["body_markdown"], packet
 

--- a/planningops/scripts/write_monday_local_mission_packet.py
+++ b/planningops/scripts/write_monday_local_mission_packet.py
@@ -69,6 +69,14 @@ def build_local_validation_snapshot(handoff_record: dict) -> tuple[str, list[dic
     return snapshot_status, records, summary_lines, action_lines
 
 
+def normalize_optional_string(raw_value: object) -> str | None:
+    if isinstance(raw_value, str):
+        value = raw_value.strip()
+        if value:
+            return value
+    return None
+
+
 def build_mission_objective(handoff_record: dict) -> str:
     target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
     if target_lines:
@@ -192,6 +200,12 @@ def main() -> int:
     target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
     mission_objective = build_mission_objective(handoff_record)
     primary_action = immediate_actions[0] if immediate_actions else (target_lines[0] if target_lines else mission_objective)
+    cross_repo_validation_packet_report_id = normalize_optional_string(
+        handoff_record.get("cross_repo_validation_packet_report_id")
+    )
+    cross_repo_validation_packet_path = normalize_optional_string(
+        handoff_record.get("cross_repo_validation_packet_path")
+    )
     (
         local_validation_snapshot_status,
         local_validation_records,
@@ -207,6 +221,8 @@ def main() -> int:
         str((validation_root / "monday-local-operator-stack-report.json").resolve()),
         str((validation_root / f"{packet_id}-monday-local-operator-stack-report.json").resolve()),
     ]
+    if cross_repo_validation_packet_path is not None:
+        expected_evidence_outputs.append(cross_repo_validation_packet_path)
 
     mission_packet = {
         "version": "v1",
@@ -231,6 +247,8 @@ def main() -> int:
         "local_validation_records": local_validation_records,
         "local_validation_summary_lines": local_validation_summary_lines,
         "local_validation_action_lines": local_validation_action_lines,
+        "cross_repo_validation_packet_report_id": cross_repo_validation_packet_report_id,
+        "cross_repo_validation_packet_path": cross_repo_validation_packet_path,
         "preflight_command": preflight_command,
         "monday_runtime_entrypoint_command": monday_runtime_entrypoint_command,
         "rollback_command": rollback_command,

--- a/planningops/scripts/write_monday_local_operator_day_packet.py
+++ b/planningops/scripts/write_monday_local_operator_day_packet.py
@@ -64,6 +64,14 @@ def normalize_local_validation_records(raw_values: object) -> list[dict]:
     return records
 
 
+def normalize_optional_string(raw_value: object) -> str | None:
+    if isinstance(raw_value, str):
+        value = raw_value.strip()
+        if value:
+            return value
+    return None
+
+
 def dedupe_preserve_order(values: list[str]) -> list[str]:
     deduped: list[str] = []
     seen: set[str] = set()
@@ -109,6 +117,8 @@ def build_body_markdown(
     target_lines: list[str],
     immediate_actions: list[str],
     attachments: list[str],
+    cross_repo_validation_packet_report_id: str | None,
+    cross_repo_validation_packet_path: str | None,
 ) -> str:
     lines = [
         "## Monday Local Operator Day Packet",
@@ -132,6 +142,12 @@ def build_body_markdown(
     lines.extend(["", "### Local Validation", *[f"- {line}" for line in local_validation_summary_lines]])
     if local_validation_action_lines:
         lines.extend(["", "### Local Validation Actions", *[f"{index}. {line}" for index, line in enumerate(local_validation_action_lines, start=1)]])
+    if cross_repo_validation_packet_report_id is not None or cross_repo_validation_packet_path is not None:
+        lines.extend(["", "### Cross-Repo Validation Packet"])
+        if cross_repo_validation_packet_report_id is not None:
+            lines.append(f"- detail packet report id: `{cross_repo_validation_packet_report_id}`")
+        if cross_repo_validation_packet_path is not None:
+            lines.append(f"- detail packet path: `{cross_repo_validation_packet_path}`")
     lines.extend(["", "### Queue", *[f"- {line}" for line in queue_lines]])
     lines.extend(["", "### Top Targets", *[f"{index}. {line}" for index, line in enumerate(target_lines, start=1)]])
     lines.extend(["", "### Immediate Actions", *[f"{index}. {line}" for index, line in enumerate(immediate_actions, start=1)]])
@@ -194,6 +210,12 @@ def main() -> int:
         normalize_string_list(mission_packet.get("immediate_actions"))
         + normalize_string_list(handoff_record.get("immediate_action_lines"))
     )
+    cross_repo_validation_packet_report_id = normalize_optional_string(
+        mission_packet.get("cross_repo_validation_packet_report_id")
+    ) or normalize_optional_string(handoff_record.get("cross_repo_validation_packet_report_id"))
+    cross_repo_validation_packet_path = normalize_optional_string(
+        mission_packet.get("cross_repo_validation_packet_path")
+    ) or normalize_optional_string(handoff_record.get("cross_repo_validation_packet_path"))
     local_validation_snapshot_status, local_validation_records, local_validation_summary_lines, local_validation_action_lines = (
         build_local_validation_snapshot(mission_packet=mission_packet, handoff_record=handoff_record)
     )
@@ -216,6 +238,8 @@ def main() -> int:
         raw_value = local_operator_artifacts.get(key)
         if isinstance(raw_value, str) and raw_value.strip():
             attachment_candidates.append(str(resolve_path(raw_value).resolve()))
+    if cross_repo_validation_packet_path is not None:
+        attachment_candidates.append(str(resolve_path(cross_repo_validation_packet_path).resolve()))
     attachments = dedupe_preserve_order(attachment_candidates)
     if not attachments:
         raise SystemExit("attachments must not be empty")
@@ -244,6 +268,8 @@ def main() -> int:
         "local_validation_records": local_validation_records,
         "local_validation_summary_lines": local_validation_summary_lines,
         "local_validation_action_lines": local_validation_action_lines,
+        "cross_repo_validation_packet_report_id": cross_repo_validation_packet_report_id,
+        "cross_repo_validation_packet_path": cross_repo_validation_packet_path,
         "queue_lines": queue_lines,
         "target_lines": target_lines,
         "immediate_actions": immediate_actions,
@@ -265,6 +291,8 @@ def main() -> int:
             target_lines=target_lines,
             immediate_actions=immediate_actions,
             attachments=attachments,
+            cross_repo_validation_packet_report_id=cross_repo_validation_packet_report_id,
+            cross_repo_validation_packet_path=cross_repo_validation_packet_path,
         ),
         "source_artifacts": {
             "mission_packet_path": str(mission_packet_path.resolve()),


### PR DESCRIPTION
## Scope
- preserve the promoted `cross-repo-validation-packet` pointer in `monday-local-mission-packet` outputs
- carry that pointer forward into `monday-local-operator-day-packet` attachments and markdown
- lock the new mission/day pointer boundary in regressions, contracts, and the rollout plan

## Summary
- add mission packet support for `cross_repo_validation_packet_report_id` and `cross_repo_validation_packet_path` from the promoted handoff record
- add day packet support for mission-first pointer reuse with legacy handoff fallback
- keep mission/day packet surfaces pointer-only while documenting that detail/action expansion remains a follow-up decision

## Validation
- `python3 -m py_compile planningops/scripts/write_monday_local_mission_packet.py planningops/scripts/write_monday_local_operator_day_packet.py`
- `bash planningops/scripts/test_write_monday_local_mission_packet.sh`
- `bash planningops/scripts/test_write_monday_local_operator_day_packet.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1000

## Risks
- mission/day packet surfaces now depend on upstream promoted packet pointers being well-formed absolute or validation-root-relative paths
- this change intentionally keeps mission/day packet surfaces pointer-only and does not inline linked packet detail/action sections yet

## Review Checklist
- [x] mission packet regression covers promoted and legacy handoff cases
- [x] day packet regression covers attachment/body propagation of the linked cross-repo packet
- [x] contract and rollout plan documentation were updated alongside the writers

## Post-Deploy Monitoring & Validation
No additional operational monitoring required; this packet only reshapes promoted validation metadata and is covered by local regressions plus docs checks.