### PR TITLE
feat(query-engine): add selected next-step source filters

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -207,6 +207,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed|triage-brief|triage-report|local-inbox-payload|monday-consumer-report` now accept explicit mission/day steering filters so operators can isolate `none` vs `primary_action_only` and promoted vs non-promoted downstream states without reopening packet-local surfaces
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries mission/day steering metadata directly and accepts the same steering filters, returning an empty/no-match handoff snapshot when the current report does not satisfy the requested downstream steering state
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief|triage-report|handoff-report` now expose an explicit downstream `selected_next_step` and `selected_next_step_source`, using the existing fail-closed precedence `local-runtime -> local-validation -> promoted cross-repo validation -> triage-target` so promoted cross-repo validation can steer summary-level next-step selection without changing mission objective or target ranking
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief|triage-report|handoff-report` now also accept `--selected-next-step-source` so operators can isolate summary surfaces where the currently selected next step is `local_runtime`, `local_validation`, `cross_repo_validation`, `triage_target`, or `none` without reopening packet-local views
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -269,4 +270,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether downstream `selected_next_step` should remain the ceiling for cross-repo steering, or whether headline/attention summary selection should ever become steering-aware without crossing the current packet-local policy boundary
+2. decide whether `selected_next_step_source` filtering is enough as the operator-facing ceiling, or whether headline/attention summary selection should ever become steering-aware without crossing the current packet-local policy boundary

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -59,6 +59,13 @@ MONDAY_VALIDATION_KIND_CHOICES = ("bridge", "consumer-report")
 MONDAY_VALIDATION_VERDICT_CHOICES = ("pass", "fail")
 CROSS_REPO_VALIDATION_PACKET_SOURCE_CHOICES = ("latest", "stamped")
 STEERING_SCOPE_CHOICES = ("none", "primary_action_only")
+SELECTED_NEXT_STEP_SOURCE_CHOICES = (
+    "none",
+    "local_runtime",
+    "local_validation",
+    "cross_repo_validation",
+    "triage_target",
+)
 LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_operator_stack_report",
     "operator_handoff_report",
@@ -1550,6 +1557,14 @@ def matches_downstream_steering_filters(
         if day_packet_primary_action_promoted is not expected:
             return False
     return True
+
+
+def matches_selected_next_step_source_filter(
+    *,
+    selected_next_step_source_filter: str | None,
+    selected_next_step_source: str,
+) -> bool:
+    return selected_next_step_source_filter is None or selected_next_step_source == selected_next_step_source_filter
 
 
 def filter_local_inbox_payload_records(
@@ -7156,6 +7171,11 @@ def parse_args() -> argparse.Namespace:
     triage_brief_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     triage_brief_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
     triage_brief_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    triage_brief_parser.add_argument(
+        "--selected-next-step-source",
+        choices=SELECTED_NEXT_STEP_SOURCE_CHOICES,
+        default=None,
+    )
     triage_brief_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     triage_brief_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_brief_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -7176,6 +7196,11 @@ def parse_args() -> argparse.Namespace:
     triage_report_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     triage_report_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
     triage_report_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    triage_report_parser.add_argument(
+        "--selected-next-step-source",
+        choices=SELECTED_NEXT_STEP_SOURCE_CHOICES,
+        default=None,
+    )
     triage_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     triage_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -7196,6 +7221,11 @@ def parse_args() -> argparse.Namespace:
     handoff_report_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     handoff_report_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
     handoff_report_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    handoff_report_parser.add_argument(
+        "--selected-next-step-source",
+        choices=SELECTED_NEXT_STEP_SOURCE_CHOICES,
+        default=None,
+    )
     handoff_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     handoff_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     handoff_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -7926,6 +7956,11 @@ def main() -> int:
             day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
         ):
             record = None
+        if record is not None and not matches_selected_next_step_source_filter(
+            selected_next_step_source_filter=args.selected_next_step_source,
+            selected_next_step_source=record.selected_next_step_source,
+        ):
+            record = None
         if args.format == "json":
             print(json.dumps({"record": None if record is None else asdict(record)}, ensure_ascii=True, indent=2))
             return 0
@@ -7962,6 +7997,11 @@ def main() -> int:
             day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
         ):
             record = None
+        if record is not None and not matches_selected_next_step_source_filter(
+            selected_next_step_source_filter=args.selected_next_step_source,
+            selected_next_step_source=record.selected_next_step_source,
+        ):
+            record = None
         if args.format == "json":
             print(json.dumps({"record": None if record is None else asdict(record)}, ensure_ascii=True, indent=2))
             return 0
@@ -7996,6 +8036,11 @@ def main() -> int:
             mission_packet_primary_action_promoted=record.mission_packet_cross_repo_validation_primary_action_promoted,
             day_packet_steering_scope=record.day_packet_cross_repo_validation_steering_scope,
             day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
+        ):
+            record = None
+        if record is not None and not matches_selected_next_step_source_filter(
+            selected_next_step_source_filter=args.selected_next_step_source,
+            selected_next_step_source=record.selected_next_step_source,
         ):
             record = None
         if args.format == "json":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -5066,6 +5066,48 @@ assert record["selected_next_step"] == (
 ), record
 PY
 
+TRIAGE_BRIEF_SELECTED_NEXT_STEP_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-brief \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --selected-next-step-source cross_repo_validation >"$TRIAGE_BRIEF_SELECTED_NEXT_STEP_FILTER_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_BRIEF_SELECTED_NEXT_STEP_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["selected_next_step_source"] == "cross_repo_validation", record
+PY
+
+TRIAGE_BRIEF_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-brief \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --selected-next-step-source local_runtime >"$TRIAGE_BRIEF_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_BRIEF_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
+PY
+
 TRIAGE_REPORT_STEERED_NEXT_STEP_OUTPUT=$(mktemp)
 python3 "$QUERY_PATH" triage-report \
   --format json \
@@ -5098,6 +5140,74 @@ assert (
     "selected next step: local-validation: repair monday_local_inbox_runtime_report "
     "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
 ) in record["markdown"], record
+PY
+
+TRIAGE_REPORT_SELECTED_NEXT_STEP_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --selected-next-step-source cross_repo_validation >"$TRIAGE_REPORT_SELECTED_NEXT_STEP_FILTER_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_SELECTED_NEXT_STEP_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["selected_next_step_source"] == "cross_repo_validation", record
+PY
+
+HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --selected-next-step-source local_validation >"$HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["selected_next_step_source"] == "local_validation", record
+assert record["selected_next_step"] == (
+    "local-validation: repair operator_handoff_report "
+    "(freshness=stale, promotability=blocked, reasons=stamped_missing)"
+), record
+PY
+
+HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --selected-next-step-source cross_repo_validation >"$HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
 PY
 
 python3 "$QUERY_PATH" local-validation-freshness \


### PR DESCRIPTION
## Scope
- add `--selected-next-step-source` filters to `triage-brief`, `triage-report`, and `handoff-report`
- let operators isolate summaries selected from `local_runtime`, `local_validation`, `cross_repo_validation`, `triage_target`, or `none`
- keep headline and attention summary selection unchanged

## Summary
- introduce selected-next-step-source filtering for downstream query surfaces that already expose `selected_next_step`
- return `record: null` for JSON and no-match output for human-readable modes when the selected summary source does not match
- extend regression coverage for both cross-repo-steered triage summaries and local-validation-selected handoff summaries

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1018

## Risks
- downstream filtering now depends on the selected-next-step precedence remaining stable across triage and handoff surfaces
- no headline or attention-summary ranking behavior changes are included in this packet

## Review Checklist
- [x] selected-next-step-source filters are wired for triage-brief, triage-report, and handoff-report
- [x] no-match behavior stays explicit in both JSON and human-readable outputs
- [x] regression fixtures cover both promoted cross-repo summaries and stronger local-validation summaries

## Post-Deploy Monitoring & Validation
- confirm `template-and-link-check`, `docs-check`, `contract-conformance`, `federated-conformance`, and `o11y-replay` stay green
- verify only the inherited red lanes remain before merge
