### PR TITLE
feat(local-runtime): steer mission packets from cross-repo validation blockers

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -200,6 +200,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries the same linked packet snapshot, detail lines, monday source validation report lines, and action lines that triage surfaces already expose, while still keeping the immutable `cross-repo-validation-packet` pointer for deep-link evidence
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now preserve the promoted `cross-repo-validation-packet` pointer inside mission/day packet surfaces so packet-only operator flows can reopen immutable cross-repo evidence without routing back through `handoff-report`
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now also carry the linked cross-repo validation snapshot, detail lines, monday source validation report lines, and action lines so mission/day packet-only flows do not lose the same operator context already available on handoff and triage surfaces
+- `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now fail-closed promote `cross_repo_validation_action_line` into mission/day action selection only when no stronger `local-runtime:` or `local-validation:` action already exists and an immutable promoted packet pointer is present
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -262,4 +263,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether mission/day packet surfaces should keep cross-repo validation as supporting context only or allow the linked `cross_repo_validation_action_line` to steer packet headline/primary action selection when monday-local blockers are downstream of cross-repo validation
+2. decide whether promoted cross-repo validation should ever steer `mission_objective` or target ranking itself, or whether action selection is the right ceiling and the packet should stay objective-stable

--- a/planningops/contracts/monday-local-mission-packet-contract.md
+++ b/planningops/contracts/monday-local-mission-packet-contract.md
@@ -94,6 +94,10 @@ Optional fields:
 5. local validation snapshot fields must be carried forward from the promoted handoff packet when present; otherwise the mission packet must emit `local_validation_snapshot_status=missing` with empty local validation collections.
 6. when the promoted handoff already points at a promoted `cross-repo-validation-packet`, the mission packet must preserve that immutable `report_id`/`path` pair instead of recomputing or rewriting it.
 7. cross-repo validation snapshot/detail/action fields must be carried forward from the promoted handoff packet when present; otherwise the mission packet must emit `cross_repo_validation_snapshot_status=missing`, `cross_repo_validation_snapshot_summary=total=0 promotable=0 blocked=0 stale=0`, and empty cross-repo detail/action collections.
+8. `primary_action` must stay fail-closed:
+   - keep the leading `local-runtime:` action when the promoted handoff already exposes one
+   - otherwise keep the leading `local-validation:` action when the promoted handoff already exposes one
+   - only promote `cross_repo_validation_action_line` to `primary_action` when both of the above are absent and the promoted handoff also carries an immutable `cross-repo-validation-packet` pointer
 
 ## Command Rules
 
@@ -137,6 +141,11 @@ Every packet must also preserve the current cross-repo validation context:
 - `cross_repo_validation_detail_lines`
 - `monday_source_validation_report_lines`
 - `cross_repo_validation_action_lines`
+
+When cross-repo validation becomes the selected next step, the mission packet must:
+- promote `cross_repo_validation_action_line` to `primary_action`
+- put that promoted action first in `immediate_actions`
+- keep `mission_objective` stable so the packet still points at the same target family
 
 ## Failure Rules
 

--- a/planningops/contracts/monday-local-operator-day-packet-contract.md
+++ b/planningops/contracts/monday-local-operator-day-packet-contract.md
@@ -52,33 +52,34 @@ Top-level required fields:
 3. `mission_packet_id`
 4. `headline`
 5. `mission_objective`
-6. `mission_prompt`
-7. `planner_profile`
-8. `launch_mode`
-9. `local_model_route`
-10. `first_action_command`
-11. `monday_runtime_entrypoint_command`
-12. `rollback_command`
-13. `queue_lines`
-14. `target_lines`
-15. `immediate_actions`
-16. `local_validation_snapshot_status`
-17. `local_validation_records`
-18. `local_validation_summary_lines`
-19. `local_validation_action_lines`
-20. `attachments`
-21. `cross_repo_validation_packet_report_id`
-22. `cross_repo_validation_packet_path`
-23. `cross_repo_validation_snapshot_status`
-24. `cross_repo_validation_snapshot_summary`
-25. `cross_repo_validation_action_line`
-26. `cross_repo_validation_detail_lines`
-27. `monday_source_validation_report_lines`
-28. `cross_repo_validation_action_lines`
-29. `body_markdown`
-30. `source_artifacts.mission_packet_path`
-31. `source_artifacts.handoff_report_path`
-32. `source_artifacts.local_operator_report_path`
+6. `primary_action`
+7. `mission_prompt`
+8. `planner_profile`
+9. `launch_mode`
+10. `local_model_route`
+11. `first_action_command`
+12. `monday_runtime_entrypoint_command`
+13. `rollback_command`
+14. `queue_lines`
+15. `target_lines`
+16. `immediate_actions`
+17. `local_validation_snapshot_status`
+18. `local_validation_records`
+19. `local_validation_summary_lines`
+20. `local_validation_action_lines`
+21. `attachments`
+22. `cross_repo_validation_packet_report_id`
+23. `cross_repo_validation_packet_path`
+24. `cross_repo_validation_snapshot_status`
+25. `cross_repo_validation_snapshot_summary`
+26. `cross_repo_validation_action_line`
+27. `cross_repo_validation_detail_lines`
+28. `monday_source_validation_report_lines`
+29. `cross_repo_validation_action_lines`
+30. `body_markdown`
+31. `source_artifacts.mission_packet_path`
+32. `source_artifacts.handoff_report_path`
+33. `source_artifacts.local_operator_report_path`
 
 Optional fields:
 - `attention_summary`
@@ -95,6 +96,7 @@ Optional fields:
 5. local validation snapshot fields must be copied from the mission packet when present; otherwise the writer may fall back to the promoted handoff snapshot and must mark that fallback explicitly; otherwise it must emit `missing` with empty collections.
 6. when the promoted mission packet already carries a promoted `cross-repo-validation-packet` pointer, the day packet must preserve that immutable `report_id`/`path` pair; only legacy mission packets may fall back to the handoff pointer.
 7. cross-repo validation snapshot/detail/action fields must be copied from the mission packet when present; otherwise the writer may fall back to the promoted handoff snapshot for legacy compatibility; otherwise it must emit `missing`, the zero-summary default, and empty cross-repo detail/action collections.
+8. `primary_action` must be copied from the promoted mission packet without recomputing it. If the copied `primary_action` is a promoted `cross_repo_validation_action_line`, the day packet headline may append that next step but must not rewrite `mission_objective`.
 
 ## Command Rules
 
@@ -130,6 +132,11 @@ Every day packet must also preserve the current cross-repo validation context:
 - `monday_source_validation_report_lines`
 - `cross_repo_validation_action_lines`
 - body-level visibility of the cross-repo snapshot, details, and actions so the next operator step does not need to reopen `handoff-report` just to recover them
+
+Every day packet must also preserve the selected mission action:
+- `primary_action`
+- body-level visibility of the selected action
+- optional headline-level visibility when the selected action was promoted from cross-repo validation
 
 ## Failure Rules
 

--- a/planningops/scripts/test_write_monday_local_mission_packet.sh
+++ b/planningops/scripts/test_write_monday_local_mission_packet.sh
@@ -17,6 +17,10 @@ LEGACY_HANDOFF_REPORT="$VALIDATION_DIR/operator-handoff-report-legacy.json"
 LEGACY_OUTPUT_PATH="$TMP_DIR/mission-packet-legacy-output.json"
 LEGACY_STDOUT_PATH="$TMP_DIR/mission-packet-legacy-stdout.json"
 LEGACY_PACKET_ID="monday-local-mission-20260401T080100Z"
+STEERED_HANDOFF_REPORT="$VALIDATION_DIR/operator-handoff-report-steered.json"
+STEERED_OUTPUT_PATH="$TMP_DIR/mission-packet-steered-output.json"
+STEERED_STDOUT_PATH="$TMP_DIR/mission-packet-steered-stdout.json"
+STEERED_PACKET_ID="monday-local-mission-20260401T080200Z"
 
 mkdir -p "$VALIDATION_DIR"
 
@@ -305,6 +309,79 @@ assert mission["monday_source_validation_report_lines"] == [], mission
 assert mission["cross_repo_validation_action_lines"] == [], mission
 assert mission["cross_repo_validation_packet_report_id"] is None, mission
 assert mission["cross_repo_validation_packet_path"] is None, mission
+PY
+
+cat >"$STEERED_HANDOFF_REPORT" <<'JSON'
+{
+  "generated_at_utc": "2026-04-01T07:02:00+00:00",
+  "report_id": "operator-handoff-20260401T070200Z",
+  "artifact_paths": {
+    "latest_report_path": "/tmp/operator-handoff-report.json",
+    "stamped_report_path": "/tmp/operator-handoff-20260401T070200Z-report.json",
+    "output_path": null
+  },
+  "record": {
+    "source_kind": "stamped",
+    "target_limit": 1,
+    "headline": "Operator handoff report: 1 attention family",
+    "attention_summary": "active=0, lagging=1, clear=0",
+    "newest_failing_summary": "planningops-local-inbox-consumer / planningops-local-inbox-consumer-20260401T103000Z / blocked",
+    "newest_recovered_summary": null,
+    "local_operator_record": null,
+    "local_operator_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
+    "local_operator_next_step": null,
+    "queue_lines": [],
+    "target_lines": [
+      "[blocked/current] planningops-local-inbox-consumer -> planningops-local-inbox-consumer-20260401T103000Z domains=launch_request,runtime_report,consumer_report"
+    ],
+    "immediate_action_lines": [
+      "triage-target: [blocked/current] planningops-local-inbox-consumer -> planningops-local-inbox-consumer-20260401T103000Z domains=launch_request,runtime_report,consumer_report"
+    ],
+    "cross_repo_validation_snapshot_status": "present",
+    "cross_repo_validation_snapshot_summary": "total=5 promotable=3 blocked=2 stale=0",
+    "cross_repo_validation_action_line": "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)",
+    "cross_repo_validation_detail_lines": [
+      "monday_local_inbox_launch_request: freshness=fresh promotability=promotable",
+      "monday_local_inbox_runtime_report: freshness=missing promotability=blocked reasons=latest_missing"
+    ],
+    "monday_source_validation_report_lines": [
+      "consumer-report schema verdict=pass errors=0 warnings=0"
+    ],
+    "cross_repo_validation_action_lines": [
+      "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)"
+    ],
+    "cross_repo_validation_packet_report_id": "cross-repo-validation-20260401T110000Z",
+    "cross_repo_validation_packet_path": "/tmp/cross-repo-validation-report.json",
+    "markdown": "## Operator Handoff Report"
+  }
+}
+JSON
+
+python3 planningops/scripts/write_monday_local_mission_packet.py \
+  --validation-root "$VALIDATION_DIR" \
+  --handoff-report "$STEERED_HANDOFF_REPORT" \
+  --local-operator-report "$LOCAL_OPERATOR_REPORT" \
+  --packet-id "$STEERED_PACKET_ID" \
+  --output "$STEERED_OUTPUT_PATH" >"$STEERED_STDOUT_PATH"
+
+python3 - <<'PY' "$STEERED_STDOUT_PATH"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+mission = doc["mission_packet"]
+assert mission["mission_objective"] == (
+    "Resolve [blocked/current] planningops-local-inbox-consumer -> "
+    "planningops-local-inbox-consumer-20260401T103000Z domains=launch_request,runtime_report,consumer_report"
+), mission
+assert mission["primary_action"] == (
+    "cross-repo-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=missing, promotability=blocked, reasons=latest_missing)"
+), mission
+assert mission["immediate_actions"][0] == mission["primary_action"], mission
+assert mission["immediate_actions"][1].startswith("triage-target:"), mission
+assert "Start with `cross-repo-validation: repair monday_local_inbox_runtime_report" in mission["mission_prompt"], mission
 PY
 
 echo "write monday local mission packet ok"

--- a/planningops/scripts/test_write_monday_local_operator_day_packet.sh
+++ b/planningops/scripts/test_write_monday_local_operator_day_packet.sh
@@ -14,6 +14,10 @@ LOCAL_OPERATOR_REPORT="$VALIDATION_DIR/monday-local-operator-stack-report.json"
 OUTPUT_PATH="$TMP_DIR/day-packet-output.json"
 STDOUT_PATH="$TMP_DIR/day-packet-stdout.json"
 DAY_PACKET_ID="monday-local-day-20260401T083000Z"
+STEERED_MISSION_PACKET="$VALIDATION_DIR/monday-local-mission-packet-steered.json"
+STEERED_OUTPUT_PATH="$TMP_DIR/day-packet-steered-output.json"
+STEERED_STDOUT_PATH="$TMP_DIR/day-packet-steered-stdout.json"
+STEERED_DAY_PACKET_ID="monday-local-day-20260401T083100Z"
 
 mkdir -p "$VALIDATION_DIR"
 
@@ -254,6 +258,7 @@ stamped_doc = json.loads(stamped_path.read_text(encoding="utf-8"))
 contract_text = Path("planningops/contracts/monday-local-operator-day-packet-contract.md").read_text(encoding="utf-8")
 assert "mission_packet_id" in contract_text, contract_text
 assert "first_action_command" in contract_text, contract_text
+assert "primary_action" in contract_text, contract_text
 assert "attachments" in contract_text, contract_text
 assert "local_validation_snapshot_status" in contract_text, contract_text
 assert "body_markdown" in contract_text, contract_text
@@ -275,6 +280,7 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert packet["version"] == "v1", packet
     assert packet["day_packet_id"] == day_packet_id, packet
     assert packet["mission_packet_id"] == "monday-local-mission-20260401T080000Z", packet
+    assert packet["primary_action"] == "local-runtime: Expose Codex and add a direct local LLM profile.", packet
     assert packet["headline"].startswith("Monday local operator day packet: Resolve [active/latest-gap]"), packet
     assert packet["mission_objective"] == (
         "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
@@ -336,6 +342,7 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert packet["source_artifacts"]["local_operator_report_path"] == str((validation_dir / "monday-local-operator-stack-report.json").resolve()), packet
     assert "## Monday Local Operator Day Packet" in packet["body_markdown"], packet
     assert "### Commands" in packet["body_markdown"], packet
+    assert "- primary action: local-runtime: Expose Codex and add a direct local LLM profile." in packet["body_markdown"], packet
     assert "### Cross-Repo Validation" in packet["body_markdown"], packet
     assert "### Cross-Repo Validation Packet" in packet["body_markdown"], packet
     assert "snapshot summary: `total=5 promotable=3 blocked=2 stale=0`" in packet["body_markdown"], packet
@@ -351,6 +358,60 @@ assert stdout_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).reso
 assert output_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), output_doc
 assert latest_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), latest_doc
 assert stamped_doc["artifact_paths"]["output_path"] == str(Path(sys.argv[2]).resolve()), stamped_doc
+PY
+
+python3 - <<'PY' "$MISSION_PACKET" "$STEERED_MISSION_PACKET" "$VALIDATION_DIR"
+import json
+import sys
+from pathlib import Path
+
+source_path = Path(sys.argv[1])
+target_path = Path(sys.argv[2])
+validation_dir = Path(sys.argv[3]).resolve()
+doc = json.loads(source_path.read_text(encoding="utf-8"))
+doc["packet_id"] = "monday-local-mission-20260401T080200Z"
+doc["artifact_paths"]["stamped_packet_path"] = str(
+    (validation_dir / "monday-local-mission-20260401T080200Z-monday-local-mission-packet.json").resolve()
+)
+doc["mission_packet"]["packet_id"] = "monday-local-mission-20260401T080200Z"
+doc["mission_packet"]["primary_action"] = (
+    "cross-repo-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=missing, promotability=blocked, reasons=latest_missing)"
+)
+doc["mission_packet"]["immediate_actions"] = [
+    doc["mission_packet"]["primary_action"],
+    "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+]
+payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
+target_path.write_text(payload, encoding="utf-8")
+(validation_dir / "monday-local-mission-20260401T080200Z-monday-local-mission-packet.json").write_text(payload, encoding="utf-8")
+PY
+
+python3 planningops/scripts/write_monday_local_operator_day_packet.py \
+  --validation-root "$VALIDATION_DIR" \
+  --mission-packet "$STEERED_MISSION_PACKET" \
+  --handoff-report "$HANDOFF_REPORT" \
+  --local-operator-report "$LOCAL_OPERATOR_REPORT" \
+  --day-packet-id "$STEERED_DAY_PACKET_ID" \
+  --output "$STEERED_OUTPUT_PATH" >"$STEERED_STDOUT_PATH"
+
+python3 - <<'PY' "$STEERED_STDOUT_PATH"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+packet = doc["day_packet"]
+assert packet["primary_action"] == (
+    "cross-repo-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=missing, promotability=blocked, reasons=latest_missing)"
+), packet
+assert packet["headline"].startswith(
+    "Monday local operator day packet: Resolve [active/latest-gap]"
+), packet
+assert "| next action: cross-repo-validation: repair monday_local_inbox_runtime_report" in packet["headline"], packet
+assert packet["immediate_actions"][0] == packet["primary_action"], packet
+assert "- primary action: cross-repo-validation: repair monday_local_inbox_runtime_report " in packet["body_markdown"], packet
 PY
 
 echo "write monday local operator day packet ok"

--- a/planningops/scripts/write_monday_local_mission_packet.py
+++ b/planningops/scripts/write_monday_local_mission_packet.py
@@ -99,6 +99,28 @@ def build_cross_repo_validation_snapshot(
     )
 
 
+def should_promote_cross_repo_primary_action(
+    *,
+    immediate_actions: list[str],
+    cross_repo_validation_action_line: str | None,
+    cross_repo_validation_packet_report_id: str | None,
+    cross_repo_validation_packet_path: str | None,
+) -> bool:
+    if cross_repo_validation_action_line is None:
+        return False
+    if cross_repo_validation_packet_report_id is None or cross_repo_validation_packet_path is None:
+        return False
+    if any(action.startswith("local-runtime:") for action in immediate_actions):
+        return False
+    if any(action.startswith("local-validation:") for action in immediate_actions):
+        return False
+    return True
+
+
+def prepend_once(values: list[str], item: str) -> list[str]:
+    return [item, *[value for value in values if value != item]]
+
+
 def build_mission_objective(handoff_record: dict) -> str:
     target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
     if target_lines:
@@ -221,13 +243,6 @@ def main() -> int:
     immediate_actions = [str(line) for line in list(handoff_record.get("immediate_action_lines") or []) if str(line).strip()]
     target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
     mission_objective = build_mission_objective(handoff_record)
-    primary_action = immediate_actions[0] if immediate_actions else (target_lines[0] if target_lines else mission_objective)
-    cross_repo_validation_packet_report_id = normalize_optional_string(
-        handoff_record.get("cross_repo_validation_packet_report_id")
-    )
-    cross_repo_validation_packet_path = normalize_optional_string(
-        handoff_record.get("cross_repo_validation_packet_path")
-    )
     (
         local_validation_snapshot_status,
         local_validation_records,
@@ -242,6 +257,20 @@ def main() -> int:
         monday_source_validation_report_lines,
         cross_repo_validation_action_lines,
     ) = build_cross_repo_validation_snapshot(handoff_record)
+    cross_repo_validation_packet_report_id = normalize_optional_string(
+        handoff_record.get("cross_repo_validation_packet_report_id")
+    )
+    cross_repo_validation_packet_path = normalize_optional_string(
+        handoff_record.get("cross_repo_validation_packet_path")
+    )
+    if should_promote_cross_repo_primary_action(
+        immediate_actions=immediate_actions,
+        cross_repo_validation_action_line=cross_repo_validation_action_line,
+        cross_repo_validation_packet_report_id=cross_repo_validation_packet_report_id,
+        cross_repo_validation_packet_path=cross_repo_validation_packet_path,
+    ):
+        immediate_actions = prepend_once(immediate_actions, cross_repo_validation_action_line)
+    primary_action = immediate_actions[0] if immediate_actions else (target_lines[0] if target_lines else mission_objective)
 
     expected_evidence_outputs = [
         str(latest_packet_path.resolve()),

--- a/planningops/scripts/write_monday_local_operator_day_packet.py
+++ b/planningops/scripts/write_monday_local_operator_day_packet.py
@@ -159,6 +159,7 @@ def build_body_markdown(
     *,
     headline: str,
     mission_objective: str,
+    primary_action: str,
     planner_profile: str,
     launch_mode: str,
     local_model_route: str,
@@ -188,6 +189,7 @@ def build_body_markdown(
         "### Snapshot",
         f"- headline: {headline}",
         f"- mission objective: {mission_objective}",
+        f"- primary action: {primary_action}",
         f"- planner profile: `{planner_profile}`",
         f"- launch mode: `{launch_mode}`",
         f"- local model route: `{local_model_route}`",
@@ -284,6 +286,7 @@ def main() -> int:
 
     mission_packet_id = require_string(mission_doc.get("packet_id"), "mission packet id")
     mission_objective = require_string(mission_packet.get("mission_objective"), "mission objective")
+    primary_action = require_string(mission_packet.get("primary_action"), "primary action")
     mission_prompt = require_string(mission_packet.get("mission_prompt"), "mission prompt")
     planner_profile = require_string(mission_packet.get("planner_profile"), "planner profile")
     launch_mode = require_string(mission_packet.get("launch_mode"), "launch mode")
@@ -295,6 +298,8 @@ def main() -> int:
     )
     rollback_command = require_string(mission_packet.get("rollback_command"), "rollback command")
     headline = f"Monday local operator day packet: {mission_objective}"
+    if primary_action.startswith("cross-repo-validation:"):
+        headline = f"{headline} | next action: {primary_action}"
 
     queue_lines = normalize_string_list(handoff_record.get("queue_lines"))
     target_lines = normalize_string_list(handoff_record.get("target_lines"))
@@ -353,6 +358,7 @@ def main() -> int:
         "mission_packet_id": mission_packet_id,
         "headline": headline,
         "mission_objective": mission_objective,
+        "primary_action": primary_action,
         "mission_prompt": mission_prompt,
         "attention_summary": str(mission_packet.get("attention_summary") or handoff_record.get("attention_summary") or ""),
         "newest_failing_summary": str(mission_packet.get("newest_failing_summary") or handoff_record.get("newest_failing_summary") or ""),
@@ -383,6 +389,7 @@ def main() -> int:
         "body_markdown": build_body_markdown(
             headline=headline,
             mission_objective=mission_objective,
+            primary_action=primary_action,
             planner_profile=planner_profile,
             launch_mode=launch_mode,
             local_model_route=local_model_route,


### PR DESCRIPTION
## Scope
- add a fail-closed rule for when cross-repo validation can steer mission `primary_action`
- copy the selected `primary_action` into day packets and expose it in headline/body surfaces
- cover both non-steered and steered mission/day packet cases in regressions
- update contracts and the rollout plan to document the new ceiling for cross-repo action steering

## Summary
- keep `local-runtime:` and `local-validation:` actions ahead of cross-repo validation when they already exist
- only promote `cross_repo_validation_action_line` when no stronger local action exists and the promoted packet pointer is present
- keep `mission_objective` stable while allowing day packet headline/body to surface the steered next action

## Validation
- `python3 -m py_compile planningops/scripts/write_monday_local_mission_packet.py planningops/scripts/write_monday_local_operator_day_packet.py`
- `bash planningops/scripts/test_write_monday_local_mission_packet.sh`
- `bash planningops/scripts/test_write_monday_local_operator_day_packet.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1004

## Risks
- steering now depends on the presence of both a cross-repo action line and an immutable promoted packet pointer, so malformed upstream packet linkage would intentionally suppress promotion
- day packet headline becomes denser only in the steered case, so downstream readers should keep using contract fields rather than parsing presentation text

## Review Checklist
- [x] mission packet regression covers local-runtime precedence and cross-repo promotion
- [x] day packet regression covers copied `primary_action` plus steered headline/body rendering
- [x] contracts and rollout plan were updated with the fail-closed steering rule

## Post-Deploy Monitoring & Validation
No additional operational monitoring required; this packet only reshapes promoted validation metadata and is covered by local regressions plus docs checks.