### PR TITLE
feat(local-runtime): encode action-only cross-repo steering policy

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -201,6 +201,7 @@ Current deliverables:
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now preserve the promoted `cross-repo-validation-packet` pointer inside mission/day packet surfaces so packet-only operator flows can reopen immutable cross-repo evidence without routing back through `handoff-report`
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now also carry the linked cross-repo validation snapshot, detail lines, monday source validation report lines, and action lines so mission/day packet-only flows do not lose the same operator context already available on handoff and triage surfaces
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now fail-closed promote `cross_repo_validation_action_line` into mission/day action selection only when no stronger `local-runtime:` or `local-validation:` action already exists and an immutable promoted packet pointer is present
+- `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now emit explicit `cross_repo_validation_steering_scope` and `cross_repo_validation_primary_action_promoted` fields so downstream packet readers can see that cross-repo validation may steer selected action but does not rewrite `mission_objective` or target ranking
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -263,4 +264,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether promoted cross-repo validation should ever steer `mission_objective` or target ranking itself, or whether action selection is the right ceiling and the packet should stay objective-stable
+2. decide whether mission/day packet query surfaces need to expose `cross_repo_validation_steering_scope` directly, or whether packet-local visibility is enough and downstream surfaces should keep reopening the promoted packet when they need the policy detail

--- a/planningops/contracts/monday-local-mission-packet-contract.md
+++ b/planningops/contracts/monday-local-mission-packet-contract.md
@@ -55,25 +55,27 @@ Top-level required fields:
 7. `local_model_route`
 8. `source_kind`
 9. `primary_action`
-10. `preflight_command`
-11. `rollback_command`
-12. `expected_evidence_outputs`
-13. `immediate_actions`
-14. `target_lines`
-15. `source_artifacts.handoff_report_path`
-16. `source_artifacts.local_operator_report_path`
-17. `local_validation_snapshot_status`
-18. `local_validation_records`
-19. `local_validation_summary_lines`
-20. `local_validation_action_lines`
-21. `cross_repo_validation_packet_report_id`
-22. `cross_repo_validation_packet_path`
-23. `cross_repo_validation_snapshot_status`
-24. `cross_repo_validation_snapshot_summary`
-25. `cross_repo_validation_action_line`
-26. `cross_repo_validation_detail_lines`
-27. `monday_source_validation_report_lines`
-28. `cross_repo_validation_action_lines`
+10. `cross_repo_validation_steering_scope`
+11. `cross_repo_validation_primary_action_promoted`
+12. `preflight_command`
+13. `rollback_command`
+14. `expected_evidence_outputs`
+15. `immediate_actions`
+16. `target_lines`
+17. `source_artifacts.handoff_report_path`
+18. `source_artifacts.local_operator_report_path`
+19. `local_validation_snapshot_status`
+20. `local_validation_records`
+21. `local_validation_summary_lines`
+22. `local_validation_action_lines`
+23. `cross_repo_validation_packet_report_id`
+24. `cross_repo_validation_packet_path`
+25. `cross_repo_validation_snapshot_status`
+26. `cross_repo_validation_snapshot_summary`
+27. `cross_repo_validation_action_line`
+28. `cross_repo_validation_detail_lines`
+29. `monday_source_validation_report_lines`
+30. `cross_repo_validation_action_lines`
 
 Optional fields:
 - `attention_summary`
@@ -98,6 +100,14 @@ Optional fields:
    - keep the leading `local-runtime:` action when the promoted handoff already exposes one
    - otherwise keep the leading `local-validation:` action when the promoted handoff already exposes one
    - only promote `cross_repo_validation_action_line` to `primary_action` when both of the above are absent and the promoted handoff also carries an immutable `cross-repo-validation-packet` pointer
+9. `cross_repo_validation_steering_scope` must be explicit:
+   - `none` when the packet keeps a stronger local action or has no immutable cross-repo packet pointer
+   - `primary_action_only` only when the selected `primary_action` equals `cross_repo_validation_action_line` and the immutable packet pointer is present
+10. `cross_repo_validation_primary_action_promoted` must be `true` if and only if `cross_repo_validation_steering_scope=primary_action_only`.
+11. cross-repo steering must stop at action selection:
+   - `mission_objective` must remain the promoted handoff objective
+   - target ordering must remain the promoted handoff ordering
+   - the writer must not retarget the packet just because cross-repo validation became the selected next action
 
 ## Command Rules
 
@@ -144,6 +154,8 @@ Every packet must also preserve the current cross-repo validation context:
 
 When cross-repo validation becomes the selected next step, the mission packet must:
 - promote `cross_repo_validation_action_line` to `primary_action`
+- set `cross_repo_validation_steering_scope=primary_action_only`
+- set `cross_repo_validation_primary_action_promoted=true`
 - put that promoted action first in `immediate_actions`
 - keep `mission_objective` stable so the packet still points at the same target family
 

--- a/planningops/contracts/monday-local-operator-day-packet-contract.md
+++ b/planningops/contracts/monday-local-operator-day-packet-contract.md
@@ -53,33 +53,35 @@ Top-level required fields:
 4. `headline`
 5. `mission_objective`
 6. `primary_action`
-7. `mission_prompt`
-8. `planner_profile`
-9. `launch_mode`
-10. `local_model_route`
-11. `first_action_command`
-12. `monday_runtime_entrypoint_command`
-13. `rollback_command`
-14. `queue_lines`
-15. `target_lines`
-16. `immediate_actions`
-17. `local_validation_snapshot_status`
-18. `local_validation_records`
-19. `local_validation_summary_lines`
-20. `local_validation_action_lines`
-21. `attachments`
-22. `cross_repo_validation_packet_report_id`
-23. `cross_repo_validation_packet_path`
-24. `cross_repo_validation_snapshot_status`
-25. `cross_repo_validation_snapshot_summary`
-26. `cross_repo_validation_action_line`
-27. `cross_repo_validation_detail_lines`
-28. `monday_source_validation_report_lines`
-29. `cross_repo_validation_action_lines`
-30. `body_markdown`
-31. `source_artifacts.mission_packet_path`
-32. `source_artifacts.handoff_report_path`
-33. `source_artifacts.local_operator_report_path`
+7. `cross_repo_validation_steering_scope`
+8. `cross_repo_validation_primary_action_promoted`
+9. `mission_prompt`
+10. `planner_profile`
+11. `launch_mode`
+12. `local_model_route`
+13. `first_action_command`
+14. `monday_runtime_entrypoint_command`
+15. `rollback_command`
+16. `queue_lines`
+17. `target_lines`
+18. `immediate_actions`
+19. `local_validation_snapshot_status`
+20. `local_validation_records`
+21. `local_validation_summary_lines`
+22. `local_validation_action_lines`
+23. `attachments`
+24. `cross_repo_validation_packet_report_id`
+25. `cross_repo_validation_packet_path`
+26. `cross_repo_validation_snapshot_status`
+27. `cross_repo_validation_snapshot_summary`
+28. `cross_repo_validation_action_line`
+29. `cross_repo_validation_detail_lines`
+30. `monday_source_validation_report_lines`
+31. `cross_repo_validation_action_lines`
+32. `body_markdown`
+33. `source_artifacts.mission_packet_path`
+34. `source_artifacts.handoff_report_path`
+35. `source_artifacts.local_operator_report_path`
 
 Optional fields:
 - `attention_summary`
@@ -96,7 +98,12 @@ Optional fields:
 5. local validation snapshot fields must be copied from the mission packet when present; otherwise the writer may fall back to the promoted handoff snapshot and must mark that fallback explicitly; otherwise it must emit `missing` with empty collections.
 6. when the promoted mission packet already carries a promoted `cross-repo-validation-packet` pointer, the day packet must preserve that immutable `report_id`/`path` pair; only legacy mission packets may fall back to the handoff pointer.
 7. cross-repo validation snapshot/detail/action fields must be copied from the mission packet when present; otherwise the writer may fall back to the promoted handoff snapshot for legacy compatibility; otherwise it must emit `missing`, the zero-summary default, and empty cross-repo detail/action collections.
-8. `primary_action` must be copied from the promoted mission packet without recomputing it. If the copied `primary_action` is a promoted `cross_repo_validation_action_line`, the day packet headline may append that next step but must not rewrite `mission_objective`.
+8. `cross_repo_validation_steering_scope` and `cross_repo_validation_primary_action_promoted` must be copied from the promoted mission packet when present; only legacy mission packets may derive them from the copied `primary_action` plus the immutable cross-repo packet pointer.
+9. `primary_action` must be copied from the promoted mission packet without recomputing it. If the copied `primary_action` is a promoted `cross_repo_validation_action_line`, the day packet headline may append that next step but must not rewrite `mission_objective`.
+10. cross-repo steering must remain action-only in the day packet too:
+   - `mission_objective` must stay mission-derived
+   - target ordering must stay mission-derived
+   - the day packet must not reinterpret cross-repo validation as a new objective
 
 ## Command Rules
 
@@ -135,7 +142,10 @@ Every day packet must also preserve the current cross-repo validation context:
 
 Every day packet must also preserve the selected mission action:
 - `primary_action`
+- `cross_repo_validation_steering_scope`
+- `cross_repo_validation_primary_action_promoted`
 - body-level visibility of the selected action
+- body-level visibility of the steering scope so downstream readers can tell that the objective stayed fixed
 - optional headline-level visibility when the selected action was promoted from cross-repo validation
 
 ## Failure Rules

--- a/planningops/scripts/test_write_monday_local_mission_packet.sh
+++ b/planningops/scripts/test_write_monday_local_mission_packet.sh
@@ -182,6 +182,8 @@ assert "monday_source_validation_report_lines" in contract_text, contract_text
 assert "cross_repo_validation_action_lines" in contract_text, contract_text
 assert "cross_repo_validation_packet_report_id" in contract_text, contract_text
 assert "cross_repo_validation_packet_path" in contract_text, contract_text
+assert "cross_repo_validation_steering_scope" in contract_text, contract_text
+assert "cross_repo_validation_primary_action_promoted" in contract_text, contract_text
 
 for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert doc["packet_id"] == packet_id, doc
@@ -198,6 +200,8 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
         "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
     ), mission
     assert mission["primary_action"] == "local-runtime: Expose Codex and add a direct local LLM profile.", mission
+    assert mission["cross_repo_validation_steering_scope"] == "none", mission
+    assert mission["cross_repo_validation_primary_action_promoted"] is False, mission
     assert mission["preflight_command"] == (
         "python3 planningops/scripts/run_monday_local_operator_stack.py "
         f"--execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id {packet_id}"
@@ -309,6 +313,8 @@ assert mission["monday_source_validation_report_lines"] == [], mission
 assert mission["cross_repo_validation_action_lines"] == [], mission
 assert mission["cross_repo_validation_packet_report_id"] is None, mission
 assert mission["cross_repo_validation_packet_path"] is None, mission
+assert mission["cross_repo_validation_steering_scope"] == "none", mission
+assert mission["cross_repo_validation_primary_action_promoted"] is False, mission
 PY
 
 cat >"$STEERED_HANDOFF_REPORT" <<'JSON'
@@ -379,6 +385,8 @@ assert mission["primary_action"] == (
     "cross-repo-validation: repair monday_local_inbox_runtime_report "
     "(freshness=missing, promotability=blocked, reasons=latest_missing)"
 ), mission
+assert mission["cross_repo_validation_steering_scope"] == "primary_action_only", mission
+assert mission["cross_repo_validation_primary_action_promoted"] is True, mission
 assert mission["immediate_actions"][0] == mission["primary_action"], mission
 assert mission["immediate_actions"][1].startswith("triage-target:"), mission
 assert "Start with `cross-repo-validation: repair monday_local_inbox_runtime_report" in mission["mission_prompt"], mission

--- a/planningops/scripts/test_write_monday_local_operator_day_packet.sh
+++ b/planningops/scripts/test_write_monday_local_operator_day_packet.sh
@@ -77,6 +77,8 @@ cat >"$MISSION_PACKET" <<'JSON'
     "cross_repo_validation_packet_report_id": "cross-repo-validation-20260401T110000Z",
     "cross_repo_validation_packet_path": "VALIDATION_ROOT_PLACEHOLDER/cross-repo-validation-report.json",
     "primary_action": "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "cross_repo_validation_steering_scope": "none",
+    "cross_repo_validation_primary_action_promoted": false,
     "immediate_actions": [
       "local-runtime: Expose Codex and add a direct local LLM profile."
     ],
@@ -270,6 +272,8 @@ assert "monday_source_validation_report_lines" in contract_text, contract_text
 assert "cross_repo_validation_action_lines" in contract_text, contract_text
 assert "cross_repo_validation_packet_report_id" in contract_text, contract_text
 assert "cross_repo_validation_packet_path" in contract_text, contract_text
+assert "cross_repo_validation_steering_scope" in contract_text, contract_text
+assert "cross_repo_validation_primary_action_promoted" in contract_text, contract_text
 
 for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert doc["day_packet_id"] == day_packet_id, doc
@@ -281,6 +285,8 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert packet["day_packet_id"] == day_packet_id, packet
     assert packet["mission_packet_id"] == "monday-local-mission-20260401T080000Z", packet
     assert packet["primary_action"] == "local-runtime: Expose Codex and add a direct local LLM profile.", packet
+    assert packet["cross_repo_validation_steering_scope"] == "none", packet
+    assert packet["cross_repo_validation_primary_action_promoted"] is False, packet
     assert packet["headline"].startswith("Monday local operator day packet: Resolve [active/latest-gap]"), packet
     assert packet["mission_objective"] == (
         "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile"
@@ -346,6 +352,8 @@ for doc in (stdout_doc, output_doc, latest_doc, stamped_doc):
     assert "### Cross-Repo Validation" in packet["body_markdown"], packet
     assert "### Cross-Repo Validation Packet" in packet["body_markdown"], packet
     assert "snapshot summary: `total=5 promotable=3 blocked=2 stale=0`" in packet["body_markdown"], packet
+    assert "steering scope: `none`" in packet["body_markdown"], packet
+    assert "primary action promoted: `false`" in packet["body_markdown"], packet
     assert "### Cross-Repo Validation Details" in packet["body_markdown"], packet
     assert "- consumer-report schema verdict=pass errors=0 warnings=0" in packet["body_markdown"], packet
     assert "### Cross-Repo Validation Actions" in packet["body_markdown"], packet
@@ -378,6 +386,8 @@ doc["mission_packet"]["primary_action"] = (
     "cross-repo-validation: repair monday_local_inbox_runtime_report "
     "(freshness=missing, promotability=blocked, reasons=latest_missing)"
 )
+doc["mission_packet"]["cross_repo_validation_steering_scope"] = "primary_action_only"
+doc["mission_packet"]["cross_repo_validation_primary_action_promoted"] = True
 doc["mission_packet"]["immediate_actions"] = [
     doc["mission_packet"]["primary_action"],
     "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
@@ -406,12 +416,16 @@ assert packet["primary_action"] == (
     "cross-repo-validation: repair monday_local_inbox_runtime_report "
     "(freshness=missing, promotability=blocked, reasons=latest_missing)"
 ), packet
+assert packet["cross_repo_validation_steering_scope"] == "primary_action_only", packet
+assert packet["cross_repo_validation_primary_action_promoted"] is True, packet
 assert packet["headline"].startswith(
     "Monday local operator day packet: Resolve [active/latest-gap]"
 ), packet
 assert "| next action: cross-repo-validation: repair monday_local_inbox_runtime_report" in packet["headline"], packet
 assert packet["immediate_actions"][0] == packet["primary_action"], packet
 assert "- primary action: cross-repo-validation: repair monday_local_inbox_runtime_report " in packet["body_markdown"], packet
+assert "steering scope: `primary_action_only`" in packet["body_markdown"], packet
+assert "primary action promoted: `true`" in packet["body_markdown"], packet
 PY
 
 echo "write monday local operator day packet ok"

--- a/planningops/scripts/write_monday_local_mission_packet.py
+++ b/planningops/scripts/write_monday_local_mission_packet.py
@@ -121,6 +121,22 @@ def prepend_once(values: list[str], item: str) -> list[str]:
     return [item, *[value for value in values if value != item]]
 
 
+def build_cross_repo_validation_steering(
+    *,
+    primary_action: str,
+    cross_repo_validation_action_line: str | None,
+    cross_repo_validation_packet_report_id: str | None,
+    cross_repo_validation_packet_path: str | None,
+) -> tuple[str, bool]:
+    promoted = (
+        cross_repo_validation_action_line is not None
+        and primary_action == cross_repo_validation_action_line
+        and cross_repo_validation_packet_report_id is not None
+        and cross_repo_validation_packet_path is not None
+    )
+    return ("primary_action_only" if promoted else "none"), promoted
+
+
 def build_mission_objective(handoff_record: dict) -> str:
     target_lines = [str(line) for line in list(handoff_record.get("target_lines") or []) if str(line).strip()]
     if target_lines:
@@ -271,6 +287,14 @@ def main() -> int:
     ):
         immediate_actions = prepend_once(immediate_actions, cross_repo_validation_action_line)
     primary_action = immediate_actions[0] if immediate_actions else (target_lines[0] if target_lines else mission_objective)
+    cross_repo_validation_steering_scope, cross_repo_validation_primary_action_promoted = (
+        build_cross_repo_validation_steering(
+            primary_action=primary_action,
+            cross_repo_validation_action_line=cross_repo_validation_action_line,
+            cross_repo_validation_packet_report_id=cross_repo_validation_packet_report_id,
+            cross_repo_validation_packet_path=cross_repo_validation_packet_path,
+        )
+    )
 
     expected_evidence_outputs = [
         str(latest_packet_path.resolve()),
@@ -300,6 +324,8 @@ def main() -> int:
         "local_runtime_summary": str(handoff_record.get("local_operator_summary") or ""),
         "local_runtime_next_step": str(handoff_record.get("local_operator_next_step") or ""),
         "primary_action": primary_action,
+        "cross_repo_validation_steering_scope": cross_repo_validation_steering_scope,
+        "cross_repo_validation_primary_action_promoted": cross_repo_validation_primary_action_promoted,
         "immediate_actions": immediate_actions,
         "target_lines": target_lines,
         "local_validation_snapshot_status": local_validation_snapshot_status,

--- a/planningops/scripts/write_monday_local_operator_day_packet.py
+++ b/planningops/scripts/write_monday_local_operator_day_packet.py
@@ -72,6 +72,12 @@ def normalize_optional_string(raw_value: object) -> str | None:
     return None
 
 
+def normalize_bool(raw_value: object) -> bool | None:
+    if isinstance(raw_value, bool):
+        return raw_value
+    return None
+
+
 def dedupe_preserve_order(values: list[str]) -> list[str]:
     deduped: list[str] = []
     seen: set[str] = set()
@@ -155,6 +161,28 @@ def build_cross_repo_validation_snapshot(
     return "missing", "total=0 promotable=0 blocked=0 stale=0", None, [], [], []
 
 
+def build_cross_repo_validation_steering(
+    *,
+    mission_packet: dict,
+    primary_action: str,
+    cross_repo_validation_action_line: str | None,
+    cross_repo_validation_packet_report_id: str | None,
+    cross_repo_validation_packet_path: str | None,
+) -> tuple[str, bool]:
+    scope = normalize_optional_string(mission_packet.get("cross_repo_validation_steering_scope"))
+    promoted = normalize_bool(mission_packet.get("cross_repo_validation_primary_action_promoted"))
+    if scope is not None:
+        return scope, promoted if promoted is not None else scope == "primary_action_only"
+
+    derived_promoted = (
+        cross_repo_validation_action_line is not None
+        and primary_action == cross_repo_validation_action_line
+        and cross_repo_validation_packet_report_id is not None
+        and cross_repo_validation_packet_path is not None
+    )
+    return ("primary_action_only" if derived_promoted else "none"), derived_promoted
+
+
 def build_body_markdown(
     *,
     headline: str,
@@ -172,6 +200,8 @@ def build_body_markdown(
     local_validation_action_lines: list[str],
     cross_repo_validation_snapshot_status: str,
     cross_repo_validation_snapshot_summary: str,
+    cross_repo_validation_steering_scope: str,
+    cross_repo_validation_primary_action_promoted: bool,
     cross_repo_validation_action_line: str | None,
     cross_repo_validation_detail_lines: list[str],
     monday_source_validation_report_lines: list[str],
@@ -212,6 +242,8 @@ def build_body_markdown(
             "### Cross-Repo Validation",
             f"- snapshot status: `{cross_repo_validation_snapshot_status}`",
             f"- snapshot summary: `{cross_repo_validation_snapshot_summary}`",
+            f"- steering scope: `{cross_repo_validation_steering_scope}`",
+            f"- primary action promoted: `{str(cross_repo_validation_primary_action_promoted).lower()}`",
         ]
     )
     if cross_repo_validation_action_line is not None:
@@ -298,8 +330,6 @@ def main() -> int:
     )
     rollback_command = require_string(mission_packet.get("rollback_command"), "rollback command")
     headline = f"Monday local operator day packet: {mission_objective}"
-    if primary_action.startswith("cross-repo-validation:"):
-        headline = f"{headline} | next action: {primary_action}"
 
     queue_lines = normalize_string_list(handoff_record.get("queue_lines"))
     target_lines = normalize_string_list(handoff_record.get("target_lines"))
@@ -321,6 +351,15 @@ def main() -> int:
         monday_source_validation_report_lines,
         cross_repo_validation_action_lines,
     ) = build_cross_repo_validation_snapshot(mission_packet=mission_packet, handoff_record=handoff_record)
+    cross_repo_validation_steering_scope, cross_repo_validation_primary_action_promoted = build_cross_repo_validation_steering(
+        mission_packet=mission_packet,
+        primary_action=primary_action,
+        cross_repo_validation_action_line=cross_repo_validation_action_line,
+        cross_repo_validation_packet_report_id=cross_repo_validation_packet_report_id,
+        cross_repo_validation_packet_path=cross_repo_validation_packet_path,
+    )
+    if cross_repo_validation_primary_action_promoted:
+        headline = f"{headline} | next action: {primary_action}"
     local_validation_snapshot_status, local_validation_records, local_validation_summary_lines, local_validation_action_lines = (
         build_local_validation_snapshot(mission_packet=mission_packet, handoff_record=handoff_record)
     )
@@ -359,6 +398,8 @@ def main() -> int:
         "headline": headline,
         "mission_objective": mission_objective,
         "primary_action": primary_action,
+        "cross_repo_validation_steering_scope": cross_repo_validation_steering_scope,
+        "cross_repo_validation_primary_action_promoted": cross_repo_validation_primary_action_promoted,
         "mission_prompt": mission_prompt,
         "attention_summary": str(mission_packet.get("attention_summary") or handoff_record.get("attention_summary") or ""),
         "newest_failing_summary": str(mission_packet.get("newest_failing_summary") or handoff_record.get("newest_failing_summary") or ""),
@@ -402,6 +443,8 @@ def main() -> int:
             local_validation_action_lines=local_validation_action_lines,
             cross_repo_validation_snapshot_status=cross_repo_validation_snapshot_status,
             cross_repo_validation_snapshot_summary=cross_repo_validation_snapshot_summary,
+            cross_repo_validation_steering_scope=cross_repo_validation_steering_scope,
+            cross_repo_validation_primary_action_promoted=cross_repo_validation_primary_action_promoted,
             cross_repo_validation_action_line=cross_repo_validation_action_line,
             cross_repo_validation_detail_lines=cross_repo_validation_detail_lines,
             monday_source_validation_report_lines=monday_source_validation_report_lines,


### PR DESCRIPTION
## Scope
- add explicit steering metadata to monday local mission/day packets
- keep cross-repo steering action-only and objective-stable
- lock the new contract with mission/day regressions

## Summary
This change encodes whether cross-repo validation actually promoted the selected next action, instead of making downstream readers infer that policy from the packet shape. Mission/day packets now carry `cross_repo_validation_steering_scope` and `cross_repo_validation_primary_action_promoted`, and day packet markdown surfaces the same policy detail for operators.

## Validation
- python3 -m py_compile planningops/scripts/write_monday_local_mission_packet.py planningops/scripts/write_monday_local_operator_day_packet.py
- bash planningops/scripts/test_write_monday_local_mission_packet.sh
- bash planningops/scripts/test_write_monday_local_operator_day_packet.sh
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench
- bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all

## Linked Issues
Closes #1006

## Risks
- downstream readers now rely on explicit steering metadata, so packet contracts and regressions were updated together
- legacy mission packets still fall back to derived steering metadata inside the day packet writer

## Review Checklist
- [ ] steering scope stays `none` for local-runtime/local-validation-led packets
- [ ] steering scope flips to `primary_action_only` only when immutable cross-repo packet evidence is present
- [ ] mission objective and target ordering remain unchanged when cross-repo action promotion happens

## Post-Deploy Monitoring & Validation
- spot check promoted mission/day packets to confirm the new steering metadata matches the selected `primary_action`
- continue watching inherited GitHub Actions failures separately from this packet
