### PR TITLE
feat(query-engine): mirror mission and day steering metadata downstream

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -203,6 +203,7 @@ Current deliverables:
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now fail-closed promote `cross_repo_validation_action_line` into mission/day action selection only when no stronger `local-runtime:` or `local-validation:` action already exists and an immutable promoted packet pointer is present
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now emit explicit `cross_repo_validation_steering_scope` and `cross_repo_validation_primary_action_promoted` fields so downstream packet readers can see that cross-repo validation may steer selected action but does not rewrite `mission_objective` or target ranking
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-mission-packet|local-day-packet` now expose latest/stamped mission/day packet records directly, including `cross_repo_validation_steering_scope`, `cross_repo_validation_primary_action_promoted`, packet source kind, and immutable cross-repo packet linkage so operators can audit action-only steering without reopening raw packet JSON
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report|local-inbox-payload|monday-consumer-report` now mirror mission/day steering metadata directly so summary-first, payload-first, and apply/result-first operator surfaces can see whether cross-repo validation only steered `primary_action` without reopening the dedicated mission/day packet queries
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -265,4 +266,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether `local-inbox-payload|monday-consumer-report|triage-*` should mirror mission/day steering metadata directly, or whether the new `local-mission-packet|local-day-packet` query surfaces should stay the canonical read path for action-only steering policy
+2. decide whether downstream surfaces need explicit filters for mission/day steering metadata, or whether the new mirrored visibility plus `local-mission-packet|local-day-packet` query surfaces are enough and filtering should stay packet-local

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -266,6 +266,10 @@ class TriageFeedRecord:
     queue_records: list[TriageQueueRecord]
     target_records: list[TriageTargetRecord]
     local_operator_record: LocalOperatorStackRecord | None
+    mission_packet_cross_repo_validation_steering_scope: str | None
+    mission_packet_cross_repo_validation_primary_action_promoted: bool | None
+    day_packet_cross_repo_validation_steering_scope: str | None
+    day_packet_cross_repo_validation_primary_action_promoted: bool | None
     cross_repo_validation_snapshot_status: str | None
     cross_repo_validation_snapshot_summary: str | None
     monday_source_validation_status: str | None
@@ -294,6 +298,10 @@ class TriageBriefRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    mission_packet_cross_repo_validation_steering_scope: str | None
+    mission_packet_cross_repo_validation_primary_action_promoted: bool | None
+    day_packet_cross_repo_validation_steering_scope: str | None
+    day_packet_cross_repo_validation_primary_action_promoted: bool | None
     cross_repo_validation_snapshot_status: str | None
     cross_repo_validation_snapshot_summary: str | None
     monday_source_validation_status: str | None
@@ -319,6 +327,10 @@ class TriageReportRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    mission_packet_cross_repo_validation_steering_scope: str | None
+    mission_packet_cross_repo_validation_primary_action_promoted: bool | None
+    day_packet_cross_repo_validation_steering_scope: str | None
+    day_packet_cross_repo_validation_primary_action_promoted: bool | None
     cross_repo_validation_snapshot_status: str | None
     cross_repo_validation_snapshot_summary: str | None
     monday_source_validation_status: str | None
@@ -477,6 +489,10 @@ class LocalInboxPayloadRecord:
     planner_profile: str | None
     launch_mode: str | None
     local_model_route: str | None
+    mission_packet_cross_repo_validation_steering_scope: str | None
+    mission_packet_cross_repo_validation_primary_action_promoted: bool | None
+    day_packet_cross_repo_validation_steering_scope: str | None
+    day_packet_cross_repo_validation_primary_action_promoted: bool | None
     local_validation_snapshot_status: str | None
     monday_validation_snapshot_status: str
     monday_validation_snapshot_summary: str
@@ -579,6 +595,10 @@ class MondayConsumerReportRecord:
     planner_profile: str | None
     launch_mode: str | None
     local_model_route: str | None
+    mission_packet_cross_repo_validation_steering_scope: str | None
+    mission_packet_cross_repo_validation_primary_action_promoted: bool | None
+    day_packet_cross_repo_validation_steering_scope: str | None
+    day_packet_cross_repo_validation_primary_action_promoted: bool | None
     local_validation_snapshot_status: str | None
     monday_validation_snapshot_status: str
     monday_validation_snapshot_summary: str
@@ -1305,6 +1325,8 @@ def build_local_inbox_payload_record(
     bridge_id = str(payload_doc.get("bridge_id"))
     payload = payload_doc.get("payload") if isinstance(payload_doc.get("payload"), dict) else {}
     source_artifacts = payload.get("source_artifacts") if isinstance(payload.get("source_artifacts"), dict) else {}
+    mission_packet_record = load_local_mission_packet_record_for_path(source_artifacts.get("mission_packet_path"))
+    day_packet_record = load_local_day_packet_record_for_path(source_artifacts.get("day_packet_path"))
     dependency_states: dict[str, str] = {}
     dependency_states["monday_local_operator_day_packet"] = build_local_validation_dependency_state(
         raw_path=source_artifacts.get("day_packet_path"),
@@ -1370,6 +1392,20 @@ def build_local_inbox_payload_record(
         planner_profile=normalize_optional_string(payload.get("planner_profile")),
         launch_mode=normalize_optional_string(payload.get("launch_mode")),
         local_model_route=normalize_optional_string(payload.get("local_model_route")),
+        mission_packet_cross_repo_validation_steering_scope=(
+            None if mission_packet_record is None else mission_packet_record.cross_repo_validation_steering_scope
+        ),
+        mission_packet_cross_repo_validation_primary_action_promoted=(
+            None
+            if mission_packet_record is None
+            else mission_packet_record.cross_repo_validation_primary_action_promoted
+        ),
+        day_packet_cross_repo_validation_steering_scope=(
+            None if day_packet_record is None else day_packet_record.cross_repo_validation_steering_scope
+        ),
+        day_packet_cross_repo_validation_primary_action_promoted=(
+            None if day_packet_record is None else day_packet_record.cross_repo_validation_primary_action_promoted
+        ),
         local_validation_snapshot_status=normalize_optional_string(payload.get("local_validation_snapshot_status")),
         monday_validation_snapshot_status=monday_validation_snapshot_status,
         monday_validation_snapshot_summary=monday_validation_snapshot_summary,
@@ -1751,6 +1787,42 @@ def discover_local_day_packet_records(*, validation_root: Path) -> list[LocalDay
     return records
 
 
+def load_local_mission_packet_record_for_path(raw_path: Any) -> LocalMissionPacketRecord | None:
+    packet_path = resolve_artifact_path(raw_path)
+    if packet_path is None:
+        return None
+    packet_doc = load_optional_json(packet_path)
+    if packet_doc is None or not is_local_mission_packet_document(packet_doc):
+        return None
+    return build_local_mission_packet_record(packet_path=packet_path, packet_doc=packet_doc)
+
+
+def load_local_day_packet_record_for_path(raw_path: Any) -> LocalDayPacketRecord | None:
+    packet_path = resolve_artifact_path(raw_path)
+    if packet_path is None:
+        return None
+    packet_doc = load_optional_json(packet_path)
+    if packet_doc is None or not is_local_day_packet_document(packet_doc):
+        return None
+    return build_local_day_packet_record(packet_path=packet_path, packet_doc=packet_doc)
+
+
+def select_latest_local_mission_packet_record(*, validation_root: Path) -> LocalMissionPacketRecord | None:
+    records = discover_local_mission_packet_records(validation_root=validation_root)
+    for record in records:
+        if record.source_kind == "latest":
+            return record
+    return records[0] if records else None
+
+
+def select_latest_local_day_packet_record(*, validation_root: Path) -> LocalDayPacketRecord | None:
+    records = discover_local_day_packet_records(validation_root=validation_root)
+    for record in records:
+        if record.source_kind == "latest":
+            return record
+    return records[0] if records else None
+
+
 def filter_local_day_packet_records(
     *,
     records: list[LocalDayPacketRecord],
@@ -1880,7 +1952,7 @@ def render_local_day_packet_markdown(records: list[LocalDayPacketRecord]) -> str
 
 def render_local_inbox_payload_table(records: list[LocalInboxPayloadRecord]) -> str:
     lines = [
-        "bridge_id\tsource\tstatus\tattention\tmessage_class\tretry_mode\tplanner_profile\tlaunch_mode\tlocal_model_route\tvalidation_snapshot\tmonday_validation_snapshot\tcross_repo_packet_report_id\tcross_repo_packet_path\tdependencies\timmediate_actions\ttargets\tattachments\tgenerated_at_utc",
+        "bridge_id\tsource\tstatus\tattention\tmessage_class\tretry_mode\tplanner_profile\tlaunch_mode\tlocal_model_route\tmission_packet_steering_scope\tmission_packet_primary_action_promoted\tday_packet_steering_scope\tday_packet_primary_action_promoted\tvalidation_snapshot\tmonday_validation_snapshot\tcross_repo_packet_report_id\tcross_repo_packet_path\tdependencies\timmediate_actions\ttargets\tattachments\tgenerated_at_utc",
     ]
     for record in records:
         lines.append(
@@ -1899,6 +1971,22 @@ def render_local_inbox_payload_table(records: list[LocalInboxPayloadRecord]) -> 
                     str(record.planner_profile or ""),
                     str(record.launch_mode or ""),
                     str(record.local_model_route or ""),
+                    str(record.mission_packet_cross_repo_validation_steering_scope or ""),
+                    (
+                        ""
+                        if record.mission_packet_cross_repo_validation_primary_action_promoted is None
+                        else (
+                            "yes"
+                            if record.mission_packet_cross_repo_validation_primary_action_promoted
+                            else "no"
+                        )
+                    ),
+                    str(record.day_packet_cross_repo_validation_steering_scope or ""),
+                    (
+                        ""
+                        if record.day_packet_cross_repo_validation_primary_action_promoted is None
+                        else ("yes" if record.day_packet_cross_repo_validation_primary_action_promoted else "no")
+                    ),
                     str(record.local_validation_snapshot_status or ""),
                     record.monday_validation_snapshot_status,
                     str(record.cross_repo_validation_packet_report_id or ""),
@@ -1916,8 +2004,8 @@ def render_local_inbox_payload_table(records: list[LocalInboxPayloadRecord]) -> 
 
 def render_local_inbox_payload_markdown(records: list[LocalInboxPayloadRecord]) -> str:
     lines = [
-        "| bridge_id | source | status | attention | message_class | retry_mode | planner_profile | launch_mode | local_model_route | validation_snapshot | monday_validation_snapshot | cross_repo_packet_report_id | cross_repo_packet_path | dependencies | immediate_actions | targets | attachments | generated_at_utc |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- |",
+        "| bridge_id | source | status | attention | message_class | retry_mode | planner_profile | launch_mode | local_model_route | mission_packet_steering_scope | mission_packet_primary_action_promoted | day_packet_steering_scope | day_packet_primary_action_promoted | validation_snapshot | monday_validation_snapshot | cross_repo_packet_report_id | cross_repo_packet_path | dependencies | immediate_actions | targets | attachments | generated_at_utc |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- |",
     ]
     sections: list[str] = []
     for record in records:
@@ -1926,6 +2014,10 @@ def render_local_inbox_payload_markdown(records: list[LocalInboxPayloadRecord]) 
             f"{'' if record.needs_human_attention is None else ('yes' if record.needs_human_attention else 'no')} | "
             f"{record.message_class_hint or ''} | {record.retry_mode or ''} | {record.planner_profile or ''} | "
             f"{record.launch_mode or ''} | {record.local_model_route or ''} | "
+            f"{record.mission_packet_cross_repo_validation_steering_scope or ''} | "
+            f"{'' if record.mission_packet_cross_repo_validation_primary_action_promoted is None else ('yes' if record.mission_packet_cross_repo_validation_primary_action_promoted else 'no')} | "
+            f"{record.day_packet_cross_repo_validation_steering_scope or ''} | "
+            f"{'' if record.day_packet_cross_repo_validation_primary_action_promoted is None else ('yes' if record.day_packet_cross_repo_validation_primary_action_promoted else 'no')} | "
             f"{record.local_validation_snapshot_status or ''} | "
             f"{record.monday_validation_snapshot_status} | "
             f"{record.cross_repo_validation_packet_report_id or ''} | "
@@ -1935,6 +2027,30 @@ def render_local_inbox_payload_markdown(records: list[LocalInboxPayloadRecord]) 
             f"{record.generated_at_utc} |"
         )
         detail_lines: list[str] = []
+        if record.mission_packet_cross_repo_validation_steering_scope is not None:
+            detail_lines.append(
+                f"- mission packet steering scope: `{record.mission_packet_cross_repo_validation_steering_scope}`"
+            )
+        if record.mission_packet_cross_repo_validation_primary_action_promoted is not None:
+            detail_lines.append(
+                "- mission packet primary action promoted: `"
+                + (
+                    "true"
+                    if record.mission_packet_cross_repo_validation_primary_action_promoted
+                    else "false"
+                )
+                + "`"
+            )
+        if record.day_packet_cross_repo_validation_steering_scope is not None:
+            detail_lines.append(
+                f"- day packet steering scope: `{record.day_packet_cross_repo_validation_steering_scope}`"
+            )
+        if record.day_packet_cross_repo_validation_primary_action_promoted is not None:
+            detail_lines.append(
+                "- day packet primary action promoted: `"
+                + ("true" if record.day_packet_cross_repo_validation_primary_action_promoted else "false")
+                + "`"
+            )
         if record.cross_repo_validation_packet_report_id is not None:
             detail_lines.append(
                 f"- detail packet report id: `{record.cross_repo_validation_packet_report_id}`"
@@ -1979,6 +2095,11 @@ def build_monday_consumer_report_record(
 ) -> MondayConsumerReportRecord:
     artifact_paths = report_doc.get("artifact_paths") if isinstance(report_doc.get("artifact_paths"), dict) else {}
     launch_request = report_doc.get("launch_request") if isinstance(report_doc.get("launch_request"), dict) else {}
+    source_artifacts = (
+        launch_request.get("source_artifacts") if isinstance(launch_request.get("source_artifacts"), dict) else {}
+    )
+    mission_packet_record = load_local_mission_packet_record_for_path(source_artifacts.get("mission_packet_path"))
+    day_packet_record = load_local_day_packet_record_for_path(source_artifacts.get("day_packet_path"))
     runtime_input_overrides = (
         launch_request.get("runtime_input_overrides") if isinstance(launch_request.get("runtime_input_overrides"), dict) else {}
     )
@@ -2045,6 +2166,20 @@ def build_monday_consumer_report_record(
         planner_profile=normalize_optional_string(launch_request.get("planner_profile")),
         launch_mode=normalize_optional_string(launch_request.get("launch_mode")),
         local_model_route=normalize_optional_string(launch_request.get("local_model_route")),
+        mission_packet_cross_repo_validation_steering_scope=(
+            None if mission_packet_record is None else mission_packet_record.cross_repo_validation_steering_scope
+        ),
+        mission_packet_cross_repo_validation_primary_action_promoted=(
+            None
+            if mission_packet_record is None
+            else mission_packet_record.cross_repo_validation_primary_action_promoted
+        ),
+        day_packet_cross_repo_validation_steering_scope=(
+            None if day_packet_record is None else day_packet_record.cross_repo_validation_steering_scope
+        ),
+        day_packet_cross_repo_validation_primary_action_promoted=(
+            None if day_packet_record is None else day_packet_record.cross_repo_validation_primary_action_promoted
+        ),
         local_validation_snapshot_status=normalize_optional_string(launch_request.get("local_validation_snapshot_status")),
         monday_validation_snapshot_status=monday_validation_snapshot_status,
         monday_validation_snapshot_summary=monday_validation_snapshot_summary,
@@ -2155,7 +2290,7 @@ def filter_monday_consumer_report_records(
 
 def render_monday_consumer_report_table(records: list[MondayConsumerReportRecord]) -> str:
     lines = [
-        "run_id\tmode\tverdict\treason_code\tconsumer_status\tcan_launch\tplanner_profile\tlaunch_mode\tlocal_model_route\tmonday_validation_snapshot\tcross_repo_packet_report_id\tcross_repo_packet_path\thas_runtime_overrides\toverride_kinds\texecution_attempted\texecution_exit_code\truntime_report_verdict\thas_runtime_report\tblock_reasons\tgenerated_at_utc",
+        "run_id\tmode\tverdict\treason_code\tconsumer_status\tcan_launch\tplanner_profile\tlaunch_mode\tlocal_model_route\tmission_packet_steering_scope\tmission_packet_primary_action_promoted\tday_packet_steering_scope\tday_packet_primary_action_promoted\tmonday_validation_snapshot\tcross_repo_packet_report_id\tcross_repo_packet_path\thas_runtime_overrides\toverride_kinds\texecution_attempted\texecution_exit_code\truntime_report_verdict\thas_runtime_report\tblock_reasons\tgenerated_at_utc",
     ]
     for record in records:
         lines.append(
@@ -2170,6 +2305,22 @@ def render_monday_consumer_report_table(records: list[MondayConsumerReportRecord
                     str(record.planner_profile or ""),
                     str(record.launch_mode or ""),
                     str(record.local_model_route or ""),
+                    str(record.mission_packet_cross_repo_validation_steering_scope or ""),
+                    (
+                        ""
+                        if record.mission_packet_cross_repo_validation_primary_action_promoted is None
+                        else (
+                            "yes"
+                            if record.mission_packet_cross_repo_validation_primary_action_promoted
+                            else "no"
+                        )
+                    ),
+                    str(record.day_packet_cross_repo_validation_steering_scope or ""),
+                    (
+                        ""
+                        if record.day_packet_cross_repo_validation_primary_action_promoted is None
+                        else ("yes" if record.day_packet_cross_repo_validation_primary_action_promoted else "no")
+                    ),
                     record.monday_validation_snapshot_status,
                     str(record.cross_repo_validation_packet_report_id or ""),
                     str(record.cross_repo_validation_packet_path or ""),
@@ -2193,8 +2344,8 @@ def render_monday_consumer_report_table(records: list[MondayConsumerReportRecord
 
 def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRecord]) -> str:
     lines = [
-        "| run_id | mode | verdict | reason_code | consumer_status | can_launch | planner_profile | launch_mode | local_model_route | monday_validation_snapshot | cross_repo_packet_report_id | cross_repo_packet_path | has_runtime_overrides | override_kinds | execution_attempted | execution_exit_code | runtime_report_verdict | has_runtime_report | block_reasons | generated_at_utc |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
+        "| run_id | mode | verdict | reason_code | consumer_status | can_launch | planner_profile | launch_mode | local_model_route | mission_packet_steering_scope | mission_packet_primary_action_promoted | day_packet_steering_scope | day_packet_primary_action_promoted | monday_validation_snapshot | cross_repo_packet_report_id | cross_repo_packet_path | has_runtime_overrides | override_kinds | execution_attempted | execution_exit_code | runtime_report_verdict | has_runtime_report | block_reasons | generated_at_utc |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
     ]
     sections: list[str] = []
     for record in records:
@@ -2203,6 +2354,10 @@ def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRec
             f"{record.consumer_status or ''} | "
             f"{'' if record.can_launch is None else ('yes' if record.can_launch else 'no')} | "
             f"{record.planner_profile or ''} | {record.launch_mode or ''} | {record.local_model_route or ''} | "
+            f"{record.mission_packet_cross_repo_validation_steering_scope or ''} | "
+            f"{'' if record.mission_packet_cross_repo_validation_primary_action_promoted is None else ('yes' if record.mission_packet_cross_repo_validation_primary_action_promoted else 'no')} | "
+            f"{record.day_packet_cross_repo_validation_steering_scope or ''} | "
+            f"{'' if record.day_packet_cross_repo_validation_primary_action_promoted is None else ('yes' if record.day_packet_cross_repo_validation_primary_action_promoted else 'no')} | "
             f"{record.monday_validation_snapshot_status} | "
             f"{record.cross_repo_validation_packet_report_id or ''} | "
             f"{record.cross_repo_validation_packet_path or ''} | "
@@ -2215,6 +2370,30 @@ def render_monday_consumer_report_markdown(records: list[MondayConsumerReportRec
             f"{', '.join(record.block_reasons)} | {record.generated_at_utc} |"
         )
         detail_lines: list[str] = []
+        if record.mission_packet_cross_repo_validation_steering_scope is not None:
+            detail_lines.append(
+                f"- mission packet steering scope: `{record.mission_packet_cross_repo_validation_steering_scope}`"
+            )
+        if record.mission_packet_cross_repo_validation_primary_action_promoted is not None:
+            detail_lines.append(
+                "- mission packet primary action promoted: `"
+                + (
+                    "true"
+                    if record.mission_packet_cross_repo_validation_primary_action_promoted
+                    else "false"
+                )
+                + "`"
+            )
+        if record.day_packet_cross_repo_validation_steering_scope is not None:
+            detail_lines.append(
+                f"- day packet steering scope: `{record.day_packet_cross_repo_validation_steering_scope}`"
+            )
+        if record.day_packet_cross_repo_validation_primary_action_promoted is not None:
+            detail_lines.append(
+                "- day packet primary action promoted: `"
+                + ("true" if record.day_packet_cross_repo_validation_primary_action_promoted else "false")
+                + "`"
+            )
         if record.cross_repo_validation_packet_report_id is not None:
             detail_lines.append(
                 f"- detail packet report id: `{record.cross_repo_validation_packet_report_id}`"
@@ -4527,6 +4706,10 @@ def build_triage_feed_record(
         source_kind=source_kind,
     )[:target_limit]
     local_operator_record = None
+    mission_packet_cross_repo_validation_steering_scope = None
+    mission_packet_cross_repo_validation_primary_action_promoted = None
+    day_packet_cross_repo_validation_steering_scope = None
+    day_packet_cross_repo_validation_primary_action_promoted = None
     cross_repo_validation_snapshot_status = None
     cross_repo_validation_snapshot_summary = None
     monday_source_validation_status = None
@@ -4539,6 +4722,22 @@ def build_triage_feed_record(
     cross_repo_validation_packet_path = None
     if family is None and run_id_prefix is None and local_records is not None:
         local_operator_record = select_latest_local_operator_stack_record(local_records)
+        latest_mission_packet_record = select_latest_local_mission_packet_record(validation_root=validation_root)
+        latest_day_packet_record = select_latest_local_day_packet_record(validation_root=validation_root)
+        if latest_mission_packet_record is not None:
+            mission_packet_cross_repo_validation_steering_scope = (
+                latest_mission_packet_record.cross_repo_validation_steering_scope
+            )
+            mission_packet_cross_repo_validation_primary_action_promoted = (
+                latest_mission_packet_record.cross_repo_validation_primary_action_promoted
+            )
+        if latest_day_packet_record is not None:
+            day_packet_cross_repo_validation_steering_scope = (
+                latest_day_packet_record.cross_repo_validation_steering_scope
+            )
+            day_packet_cross_repo_validation_primary_action_promoted = (
+                latest_day_packet_record.cross_repo_validation_primary_action_promoted
+            )
         cross_repo_validation_record = build_cross_repo_validation_report_record(
             validation_root=validation_root,
             consumer_root=consumer_root,
@@ -4575,6 +4774,14 @@ def build_triage_feed_record(
         queue_records=queue_records,
         target_records=target_records,
         local_operator_record=local_operator_record,
+        mission_packet_cross_repo_validation_steering_scope=mission_packet_cross_repo_validation_steering_scope,
+        mission_packet_cross_repo_validation_primary_action_promoted=(
+            mission_packet_cross_repo_validation_primary_action_promoted
+        ),
+        day_packet_cross_repo_validation_steering_scope=day_packet_cross_repo_validation_steering_scope,
+        day_packet_cross_repo_validation_primary_action_promoted=(
+            day_packet_cross_repo_validation_primary_action_promoted
+        ),
         cross_repo_validation_snapshot_status=cross_repo_validation_snapshot_status,
         cross_repo_validation_snapshot_summary=cross_repo_validation_snapshot_summary,
         monday_source_validation_status=monday_source_validation_status,
@@ -4598,6 +4805,28 @@ def render_triage_feed_table(record: TriageFeedRecord) -> str:
     if record.cross_repo_validation_snapshot_status is not None:
         sections.extend(
             [
+                f"mission_packet_cross_repo_validation_steering_scope\t{record.mission_packet_cross_repo_validation_steering_scope or ''}",
+                (
+                    "mission_packet_cross_repo_validation_primary_action_promoted\t"
+                    + (
+                        ""
+                        if record.mission_packet_cross_repo_validation_primary_action_promoted is None
+                        else (
+                            "yes"
+                            if record.mission_packet_cross_repo_validation_primary_action_promoted
+                            else "no"
+                        )
+                    )
+                ),
+                f"day_packet_cross_repo_validation_steering_scope\t{record.day_packet_cross_repo_validation_steering_scope or ''}",
+                (
+                    "day_packet_cross_repo_validation_primary_action_promoted\t"
+                    + (
+                        ""
+                        if record.day_packet_cross_repo_validation_primary_action_promoted is None
+                        else ("yes" if record.day_packet_cross_repo_validation_primary_action_promoted else "no")
+                    )
+                ),
                 f"cross_repo_validation_snapshot_status\t{record.cross_repo_validation_snapshot_status}",
                 f"cross_repo_validation_snapshot_summary\t{record.cross_repo_validation_snapshot_summary or ''}",
                 f"monday_source_validation_status\t{record.monday_source_validation_status or ''}",
@@ -4652,6 +4881,30 @@ def render_triage_feed_markdown(record: TriageFeedRecord) -> str:
         cross_repo_lines = [
             "### Cross-Repo Validation",
             "",
+            f"- mission packet steering scope: `{record.mission_packet_cross_repo_validation_steering_scope or ''}`",
+            (
+                "- mission packet primary action promoted: `"
+                + (
+                    ""
+                    if record.mission_packet_cross_repo_validation_primary_action_promoted is None
+                    else (
+                        "true"
+                        if record.mission_packet_cross_repo_validation_primary_action_promoted
+                        else "false"
+                    )
+                )
+                + "`"
+            ),
+            f"- day packet steering scope: `{record.day_packet_cross_repo_validation_steering_scope or ''}`",
+            (
+                "- day packet primary action promoted: `"
+                + (
+                    ""
+                    if record.day_packet_cross_repo_validation_primary_action_promoted is None
+                    else ("true" if record.day_packet_cross_repo_validation_primary_action_promoted else "false")
+                )
+                + "`"
+            ),
             f"- snapshot status: `{record.cross_repo_validation_snapshot_status}`",
             f"- snapshot summary: `{record.cross_repo_validation_snapshot_summary or ''}`",
             f"- monday source validation status: `{record.monday_source_validation_status or ''}`",
@@ -4769,6 +5022,16 @@ def build_triage_brief_record(
         local_operator_record=feed.local_operator_record,
         local_operator_summary=build_local_operator_summary(feed.local_operator_record),
         local_operator_next_step=build_local_operator_next_step(feed.local_operator_record),
+        mission_packet_cross_repo_validation_steering_scope=(
+            feed.mission_packet_cross_repo_validation_steering_scope
+        ),
+        mission_packet_cross_repo_validation_primary_action_promoted=(
+            feed.mission_packet_cross_repo_validation_primary_action_promoted
+        ),
+        day_packet_cross_repo_validation_steering_scope=feed.day_packet_cross_repo_validation_steering_scope,
+        day_packet_cross_repo_validation_primary_action_promoted=(
+            feed.day_packet_cross_repo_validation_primary_action_promoted
+        ),
         cross_repo_validation_snapshot_status=feed.cross_repo_validation_snapshot_status,
         cross_repo_validation_snapshot_summary=feed.cross_repo_validation_snapshot_summary,
         monday_source_validation_status=feed.monday_source_validation_status,
@@ -4804,6 +5067,28 @@ def render_triage_brief_table(record: TriageBriefRecord) -> str:
     if record.cross_repo_validation_snapshot_status is not None:
         sections.extend(
             [
+                f"mission_packet_cross_repo_validation_steering_scope\t{record.mission_packet_cross_repo_validation_steering_scope or ''}",
+                (
+                    "mission_packet_cross_repo_validation_primary_action_promoted\t"
+                    + (
+                        ""
+                        if record.mission_packet_cross_repo_validation_primary_action_promoted is None
+                        else (
+                            "yes"
+                            if record.mission_packet_cross_repo_validation_primary_action_promoted
+                            else "no"
+                        )
+                    )
+                ),
+                f"day_packet_cross_repo_validation_steering_scope\t{record.day_packet_cross_repo_validation_steering_scope or ''}",
+                (
+                    "day_packet_cross_repo_validation_primary_action_promoted\t"
+                    + (
+                        ""
+                        if record.day_packet_cross_repo_validation_primary_action_promoted is None
+                        else ("yes" if record.day_packet_cross_repo_validation_primary_action_promoted else "no")
+                    )
+                ),
                 f"cross_repo_validation_snapshot_status\t{record.cross_repo_validation_snapshot_status}",
                 f"cross_repo_validation_snapshot_summary\t{record.cross_repo_validation_snapshot_summary or ''}",
                 f"monday_source_validation_status\t{record.monday_source_validation_status or ''}",
@@ -4855,6 +5140,30 @@ def render_triage_brief_markdown(record: TriageBriefRecord) -> str:
             [
                 "",
                 "### Cross-Repo Validation",
+                f"- mission packet steering scope: `{record.mission_packet_cross_repo_validation_steering_scope or ''}`",
+                (
+                    "- mission packet primary action promoted: `"
+                    + (
+                        ""
+                        if record.mission_packet_cross_repo_validation_primary_action_promoted is None
+                        else (
+                            "true"
+                            if record.mission_packet_cross_repo_validation_primary_action_promoted
+                            else "false"
+                        )
+                    )
+                    + "`"
+                ),
+                f"- day packet steering scope: `{record.day_packet_cross_repo_validation_steering_scope or ''}`",
+                (
+                    "- day packet primary action promoted: `"
+                    + (
+                        ""
+                        if record.day_packet_cross_repo_validation_primary_action_promoted is None
+                        else ("true" if record.day_packet_cross_repo_validation_primary_action_promoted else "false")
+                    )
+                    + "`"
+                ),
                 f"- snapshot status: `{record.cross_repo_validation_snapshot_status}`",
                 f"- snapshot summary: `{record.cross_repo_validation_snapshot_summary or ''}`",
                 f"- monday source validation status: `{record.monday_source_validation_status or ''}`",
@@ -4952,6 +5261,30 @@ def build_triage_report_record(
             [
                 "",
                 "### Cross-Repo Validation",
+                f"- mission packet steering scope: `{brief.mission_packet_cross_repo_validation_steering_scope or ''}`",
+                (
+                    "- mission packet primary action promoted: `"
+                    + (
+                        ""
+                        if brief.mission_packet_cross_repo_validation_primary_action_promoted is None
+                        else (
+                            "true"
+                            if brief.mission_packet_cross_repo_validation_primary_action_promoted
+                            else "false"
+                        )
+                    )
+                    + "`"
+                ),
+                f"- day packet steering scope: `{brief.day_packet_cross_repo_validation_steering_scope or ''}`",
+                (
+                    "- day packet primary action promoted: `"
+                    + (
+                        ""
+                        if brief.day_packet_cross_repo_validation_primary_action_promoted is None
+                        else ("true" if brief.day_packet_cross_repo_validation_primary_action_promoted else "false")
+                    )
+                    + "`"
+                ),
                 f"- snapshot status: `{brief.cross_repo_validation_snapshot_status}`",
                 f"- snapshot summary: `{brief.cross_repo_validation_snapshot_summary or ''}`",
                 f"- monday source validation status: `{brief.monday_source_validation_status or ''}`",
@@ -5006,6 +5339,16 @@ def build_triage_report_record(
         local_operator_record=brief.local_operator_record,
         local_operator_summary=brief.local_operator_summary,
         local_operator_next_step=brief.local_operator_next_step,
+        mission_packet_cross_repo_validation_steering_scope=(
+            brief.mission_packet_cross_repo_validation_steering_scope
+        ),
+        mission_packet_cross_repo_validation_primary_action_promoted=(
+            brief.mission_packet_cross_repo_validation_primary_action_promoted
+        ),
+        day_packet_cross_repo_validation_steering_scope=brief.day_packet_cross_repo_validation_steering_scope,
+        day_packet_cross_repo_validation_primary_action_promoted=(
+            brief.day_packet_cross_repo_validation_primary_action_promoted
+        ),
         cross_repo_validation_snapshot_status=brief.cross_repo_validation_snapshot_status,
         cross_repo_validation_snapshot_summary=brief.cross_repo_validation_snapshot_summary,
         monday_source_validation_status=brief.monday_source_validation_status,
@@ -5039,6 +5382,28 @@ def render_triage_report_table(record: TriageReportRecord) -> str:
     if record.cross_repo_validation_snapshot_status is not None:
         sections.extend(
             [
+                f"mission_packet_cross_repo_validation_steering_scope\t{record.mission_packet_cross_repo_validation_steering_scope or ''}",
+                (
+                    "mission_packet_cross_repo_validation_primary_action_promoted\t"
+                    + (
+                        ""
+                        if record.mission_packet_cross_repo_validation_primary_action_promoted is None
+                        else (
+                            "yes"
+                            if record.mission_packet_cross_repo_validation_primary_action_promoted
+                            else "no"
+                        )
+                    )
+                ),
+                f"day_packet_cross_repo_validation_steering_scope\t{record.day_packet_cross_repo_validation_steering_scope or ''}",
+                (
+                    "day_packet_cross_repo_validation_primary_action_promoted\t"
+                    + (
+                        ""
+                        if record.day_packet_cross_repo_validation_primary_action_promoted is None
+                        else ("yes" if record.day_packet_cross_repo_validation_primary_action_promoted else "no")
+                    )
+                ),
                 f"cross_repo_validation_snapshot_status\t{record.cross_repo_validation_snapshot_status}",
                 f"cross_repo_validation_snapshot_summary\t{record.cross_repo_validation_snapshot_summary or ''}",
                 f"monday_source_validation_status\t{record.monday_source_validation_status or ''}",

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -3653,14 +3653,14 @@ JSON
 cat >"$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/launch-request.json" <<JSON
 {
   "source_bridge_id": "monday-local-inbox-20260401T084500Z",
-  "source_day_packet_id": "monday-local-day-20260401T083000Z",
-  "source_mission_packet_id": "monday-local-mission-20260401T080000Z",
+  "source_day_packet_id": "monday-local-day-20260401T083100Z",
+  "source_mission_packet_id": "monday-local-mission-20260401T080200Z",
   "mission_objective": "Resolve [active/latest-gap] federated-ci-local -> federated-ci-local-20260301 domains=checkpoint,readiness,reconcile",
   "planner_profile": "local_ollama",
   "launch_mode": "direct",
   "local_model_route": "direct_local_ollama",
-  "first_action_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id monday-local-mission-20260401T080000Z",
-  "monday_runtime_entrypoint_command": "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local_ollama --run-id monday-local-mission-20260401T080000Z",
+  "first_action_command": "python3 planningops/scripts/run_monday_local_operator_stack.py --execution-mode direct --direct-profile local_ollama --probe-endpoints on --run-id monday-local-mission-20260401T080200Z",
+  "monday_runtime_entrypoint_command": "cd ../monday && python3 scripts/run_local_runtime_smoke.py --profile local_ollama --run-id monday-local-mission-20260401T080200Z",
   "rollback_command": "cd ../platform-provider-gateway && bash scripts/litellm_stack_launcher.sh --mode start",
   "recommended_wait_minutes": 5,
   "needs_human_attention": true,
@@ -3684,8 +3684,8 @@ cat >"$MONDAY_CONSUMER_DIR/planningops-local-inbox-consumer-20260401T103000Z/lau
     "local_ollama"
   ],
   "source_artifacts": {
-    "day_packet_path": "$VALIDATION_DIR/monday-local-operator-day-packet.json",
-    "mission_packet_path": "$VALIDATION_DIR/monday-local-mission-packet.json",
+    "day_packet_path": "$VALIDATION_DIR/monday-local-day-20260401T083100Z-monday-local-operator-day-packet.json",
+    "mission_packet_path": "$VALIDATION_DIR/monday-local-mission-20260401T080200Z-monday-local-mission-packet.json",
     "handoff_report_path": "$VALIDATION_DIR/operator-handoff-report.json",
     "local_operator_report_path": "$VALIDATION_DIR/monday-local-operator-stack-report.json"
   }
@@ -4480,6 +4480,10 @@ records = doc["records"]
 latest, stamped_current, stamped_old = records
 
 for record in (latest, stamped_current):
+    assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
+    assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is False, record
+    assert record["day_packet_cross_repo_validation_steering_scope"] == "none", record
+    assert record["day_packet_cross_repo_validation_primary_action_promoted"] is False, record
     assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
     assert record["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), record
     assert record["cross_repo_validation_detail_lines"] == [
@@ -4501,6 +4505,10 @@ for record in (latest, stamped_current):
 
 assert stamped_old["cross_repo_validation_packet_report_id"] is None, stamped_old
 assert stamped_old["cross_repo_validation_packet_path"] is None, stamped_old
+assert stamped_old["mission_packet_cross_repo_validation_steering_scope"] == "none", stamped_old
+assert stamped_old["mission_packet_cross_repo_validation_primary_action_promoted"] is False, stamped_old
+assert stamped_old["day_packet_cross_repo_validation_steering_scope"] == "none", stamped_old
+assert stamped_old["day_packet_cross_repo_validation_primary_action_promoted"] is False, stamped_old
 assert stamped_old["cross_repo_validation_detail_lines"] == [], stamped_old
 assert stamped_old["monday_source_validation_report_lines"] == [], stamped_old
 assert stamped_old["cross_repo_validation_action_lines"] == [], stamped_old
@@ -4518,6 +4526,10 @@ import sys
 
 markdown = Path(sys.argv[1]).read_text(encoding="utf-8")
 assert "### Cross-Repo Validation Details: `monday-local-inbox-20260401T084500Z`" in markdown, markdown
+assert "mission packet steering scope: `none`" in markdown, markdown
+assert "mission packet primary action promoted: `false`" in markdown, markdown
+assert "day packet steering scope: `none`" in markdown, markdown
+assert "day packet primary action promoted: `false`" in markdown, markdown
 assert "detail packet report id: `cross-repo-validation-20260401T110000Z`" in markdown, markdown
 assert "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing" in markdown, markdown
 assert "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes" in markdown, markdown
@@ -4539,6 +4551,10 @@ doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 records = doc["records"]
 blocked, passed_apply, dry_run = records
 
+assert blocked["mission_packet_cross_repo_validation_steering_scope"] == "primary_action_only", blocked
+assert blocked["mission_packet_cross_repo_validation_primary_action_promoted"] is True, blocked
+assert blocked["day_packet_cross_repo_validation_steering_scope"] == "primary_action_only", blocked
+assert blocked["day_packet_cross_repo_validation_primary_action_promoted"] is True, blocked
 assert blocked["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", blocked
 assert blocked["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), blocked
 assert blocked["cross_repo_validation_detail_lines"] == [
@@ -4559,6 +4575,10 @@ assert blocked["cross_repo_validation_action_lines"] == [
 ], blocked
 
 for record in (passed_apply, dry_run):
+    assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
+    assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is False, record
+    assert record["day_packet_cross_repo_validation_steering_scope"] == "none", record
+    assert record["day_packet_cross_repo_validation_primary_action_promoted"] is False, record
     assert record["cross_repo_validation_packet_report_id"] is None, record
     assert record["cross_repo_validation_packet_path"] is None, record
     assert record["cross_repo_validation_detail_lines"] == [], record
@@ -4579,6 +4599,10 @@ import sys
 
 markdown = Path(sys.argv[1]).read_text(encoding="utf-8")
 assert "### Cross-Repo Validation Details: `planningops-local-inbox-consumer-20260401T103000Z`" in markdown, markdown
+assert "mission packet steering scope: `primary_action_only`" in markdown, markdown
+assert "mission packet primary action promoted: `true`" in markdown, markdown
+assert "day packet steering scope: `primary_action_only`" in markdown, markdown
+assert "day packet primary action promoted: `true`" in markdown, markdown
 assert "detail packet report id: `cross-repo-validation-20260401T110000Z`" in markdown, markdown
 assert "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing" in markdown, markdown
 assert "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes" in markdown, markdown
@@ -4662,6 +4686,10 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
+assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is False, record
+assert record["day_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["day_packet_cross_repo_validation_primary_action_promoted"] is False, record
 assert record["cross_repo_validation_snapshot_status"] == "present", record
 assert record["cross_repo_validation_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", record
 assert record["monday_source_validation_status"] == "attention", record
@@ -4706,6 +4734,10 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
+assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is False, record
+assert record["day_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["day_packet_cross_repo_validation_primary_action_promoted"] is False, record
 assert record["cross_repo_validation_snapshot_status"] == "present", record
 assert record["cross_repo_validation_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", record
 assert record["monday_source_validation_status"] == "attention", record
@@ -4777,6 +4809,10 @@ assert record["cross_repo_validation_action_lines"] == [
 assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
 assert record["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), record
 assert "### Cross-Repo Validation" in record["markdown"], record
+assert "mission packet steering scope: `none`" in record["markdown"], record
+assert "mission packet primary action promoted: `false`" in record["markdown"], record
+assert "day packet steering scope: `none`" in record["markdown"], record
+assert "day packet primary action promoted: `false`" in record["markdown"], record
 assert "snapshot summary: `total=5 promotable=3 blocked=2 stale=0`" in record["markdown"], record
 assert "monday source validation summary: `total=2 pass=1 fail=1 errors=2 warnings=1`" in record["markdown"], record
 assert "### Cross-Repo Validation Details" in record["markdown"], record


### PR DESCRIPTION
## Scope
- mirror mission/day steering metadata into downstream operator query surfaces
- keep mission/day packet queries as the detailed source while exposing steering visibility where operators already work

## Summary
- add mission/day steering scope and promotion fields to `triage-feed`, `triage-brief`, `triage-report`, `local-inbox-payload`, and `monday-consumer-report`
- resolve payload and consumer linkage through mission/day packet source artifact paths so blocked runs surface stamped steering state correctly
- extend regression coverage for triage, payload, and consumer surfaces and update the rollout plan to reflect the new downstream visibility

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1010

## Risks
- downstream surfaces now depend on mission/day packet steering fields staying schema-stable
- consumer coverage assumes source artifact paths point at the intended stamped mission/day packet when steering promotion occurred

## Review Checklist
- [ ] confirm triage surfaces show steering metadata without changing cross-repo packet semantics
- [ ] confirm payload and consumer views only surface promoted steering where the linked mission/day packet warrants it
- [ ] confirm docs plan matches the delivered downstream visibility

## Post-Deploy Monitoring & Validation
- watch `template-and-link-check`, `docs-check`, `contract-conformance`, `federated-conformance`, and `o11y-replay`
- treat inherited `validate-and-dry-run`, `provider-profile`, `runtime-handoff`, `monday-harness-projection`, `loop-guardrails`, and `federated-summary` as unrelated unless behavior changes
