### PR TITLE
feat(query-engine): steer downstream next-step summaries

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -2,7 +2,7 @@
 title: plan: Monday Local Codex Runtime Rollout
 type: plan
 date: 2026-04-01
-updated: 2026-04-02
+updated: 2026-04-04
 initiative: unified-personal-agent-platform
 lifecycle: workbench
 status: active
@@ -206,6 +206,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report|local-inbox-payload|monday-consumer-report` now mirror mission/day steering metadata directly so summary-first, payload-first, and apply/result-first operator surfaces can see whether cross-repo validation only steered `primary_action` without reopening the dedicated mission/day packet queries
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report|local-inbox-payload|monday-consumer-report` now accept explicit mission/day steering filters so operators can isolate `none` vs `primary_action_only` and promoted vs non-promoted downstream states without reopening packet-local surfaces
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries mission/day steering metadata directly and accepts the same steering filters, returning an empty/no-match handoff snapshot when the current report does not satisfy the requested downstream steering state
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief|triage-report|handoff-report` now expose an explicit downstream `selected_next_step` and `selected_next_step_source`, using the existing fail-closed precedence `local-runtime -> local-validation -> promoted cross-repo validation -> triage-target` so promoted cross-repo validation can steer summary-level next-step selection without changing mission objective or target ranking
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -268,4 +269,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether mirrored steering metadata should stay query-only/filter-only even after handoff parity, or whether any downstream summary selection and ranking should eventually become steering-aware beyond the current packet-local policy boundary
+2. decide whether downstream `selected_next_step` should remain the ceiling for cross-repo steering, or whether headline/attention summary selection should ever become steering-aware without crossing the current packet-local policy boundary

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -298,6 +298,8 @@ class TriageBriefRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    selected_next_step_source: str
+    selected_next_step: str | None
     mission_packet_cross_repo_validation_steering_scope: str | None
     mission_packet_cross_repo_validation_primary_action_promoted: bool | None
     day_packet_cross_repo_validation_steering_scope: str | None
@@ -327,6 +329,8 @@ class TriageReportRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    selected_next_step_source: str
+    selected_next_step: str | None
     mission_packet_cross_repo_validation_steering_scope: str | None
     mission_packet_cross_repo_validation_primary_action_promoted: bool | None
     day_packet_cross_repo_validation_steering_scope: str | None
@@ -357,6 +361,8 @@ class HandoffReportRecord:
     local_operator_record: LocalOperatorStackRecord | None
     local_operator_summary: str | None
     local_operator_next_step: str | None
+    selected_next_step_source: str
+    selected_next_step: str | None
     mission_packet_cross_repo_validation_steering_scope: str | None
     mission_packet_cross_repo_validation_primary_action_promoted: bool | None
     day_packet_cross_repo_validation_steering_scope: str | None
@@ -1134,6 +1140,58 @@ def build_local_operator_next_step(record: LocalOperatorStackRecord | None) -> s
     if record is None or not record.recommended_next_steps:
         return None
     return record.recommended_next_steps[0]
+
+
+def cross_repo_primary_action_promoted(
+    *,
+    mission_packet_steering_scope: str | None,
+    mission_packet_primary_action_promoted: bool | None,
+    day_packet_steering_scope: str | None,
+    day_packet_primary_action_promoted: bool | None,
+) -> bool:
+    return (
+        (
+            mission_packet_steering_scope == "primary_action_only"
+            and mission_packet_primary_action_promoted is True
+        )
+        or (
+            day_packet_steering_scope == "primary_action_only"
+            and day_packet_primary_action_promoted is True
+        )
+    )
+
+
+def build_selected_downstream_next_step(
+    *,
+    local_operator_next_step: str | None,
+    local_validation_action_line: str | None = None,
+    cross_repo_validation_action_line: str | None = None,
+    triage_target_line: str | None = None,
+    mission_packet_steering_scope: str | None,
+    mission_packet_primary_action_promoted: bool | None,
+    day_packet_steering_scope: str | None,
+    day_packet_primary_action_promoted: bool | None,
+) -> tuple[str, str | None]:
+    if local_operator_next_step is not None:
+        return "local_runtime", f"local-runtime: {local_operator_next_step}"
+    if local_validation_action_line is not None:
+        return "local_validation", local_validation_action_line
+    if cross_repo_validation_action_line is not None and cross_repo_primary_action_promoted(
+        mission_packet_steering_scope=mission_packet_steering_scope,
+        mission_packet_primary_action_promoted=mission_packet_primary_action_promoted,
+        day_packet_steering_scope=day_packet_steering_scope,
+        day_packet_primary_action_promoted=day_packet_primary_action_promoted,
+    ):
+        return "cross_repo_validation", cross_repo_validation_action_line
+    if triage_target_line is not None:
+        return "triage_target", f"triage-target: {triage_target_line}"
+    return "none", None
+
+
+def append_unique_action_line(lines: list[str], line: str | None) -> None:
+    if line is None or line in lines:
+        return
+    lines.append(line)
 
 
 def resolve_nested_value(doc: dict[str, Any], *keys: str) -> Any:
@@ -5076,6 +5134,17 @@ def build_triage_brief_record(
         )
         for target in feed.target_records
     ]
+    selected_next_step_source, selected_next_step = build_selected_downstream_next_step(
+        local_operator_next_step=build_local_operator_next_step(feed.local_operator_record),
+        cross_repo_validation_action_line=feed.cross_repo_validation_action_line,
+        triage_target_line=None if not target_lines else target_lines[0],
+        mission_packet_steering_scope=feed.mission_packet_cross_repo_validation_steering_scope,
+        mission_packet_primary_action_promoted=(
+            feed.mission_packet_cross_repo_validation_primary_action_promoted
+        ),
+        day_packet_steering_scope=feed.day_packet_cross_repo_validation_steering_scope,
+        day_packet_primary_action_promoted=feed.day_packet_cross_repo_validation_primary_action_promoted,
+    )
     return TriageBriefRecord(
         source_kind=source_kind,
         target_limit=target_limit,
@@ -5091,6 +5160,8 @@ def build_triage_brief_record(
         local_operator_record=feed.local_operator_record,
         local_operator_summary=build_local_operator_summary(feed.local_operator_record),
         local_operator_next_step=build_local_operator_next_step(feed.local_operator_record),
+        selected_next_step_source=selected_next_step_source,
+        selected_next_step=selected_next_step,
         mission_packet_cross_repo_validation_steering_scope=(
             feed.mission_packet_cross_repo_validation_steering_scope
         ),
@@ -5133,6 +5204,8 @@ def render_triage_brief_table(record: TriageBriefRecord) -> str:
         sections.append(f"local_operator\t{record.local_operator_summary}")
     if record.local_operator_next_step is not None:
         sections.append(f"local_operator_next_step\t{record.local_operator_next_step}")
+    sections.append(f"selected_next_step_source\t{record.selected_next_step_source}")
+    sections.append(f"selected_next_step\t{record.selected_next_step or ''}")
     if record.cross_repo_validation_snapshot_status is not None:
         sections.extend(
             [
@@ -5204,6 +5277,8 @@ def render_triage_brief_markdown(record: TriageBriefRecord) -> str:
         lines.append(f"- local operator: `{record.local_operator_summary}`")
     if record.local_operator_next_step is not None:
         lines.append(f"- local operator next step: {record.local_operator_next_step}")
+    lines.append(f"- selected next step source: `{record.selected_next_step_source}`")
+    lines.append(f"- selected next step: {record.selected_next_step or ''}")
     if record.cross_repo_validation_snapshot_status is not None:
         lines.extend(
             [
@@ -5325,6 +5400,8 @@ def build_triage_report_record(
         markdown_lines.append(f"- local operator: `{brief.local_operator_summary}`")
     if brief.local_operator_next_step is not None:
         markdown_lines.append(f"- local operator next step: {brief.local_operator_next_step}")
+    markdown_lines.append(f"- selected next step source: `{brief.selected_next_step_source}`")
+    markdown_lines.append(f"- selected next step: {brief.selected_next_step or ''}")
     if brief.cross_repo_validation_snapshot_status is not None:
         markdown_lines.extend(
             [
@@ -5408,6 +5485,8 @@ def build_triage_report_record(
         local_operator_record=brief.local_operator_record,
         local_operator_summary=brief.local_operator_summary,
         local_operator_next_step=brief.local_operator_next_step,
+        selected_next_step_source=brief.selected_next_step_source,
+        selected_next_step=brief.selected_next_step,
         mission_packet_cross_repo_validation_steering_scope=(
             brief.mission_packet_cross_repo_validation_steering_scope
         ),
@@ -5448,6 +5527,8 @@ def render_triage_report_table(record: TriageReportRecord) -> str:
         sections.append(f"local_operator\t{record.local_operator_summary}")
     if record.local_operator_next_step is not None:
         sections.append(f"local_operator_next_step\t{record.local_operator_next_step}")
+    sections.append(f"selected_next_step_source\t{record.selected_next_step_source}")
+    sections.append(f"selected_next_step\t{record.selected_next_step or ''}")
     if record.cross_repo_validation_snapshot_status is not None:
         sections.extend(
             [
@@ -5581,15 +5662,36 @@ def build_handoff_report_record(
             cross_repo_validation_packet_report_id = packet_record.report_id
             cross_repo_validation_packet_path = packet_record.report_path
     headline = f"Operator handoff report: {triage_report.headline.removeprefix('Federated CI triage report: ')}"
+    selected_next_step_source, selected_next_step = build_selected_downstream_next_step(
+        local_operator_next_step=triage_report.local_operator_next_step,
+        local_validation_action_line=None if not local_validation_action_lines else local_validation_action_lines[0],
+        cross_repo_validation_action_line=cross_repo_validation_action_line,
+        triage_target_line=None if not triage_report.target_lines else triage_report.target_lines[0],
+        mission_packet_steering_scope=triage_report.mission_packet_cross_repo_validation_steering_scope,
+        mission_packet_primary_action_promoted=(
+            triage_report.mission_packet_cross_repo_validation_primary_action_promoted
+        ),
+        day_packet_steering_scope=triage_report.day_packet_cross_repo_validation_steering_scope,
+        day_packet_primary_action_promoted=triage_report.day_packet_cross_repo_validation_primary_action_promoted,
+    )
     immediate_action_lines: list[str] = []
-    if triage_report.local_operator_next_step is not None:
-        immediate_action_lines.append(f"local-runtime: {triage_report.local_operator_next_step}")
-    if local_validation_action_lines:
-        immediate_action_lines.append(local_validation_action_lines[0])
-    if triage_report.target_lines:
-        immediate_action_lines.append(f"triage-target: {triage_report.target_lines[0]}")
-    if len(triage_report.target_lines) > 1:
-        immediate_action_lines.append(f"follow-up: {triage_report.target_lines[1]}")
+    append_unique_action_line(immediate_action_lines, selected_next_step)
+    append_unique_action_line(
+        immediate_action_lines,
+        None if triage_report.local_operator_next_step is None else f"local-runtime: {triage_report.local_operator_next_step}",
+    )
+    append_unique_action_line(
+        immediate_action_lines,
+        None if not local_validation_action_lines else local_validation_action_lines[0],
+    )
+    append_unique_action_line(
+        immediate_action_lines,
+        None if not triage_report.target_lines else f"triage-target: {triage_report.target_lines[0]}",
+    )
+    append_unique_action_line(
+        immediate_action_lines,
+        None if len(triage_report.target_lines) <= 1 else f"follow-up: {triage_report.target_lines[1]}",
+    )
 
     markdown_lines = [
         "## Operator Handoff Report",
@@ -5610,6 +5712,8 @@ def build_handoff_report_record(
         markdown_lines.append(f"- local operator: `{triage_report.local_operator_summary}`")
     if triage_report.local_operator_next_step is not None:
         markdown_lines.append(f"- local operator next step: {triage_report.local_operator_next_step}")
+    markdown_lines.append(f"- selected next step source: `{selected_next_step_source}`")
+    markdown_lines.append(f"- selected next step: {selected_next_step or ''}")
     markdown_lines.extend(
         [
             "",
@@ -5725,6 +5829,8 @@ def build_handoff_report_record(
         local_operator_record=triage_report.local_operator_record,
         local_operator_summary=triage_report.local_operator_summary,
         local_operator_next_step=triage_report.local_operator_next_step,
+        selected_next_step_source=selected_next_step_source,
+        selected_next_step=selected_next_step,
         mission_packet_cross_repo_validation_steering_scope=(
             triage_report.mission_packet_cross_repo_validation_steering_scope
         ),
@@ -5778,6 +5884,8 @@ def render_handoff_report_table(record: HandoffReportRecord) -> str:
         sections.append(f"local_operator\t{record.local_operator_summary}")
     if record.local_operator_next_step is not None:
         sections.append(f"local_operator_next_step\t{record.local_operator_next_step}")
+    sections.append(f"selected_next_step_source\t{record.selected_next_step_source}")
+    sections.append(f"selected_next_step\t{record.selected_next_step or ''}")
     sections.append(
         f"mission_packet_cross_repo_validation_steering_scope\t{record.mission_packet_cross_repo_validation_steering_scope or ''}"
     )

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1700,6 +1700,8 @@ assert record["local_operator_summary"] == (
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
 assert record["local_operator_next_step"] == "Expose Codex and add a direct local LLM profile.", record
+assert record["selected_next_step_source"] == "local_runtime", record
+assert record["selected_next_step"] == "local-runtime: Expose Codex and add a direct local LLM profile.", record
 assert record["cross_repo_validation_snapshot_status"] == "missing", record
 assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
 assert record["monday_source_validation_status"] == "missing", record
@@ -1748,6 +1750,8 @@ assert record["local_operator_summary"] == (
     "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
+assert record["selected_next_step_source"] == "local_runtime", record
+assert record["selected_next_step"] == "local-runtime: Expose Codex and add a direct local LLM profile.", record
 assert record["cross_repo_validation_snapshot_status"] == "missing", record
 assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
 assert record["monday_source_validation_status"] == "missing", record
@@ -1791,6 +1795,8 @@ assert record["local_operator_summary"] == (
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
 assert record["local_operator_next_step"] == "Expose Codex and add a direct local LLM profile.", record
+assert record["selected_next_step_source"] == "local_runtime", record
+assert record["selected_next_step"] == "local-runtime: Expose Codex and add a direct local LLM profile.", record
 assert record["cross_repo_validation_snapshot_status"] == "missing", record
 assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
 assert record["monday_source_validation_status"] == "missing", record
@@ -1842,6 +1848,8 @@ assert record["local_operator_summary"] == (
     "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
+assert record["selected_next_step_source"] == "local_runtime", record
+assert record["selected_next_step"] == "local-runtime: Expose Codex and add a direct local LLM profile.", record
 assert record["cross_repo_validation_snapshot_status"] == "missing", record
 assert record["cross_repo_validation_snapshot_summary"] == "total=0 promotable=0 blocked=0 stale=0", record
 assert record["monday_source_validation_status"] == "missing", record
@@ -2473,6 +2481,8 @@ assert record["local_operator_summary"] == (
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
 assert record["local_operator_next_step"] == "Expose Codex and add a direct local LLM profile.", record
+assert record["selected_next_step_source"] == "local_runtime", record
+assert record["selected_next_step"] == "local-runtime: Expose Codex and add a direct local LLM profile.", record
 assert record["local_validation_snapshot_status"] == "present", record
 assert record["local_validation_snapshot_summary"] == "total=8 promotable=4 blocked=4 stale=1", record
 assert record["monday_validation_snapshot_status"] == "missing", record
@@ -2578,6 +2588,8 @@ assert record["local_operator_summary"] == (
     "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
     "stack=skipped direct=skipped mode=both reason=readiness_blocked"
 ), record
+assert record["selected_next_step_source"] == "local_runtime", record
+assert record["selected_next_step"] == "local-runtime: Expose Codex and add a direct local LLM profile.", record
 assert record["local_validation_snapshot_status"] == "present", record
 assert record["local_validation_snapshot_summary"] == "total=8 promotable=4 blocked=4 stale=1", record
 assert record["monday_validation_snapshot_status"] == "missing", record
@@ -2592,6 +2604,8 @@ assert record["cross_repo_validation_action_line"] == (
     "local-validation: repair monday_local_inbox_runtime_report "
     "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
 ), record
+assert record["selected_next_step_source"] == "local_runtime", record
+assert record["selected_next_step"] == "local-runtime: Expose Codex and add a direct local LLM profile.", record
 assert record["cross_repo_validation_detail_lines"] == [
     "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
     "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
@@ -4438,6 +4452,8 @@ assert record["cross_repo_validation_action_line"] == (
     "local-validation: repair monday_local_inbox_runtime_report "
     "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
 ), record
+assert record["selected_next_step_source"] == "local_runtime", record
+assert record["selected_next_step"] == "local-runtime: Expose Codex and add a direct local LLM profile.", record
 assert record["cross_repo_validation_detail_lines"] == [
     "mirror: monday_local_inbox_launch_request: freshness=fresh promotability=promotable dependencies=monday_local_operator_inbox_payload=current",
     "mirror: monday_local_inbox_runtime_report: freshness=fresh promotability=blocked reasons=source_artifact_missing dependencies=monday_local_operator_inbox_payload=current,monday_local_inbox_launch_request=current",
@@ -4990,6 +5006,98 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 assert doc["record"] is None, doc
+PY
+
+python3 - <<'PY' "$VALIDATION_DIR" "$LOCAL_OPERATOR_DIR"
+import json
+import sys
+from pathlib import Path
+
+validation_dir = Path(sys.argv[1]).resolve()
+local_root = Path(sys.argv[2]).resolve()
+
+mission_latest_path = validation_dir / "monday-local-mission-packet.json"
+mission_steered_path = validation_dir / "monday-local-mission-20260401T080200Z-monday-local-mission-packet.json"
+day_latest_path = validation_dir / "monday-local-operator-day-packet.json"
+day_steered_path = validation_dir / "monday-local-day-20260401T083100Z-monday-local-operator-day-packet.json"
+
+mission_doc = json.loads(mission_steered_path.read_text(encoding="utf-8"))
+mission_doc["artifact_paths"]["latest_packet_path"] = str(mission_latest_path.resolve())
+mission_doc["artifact_paths"]["stamped_packet_path"] = str(mission_steered_path.resolve())
+mission_latest_path.write_text(json.dumps(mission_doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+day_doc = json.loads(day_steered_path.read_text(encoding="utf-8"))
+day_doc["artifact_paths"]["latest_packet_path"] = str(day_latest_path.resolve())
+day_doc["artifact_paths"]["stamped_packet_path"] = str(day_steered_path.resolve())
+day_latest_path.write_text(json.dumps(day_doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+local_report_path = local_root / "monday-local-operator-stack-20260401T060524Z.json"
+local_doc = json.loads(local_report_path.read_text(encoding="utf-8"))
+local_doc["recommended_next_steps"] = []
+local_report_path.write_text(json.dumps(local_doc, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+PY
+
+TRIAGE_BRIEF_STEERED_NEXT_STEP_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-brief \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_BRIEF_STEERED_NEXT_STEP_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_BRIEF_STEERED_NEXT_STEP_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["mission_packet_cross_repo_validation_steering_scope"] == "primary_action_only", record
+assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is True, record
+assert record["day_packet_cross_repo_validation_steering_scope"] == "primary_action_only", record
+assert record["day_packet_cross_repo_validation_primary_action_promoted"] is True, record
+assert record["local_operator_next_step"] is None, record
+assert record["selected_next_step_source"] == "cross_repo_validation", record
+assert record["selected_next_step"] == (
+    "local-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+), record
+PY
+
+TRIAGE_REPORT_STEERED_NEXT_STEP_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" >"$TRIAGE_REPORT_STEERED_NEXT_STEP_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_STEERED_NEXT_STEP_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record["mission_packet_cross_repo_validation_steering_scope"] == "primary_action_only", record
+assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is True, record
+assert record["day_packet_cross_repo_validation_steering_scope"] == "primary_action_only", record
+assert record["day_packet_cross_repo_validation_primary_action_promoted"] is True, record
+assert record["local_operator_next_step"] is None, record
+assert record["selected_next_step_source"] == "cross_repo_validation", record
+assert record["selected_next_step"] == (
+    "local-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+), record
+assert "selected next step source: `cross_repo_validation`" in record["markdown"], record
+assert (
+    "selected next step: local-validation: repair monday_local_inbox_runtime_report "
+    "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
+) in record["markdown"], record
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \


### PR DESCRIPTION
## Scope
- make triage and handoff summary-level next-step selection steering-aware
- keep the existing fail-closed steering boundary intact

## Summary
- add `selected_next_step_source` and `selected_next_step` to `triage-brief`, `triage-report`, and `handoff-report`
- use precedence `local-runtime -> local-validation -> promoted cross-repo validation -> triage-target`
- prove that promoted cross-repo validation becomes the selected summary action only after higher-precedence local steps are absent

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1016

## Risks
- changes downstream summary surfaces and regression fixtures, but keeps mission objective and target ranking policy unchanged

## Review Checklist
- [ ] Verify downstream summary surfaces expose the new selected next-step fields
- [ ] Verify selected next-step precedence stays fail-closed
- [ ] Verify steered cross-repo action only surfaces when stronger local steps are absent

## Post-Deploy Monitoring & Validation
- spot-check `triage-brief`, `triage-report`, and `handoff-report` on latest validation artifacts to confirm selected next-step source matches the mirrored mission/day steering state
