### PR TITLE
feat(query-engine): add mission and day packet query surfaces

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -202,6 +202,7 @@ Current deliverables:
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now also carry the linked cross-repo validation snapshot, detail lines, monday source validation report lines, and action lines so mission/day packet-only flows do not lose the same operator context already available on handoff and triage surfaces
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now fail-closed promote `cross_repo_validation_action_line` into mission/day action selection only when no stronger `local-runtime:` or `local-validation:` action already exists and an immutable promoted packet pointer is present
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now emit explicit `cross_repo_validation_steering_scope` and `cross_repo_validation_primary_action_promoted` fields so downstream packet readers can see that cross-repo validation may steer selected action but does not rewrite `mission_objective` or target ranking
+- `planningops/scripts/federation/query_federated_ci_artifacts.py local-mission-packet|local-day-packet` now expose latest/stamped mission/day packet records directly, including `cross_repo_validation_steering_scope`, `cross_repo_validation_primary_action_promoted`, packet source kind, and immutable cross-repo packet linkage so operators can audit action-only steering without reopening raw packet JSON
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -264,4 +265,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether mission/day packet query surfaces need to expose `cross_repo_validation_steering_scope` directly, or whether packet-local visibility is enough and downstream surfaces should keep reopening the promoted packet when they need the policy detail
+2. decide whether `local-inbox-payload|monday-consumer-report|triage-*` should mirror mission/day steering metadata directly, or whether the new `local-mission-packet|local-day-packet` query surfaces should stay the canonical read path for action-only steering policy

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -50,6 +50,7 @@ LOCAL_OPERATOR_VERDICT_CHOICES = ("pass", "fail", "planned")
 LOCAL_OPERATOR_READINESS_CHOICES = ("ready", "bootstrap_required", "blocked", "unknown")
 LOCAL_OPERATOR_STEP_STATUS_CHOICES = ("pass", "fail", "planned", "skipped", "report_only", "unknown", "missing")
 LOCAL_INBOX_PAYLOAD_SOURCE_CHOICES = ("all", "latest", "stamped")
+LOCAL_PACKET_SOURCE_CHOICES = ("all", "latest", "stamped")
 LOCAL_INBOX_PAYLOAD_STATUS_CHOICES = ("ready", "blocked")
 MONDAY_CONSUMER_MODE_CHOICES = ("dry-run", "apply")
 MONDAY_CONSUMER_VERDICT_CHOICES = ("pass", "fail", "blocked")
@@ -57,6 +58,7 @@ MONDAY_CONSUMER_STATUS_CHOICES = ("ready_to_launch", "blocked")
 MONDAY_VALIDATION_KIND_CHOICES = ("bridge", "consumer-report")
 MONDAY_VALIDATION_VERDICT_CHOICES = ("pass", "fail")
 CROSS_REPO_VALIDATION_PACKET_SOURCE_CHOICES = ("latest", "stamped")
+STEERING_SCOPE_CHOICES = ("none", "primary_action_only")
 LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_operator_stack_report",
     "operator_handoff_report",
@@ -500,6 +502,70 @@ class LocalInboxPayloadRecord:
 
 
 @dataclass(frozen=True)
+class LocalMissionPacketRecord:
+    packet_id: str
+    source_kind: str
+    packet_path: str
+    generated_at_utc: str
+    contract_ref: str | None
+    latest_packet_path: str | None
+    stamped_packet_path: str | None
+    output_path: str | None
+    mission_objective: str | None
+    primary_action: str | None
+    cross_repo_validation_steering_scope: str
+    cross_repo_validation_primary_action_promoted: bool
+    planner_profile: str | None
+    launch_mode: str | None
+    local_model_route: str | None
+    local_validation_snapshot_status: str | None
+    cross_repo_validation_snapshot_status: str | None
+    cross_repo_validation_snapshot_summary: str | None
+    cross_repo_validation_action_line: str | None
+    cross_repo_validation_packet_report_id: str | None
+    cross_repo_validation_packet_path: str | None
+    immediate_actions: list[str]
+    target_lines: list[str]
+    local_validation_action_lines: list[str]
+    cross_repo_validation_action_lines: list[str]
+    cross_repo_validation_detail_lines: list[str]
+    monday_source_validation_report_lines: list[str]
+
+
+@dataclass(frozen=True)
+class LocalDayPacketRecord:
+    day_packet_id: str
+    mission_packet_id: str | None
+    source_kind: str
+    packet_path: str
+    generated_at_utc: str
+    contract_ref: str | None
+    latest_packet_path: str | None
+    stamped_packet_path: str | None
+    output_path: str | None
+    headline: str | None
+    mission_objective: str | None
+    primary_action: str | None
+    cross_repo_validation_steering_scope: str
+    cross_repo_validation_primary_action_promoted: bool
+    planner_profile: str | None
+    launch_mode: str | None
+    local_model_route: str | None
+    local_validation_snapshot_status: str | None
+    cross_repo_validation_snapshot_status: str | None
+    cross_repo_validation_snapshot_summary: str | None
+    cross_repo_validation_action_line: str | None
+    cross_repo_validation_packet_report_id: str | None
+    cross_repo_validation_packet_path: str | None
+    immediate_actions: list[str]
+    target_lines: list[str]
+    local_validation_action_lines: list[str]
+    cross_repo_validation_action_lines: list[str]
+    cross_repo_validation_detail_lines: list[str]
+    monday_source_validation_report_lines: list[str]
+
+
+@dataclass(frozen=True)
 class MondayConsumerReportRecord:
     run_id: str
     report_path: str
@@ -861,6 +927,12 @@ def normalize_optional_string(value: Any) -> str | None:
     return normalized or None
 
 
+def normalize_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
 def normalize_string_list(values: Any) -> list[str]:
     return [str(value) for value in list(values or []) if str(value).strip()]
 
@@ -1057,8 +1129,24 @@ def source_kind_for_local_inbox_payload_path(path: Path) -> str:
     return "latest" if path.name == "monday-local-operator-inbox-payload.json" else "stamped"
 
 
+def source_kind_for_local_mission_packet_path(path: Path) -> str:
+    return "latest" if path.name == "monday-local-mission-packet.json" else "stamped"
+
+
+def source_kind_for_local_day_packet_path(path: Path) -> str:
+    return "latest" if path.name == "monday-local-operator-day-packet.json" else "stamped"
+
+
 def is_local_inbox_payload_document(doc: dict[str, Any]) -> bool:
     return isinstance(doc.get("bridge_id"), str) and isinstance(doc.get("payload"), dict)
+
+
+def is_local_mission_packet_document(doc: dict[str, Any]) -> bool:
+    return isinstance(doc.get("packet_id"), str) and isinstance(doc.get("mission_packet"), dict)
+
+
+def is_local_day_packet_document(doc: dict[str, Any]) -> bool:
+    return isinstance(doc.get("day_packet_id"), str) and isinstance(doc.get("day_packet"), dict)
 
 
 def is_monday_consumer_report_document(doc: dict[str, Any]) -> bool:
@@ -1379,6 +1467,415 @@ def filter_local_inbox_payload_records(
             if has_dependency_state in record.dependency_states.values()
         ]
     return filtered
+
+
+def build_local_mission_packet_record(*, packet_path: Path, packet_doc: dict[str, Any]) -> LocalMissionPacketRecord:
+    mission_packet = packet_doc.get("mission_packet") if isinstance(packet_doc.get("mission_packet"), dict) else {}
+    return LocalMissionPacketRecord(
+        packet_id=str(packet_doc.get("packet_id")),
+        source_kind=source_kind_for_local_mission_packet_path(packet_path),
+        packet_path=str(packet_path.resolve()),
+        generated_at_utc=str(packet_doc.get("generated_at_utc") or ""),
+        contract_ref=normalize_optional_string(packet_doc.get("contract_ref")),
+        latest_packet_path=normalize_artifact_path(resolve_nested_value(packet_doc, "artifact_paths", "latest_packet_path")),
+        stamped_packet_path=normalize_artifact_path(resolve_nested_value(packet_doc, "artifact_paths", "stamped_packet_path")),
+        output_path=normalize_artifact_path(resolve_nested_value(packet_doc, "artifact_paths", "output_path")),
+        mission_objective=normalize_optional_string(mission_packet.get("mission_objective")),
+        primary_action=normalize_optional_string(mission_packet.get("primary_action")),
+        cross_repo_validation_steering_scope=(
+            normalize_optional_string(mission_packet.get("cross_repo_validation_steering_scope")) or "none"
+        ),
+        cross_repo_validation_primary_action_promoted=(
+            normalize_bool(mission_packet.get("cross_repo_validation_primary_action_promoted")) or False
+        ),
+        planner_profile=normalize_optional_string(mission_packet.get("planner_profile")),
+        launch_mode=normalize_optional_string(mission_packet.get("launch_mode")),
+        local_model_route=normalize_optional_string(mission_packet.get("local_model_route")),
+        local_validation_snapshot_status=normalize_optional_string(mission_packet.get("local_validation_snapshot_status")),
+        cross_repo_validation_snapshot_status=normalize_optional_string(
+            mission_packet.get("cross_repo_validation_snapshot_status")
+        ),
+        cross_repo_validation_snapshot_summary=normalize_optional_string(
+            mission_packet.get("cross_repo_validation_snapshot_summary")
+        ),
+        cross_repo_validation_action_line=normalize_optional_string(
+            mission_packet.get("cross_repo_validation_action_line")
+        ),
+        cross_repo_validation_packet_report_id=normalize_optional_string(
+            mission_packet.get("cross_repo_validation_packet_report_id")
+        ),
+        cross_repo_validation_packet_path=normalize_optional_string(
+            mission_packet.get("cross_repo_validation_packet_path")
+        ),
+        immediate_actions=normalize_string_list(mission_packet.get("immediate_actions")),
+        target_lines=normalize_string_list(mission_packet.get("target_lines")),
+        local_validation_action_lines=normalize_string_list(mission_packet.get("local_validation_action_lines")),
+        cross_repo_validation_action_lines=normalize_string_list(
+            mission_packet.get("cross_repo_validation_action_lines")
+        ),
+        cross_repo_validation_detail_lines=normalize_string_list(
+            mission_packet.get("cross_repo_validation_detail_lines")
+        ),
+        monday_source_validation_report_lines=normalize_string_list(
+            mission_packet.get("monday_source_validation_report_lines")
+        ),
+    )
+
+
+def discover_local_mission_packet_records(*, validation_root: Path) -> list[LocalMissionPacketRecord]:
+    paths: list[Path] = []
+    latest_path = validation_root / "monday-local-mission-packet.json"
+    if latest_path.exists():
+        paths.append(latest_path)
+    paths.extend(sorted(validation_root.glob("*-monday-local-mission-packet.json")))
+
+    records: list[LocalMissionPacketRecord] = []
+    for path in paths:
+        if path.name.startswith(".") or path.name.startswith("._"):
+            continue
+        try:
+            doc = load_json(path)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if not is_local_mission_packet_document(doc):
+            continue
+        records.append(build_local_mission_packet_record(packet_path=path, packet_doc=doc))
+    records.sort(
+        key=lambda record: (
+            record.generated_at_utc,
+            record.packet_id,
+            1 if record.source_kind == "latest" else 0,
+            record.packet_path,
+        ),
+        reverse=True,
+    )
+    return records
+
+
+def filter_local_mission_packet_records(
+    *,
+    records: list[LocalMissionPacketRecord],
+    packet_id_prefix: str | None = None,
+    source_kind: str = "latest",
+    planner_profile: str | None = None,
+    launch_mode: str | None = None,
+    local_model_route: str | None = None,
+    steering_scope: str | None = None,
+    primary_action_promoted: str | None = None,
+) -> list[LocalMissionPacketRecord]:
+    filtered = records
+    if packet_id_prefix:
+        filtered = [record for record in filtered if record.packet_id.startswith(packet_id_prefix)]
+    if source_kind != "all":
+        filtered = [record for record in filtered if record.source_kind == source_kind]
+    if planner_profile:
+        filtered = [record for record in filtered if record.planner_profile == planner_profile]
+    if launch_mode:
+        filtered = [record for record in filtered if record.launch_mode == launch_mode]
+    if local_model_route:
+        filtered = [record for record in filtered if record.local_model_route == local_model_route]
+    if steering_scope:
+        filtered = [record for record in filtered if record.cross_repo_validation_steering_scope == steering_scope]
+    if primary_action_promoted is not None:
+        expected = primary_action_promoted == "yes"
+        filtered = [
+            record for record in filtered if record.cross_repo_validation_primary_action_promoted is expected
+        ]
+    return filtered
+
+
+def render_local_mission_packet_table(records: list[LocalMissionPacketRecord]) -> str:
+    lines = [
+        "packet_id\tsource\tplanner_profile\tlaunch_mode\tlocal_model_route\tsteering_scope\tprimary_action_promoted\tcross_repo_snapshot\tcross_repo_packet_report_id\timmediate_actions\ttargets\tgenerated_at_utc",
+    ]
+    for record in records:
+        lines.append(
+            "\t".join(
+                [
+                    record.packet_id,
+                    record.source_kind,
+                    str(record.planner_profile or ""),
+                    str(record.launch_mode or ""),
+                    str(record.local_model_route or ""),
+                    record.cross_repo_validation_steering_scope,
+                    "yes" if record.cross_repo_validation_primary_action_promoted else "no",
+                    str(record.cross_repo_validation_snapshot_status or ""),
+                    str(record.cross_repo_validation_packet_report_id or ""),
+                    str(len(record.immediate_actions)),
+                    str(len(record.target_lines)),
+                    record.generated_at_utc,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_local_mission_packet_markdown(records: list[LocalMissionPacketRecord]) -> str:
+    lines = [
+        "| packet_id | source | planner_profile | launch_mode | local_model_route | steering_scope | primary_action_promoted | cross_repo_snapshot | cross_repo_packet_report_id | immediate_actions | targets | generated_at_utc |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | --- |",
+    ]
+    sections: list[str] = []
+    for record in records:
+        lines.append(
+            f"| `{record.packet_id}` | {record.source_kind} | {record.planner_profile or ''} | "
+            f"{record.launch_mode or ''} | {record.local_model_route or ''} | "
+            f"{record.cross_repo_validation_steering_scope} | "
+            f"{'yes' if record.cross_repo_validation_primary_action_promoted else 'no'} | "
+            f"{record.cross_repo_validation_snapshot_status or ''} | "
+            f"{record.cross_repo_validation_packet_report_id or ''} | "
+            f"{len(record.immediate_actions)} | {len(record.target_lines)} | {record.generated_at_utc} |"
+        )
+        sections.extend(
+            [
+                "",
+                f"## `{record.packet_id}` local mission packet",
+                "",
+                f"- source_kind: `{record.source_kind}`",
+                f"- packet_path: `{record.packet_path}`",
+                f"- mission_objective: `{record.mission_objective or ''}`",
+                f"- primary_action: `{record.primary_action or ''}`",
+                f"- steering_scope: `{record.cross_repo_validation_steering_scope}`",
+                f"- primary_action_promoted: `{'true' if record.cross_repo_validation_primary_action_promoted else 'false'}`",
+                f"- cross_repo_snapshot_status: `{record.cross_repo_validation_snapshot_status or ''}`",
+                f"- cross_repo_snapshot_summary: `{record.cross_repo_validation_snapshot_summary or ''}`",
+            ]
+        )
+        if record.cross_repo_validation_packet_report_id or record.cross_repo_validation_packet_path:
+            sections.extend(["", "### Cross-Repo Validation Packet"])
+            if record.cross_repo_validation_packet_report_id:
+                sections.append(f"- report_id: `{record.cross_repo_validation_packet_report_id}`")
+            if record.cross_repo_validation_packet_path:
+                sections.append(f"- path: `{record.cross_repo_validation_packet_path}`")
+        if record.cross_repo_validation_detail_lines or record.monday_source_validation_report_lines:
+            sections.extend(
+                [
+                    "",
+                    "### Cross-Repo Validation Details",
+                    *[f"- {line}" for line in record.cross_repo_validation_detail_lines],
+                    *[f"- {line}" for line in record.monday_source_validation_report_lines],
+                ]
+            )
+        if record.cross_repo_validation_action_lines:
+            sections.extend(
+                [
+                    "",
+                    "### Cross-Repo Validation Actions",
+                    *[
+                        f"{index}. {line}"
+                        for index, line in enumerate(record.cross_repo_validation_action_lines, start=1)
+                    ],
+                ]
+            )
+    return "\n".join(lines + sections)
+
+
+def build_local_day_packet_record(*, packet_path: Path, packet_doc: dict[str, Any]) -> LocalDayPacketRecord:
+    day_packet = packet_doc.get("day_packet") if isinstance(packet_doc.get("day_packet"), dict) else {}
+    return LocalDayPacketRecord(
+        day_packet_id=str(packet_doc.get("day_packet_id")),
+        mission_packet_id=normalize_optional_string(day_packet.get("mission_packet_id")),
+        source_kind=source_kind_for_local_day_packet_path(packet_path),
+        packet_path=str(packet_path.resolve()),
+        generated_at_utc=str(packet_doc.get("generated_at_utc") or ""),
+        contract_ref=normalize_optional_string(packet_doc.get("contract_ref")),
+        latest_packet_path=normalize_artifact_path(resolve_nested_value(packet_doc, "artifact_paths", "latest_packet_path")),
+        stamped_packet_path=normalize_artifact_path(resolve_nested_value(packet_doc, "artifact_paths", "stamped_packet_path")),
+        output_path=normalize_artifact_path(resolve_nested_value(packet_doc, "artifact_paths", "output_path")),
+        headline=normalize_optional_string(day_packet.get("headline")),
+        mission_objective=normalize_optional_string(day_packet.get("mission_objective")),
+        primary_action=normalize_optional_string(day_packet.get("primary_action")),
+        cross_repo_validation_steering_scope=(
+            normalize_optional_string(day_packet.get("cross_repo_validation_steering_scope")) or "none"
+        ),
+        cross_repo_validation_primary_action_promoted=(
+            normalize_bool(day_packet.get("cross_repo_validation_primary_action_promoted")) or False
+        ),
+        planner_profile=normalize_optional_string(day_packet.get("planner_profile")),
+        launch_mode=normalize_optional_string(day_packet.get("launch_mode")),
+        local_model_route=normalize_optional_string(day_packet.get("local_model_route")),
+        local_validation_snapshot_status=normalize_optional_string(day_packet.get("local_validation_snapshot_status")),
+        cross_repo_validation_snapshot_status=normalize_optional_string(
+            day_packet.get("cross_repo_validation_snapshot_status")
+        ),
+        cross_repo_validation_snapshot_summary=normalize_optional_string(
+            day_packet.get("cross_repo_validation_snapshot_summary")
+        ),
+        cross_repo_validation_action_line=normalize_optional_string(
+            day_packet.get("cross_repo_validation_action_line")
+        ),
+        cross_repo_validation_packet_report_id=normalize_optional_string(
+            day_packet.get("cross_repo_validation_packet_report_id")
+        ),
+        cross_repo_validation_packet_path=normalize_optional_string(
+            day_packet.get("cross_repo_validation_packet_path")
+        ),
+        immediate_actions=normalize_string_list(day_packet.get("immediate_actions")),
+        target_lines=normalize_string_list(day_packet.get("target_lines")),
+        local_validation_action_lines=normalize_string_list(day_packet.get("local_validation_action_lines")),
+        cross_repo_validation_action_lines=normalize_string_list(day_packet.get("cross_repo_validation_action_lines")),
+        cross_repo_validation_detail_lines=normalize_string_list(day_packet.get("cross_repo_validation_detail_lines")),
+        monday_source_validation_report_lines=normalize_string_list(
+            day_packet.get("monday_source_validation_report_lines")
+        ),
+    )
+
+
+def discover_local_day_packet_records(*, validation_root: Path) -> list[LocalDayPacketRecord]:
+    paths: list[Path] = []
+    latest_path = validation_root / "monday-local-operator-day-packet.json"
+    if latest_path.exists():
+        paths.append(latest_path)
+    paths.extend(sorted(validation_root.glob("*-monday-local-operator-day-packet.json")))
+
+    records: list[LocalDayPacketRecord] = []
+    for path in paths:
+        if path.name.startswith(".") or path.name.startswith("._"):
+            continue
+        try:
+            doc = load_json(path)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if not is_local_day_packet_document(doc):
+            continue
+        records.append(build_local_day_packet_record(packet_path=path, packet_doc=doc))
+    records.sort(
+        key=lambda record: (
+            record.generated_at_utc,
+            record.day_packet_id,
+            1 if record.source_kind == "latest" else 0,
+            record.packet_path,
+        ),
+        reverse=True,
+    )
+    return records
+
+
+def filter_local_day_packet_records(
+    *,
+    records: list[LocalDayPacketRecord],
+    day_packet_id_prefix: str | None = None,
+    mission_packet_id_prefix: str | None = None,
+    source_kind: str = "latest",
+    planner_profile: str | None = None,
+    launch_mode: str | None = None,
+    local_model_route: str | None = None,
+    steering_scope: str | None = None,
+    primary_action_promoted: str | None = None,
+) -> list[LocalDayPacketRecord]:
+    filtered = records
+    if day_packet_id_prefix:
+        filtered = [record for record in filtered if record.day_packet_id.startswith(day_packet_id_prefix)]
+    if mission_packet_id_prefix:
+        filtered = [
+            record
+            for record in filtered
+            if record.mission_packet_id is not None and record.mission_packet_id.startswith(mission_packet_id_prefix)
+        ]
+    if source_kind != "all":
+        filtered = [record for record in filtered if record.source_kind == source_kind]
+    if planner_profile:
+        filtered = [record for record in filtered if record.planner_profile == planner_profile]
+    if launch_mode:
+        filtered = [record for record in filtered if record.launch_mode == launch_mode]
+    if local_model_route:
+        filtered = [record for record in filtered if record.local_model_route == local_model_route]
+    if steering_scope:
+        filtered = [record for record in filtered if record.cross_repo_validation_steering_scope == steering_scope]
+    if primary_action_promoted is not None:
+        expected = primary_action_promoted == "yes"
+        filtered = [
+            record for record in filtered if record.cross_repo_validation_primary_action_promoted is expected
+        ]
+    return filtered
+
+
+def render_local_day_packet_table(records: list[LocalDayPacketRecord]) -> str:
+    lines = [
+        "day_packet_id\tmission_packet_id\tsource\tplanner_profile\tlaunch_mode\tlocal_model_route\tsteering_scope\tprimary_action_promoted\tcross_repo_snapshot\tcross_repo_packet_report_id\timmediate_actions\ttargets\tgenerated_at_utc",
+    ]
+    for record in records:
+        lines.append(
+            "\t".join(
+                [
+                    record.day_packet_id,
+                    str(record.mission_packet_id or ""),
+                    record.source_kind,
+                    str(record.planner_profile or ""),
+                    str(record.launch_mode or ""),
+                    str(record.local_model_route or ""),
+                    record.cross_repo_validation_steering_scope,
+                    "yes" if record.cross_repo_validation_primary_action_promoted else "no",
+                    str(record.cross_repo_validation_snapshot_status or ""),
+                    str(record.cross_repo_validation_packet_report_id or ""),
+                    str(len(record.immediate_actions)),
+                    str(len(record.target_lines)),
+                    record.generated_at_utc,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_local_day_packet_markdown(records: list[LocalDayPacketRecord]) -> str:
+    lines = [
+        "| day_packet_id | mission_packet_id | source | planner_profile | launch_mode | local_model_route | steering_scope | primary_action_promoted | cross_repo_snapshot | cross_repo_packet_report_id | immediate_actions | targets | generated_at_utc |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | --- |",
+    ]
+    sections: list[str] = []
+    for record in records:
+        lines.append(
+            f"| `{record.day_packet_id}` | `{record.mission_packet_id or ''}` | {record.source_kind} | "
+            f"{record.planner_profile or ''} | {record.launch_mode or ''} | {record.local_model_route or ''} | "
+            f"{record.cross_repo_validation_steering_scope} | "
+            f"{'yes' if record.cross_repo_validation_primary_action_promoted else 'no'} | "
+            f"{record.cross_repo_validation_snapshot_status or ''} | "
+            f"{record.cross_repo_validation_packet_report_id or ''} | "
+            f"{len(record.immediate_actions)} | {len(record.target_lines)} | {record.generated_at_utc} |"
+        )
+        sections.extend(
+            [
+                "",
+                f"## `{record.day_packet_id}` local day packet",
+                "",
+                f"- source_kind: `{record.source_kind}`",
+                f"- packet_path: `{record.packet_path}`",
+                f"- headline: `{record.headline or ''}`",
+                f"- mission_objective: `{record.mission_objective or ''}`",
+                f"- primary_action: `{record.primary_action or ''}`",
+                f"- steering_scope: `{record.cross_repo_validation_steering_scope}`",
+                f"- primary_action_promoted: `{'true' if record.cross_repo_validation_primary_action_promoted else 'false'}`",
+                f"- cross_repo_snapshot_status: `{record.cross_repo_validation_snapshot_status or ''}`",
+                f"- cross_repo_snapshot_summary: `{record.cross_repo_validation_snapshot_summary or ''}`",
+            ]
+        )
+        if record.cross_repo_validation_packet_report_id or record.cross_repo_validation_packet_path:
+            sections.extend(["", "### Cross-Repo Validation Packet"])
+            if record.cross_repo_validation_packet_report_id:
+                sections.append(f"- report_id: `{record.cross_repo_validation_packet_report_id}`")
+            if record.cross_repo_validation_packet_path:
+                sections.append(f"- path: `{record.cross_repo_validation_packet_path}`")
+        if record.cross_repo_validation_detail_lines or record.monday_source_validation_report_lines:
+            sections.extend(
+                [
+                    "",
+                    "### Cross-Repo Validation Details",
+                    *[f"- {line}" for line in record.cross_repo_validation_detail_lines],
+                    *[f"- {line}" for line in record.monday_source_validation_report_lines],
+                ]
+            )
+        if record.cross_repo_validation_action_lines:
+            sections.extend(
+                [
+                    "",
+                    "### Cross-Repo Validation Actions",
+                    *[
+                        f"{index}. {line}"
+                        for index, line in enumerate(record.cross_repo_validation_action_lines, start=1)
+                    ],
+                ]
+            )
+    return "\n".join(lines + sections)
 
 
 def render_local_inbox_payload_table(records: list[LocalInboxPayloadRecord]) -> str:
@@ -6117,6 +6614,37 @@ def parse_args() -> argparse.Namespace:
     local_validation_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
     local_validation_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
 
+    local_mission_packet_parser = subparsers.add_parser(
+        "local-mission-packet",
+        help="list promoted monday local mission packets",
+    )
+    local_mission_packet_parser.add_argument("--packet-id-prefix", default=None)
+    local_mission_packet_parser.add_argument("--source-kind", choices=LOCAL_PACKET_SOURCE_CHOICES, default="latest")
+    local_mission_packet_parser.add_argument("--planner-profile", default=None)
+    local_mission_packet_parser.add_argument("--launch-mode", default=None)
+    local_mission_packet_parser.add_argument("--local-model-route", default=None)
+    local_mission_packet_parser.add_argument("--steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    local_mission_packet_parser.add_argument("--primary-action-promoted", choices=["yes", "no"], default=None)
+    local_mission_packet_parser.add_argument("--limit", type=int, default=20)
+    local_mission_packet_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    local_mission_packet_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+
+    local_day_packet_parser = subparsers.add_parser(
+        "local-day-packet",
+        help="list promoted monday local operator day packets",
+    )
+    local_day_packet_parser.add_argument("--day-packet-id-prefix", default=None)
+    local_day_packet_parser.add_argument("--mission-packet-id-prefix", default=None)
+    local_day_packet_parser.add_argument("--source-kind", choices=LOCAL_PACKET_SOURCE_CHOICES, default="latest")
+    local_day_packet_parser.add_argument("--planner-profile", default=None)
+    local_day_packet_parser.add_argument("--launch-mode", default=None)
+    local_day_packet_parser.add_argument("--local-model-route", default=None)
+    local_day_packet_parser.add_argument("--steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    local_day_packet_parser.add_argument("--primary-action-promoted", choices=["yes", "no"], default=None)
+    local_day_packet_parser.add_argument("--limit", type=int, default=20)
+    local_day_packet_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
+    local_day_packet_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
+
     local_inbox_payload_parser = subparsers.add_parser(
         "local-inbox-payload",
         help="list promoted monday local inbox payload bridge artifacts",
@@ -6254,6 +6782,51 @@ def main() -> int:
             print(render_local_validation_freshness_markdown(local_validation_records))
             return 0
         print(render_local_validation_freshness_table(local_validation_records))
+        return 0
+
+    if args.command == "local-mission-packet":
+        mission_packet_records = discover_local_mission_packet_records(validation_root=validation_root)
+        mission_packet_records = filter_local_mission_packet_records(
+            records=mission_packet_records,
+            packet_id_prefix=args.packet_id_prefix,
+            source_kind=args.source_kind,
+            planner_profile=args.planner_profile,
+            launch_mode=args.launch_mode,
+            local_model_route=args.local_model_route,
+            steering_scope=args.steering_scope,
+            primary_action_promoted=args.primary_action_promoted,
+        )
+        mission_packet_records = mission_packet_records[: args.limit]
+        if args.format == "json":
+            print(json.dumps({"records": [asdict(record) for record in mission_packet_records]}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_local_mission_packet_markdown(mission_packet_records))
+            return 0
+        print(render_local_mission_packet_table(mission_packet_records))
+        return 0
+
+    if args.command == "local-day-packet":
+        day_packet_records = discover_local_day_packet_records(validation_root=validation_root)
+        day_packet_records = filter_local_day_packet_records(
+            records=day_packet_records,
+            day_packet_id_prefix=args.day_packet_id_prefix,
+            mission_packet_id_prefix=args.mission_packet_id_prefix,
+            source_kind=args.source_kind,
+            planner_profile=args.planner_profile,
+            launch_mode=args.launch_mode,
+            local_model_route=args.local_model_route,
+            steering_scope=args.steering_scope,
+            primary_action_promoted=args.primary_action_promoted,
+        )
+        day_packet_records = day_packet_records[: args.limit]
+        if args.format == "json":
+            print(json.dumps({"records": [asdict(record) for record in day_packet_records]}, ensure_ascii=True, indent=2))
+            return 0
+        if args.format == "markdown":
+            print(render_local_day_packet_markdown(day_packet_records))
+            return 0
+        print(render_local_day_packet_table(day_packet_records))
         return 0
 
     if args.command == "local-inbox-payload":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -666,6 +666,10 @@ LOCAL_VALIDATION_WITH_CONSUMER_OUTPUT="$TMP_DIR/local-validation-freshness-with-
 LOCAL_VALIDATION_WITH_CROSS_REPO_REPORT_OUTPUT="$TMP_DIR/local-validation-freshness-with-cross-repo-report.json"
 LOCAL_VALIDATION_CROSS_REPO_REPORT_OUTPUT="$TMP_DIR/local-validation-cross-repo-report.json"
 LOCAL_VALIDATION_RUNTIME_BLOCKED_OUTPUT="$TMP_DIR/local-validation-runtime-blocked.json"
+LOCAL_MISSION_PACKET_OUTPUT="$TMP_DIR/local-mission-packet.json"
+LOCAL_MISSION_PACKET_STEERED_OUTPUT="$TMP_DIR/local-mission-packet-steered.json"
+LOCAL_DAY_PACKET_OUTPUT="$TMP_DIR/local-day-packet.json"
+LOCAL_DAY_PACKET_STEERED_OUTPUT="$TMP_DIR/local-day-packet-steered.json"
 LOCAL_INBOX_PAYLOAD_OUTPUT="$TMP_DIR/local-inbox-payload.json"
 LOCAL_INBOX_PAYLOAD_ALL_OUTPUT="$TMP_DIR/local-inbox-payload-all.json"
 LOCAL_INBOX_PAYLOAD_FILTERED_OUTPUT="$TMP_DIR/local-inbox-payload-filtered.json"
@@ -1964,6 +1968,23 @@ cat >"$VALIDATION_DIR/monday-local-mission-packet.json" <<'JSON'
     "local_runtime_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
     "local_runtime_next_step": "Expose Codex and add a direct local LLM profile.",
     "primary_action": "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "cross_repo_validation_steering_scope": "none",
+    "cross_repo_validation_primary_action_promoted": false,
+    "cross_repo_validation_snapshot_status": "present",
+    "cross_repo_validation_snapshot_summary": "total=5 promotable=3 blocked=2 stale=0",
+    "cross_repo_validation_action_line": "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)",
+    "cross_repo_validation_detail_lines": [
+      "monday_local_inbox_launch_request: freshness=fresh promotability=promotable",
+      "monday_local_inbox_runtime_report: freshness=missing promotability=blocked reasons=latest_missing"
+    ],
+    "monday_source_validation_report_lines": [
+      "consumer-report schema verdict=pass errors=0 warnings=0"
+    ],
+    "cross_repo_validation_action_lines": [
+      "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)"
+    ],
+    "cross_repo_validation_packet_report_id": "cross-repo-validation-20260401T110000Z",
+    "cross_repo_validation_packet_path": "VALIDATION_ROOT_PLACEHOLDER/cross-repo-validation-report.json",
     "immediate_actions": [
       "local-runtime: Expose Codex and add a direct local LLM profile."
     ],
@@ -1997,11 +2018,36 @@ doc["mission_packet"]["expected_evidence_outputs"] = [
     str((validation_dir / "monday-local-mission-packet.json").resolve()),
     str((validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").resolve()),
 ]
+doc["mission_packet"]["cross_repo_validation_packet_path"] = str(
+    (validation_dir / "cross-repo-validation-report.json").resolve()
+)
 doc["mission_packet"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
 doc["mission_packet"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
 payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
 path.write_text(payload, encoding="utf-8")
 (validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").write_text(payload, encoding="utf-8")
+
+steered_doc = json.loads(payload)
+steered_doc["generated_at_utc"] = "2026-04-01T08:02:00+00:00"
+steered_doc["packet_id"] = "monday-local-mission-20260401T080200Z"
+steered_doc["artifact_paths"]["stamped_packet_path"] = str(
+    (validation_dir / "monday-local-mission-20260401T080200Z-monday-local-mission-packet.json").resolve()
+)
+steered_doc["mission_packet"]["packet_id"] = "monday-local-mission-20260401T080200Z"
+steered_doc["mission_packet"]["primary_action"] = (
+    "cross-repo-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=missing, promotability=blocked, reasons=latest_missing)"
+)
+steered_doc["mission_packet"]["cross_repo_validation_steering_scope"] = "primary_action_only"
+steered_doc["mission_packet"]["cross_repo_validation_primary_action_promoted"] = True
+steered_doc["mission_packet"]["immediate_actions"] = [
+    steered_doc["mission_packet"]["primary_action"],
+    "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+]
+(validation_dir / "monday-local-mission-20260401T080200Z-monday-local-mission-packet.json").write_text(
+    json.dumps(steered_doc, ensure_ascii=True, indent=2) + "\n",
+    encoding="utf-8",
+)
 PY
 
 cat >"$VALIDATION_DIR/monday-local-operator-day-packet.json" <<'JSON'
@@ -2020,6 +2066,9 @@ cat >"$VALIDATION_DIR/monday-local-operator-day-packet.json" <<'JSON'
     "mission_packet_id": "monday-local-mission-20260401T080000Z",
     "headline": "Monday local operator day packet: Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
     "mission_objective": "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+    "primary_action": "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "cross_repo_validation_steering_scope": "none",
+    "cross_repo_validation_primary_action_promoted": false,
     "mission_prompt": "Use monday planner profile `local_ollama` via `direct_local_ollama`.",
     "planner_profile": "local_ollama",
     "launch_mode": "direct",
@@ -2040,6 +2089,21 @@ cat >"$VALIDATION_DIR/monday-local-operator-day-packet.json" <<'JSON'
       "local-validation: repair operator_handoff_report (freshness=stale, promotability=blocked, reasons=stamped_missing)",
       "local-validation: repair monday_local_mission_packet (freshness=fresh, promotability=blocked, reasons=missing_rollback_command)"
     ],
+    "cross_repo_validation_snapshot_status": "present",
+    "cross_repo_validation_snapshot_summary": "total=5 promotable=3 blocked=2 stale=0",
+    "cross_repo_validation_action_line": "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)",
+    "cross_repo_validation_detail_lines": [
+      "monday_local_inbox_launch_request: freshness=fresh promotability=promotable",
+      "monday_local_inbox_runtime_report: freshness=missing promotability=blocked reasons=latest_missing"
+    ],
+    "monday_source_validation_report_lines": [
+      "consumer-report schema verdict=pass errors=0 warnings=0"
+    ],
+    "cross_repo_validation_action_lines": [
+      "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)"
+    ],
+    "cross_repo_validation_packet_report_id": "cross-repo-validation-20260401T110000Z",
+    "cross_repo_validation_packet_path": "VALIDATION_ROOT_PLACEHOLDER/cross-repo-validation-report.json",
     "queue_lines": [
       "active: targets=1 newest=federated-ci-local/federated-ci-local-20260301 domains=checkpoint=1,readiness=1,reconcile=1"
     ],
@@ -2080,12 +2144,44 @@ doc["day_packet"]["attachments"] = [
     str((validation_dir / "operator-handoff-report.json").resolve()),
     str((validation_dir / "monday-local-operator-stack-report.json").resolve()),
 ]
+doc["day_packet"]["cross_repo_validation_packet_path"] = str(
+    (validation_dir / "cross-repo-validation-report.json").resolve()
+)
 doc["day_packet"]["source_artifacts"]["mission_packet_path"] = str((validation_dir / "monday-local-mission-packet.json").resolve())
 doc["day_packet"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
 doc["day_packet"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
 payload = json.dumps(doc, ensure_ascii=True, indent=2) + "\n"
 path.write_text(payload, encoding="utf-8")
 (validation_dir / "monday-local-day-20260401T083000Z-monday-local-operator-day-packet.json").write_text(payload, encoding="utf-8")
+
+steered_doc = json.loads(payload)
+steered_doc["generated_at_utc"] = "2026-04-01T08:31:00+00:00"
+steered_doc["day_packet_id"] = "monday-local-day-20260401T083100Z"
+steered_doc["artifact_paths"]["stamped_packet_path"] = str(
+    (validation_dir / "monday-local-day-20260401T083100Z-monday-local-operator-day-packet.json").resolve()
+)
+steered_doc["day_packet"]["day_packet_id"] = "monday-local-day-20260401T083100Z"
+steered_doc["day_packet"]["mission_packet_id"] = "monday-local-mission-20260401T080200Z"
+steered_doc["day_packet"]["primary_action"] = (
+    "cross-repo-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=missing, promotability=blocked, reasons=latest_missing)"
+)
+steered_doc["day_packet"]["cross_repo_validation_steering_scope"] = "primary_action_only"
+steered_doc["day_packet"]["cross_repo_validation_primary_action_promoted"] = True
+steered_doc["day_packet"]["headline"] = (
+    "Monday local operator day packet: Resolve [active/latest-gap] federated-ci-local -> "
+    "federated-ci-local-20260301 domains=checkpoint,readiness,reconcile | next action: "
+    "cross-repo-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=missing, promotability=blocked, reasons=latest_missing)"
+)
+steered_doc["day_packet"]["immediate_actions"] = [
+    steered_doc["day_packet"]["primary_action"],
+    "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+]
+(validation_dir / "monday-local-day-20260401T083100Z-monday-local-operator-day-packet.json").write_text(
+    json.dumps(steered_doc, ensure_ascii=True, indent=2) + "\n",
+    encoding="utf-8",
+)
 PY
 
 cat >"$VALIDATION_DIR/monday-local-operator-inbox-payload.json" <<'JSON'
@@ -2992,6 +3088,23 @@ cat >"$VALIDATION_DIR/monday-local-mission-packet.json" <<'JSON'
     "local_runtime_summary": "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked stack=skipped direct=skipped mode=both reason=readiness_blocked",
     "local_runtime_next_step": "Expose Codex and add a direct local LLM profile.",
     "primary_action": "local-runtime: Expose Codex and add a direct local LLM profile.",
+    "cross_repo_validation_steering_scope": "none",
+    "cross_repo_validation_primary_action_promoted": false,
+    "cross_repo_validation_snapshot_status": "present",
+    "cross_repo_validation_snapshot_summary": "total=5 promotable=3 blocked=2 stale=0",
+    "cross_repo_validation_action_line": "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)",
+    "cross_repo_validation_detail_lines": [
+      "monday_local_inbox_launch_request: freshness=fresh promotability=promotable",
+      "monday_local_inbox_runtime_report: freshness=missing promotability=blocked reasons=latest_missing"
+    ],
+    "monday_source_validation_report_lines": [
+      "consumer-report schema verdict=pass errors=0 warnings=0"
+    ],
+    "cross_repo_validation_action_lines": [
+      "cross-repo-validation: repair monday_local_inbox_runtime_report (freshness=missing, promotability=blocked, reasons=latest_missing)"
+    ],
+    "cross_repo_validation_packet_report_id": "cross-repo-validation-20260401T110000Z",
+    "cross_repo_validation_packet_path": "VALIDATION_ROOT_PLACEHOLDER/cross-repo-validation-report.json",
     "immediate_actions": [
       "local-runtime: Expose Codex and add a direct local LLM profile."
     ],
@@ -3025,6 +3138,9 @@ doc["mission_packet"]["expected_evidence_outputs"] = [
     str((validation_dir / "monday-local-mission-packet.json").resolve()),
     str((validation_dir / "monday-local-mission-20260401T080000Z-monday-local-mission-packet.json").resolve()),
 ]
+doc["mission_packet"]["cross_repo_validation_packet_path"] = str(
+    (validation_dir / "cross-repo-validation-report.json").resolve()
+)
 doc["mission_packet"]["source_artifacts"]["handoff_report_path"] = str((validation_dir / "operator-handoff-report.json").resolve())
 doc["mission_packet"]["source_artifacts"]["local_operator_report_path"] = str((validation_dir / "monday-local-operator-stack-report.json").resolve())
 path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
@@ -3032,6 +3148,119 @@ path.write_text(json.dumps(doc, ensure_ascii=True, indent=2) + "\n", encoding="u
     json.dumps(doc, ensure_ascii=True, indent=2) + "\n",
     encoding="utf-8",
 )
+
+steered_doc = json.loads(path.read_text(encoding="utf-8"))
+steered_doc["generated_at_utc"] = "2026-04-01T08:02:00+00:00"
+steered_doc["packet_id"] = "monday-local-mission-20260401T080200Z"
+steered_doc["artifact_paths"]["stamped_packet_path"] = str(
+    (validation_dir / "monday-local-mission-20260401T080200Z-monday-local-mission-packet.json").resolve()
+)
+steered_doc["mission_packet"]["packet_id"] = "monday-local-mission-20260401T080200Z"
+steered_doc["mission_packet"]["primary_action"] = (
+    "cross-repo-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=missing, promotability=blocked, reasons=latest_missing)"
+)
+steered_doc["mission_packet"]["cross_repo_validation_steering_scope"] = "primary_action_only"
+steered_doc["mission_packet"]["cross_repo_validation_primary_action_promoted"] = True
+steered_doc["mission_packet"]["immediate_actions"] = [
+    steered_doc["mission_packet"]["primary_action"],
+    "triage-target: [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
+]
+(validation_dir / "monday-local-mission-20260401T080200Z-monday-local-mission-packet.json").write_text(
+    json.dumps(steered_doc, ensure_ascii=True, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+python3 "$QUERY_PATH" local-mission-packet \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_MISSION_PACKET_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_MISSION_PACKET_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["packet_id"] == "monday-local-mission-20260401T080000Z", record
+assert record["source_kind"] == "latest", record
+assert record["primary_action"] == "local-runtime: Expose Codex and add a direct local LLM profile.", record
+assert record["cross_repo_validation_steering_scope"] == "none", record
+assert record["cross_repo_validation_primary_action_promoted"] is False, record
+assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
+assert record["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), record
+assert record["cross_repo_validation_snapshot_status"] == "present", record
+PY
+
+python3 "$QUERY_PATH" local-mission-packet \
+  --source-kind stamped \
+  --steering-scope primary_action_only \
+  --primary-action-promoted yes \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_MISSION_PACKET_STEERED_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_MISSION_PACKET_STEERED_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["packet_id"] == "monday-local-mission-20260401T080200Z", record
+assert record["source_kind"] == "stamped", record
+assert record["cross_repo_validation_steering_scope"] == "primary_action_only", record
+assert record["cross_repo_validation_primary_action_promoted"] is True, record
+assert record["primary_action"].startswith("cross-repo-validation: repair monday_local_inbox_runtime_report"), record
+PY
+
+python3 "$QUERY_PATH" local-day-packet \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_DAY_PACKET_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_DAY_PACKET_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["day_packet_id"] == "monday-local-day-20260401T083000Z", record
+assert record["source_kind"] == "latest", record
+assert record["cross_repo_validation_steering_scope"] == "none", record
+assert record["cross_repo_validation_primary_action_promoted"] is False, record
+assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
+assert record["headline"].startswith("Monday local operator day packet: Resolve [active/latest-gap]"), record
+PY
+
+python3 "$QUERY_PATH" local-day-packet \
+  --source-kind stamped \
+  --steering-scope primary_action_only \
+  --primary-action-promoted yes \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_DAY_PACKET_STEERED_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_DAY_PACKET_STEERED_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["day_packet_id"] == "monday-local-day-20260401T083100Z", record
+assert record["source_kind"] == "stamped", record
+assert record["cross_repo_validation_steering_scope"] == "primary_action_only", record
+assert record["cross_repo_validation_primary_action_promoted"] is True, record
+assert "| next action: cross-repo-validation: repair monday_local_inbox_runtime_report" in record["headline"], record
+assert record["primary_action"].startswith("cross-repo-validation: repair monday_local_inbox_runtime_report"), record
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \


### PR DESCRIPTION
## Scope
- add dedicated `local-mission-packet` and `local-day-packet` query surfaces to the federated query engine
- expose action-only cross-repo steering metadata, source kind, and immutable packet linkage directly from promoted mission/day packets
- cover latest and stamped mission/day packet records with regression fixtures and filtering assertions

## Summary
- `query_federated_ci_artifacts.py` now supports `local-mission-packet` and `local-day-packet` commands with filters for source kind, steering scope, action promotion, planner profile, launch mode, and local model route
- `test_query_federated_ci_artifacts.sh` now exercises latest and stamped mission/day packet queries, including steered cross-repo action cases
- the rollout plan now records mission/day packet query surfaces as the canonical steering-audit path and moves the next packet to downstream steering metadata exposure decisions

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1008

## Risks
- query regressions depend on synthetic packet fixtures that must stay aligned with mission/day packet contracts as those writers evolve
- mission/day steering metadata remains query-only in this packet, so downstream surfaces still need an explicit follow-up if they should mirror these policy fields

## Review Checklist
- [x] query engine exposes both latest and stamped mission/day packet records
- [x] steering metadata is filterable without reopening raw packet JSON
- [x] regression coverage includes a cross-repo-steered mission/day packet case
- [x] rollout plan records the new operator read path and next packet boundary

## Post-Deploy Monitoring & Validation
- confirm `template-and-link-check`, `docs-check`, `contract-conformance`, `federated-conformance`, and `o11y-replay` pass on the PR
- confirm only the inherited runtime/profile/harness guardrail lanes remain red before admin merge
- spot-check `local-mission-packet` and `local-day-packet` output against promoted validation artifacts in the next operator packet follow-up
