### PR TITLE
feat(local-runtime): add cross-repo details to mission and day packets

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -199,6 +199,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-inbox-payload|monday-consumer-report` now also carry the linked packet's dedicated cross-repo detail lines and action lines in their markdown/json surfaces so operators can stay in payload-first or apply/result-first views without reopening the promoted packet immediately
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries the same linked packet snapshot, detail lines, monday source validation report lines, and action lines that triage surfaces already expose, while still keeping the immutable `cross-repo-validation-packet` pointer for deep-link evidence
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now preserve the promoted `cross-repo-validation-packet` pointer inside mission/day packet surfaces so packet-only operator flows can reopen immutable cross-repo evidence without routing back through `handoff-report`
+- `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now also carry the linked cross-repo validation snapshot, detail lines, monday source validation report lines, and action lines so mission/day packet-only flows do not lose the same operator context already available on handoff and triage surfaces
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -261,4 +262,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether mission/day packet surfaces should stay pointer-only for promoted `cross-repo-validation-packet` evidence or also inline packet detail/action sections the way triage, payload-first, apply/result-first, and handoff now do
+2. decide whether mission/day packet surfaces should keep cross-repo validation as supporting context only or allow the linked `cross_repo_validation_action_line` to steer packet headline/primary action selection when monday-local blockers are downstream of cross-repo validation

--- a/planningops/contracts/monday-local-mission-packet-contract.md
+++ b/planningops/contracts/monday-local-mission-packet-contract.md
@@ -68,6 +68,12 @@ Top-level required fields:
 20. `local_validation_action_lines`
 21. `cross_repo_validation_packet_report_id`
 22. `cross_repo_validation_packet_path`
+23. `cross_repo_validation_snapshot_status`
+24. `cross_repo_validation_snapshot_summary`
+25. `cross_repo_validation_action_line`
+26. `cross_repo_validation_detail_lines`
+27. `monday_source_validation_report_lines`
+28. `cross_repo_validation_action_lines`
 
 Optional fields:
 - `attention_summary`
@@ -87,6 +93,7 @@ Optional fields:
 4. `expected_evidence_outputs` must point at deterministic artifact paths that the chosen launch path is expected to refresh.
 5. local validation snapshot fields must be carried forward from the promoted handoff packet when present; otherwise the mission packet must emit `local_validation_snapshot_status=missing` with empty local validation collections.
 6. when the promoted handoff already points at a promoted `cross-repo-validation-packet`, the mission packet must preserve that immutable `report_id`/`path` pair instead of recomputing or rewriting it.
+7. cross-repo validation snapshot/detail/action fields must be carried forward from the promoted handoff packet when present; otherwise the mission packet must emit `cross_repo_validation_snapshot_status=missing`, `cross_repo_validation_snapshot_summary=total=0 promotable=0 blocked=0 stale=0`, and empty cross-repo detail/action collections.
 
 ## Command Rules
 
@@ -122,6 +129,14 @@ When present upstream, every packet must also preserve the promoted cross-repo v
 - immutable `cross_repo_validation_packet_report_id`
 - immutable `cross_repo_validation_packet_path`
 - the packet path must stay reusable as downstream evidence instead of being collapsed into prompt-local prose
+
+Every packet must also preserve the current cross-repo validation context:
+- `cross_repo_validation_snapshot_status`
+- `cross_repo_validation_snapshot_summary`
+- optional `cross_repo_validation_action_line`
+- `cross_repo_validation_detail_lines`
+- `monday_source_validation_report_lines`
+- `cross_repo_validation_action_lines`
 
 ## Failure Rules
 

--- a/planningops/contracts/monday-local-operator-day-packet-contract.md
+++ b/planningops/contracts/monday-local-operator-day-packet-contract.md
@@ -69,10 +69,16 @@ Top-level required fields:
 20. `attachments`
 21. `cross_repo_validation_packet_report_id`
 22. `cross_repo_validation_packet_path`
-23. `body_markdown`
-24. `source_artifacts.mission_packet_path`
-25. `source_artifacts.handoff_report_path`
-26. `source_artifacts.local_operator_report_path`
+23. `cross_repo_validation_snapshot_status`
+24. `cross_repo_validation_snapshot_summary`
+25. `cross_repo_validation_action_line`
+26. `cross_repo_validation_detail_lines`
+27. `monday_source_validation_report_lines`
+28. `cross_repo_validation_action_lines`
+29. `body_markdown`
+30. `source_artifacts.mission_packet_path`
+31. `source_artifacts.handoff_report_path`
+32. `source_artifacts.local_operator_report_path`
 
 Optional fields:
 - `attention_summary`
@@ -88,6 +94,7 @@ Optional fields:
 4. `attachments` must include the latest + stamped day packet paths and the source artifact references needed to reopen the launch context.
 5. local validation snapshot fields must be copied from the mission packet when present; otherwise the writer may fall back to the promoted handoff snapshot and must mark that fallback explicitly; otherwise it must emit `missing` with empty collections.
 6. when the promoted mission packet already carries a promoted `cross-repo-validation-packet` pointer, the day packet must preserve that immutable `report_id`/`path` pair; only legacy mission packets may fall back to the handoff pointer.
+7. cross-repo validation snapshot/detail/action fields must be copied from the mission packet when present; otherwise the writer may fall back to the promoted handoff snapshot for legacy compatibility; otherwise it must emit `missing`, the zero-summary default, and empty cross-repo detail/action collections.
 
 ## Command Rules
 
@@ -114,6 +121,15 @@ When present, every day packet must also preserve the promoted cross-repo valida
 - immutable `cross_repo_validation_packet_path`
 - attachment reuse of the packet path so operators can reopen the promoted evidence directly from the day packet
 - body-level visibility of the pointer so the deep link survives packet-only handoff flows
+
+Every day packet must also preserve the current cross-repo validation context:
+- `cross_repo_validation_snapshot_status`
+- `cross_repo_validation_snapshot_summary`
+- optional `cross_repo_validation_action_line`
+- `cross_repo_validation_detail_lines`
+- `monday_source_validation_report_lines`
+- `cross_repo_validation_action_lines`
+- body-level visibility of the cross-repo snapshot, details, and actions so the next operator step does not need to reopen `handoff-report` just to recover them
 
 ## Failure Rules
 

--- a/planningops/scripts/test_write_monday_local_mission_packet.sh
+++ b/planningops/scripts/test_write_monday_local_mission_packet.sh
@@ -79,6 +79,19 @@ cat >"$HANDOFF_REPORT" <<'JSON'
     "local_validation_action_lines": [
       "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)"
     ],
+    "cross_repo_validation_snapshot_status": "present",
+    "cross_repo_validation_snapshot_summary": "total=5 promotable=3 blocked=2 stale=0",
+    "cross_repo_validation_action_line": "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)",
+    "cross_repo_validation_detail_lines": [
+      "monday_local_inbox_launch_request: freshness=fresh promotability=promotable",
+      "monday_local_inbox_runtime_report: freshness=missing promotability=blocked reasons=latest_missing"
+    ],
+    "monday_source_validation_report_lines": [
+      "consumer-report schema verdict=pass errors=0 warnings=0"
+    ],
+    "cross_repo_validation_action_lines": [
+      "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)"
+    ],
     "cross_repo_validation_packet_report_id": "cross-repo-validation-20260401T110000Z",
     "cross_repo_validation_packet_path": "/tmp/cross-repo-validation-report.json",
     "markdown": "## Operator Handoff Report"
@@ -157,6 +170,14 @@ assert "local_validation_snapshot_status" in contract_text, contract_text
 assert "local_validation_records" in contract_text, contract_text
 assert "local_validation_summary_lines" in contract_text, contract_text
 assert "local_validation_action_lines" in contract_text, contract_text
+assert "cross_repo_validation_snapshot_status" in contract_text, contract_text
+assert "cross_repo_validation_snapshot_summary" in contract_text, contract_text
+assert "cross_repo_validation_action_line" in contract_text, contract_text
+assert "cross_repo_validation_detail_lines" in contract_text, contract_text
+assert "monday_source_validation_report_lines" in contract_text, contract_text
+assert "cross_repo_validation_action_lines" in contract_text, contract_text
+assert "cross_repo_validation_packet_report_id" in contract_text, contract_text
+assert "cross_repo_validation_packet_path" in contract_text, contract_text
 
 for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert doc["packet_id"] == packet_id, doc
@@ -196,6 +217,22 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     ], mission
     assert mission["local_validation_action_lines"] == [
         "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)"
+    ], mission
+    assert mission["cross_repo_validation_snapshot_status"] == "present", mission
+    assert mission["cross_repo_validation_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", mission
+    assert mission["cross_repo_validation_action_line"] == (
+        "cross-repo-validation: repair monday_local_inbox_runtime_report "
+        "(freshness=missing, promotability=blocked, reasons=latest_missing)"
+    ), mission
+    assert mission["cross_repo_validation_detail_lines"] == [
+        "monday_local_inbox_launch_request: freshness=fresh promotability=promotable",
+        "monday_local_inbox_runtime_report: freshness=missing promotability=blocked reasons=latest_missing",
+    ], mission
+    assert mission["monday_source_validation_report_lines"] == [
+        "consumer-report schema verdict=pass errors=0 warnings=0",
+    ], mission
+    assert mission["cross_repo_validation_action_lines"] == [
+        "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)",
     ], mission
     assert mission["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", mission
     assert mission["cross_repo_validation_packet_path"] == "/tmp/cross-repo-validation-report.json", mission
@@ -260,6 +297,12 @@ assert mission["local_validation_snapshot_status"] == "missing", mission
 assert mission["local_validation_records"] == [], mission
 assert mission["local_validation_summary_lines"] == [], mission
 assert mission["local_validation_action_lines"] == [], mission
+assert mission["cross_repo_validation_snapshot_status"] == "missing", mission
+assert mission["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", mission
+assert mission["cross_repo_validation_action_line"] is None, mission
+assert mission["cross_repo_validation_detail_lines"] == [], mission
+assert mission["monday_source_validation_report_lines"] == [], mission
+assert mission["cross_repo_validation_action_lines"] == [], mission
 assert mission["cross_repo_validation_packet_report_id"] is None, mission
 assert mission["cross_repo_validation_packet_path"] is None, mission
 PY

--- a/planningops/scripts/test_write_monday_local_operator_day_packet.sh
+++ b/planningops/scripts/test_write_monday_local_operator_day_packet.sh
@@ -57,6 +57,19 @@ cat >"$MISSION_PACKET" <<'JSON'
       "operator_handoff_report: freshness=fresh promotability=promotable"
     ],
     "local_validation_action_lines": [],
+    "cross_repo_validation_snapshot_status": "present",
+    "cross_repo_validation_snapshot_summary": "total=5 promotable=3 blocked=2 stale=0",
+    "cross_repo_validation_action_line": "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)",
+    "cross_repo_validation_detail_lines": [
+      "monday_local_inbox_launch_request: freshness=fresh promotability=promotable",
+      "monday_local_inbox_runtime_report: freshness=missing promotability=blocked reasons=latest_missing"
+    ],
+    "monday_source_validation_report_lines": [
+      "consumer-report schema verdict=pass errors=0 warnings=0"
+    ],
+    "cross_repo_validation_action_lines": [
+      "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)"
+    ],
     "cross_repo_validation_packet_report_id": "cross-repo-validation-20260401T110000Z",
     "cross_repo_validation_packet_path": "VALIDATION_ROOT_PLACEHOLDER/cross-repo-validation-report.json",
     "primary_action": "local-runtime: Expose Codex and add a direct local LLM profile.",
@@ -146,6 +159,18 @@ cat >"$HANDOFF_REPORT" <<'JSON'
       "monday_local_operator_stack_report: freshness=fresh promotability=promotable"
     ],
     "local_validation_action_lines": [],
+    "cross_repo_validation_snapshot_status": "present",
+    "cross_repo_validation_snapshot_summary": "total=2 promotable=1 blocked=1 stale=0",
+    "cross_repo_validation_action_line": "cross-repo-validation: repair monday_local_inbox_bridge_schema_validation (freshness=stale, promotability=blocked, reasons=stamped_missing)",
+    "cross_repo_validation_detail_lines": [
+      "monday_local_inbox_bridge_schema_validation: freshness=stale promotability=blocked reasons=stamped_missing"
+    ],
+    "monday_source_validation_report_lines": [
+      "bridge schema verdict=warn errors=0 warnings=1"
+    ],
+    "cross_repo_validation_action_lines": [
+      "cross-repo-validation: repair monday_local_inbox_bridge_schema_validation (freshness=stale, promotability=blocked, reasons=stamped_missing)"
+    ],
     "markdown": "## Operator Handoff Report"
   }
 }
@@ -232,6 +257,14 @@ assert "first_action_command" in contract_text, contract_text
 assert "attachments" in contract_text, contract_text
 assert "local_validation_snapshot_status" in contract_text, contract_text
 assert "body_markdown" in contract_text, contract_text
+assert "cross_repo_validation_snapshot_status" in contract_text, contract_text
+assert "cross_repo_validation_snapshot_summary" in contract_text, contract_text
+assert "cross_repo_validation_action_line" in contract_text, contract_text
+assert "cross_repo_validation_detail_lines" in contract_text, contract_text
+assert "monday_source_validation_report_lines" in contract_text, contract_text
+assert "cross_repo_validation_action_lines" in contract_text, contract_text
+assert "cross_repo_validation_packet_report_id" in contract_text, contract_text
+assert "cross_repo_validation_packet_path" in contract_text, contract_text
 
 for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert doc["day_packet_id"] == day_packet_id, doc
@@ -264,6 +297,22 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
         "monday_local_operator_stack_report: freshness=fresh promotability=promotable",
         "operator_handoff_report: freshness=fresh promotability=promotable",
     ], packet
+    assert packet["cross_repo_validation_snapshot_status"] == "present", packet
+    assert packet["cross_repo_validation_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", packet
+    assert packet["cross_repo_validation_action_line"] == (
+        "cross-repo-validation: repair monday_local_inbox_runtime_report "
+        "(freshness=missing, promotability=blocked, reasons=latest_missing)"
+    ), packet
+    assert packet["cross_repo_validation_detail_lines"] == [
+        "monday_local_inbox_launch_request: freshness=fresh promotability=promotable",
+        "monday_local_inbox_runtime_report: freshness=missing promotability=blocked reasons=latest_missing",
+    ], packet
+    assert packet["monday_source_validation_report_lines"] == [
+        "consumer-report schema verdict=pass errors=0 warnings=0",
+    ], packet
+    assert packet["cross_repo_validation_action_lines"] == [
+        "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)",
+    ], packet
     assert packet["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", packet
     assert packet["cross_repo_validation_packet_path"] == str((validation_dir / "cross-repo-validation-report.json").resolve()), packet
     assert packet["queue_lines"] == [
@@ -287,7 +336,12 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert packet["source_artifacts"]["local_operator_report_path"] == str((validation_dir / "monday-local-operator-stack-report.json").resolve()), packet
     assert "## Monday Local Operator Day Packet" in packet["body_markdown"], packet
     assert "### Commands" in packet["body_markdown"], packet
+    assert "### Cross-Repo Validation" in packet["body_markdown"], packet
     assert "### Cross-Repo Validation Packet" in packet["body_markdown"], packet
+    assert "snapshot summary: `total=5 promotable=3 blocked=2 stale=0`" in packet["body_markdown"], packet
+    assert "### Cross-Repo Validation Details" in packet["body_markdown"], packet
+    assert "- consumer-report schema verdict=pass errors=0 warnings=0" in packet["body_markdown"], packet
+    assert "### Cross-Repo Validation Actions" in packet["body_markdown"], packet
     assert "detail packet report id: `cross-repo-validation-20260401T110000Z`" in packet["body_markdown"], packet
     assert str((validation_dir / "cross-repo-validation-report.json").resolve()) in packet["body_markdown"], packet
     assert "### Local Validation" in packet["body_markdown"], packet

--- a/planningops/scripts/write_monday_local_mission_packet.py
+++ b/planningops/scripts/write_monday_local_mission_packet.py
@@ -77,6 +77,28 @@ def normalize_optional_string(raw_value: object) -> str | None:
     return None
 
 
+def build_cross_repo_validation_snapshot(
+    handoff_record: dict,
+) -> tuple[str, str, str | None, list[str], list[str], list[str]]:
+    snapshot_status = normalize_optional_string(handoff_record.get("cross_repo_validation_snapshot_status")) or "missing"
+    snapshot_summary = (
+        normalize_optional_string(handoff_record.get("cross_repo_validation_snapshot_summary"))
+        or "total=0 promotable=0 blocked=0 stale=0"
+    )
+    action_line = normalize_optional_string(handoff_record.get("cross_repo_validation_action_line"))
+    detail_lines = normalize_string_list(handoff_record.get("cross_repo_validation_detail_lines"))
+    monday_source_validation_report_lines = normalize_string_list(handoff_record.get("monday_source_validation_report_lines"))
+    action_lines = normalize_string_list(handoff_record.get("cross_repo_validation_action_lines"))
+    return (
+        snapshot_status,
+        snapshot_summary,
+        action_line,
+        detail_lines,
+        monday_source_validation_report_lines,
+        action_lines,
+    )
+
+
 def build_mission_objective(handoff_record: dict) -> str:
     target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
     if target_lines:
@@ -212,6 +234,14 @@ def main() -> int:
         local_validation_summary_lines,
         local_validation_action_lines,
     ) = build_local_validation_snapshot(handoff_record)
+    (
+        cross_repo_validation_snapshot_status,
+        cross_repo_validation_snapshot_summary,
+        cross_repo_validation_action_line,
+        cross_repo_validation_detail_lines,
+        monday_source_validation_report_lines,
+        cross_repo_validation_action_lines,
+    ) = build_cross_repo_validation_snapshot(handoff_record)
 
     expected_evidence_outputs = [
         str(latest_packet_path.resolve()),
@@ -247,6 +277,12 @@ def main() -> int:
         "local_validation_records": local_validation_records,
         "local_validation_summary_lines": local_validation_summary_lines,
         "local_validation_action_lines": local_validation_action_lines,
+        "cross_repo_validation_snapshot_status": cross_repo_validation_snapshot_status,
+        "cross_repo_validation_snapshot_summary": cross_repo_validation_snapshot_summary,
+        "cross_repo_validation_action_line": cross_repo_validation_action_line,
+        "cross_repo_validation_detail_lines": cross_repo_validation_detail_lines,
+        "monday_source_validation_report_lines": monday_source_validation_report_lines,
+        "cross_repo_validation_action_lines": cross_repo_validation_action_lines,
         "cross_repo_validation_packet_report_id": cross_repo_validation_packet_report_id,
         "cross_repo_validation_packet_path": cross_repo_validation_packet_path,
         "preflight_command": preflight_command,

--- a/planningops/scripts/write_monday_local_operator_day_packet.py
+++ b/planningops/scripts/write_monday_local_operator_day_packet.py
@@ -99,6 +99,62 @@ def build_local_validation_snapshot(*, mission_packet: dict, handoff_record: dic
     return "missing", [], [], []
 
 
+def build_cross_repo_validation_snapshot(
+    *,
+    mission_packet: dict,
+    handoff_record: dict,
+) -> tuple[str, str, str | None, list[str], list[str], list[str]]:
+    snapshot_status = normalize_optional_string(mission_packet.get("cross_repo_validation_snapshot_status"))
+    snapshot_summary = normalize_optional_string(mission_packet.get("cross_repo_validation_snapshot_summary"))
+    action_line = normalize_optional_string(mission_packet.get("cross_repo_validation_action_line"))
+    detail_lines = normalize_string_list(mission_packet.get("cross_repo_validation_detail_lines"))
+    monday_source_validation_report_lines = normalize_string_list(mission_packet.get("monday_source_validation_report_lines"))
+    action_lines = normalize_string_list(mission_packet.get("cross_repo_validation_action_lines"))
+    if (
+        snapshot_status is not None
+        or snapshot_summary is not None
+        or action_line is not None
+        or detail_lines
+        or monday_source_validation_report_lines
+        or action_lines
+    ):
+        return (
+            snapshot_status or "missing",
+            snapshot_summary or "total=0 promotable=0 blocked=0 stale=0",
+            action_line,
+            detail_lines,
+            monday_source_validation_report_lines,
+            action_lines,
+        )
+
+    fallback_status = normalize_optional_string(handoff_record.get("cross_repo_validation_snapshot_status"))
+    fallback_summary = normalize_optional_string(handoff_record.get("cross_repo_validation_snapshot_summary"))
+    fallback_action_line = normalize_optional_string(handoff_record.get("cross_repo_validation_action_line"))
+    fallback_detail_lines = normalize_string_list(handoff_record.get("cross_repo_validation_detail_lines"))
+    fallback_monday_source_validation_report_lines = normalize_string_list(
+        handoff_record.get("monday_source_validation_report_lines")
+    )
+    fallback_action_lines = normalize_string_list(handoff_record.get("cross_repo_validation_action_lines"))
+    if (
+        fallback_status is not None
+        or fallback_summary is not None
+        or fallback_action_line is not None
+        or fallback_detail_lines
+        or fallback_monday_source_validation_report_lines
+        or fallback_action_lines
+    ):
+        return (
+            fallback_status or "carried_from_handoff",
+            fallback_summary or "total=0 promotable=0 blocked=0 stale=0",
+            fallback_action_line,
+            fallback_detail_lines,
+            fallback_monday_source_validation_report_lines,
+            fallback_action_lines,
+        )
+
+    return "missing", "total=0 promotable=0 blocked=0 stale=0", None, [], [], []
+
+
 def build_body_markdown(
     *,
     headline: str,
@@ -113,6 +169,12 @@ def build_body_markdown(
     local_runtime_next_step: str | None,
     local_validation_summary_lines: list[str],
     local_validation_action_lines: list[str],
+    cross_repo_validation_snapshot_status: str,
+    cross_repo_validation_snapshot_summary: str,
+    cross_repo_validation_action_line: str | None,
+    cross_repo_validation_detail_lines: list[str],
+    monday_source_validation_report_lines: list[str],
+    cross_repo_validation_action_lines: list[str],
     queue_lines: list[str],
     target_lines: list[str],
     immediate_actions: list[str],
@@ -142,12 +204,42 @@ def build_body_markdown(
     lines.extend(["", "### Local Validation", *[f"- {line}" for line in local_validation_summary_lines]])
     if local_validation_action_lines:
         lines.extend(["", "### Local Validation Actions", *[f"{index}. {line}" for index, line in enumerate(local_validation_action_lines, start=1)]])
+    lines.extend(
+        [
+            "",
+            "### Cross-Repo Validation",
+            f"- snapshot status: `{cross_repo_validation_snapshot_status}`",
+            f"- snapshot summary: `{cross_repo_validation_snapshot_summary}`",
+        ]
+    )
+    if cross_repo_validation_action_line is not None:
+        lines.append(f"- next action: {cross_repo_validation_action_line}")
     if cross_repo_validation_packet_report_id is not None or cross_repo_validation_packet_path is not None:
         lines.extend(["", "### Cross-Repo Validation Packet"])
         if cross_repo_validation_packet_report_id is not None:
             lines.append(f"- detail packet report id: `{cross_repo_validation_packet_report_id}`")
         if cross_repo_validation_packet_path is not None:
             lines.append(f"- detail packet path: `{cross_repo_validation_packet_path}`")
+    if cross_repo_validation_detail_lines or monday_source_validation_report_lines:
+        lines.extend(
+            [
+                "",
+                "### Cross-Repo Validation Details",
+                *[f"- {line}" for line in cross_repo_validation_detail_lines],
+                *[f"- {line}" for line in monday_source_validation_report_lines],
+            ]
+        )
+    if cross_repo_validation_action_lines:
+        lines.extend(
+            [
+                "",
+                "### Cross-Repo Validation Actions",
+                *[
+                    f"{index}. {line}"
+                    for index, line in enumerate(cross_repo_validation_action_lines, start=1)
+                ],
+            ]
+        )
     lines.extend(["", "### Queue", *[f"- {line}" for line in queue_lines]])
     lines.extend(["", "### Top Targets", *[f"{index}. {line}" for index, line in enumerate(target_lines, start=1)]])
     lines.extend(["", "### Immediate Actions", *[f"{index}. {line}" for index, line in enumerate(immediate_actions, start=1)]])
@@ -216,6 +308,14 @@ def main() -> int:
     cross_repo_validation_packet_path = normalize_optional_string(
         mission_packet.get("cross_repo_validation_packet_path")
     ) or normalize_optional_string(handoff_record.get("cross_repo_validation_packet_path"))
+    (
+        cross_repo_validation_snapshot_status,
+        cross_repo_validation_snapshot_summary,
+        cross_repo_validation_action_line,
+        cross_repo_validation_detail_lines,
+        monday_source_validation_report_lines,
+        cross_repo_validation_action_lines,
+    ) = build_cross_repo_validation_snapshot(mission_packet=mission_packet, handoff_record=handoff_record)
     local_validation_snapshot_status, local_validation_records, local_validation_summary_lines, local_validation_action_lines = (
         build_local_validation_snapshot(mission_packet=mission_packet, handoff_record=handoff_record)
     )
@@ -268,6 +368,12 @@ def main() -> int:
         "local_validation_records": local_validation_records,
         "local_validation_summary_lines": local_validation_summary_lines,
         "local_validation_action_lines": local_validation_action_lines,
+        "cross_repo_validation_snapshot_status": cross_repo_validation_snapshot_status,
+        "cross_repo_validation_snapshot_summary": cross_repo_validation_snapshot_summary,
+        "cross_repo_validation_action_line": cross_repo_validation_action_line,
+        "cross_repo_validation_detail_lines": cross_repo_validation_detail_lines,
+        "monday_source_validation_report_lines": monday_source_validation_report_lines,
+        "cross_repo_validation_action_lines": cross_repo_validation_action_lines,
         "cross_repo_validation_packet_report_id": cross_repo_validation_packet_report_id,
         "cross_repo_validation_packet_path": cross_repo_validation_packet_path,
         "queue_lines": queue_lines,
@@ -287,6 +393,12 @@ def main() -> int:
             local_runtime_next_step=local_runtime_next_step or None,
             local_validation_summary_lines=local_validation_summary_lines,
             local_validation_action_lines=local_validation_action_lines,
+            cross_repo_validation_snapshot_status=cross_repo_validation_snapshot_status,
+            cross_repo_validation_snapshot_summary=cross_repo_validation_snapshot_summary,
+            cross_repo_validation_action_line=cross_repo_validation_action_line,
+            cross_repo_validation_detail_lines=cross_repo_validation_detail_lines,
+            monday_source_validation_report_lines=monday_source_validation_report_lines,
+            cross_repo_validation_action_lines=cross_repo_validation_action_lines,
             queue_lines=queue_lines,
             target_lines=target_lines,
             immediate_actions=immediate_actions,


### PR DESCRIPTION
## Scope
- preserve cross-repo validation snapshot, detail, monday source validation, and action fields in mission packets
- carry the same context into day packets with mission-first precedence and legacy handoff fallback
- expose linked cross-repo validation details/actions directly in day packet markdown
- lock the new mission/day context boundary in regressions, contracts, and the rollout plan

## Summary
- add mission packet support for `cross_repo_validation_snapshot_status`, `cross_repo_validation_snapshot_summary`, `cross_repo_validation_action_line`, detail lines, source report lines, and action lines
- add matching day packet support with mission-first reuse so packet-only flows no longer need to reopen `handoff-report` for cross-repo specifics
- keep the immutable `cross-repo-validation-packet` deep link while expanding the packet-local operator context around it

## Validation
- `python3 -m py_compile planningops/scripts/write_monday_local_mission_packet.py planningops/scripts/write_monday_local_operator_day_packet.py`
- `bash planningops/scripts/test_write_monday_local_mission_packet.sh`
- `bash planningops/scripts/test_write_monday_local_operator_day_packet.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1002

## Risks
- mission/day packet contracts now assume the same zero-summary default for missing cross-repo validation context that other operator surfaces already use
- day packet markdown is denser, so any future packet consumer that parses headings must keep using the contract rather than section order heuristics

## Review Checklist
- [x] mission packet regression covers promoted and legacy cross-repo validation context handling
- [x] day packet regression covers mission-first context precedence over legacy handoff fallback
- [x] contract and rollout plan documentation were updated alongside the writers

## Post-Deploy Monitoring & Validation
No additional operational monitoring required; this packet only reshapes promoted validation metadata and is covered by local regressions plus docs checks.