### PR TITLE
feat(query-engine): add handoff steering metadata filters

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -205,6 +205,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py local-mission-packet|local-day-packet` now expose latest/stamped mission/day packet records directly, including `cross_repo_validation_steering_scope`, `cross_repo_validation_primary_action_promoted`, packet source kind, and immutable cross-repo packet linkage so operators can audit action-only steering without reopening raw packet JSON
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report|local-inbox-payload|monday-consumer-report` now mirror mission/day steering metadata directly so summary-first, payload-first, and apply/result-first operator surfaces can see whether cross-repo validation only steered `primary_action` without reopening the dedicated mission/day packet queries
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report|local-inbox-payload|monday-consumer-report` now accept explicit mission/day steering filters so operators can isolate `none` vs `primary_action_only` and promoted vs non-promoted downstream states without reopening packet-local surfaces
+- `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries mission/day steering metadata directly and accepts the same steering filters, returning an empty/no-match handoff snapshot when the current report does not satisfy the requested downstream steering state
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -267,4 +268,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether mirrored steering metadata should stay query-only/filter-only on downstream surfaces, or whether it should also steer downstream summary selection and ranking beyond the current packet-local policy boundary
+2. decide whether mirrored steering metadata should stay query-only/filter-only even after handoff parity, or whether any downstream summary selection and ranking should eventually become steering-aware beyond the current packet-local policy boundary

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -357,6 +357,10 @@ class HandoffReportRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    mission_packet_cross_repo_validation_steering_scope: str | None
+    mission_packet_cross_repo_validation_primary_action_promoted: bool | None
+    day_packet_cross_repo_validation_steering_scope: str | None
+    day_packet_cross_repo_validation_primary_action_promoted: bool | None
     local_validation_snapshot_status: str
     local_validation_snapshot_summary: str
     local_validation_records: list[LocalValidationFreshnessRecord]
@@ -5637,6 +5641,34 @@ def build_handoff_report_record(
         [
             "",
             "### Cross-Repo Validation",
+            f"- mission packet steering scope: `{triage_report.mission_packet_cross_repo_validation_steering_scope or ''}`",
+            (
+                "- mission packet primary action promoted: `"
+                + (
+                    ""
+                    if triage_report.mission_packet_cross_repo_validation_primary_action_promoted is None
+                    else (
+                        "true"
+                        if triage_report.mission_packet_cross_repo_validation_primary_action_promoted
+                        else "false"
+                    )
+                )
+                + "`"
+            ),
+            f"- day packet steering scope: `{triage_report.day_packet_cross_repo_validation_steering_scope or ''}`",
+            (
+                "- day packet primary action promoted: `"
+                + (
+                    ""
+                    if triage_report.day_packet_cross_repo_validation_primary_action_promoted is None
+                    else (
+                        "true"
+                        if triage_report.day_packet_cross_repo_validation_primary_action_promoted
+                        else "false"
+                    )
+                )
+                + "`"
+            ),
             f"- snapshot status: `{cross_repo_validation_snapshot_status}`",
             f"- snapshot summary: `{cross_repo_validation_snapshot_summary}`",
             f"- monday source validation status: `{monday_source_validation_status}`",
@@ -5693,6 +5725,18 @@ def build_handoff_report_record(
         local_operator_record=triage_report.local_operator_record,
         local_operator_summary=triage_report.local_operator_summary,
         local_operator_next_step=triage_report.local_operator_next_step,
+        mission_packet_cross_repo_validation_steering_scope=(
+            triage_report.mission_packet_cross_repo_validation_steering_scope
+        ),
+        mission_packet_cross_repo_validation_primary_action_promoted=(
+            triage_report.mission_packet_cross_repo_validation_primary_action_promoted
+        ),
+        day_packet_cross_repo_validation_steering_scope=(
+            triage_report.day_packet_cross_repo_validation_steering_scope
+        ),
+        day_packet_cross_repo_validation_primary_action_promoted=(
+            triage_report.day_packet_cross_repo_validation_primary_action_promoted
+        ),
         local_validation_snapshot_status=local_validation_snapshot_status,
         local_validation_snapshot_summary=local_validation_snapshot_summary,
         local_validation_records=local_validation_records,
@@ -5734,6 +5778,32 @@ def render_handoff_report_table(record: HandoffReportRecord) -> str:
         sections.append(f"local_operator\t{record.local_operator_summary}")
     if record.local_operator_next_step is not None:
         sections.append(f"local_operator_next_step\t{record.local_operator_next_step}")
+    sections.append(
+        f"mission_packet_cross_repo_validation_steering_scope\t{record.mission_packet_cross_repo_validation_steering_scope or ''}"
+    )
+    sections.append(
+        "mission_packet_cross_repo_validation_primary_action_promoted\t"
+        + (
+            ""
+            if record.mission_packet_cross_repo_validation_primary_action_promoted is None
+            else (
+                "yes"
+                if record.mission_packet_cross_repo_validation_primary_action_promoted
+                else "no"
+            )
+        )
+    )
+    sections.append(
+        f"day_packet_cross_repo_validation_steering_scope\t{record.day_packet_cross_repo_validation_steering_scope or ''}"
+    )
+    sections.append(
+        "day_packet_cross_repo_validation_primary_action_promoted\t"
+        + (
+            ""
+            if record.day_packet_cross_repo_validation_primary_action_promoted is None
+            else ("yes" if record.day_packet_cross_repo_validation_primary_action_promoted else "no")
+        )
+    )
     sections.append(f"local_validation_snapshot_status\t{record.local_validation_snapshot_status}")
     sections.append(f"local_validation_snapshot_summary\t{record.local_validation_snapshot_summary}")
     sections.extend(["local_validation", *record.local_validation_summary_lines])
@@ -7014,6 +7084,10 @@ def parse_args() -> argparse.Namespace:
     handoff_report_parser.add_argument("--run-id-prefix", default=None)
     handoff_report_parser.add_argument("--source-kind", choices=["all", "stamped", "latest"], default="stamped")
     handoff_report_parser.add_argument("--target-limit", type=int, default=3)
+    handoff_report_parser.add_argument("--mission-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    handoff_report_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    handoff_report_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
+    handoff_report_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     handoff_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     handoff_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     handoff_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -7805,8 +7879,22 @@ def main() -> int:
             source_kind=args.source_kind,
             target_limit=args.target_limit,
         )
+        if not matches_downstream_steering_filters(
+            mission_packet_steering_scope_filter=args.mission_packet_steering_scope,
+            mission_packet_primary_action_promoted_filter=args.mission_packet_primary_action_promoted,
+            day_packet_steering_scope_filter=args.day_packet_steering_scope,
+            day_packet_primary_action_promoted_filter=args.day_packet_primary_action_promoted,
+            mission_packet_steering_scope=record.mission_packet_cross_repo_validation_steering_scope,
+            mission_packet_primary_action_promoted=record.mission_packet_cross_repo_validation_primary_action_promoted,
+            day_packet_steering_scope=record.day_packet_cross_repo_validation_steering_scope,
+            day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
+        ):
+            record = None
         if args.format == "json":
-            print(json.dumps({"record": asdict(record)}, ensure_ascii=True, indent=2))
+            print(json.dumps({"record": None if record is None else asdict(record)}, ensure_ascii=True, indent=2))
+            return 0
+        if record is None:
+            print("_No matching handoff report._" if args.format == "markdown" else "no matching handoff report")
             return 0
         if args.format == "markdown":
             print(render_handoff_report_markdown(record))

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -4426,6 +4426,10 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
+assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is False, record
+assert record["day_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["day_packet_cross_repo_validation_primary_action_promoted"] is False, record
 assert record["cross_repo_validation_snapshot_status"] == "present", record
 assert record["cross_repo_validation_snapshot_summary"] == "total=5 promotable=3 blocked=2 stale=0", record
 assert record["monday_source_validation_status"] == "attention", record
@@ -4453,6 +4457,10 @@ assert record["cross_repo_validation_action_lines"] == [
 assert record["cross_repo_validation_packet_report_id"] == "cross-repo-validation-20260401T110000Z", record
 assert record["cross_repo_validation_packet_path"].endswith("/cross-repo-validation-report.json"), record
 assert "### Cross-Repo Validation" in record["markdown"], record
+assert "mission packet steering scope: `none`" in record["markdown"], record
+assert "mission packet primary action promoted: `false`" in record["markdown"], record
+assert "day packet steering scope: `none`" in record["markdown"], record
+assert "day packet primary action promoted: `false`" in record["markdown"], record
 assert "snapshot summary: `total=5 promotable=3 blocked=2 stale=0`" in record["markdown"], record
 assert "monday source validation summary: `total=2 pass=1 fail=1 errors=2 warnings=1`" in record["markdown"], record
 assert "### Cross-Repo Validation Packet" in record["markdown"], record
@@ -4463,6 +4471,50 @@ assert "detail packet path: `" in record["markdown"], record
 assert "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing" in record["markdown"], record
 assert "source: consumer-report: verdict=fail errors=2 warnings=1 artifact_exists=yes schema_exists=yes" in record["markdown"], record
 assert "1. local-validation: repair monday_local_inbox_runtime_report (freshness=fresh, promotability=blocked, reasons=source_artifact_missing)" in record["markdown"], record
+PY
+
+HANDOFF_REPORT_STEERING_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --mission-packet-steering-scope none \
+  --day-packet-primary-action-promoted no >"$HANDOFF_REPORT_STEERING_FILTER_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_STEERING_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
+assert record["day_packet_cross_repo_validation_primary_action_promoted"] is False, record
+PY
+
+HANDOFF_REPORT_STEERING_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --mission-packet-steering-scope primary_action_only >"$HANDOFF_REPORT_STEERING_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_STEERING_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
 PY
 
 python3 "$QUERY_PATH" local-inbox-payload \


### PR DESCRIPTION
## Scope
- add mission/day steering metadata and filters to the handoff report query surface
- keep handoff semantics aligned with triage, payload, and consumer operator views

## Summary
- carry mission/day steering scope and promoted-state fields into `handoff-report` JSON, table, and markdown output
- add handoff query filters for mission/day steering state and return `record: null` for JSON or a no-match message for human-readable output when the current handoff snapshot does not satisfy the requested steering state
- extend regression coverage and update the rollout plan to reflect handoff parity with downstream steering filters

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1014

## Risks
- handoff output now depends on triage report steering fields remaining stable as the carry-forward source
- handoff no-match behavior intentionally uses empty snapshots rather than errors, which changes query semantics for filtered misses

## Review Checklist
- [ ] confirm handoff JSON/table/markdown now expose mission/day steering fields consistently
- [ ] confirm matching and non-matching handoff steering filters behave the same way as other downstream single-record surfaces
- [ ] confirm rollout plan reflects handoff parity without expanding steering authority

## Post-Deploy Monitoring & Validation
- watch `template-and-link-check`, `docs-check`, `contract-conformance`, `federated-conformance`, and `o11y-replay`
- treat inherited `validate-and-dry-run`, `provider-profile`, `runtime-handoff`, `monday-harness-projection`, `loop-guardrails`, and `federated-summary` as unrelated unless behavior changes
