### PR TITLE
feat(query-engine): add downstream steering metadata filters

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -204,6 +204,7 @@ Current deliverables:
 - `planningops/scripts/write_monday_local_mission_packet.py|write_monday_local_operator_day_packet.py` now emit explicit `cross_repo_validation_steering_scope` and `cross_repo_validation_primary_action_promoted` fields so downstream packet readers can see that cross-repo validation may steer selected action but does not rewrite `mission_objective` or target ranking
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-mission-packet|local-day-packet` now expose latest/stamped mission/day packet records directly, including `cross_repo_validation_steering_scope`, `cross_repo_validation_primary_action_promoted`, packet source kind, and immutable cross-repo packet linkage so operators can audit action-only steering without reopening raw packet JSON
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report|local-inbox-payload|monday-consumer-report` now mirror mission/day steering metadata directly so summary-first, payload-first, and apply/result-first operator surfaces can see whether cross-repo validation only steered `primary_action` without reopening the dedicated mission/day packet queries
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report|local-inbox-payload|monday-consumer-report` now accept explicit mission/day steering filters so operators can isolate `none` vs `primary_action_only` and promoted vs non-promoted downstream states without reopening packet-local surfaces
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -266,4 +267,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether downstream surfaces need explicit filters for mission/day steering metadata, or whether the new mirrored visibility plus `local-mission-packet|local-day-packet` query surfaces are enough and filtering should stay packet-local
+2. decide whether mirrored steering metadata should stay query-only/filter-only on downstream surfaces, or whether it should also steer downstream summary selection and ranking beyond the current packet-local policy boundary

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -1461,6 +1461,35 @@ def discover_local_inbox_payload_records(*, validation_root: Path) -> list[Local
     return records
 
 
+def matches_downstream_steering_filters(
+    *,
+    mission_packet_steering_scope_filter: str | None = None,
+    mission_packet_primary_action_promoted_filter: str | None = None,
+    day_packet_steering_scope_filter: str | None = None,
+    day_packet_primary_action_promoted_filter: str | None = None,
+    mission_packet_steering_scope: str | None,
+    mission_packet_primary_action_promoted: bool | None,
+    day_packet_steering_scope: str | None,
+    day_packet_primary_action_promoted: bool | None,
+) -> bool:
+    if (
+        mission_packet_steering_scope_filter is not None
+        and mission_packet_steering_scope != mission_packet_steering_scope_filter
+    ):
+        return False
+    if mission_packet_primary_action_promoted_filter is not None:
+        expected = mission_packet_primary_action_promoted_filter == "yes"
+        if mission_packet_primary_action_promoted is not expected:
+            return False
+    if day_packet_steering_scope_filter is not None and day_packet_steering_scope != day_packet_steering_scope_filter:
+        return False
+    if day_packet_primary_action_promoted_filter is not None:
+        expected = day_packet_primary_action_promoted_filter == "yes"
+        if day_packet_primary_action_promoted is not expected:
+            return False
+    return True
+
+
 def filter_local_inbox_payload_records(
     *,
     records: list[LocalInboxPayloadRecord],
@@ -1473,6 +1502,10 @@ def filter_local_inbox_payload_records(
     local_model_route: str | None = None,
     local_validation_snapshot_status: str | None = None,
     has_dependency_state: str | None = None,
+    mission_packet_steering_scope: str | None = None,
+    mission_packet_primary_action_promoted: str | None = None,
+    day_packet_steering_scope: str | None = None,
+    day_packet_primary_action_promoted: str | None = None,
 ) -> list[LocalInboxPayloadRecord]:
     filtered = records
     if bridge_id_prefix:
@@ -1502,6 +1535,20 @@ def filter_local_inbox_payload_records(
             for record in filtered
             if has_dependency_state in record.dependency_states.values()
         ]
+    filtered = [
+        record
+        for record in filtered
+        if matches_downstream_steering_filters(
+            mission_packet_steering_scope_filter=mission_packet_steering_scope,
+            mission_packet_primary_action_promoted_filter=mission_packet_primary_action_promoted,
+            day_packet_steering_scope_filter=day_packet_steering_scope,
+            day_packet_primary_action_promoted_filter=day_packet_primary_action_promoted,
+            mission_packet_steering_scope=record.mission_packet_cross_repo_validation_steering_scope,
+            mission_packet_primary_action_promoted=record.mission_packet_cross_repo_validation_primary_action_promoted,
+            day_packet_steering_scope=record.day_packet_cross_repo_validation_steering_scope,
+            day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
+        )
+    ]
     return filtered
 
 
@@ -2253,6 +2300,10 @@ def filter_monday_consumer_report_records(
     override_kind: str | None = None,
     has_runtime_report: str | None = None,
     execution_attempted: str | None = None,
+    mission_packet_steering_scope: str | None = None,
+    mission_packet_primary_action_promoted: str | None = None,
+    day_packet_steering_scope: str | None = None,
+    day_packet_primary_action_promoted: str | None = None,
 ) -> list[MondayConsumerReportRecord]:
     filtered = records
     if run_id_prefix:
@@ -2285,6 +2336,20 @@ def filter_monday_consumer_report_records(
     if execution_attempted is not None:
         expected = execution_attempted == "yes"
         filtered = [record for record in filtered if record.execution_attempted is expected]
+    filtered = [
+        record
+        for record in filtered
+        if matches_downstream_steering_filters(
+            mission_packet_steering_scope_filter=mission_packet_steering_scope,
+            mission_packet_primary_action_promoted_filter=mission_packet_primary_action_promoted,
+            day_packet_steering_scope_filter=day_packet_steering_scope,
+            day_packet_primary_action_promoted_filter=day_packet_primary_action_promoted,
+            mission_packet_steering_scope=record.mission_packet_cross_repo_validation_steering_scope,
+            mission_packet_primary_action_promoted=record.mission_packet_cross_repo_validation_primary_action_promoted,
+            day_packet_steering_scope=record.day_packet_cross_repo_validation_steering_scope,
+            day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
+        )
+    ]
     return filtered
 
 
@@ -6889,6 +6954,10 @@ def parse_args() -> argparse.Namespace:
     triage_feed_parser.add_argument("--run-id-prefix", default=None)
     triage_feed_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
     triage_feed_parser.add_argument("--target-limit", type=int, default=3)
+    triage_feed_parser.add_argument("--mission-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    triage_feed_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    triage_feed_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    triage_feed_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     triage_feed_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
     triage_feed_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_feed_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -6905,6 +6974,10 @@ def parse_args() -> argparse.Namespace:
     triage_brief_parser.add_argument("--run-id-prefix", default=None)
     triage_brief_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
     triage_brief_parser.add_argument("--target-limit", type=int, default=3)
+    triage_brief_parser.add_argument("--mission-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    triage_brief_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    triage_brief_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    triage_brief_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     triage_brief_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     triage_brief_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_brief_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -6921,6 +6994,10 @@ def parse_args() -> argparse.Namespace:
     triage_report_parser.add_argument("--run-id-prefix", default=None)
     triage_report_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
     triage_report_parser.add_argument("--target-limit", type=int, default=3)
+    triage_report_parser.add_argument("--mission-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    triage_report_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    triage_report_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    triage_report_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     triage_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     triage_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -7027,6 +7104,10 @@ def parse_args() -> argparse.Namespace:
     local_inbox_payload_parser.add_argument("--local-model-route", default=None)
     local_inbox_payload_parser.add_argument("--local-validation-snapshot-status", default=None)
     local_inbox_payload_parser.add_argument("--has-dependency-state", choices=["current", "stale", "missing"], default=None)
+    local_inbox_payload_parser.add_argument("--mission-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    local_inbox_payload_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    local_inbox_payload_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    local_inbox_payload_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     local_inbox_payload_parser.add_argument("--limit", type=int, default=20)
     local_inbox_payload_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
     local_inbox_payload_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -7048,6 +7129,10 @@ def parse_args() -> argparse.Namespace:
     monday_consumer_parser.add_argument("--override-kind", choices=["planner_runtime_config", "runtime_profile_file"], default=None)
     monday_consumer_parser.add_argument("--has-runtime-report", choices=["yes", "no"], default=None)
     monday_consumer_parser.add_argument("--execution-attempted", choices=["yes", "no"], default=None)
+    monday_consumer_parser.add_argument("--mission-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    monday_consumer_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    monday_consumer_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    monday_consumer_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     monday_consumer_parser.add_argument("--limit", type=int, default=20)
     monday_consumer_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
     monday_consumer_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -7207,6 +7292,10 @@ def main() -> int:
             local_model_route=args.local_model_route,
             local_validation_snapshot_status=args.local_validation_snapshot_status,
             has_dependency_state=args.has_dependency_state,
+            mission_packet_steering_scope=args.mission_packet_steering_scope,
+            mission_packet_primary_action_promoted=args.mission_packet_primary_action_promoted,
+            day_packet_steering_scope=args.day_packet_steering_scope,
+            day_packet_primary_action_promoted=args.day_packet_primary_action_promoted,
         )
         inbox_payload_records = inbox_payload_records[: args.limit]
         if args.format == "json":
@@ -7238,6 +7327,10 @@ def main() -> int:
             override_kind=args.override_kind,
             has_runtime_report=args.has_runtime_report,
             execution_attempted=args.execution_attempted,
+            mission_packet_steering_scope=args.mission_packet_steering_scope,
+            mission_packet_primary_action_promoted=args.mission_packet_primary_action_promoted,
+            day_packet_steering_scope=args.day_packet_steering_scope,
+            day_packet_primary_action_promoted=args.day_packet_primary_action_promoted,
         )
         consumer_records = consumer_records[: args.limit]
         if args.format == "json":
@@ -7604,8 +7697,22 @@ def main() -> int:
             source_kind=args.source_kind,
             target_limit=args.target_limit,
         )
+        if not matches_downstream_steering_filters(
+            mission_packet_steering_scope_filter=args.mission_packet_steering_scope,
+            mission_packet_primary_action_promoted_filter=args.mission_packet_primary_action_promoted,
+            day_packet_steering_scope_filter=args.day_packet_steering_scope,
+            day_packet_primary_action_promoted_filter=args.day_packet_primary_action_promoted,
+            mission_packet_steering_scope=record.mission_packet_cross_repo_validation_steering_scope,
+            mission_packet_primary_action_promoted=record.mission_packet_cross_repo_validation_primary_action_promoted,
+            day_packet_steering_scope=record.day_packet_cross_repo_validation_steering_scope,
+            day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
+        ):
+            record = None
         if args.format == "json":
-            print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            print(json.dumps({"record": None if record is None else asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if record is None:
+            print("_No matching triage feed._" if args.format == "markdown" else "no matching triage feed")
             return 0
         if args.format == "markdown":
             print(render_triage_feed_markdown(record))
@@ -7626,8 +7733,22 @@ def main() -> int:
             source_kind=args.source_kind,
             target_limit=args.target_limit,
         )
+        if not matches_downstream_steering_filters(
+            mission_packet_steering_scope_filter=args.mission_packet_steering_scope,
+            mission_packet_primary_action_promoted_filter=args.mission_packet_primary_action_promoted,
+            day_packet_steering_scope_filter=args.day_packet_steering_scope,
+            day_packet_primary_action_promoted_filter=args.day_packet_primary_action_promoted,
+            mission_packet_steering_scope=record.mission_packet_cross_repo_validation_steering_scope,
+            mission_packet_primary_action_promoted=record.mission_packet_cross_repo_validation_primary_action_promoted,
+            day_packet_steering_scope=record.day_packet_cross_repo_validation_steering_scope,
+            day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
+        ):
+            record = None
         if args.format == "json":
-            print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            print(json.dumps({"record": None if record is None else asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if record is None:
+            print("_No matching triage brief._" if args.format == "markdown" else "no matching triage brief")
             return 0
         if args.format == "markdown":
             print(render_triage_brief_markdown(record))
@@ -7648,8 +7769,22 @@ def main() -> int:
             source_kind=args.source_kind,
             target_limit=args.target_limit,
         )
+        if not matches_downstream_steering_filters(
+            mission_packet_steering_scope_filter=args.mission_packet_steering_scope,
+            mission_packet_primary_action_promoted_filter=args.mission_packet_primary_action_promoted,
+            day_packet_steering_scope_filter=args.day_packet_steering_scope,
+            day_packet_primary_action_promoted_filter=args.day_packet_primary_action_promoted,
+            mission_packet_steering_scope=record.mission_packet_cross_repo_validation_steering_scope,
+            mission_packet_primary_action_promoted=record.mission_packet_cross_repo_validation_primary_action_promoted,
+            day_packet_steering_scope=record.day_packet_cross_repo_validation_steering_scope,
+            day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
+        ):
+            record = None
         if args.format == "json":
-            print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            print(json.dumps({"record": None if record is None else asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if record is None:
+            print("_No matching triage report._" if args.format == "markdown" else "no matching triage report")
             return 0
         if args.format == "markdown":
             print(render_triage_report_markdown(record))

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -4824,6 +4824,122 @@ assert "detail packet report id: `cross-repo-validation-20260401T110000Z`" in re
 assert "detail packet path: `" in record["markdown"], record
 PY
 
+LOCAL_INBOX_PAYLOAD_STEERING_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" local-inbox-payload \
+  --source-kind latest \
+  --mission-packet-steering-scope none \
+  --mission-packet-primary-action-promoted no \
+  --day-packet-steering-scope none \
+  --day-packet-primary-action-promoted no \
+  --format json \
+  --validation-root "$VALIDATION_DIR" >"$LOCAL_INBOX_PAYLOAD_STEERING_FILTER_OUTPUT"
+
+python3 - <<'PY' "$LOCAL_INBOX_PAYLOAD_STEERING_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["bridge_id"] == "monday-local-inbox-20260401T084500Z", record
+assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is False, record
+assert record["day_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["day_packet_cross_repo_validation_primary_action_promoted"] is False, record
+PY
+
+MONDAY_CONSUMER_STEERING_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" monday-consumer-report \
+  --mission-packet-steering-scope primary_action_only \
+  --mission-packet-primary-action-promoted yes \
+  --day-packet-steering-scope primary_action_only \
+  --day-packet-primary-action-promoted yes \
+  --format json \
+  --validation-root "$VALIDATION_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" >"$MONDAY_CONSUMER_STEERING_FILTER_OUTPUT"
+
+python3 - <<'PY' "$MONDAY_CONSUMER_STEERING_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+records = doc["records"]
+assert len(records) == 1, records
+record = records[0]
+assert record["run_id"] == "planningops-local-inbox-consumer-20260401T103000Z", record
+assert record["mission_packet_cross_repo_validation_steering_scope"] == "primary_action_only", record
+assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is True, record
+assert record["day_packet_cross_repo_validation_steering_scope"] == "primary_action_only", record
+assert record["day_packet_cross_repo_validation_primary_action_promoted"] is True, record
+PY
+
+TRIAGE_FEED_STEERING_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-feed \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --mission-packet-steering-scope none \
+  --day-packet-primary-action-promoted no >"$TRIAGE_FEED_STEERING_FILTER_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_FEED_STEERING_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["day_packet_cross_repo_validation_primary_action_promoted"] is False, record
+PY
+
+TRIAGE_BRIEF_STEERING_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-brief \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --mission-packet-steering-scope primary_action_only >"$TRIAGE_BRIEF_STEERING_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_BRIEF_STEERING_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
+PY
+
+TRIAGE_REPORT_STEERING_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --day-packet-primary-action-promoted yes >"$TRIAGE_REPORT_STEERING_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_STEERING_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
+PY
+
 python3 "$QUERY_PATH" local-validation-freshness \
   --artifact-family monday_local_inbox_runtime_report \
   --promotability-status blocked \


### PR DESCRIPTION
## Scope
- add downstream steering filters to operator-facing query surfaces
- keep steering policy packet-local while making mirrored metadata filterable where operators already read state

## Summary
- add mission/day steering scope and promoted-state filter args to `local-inbox-payload` and `monday-consumer-report`
- add the same filter vocabulary to `triage-feed`, `triage-brief`, and `triage-report`, returning `record: null` for JSON and a no-match message for human-readable output when the current snapshot does not match
- extend regression coverage for positive and negative downstream steering filter cases and update the rollout plan to reflect filterable mirrored visibility

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1012

## Risks
- downstream filter names now become part of the operator query contract and need to stay aligned with mirrored field names
- triage no-match behavior now intentionally differs from packet-not-found behavior by returning an empty snapshot instead of an error

## Review Checklist
- [ ] confirm payload and consumer surfaces filter correctly on both `none/no` and `primary_action_only/yes`
- [ ] confirm triage surfaces preserve their existing snapshot content when filters match and return empty snapshots cleanly when they do not
- [ ] confirm rollout plan reflects downstream filterability rather than new steering authority

## Post-Deploy Monitoring & Validation
- watch `template-and-link-check`, `docs-check`, `contract-conformance`, `federated-conformance`, and `o11y-replay`
- treat inherited `validate-and-dry-run`, `provider-profile`, `runtime-handoff`, `monday-harness-projection`, `loop-guardrails`, and `federated-summary` as unrelated unless behavior changes
