### PR TITLE
feat(query-engine): add summary source filters

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -208,6 +208,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py handoff-report` now carries mission/day steering metadata directly and accepts the same steering filters, returning an empty/no-match handoff snapshot when the current report does not satisfy the requested downstream steering state
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief|triage-report|handoff-report` now expose an explicit downstream `selected_next_step` and `selected_next_step_source`, using the existing fail-closed precedence `local-runtime -> local-validation -> promoted cross-repo validation -> triage-target` so promoted cross-repo validation can steer summary-level next-step selection without changing mission objective or target ranking
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief|triage-report|handoff-report` now also accept `--selected-next-step-source` so operators can isolate summary surfaces where the currently selected next step is `local_runtime`, `local_validation`, `cross_repo_validation`, `triage_target`, or `none` without reopening packet-local views
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now expose explicit `headline_source` and `attention_summary_source` metadata and accept matching filters, making the current `triage_snapshot`-owned summary ceiling query-visible without actually letting cross-repo steering rewrite headline or attention-summary composition
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -270,4 +271,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether `selected_next_step_source` filtering is enough as the operator-facing ceiling, or whether headline/attention summary selection should ever become steering-aware without crossing the current packet-local policy boundary
+2. decide whether explicit `headline_source` / `attention_summary_source` metadata is the right operator-facing ceiling, or whether headline/attention summary selection should ever become steering-aware without crossing the current packet-local policy boundary

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -66,6 +66,14 @@ SELECTED_NEXT_STEP_SOURCE_CHOICES = (
     "cross_repo_validation",
     "triage_target",
 )
+SUMMARY_SOURCE_CHOICES = (
+    "none",
+    "triage_snapshot",
+    "local_runtime",
+    "local_validation",
+    "cross_repo_validation",
+    "triage_target",
+)
 LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_operator_stack_report",
     "operator_handoff_report",
@@ -330,7 +338,9 @@ class TriageReportRecord:
     source_kind: str
     target_limit: int
     headline: str
+    headline_source: str
     attention_summary: str
+    attention_summary_source: str
     newest_failing_summary: str
     newest_recovered_summary: str | None
     local_operator_record: LocalOperatorStackRecord | None
@@ -362,7 +372,9 @@ class HandoffReportRecord:
     source_kind: str
     target_limit: int
     headline: str
+    headline_source: str
     attention_summary: str
+    attention_summary_source: str
     newest_failing_summary: str
     newest_recovered_summary: str | None
     local_operator_record: LocalOperatorStackRecord | None
@@ -1565,6 +1577,14 @@ def matches_selected_next_step_source_filter(
     selected_next_step_source: str,
 ) -> bool:
     return selected_next_step_source_filter is None or selected_next_step_source == selected_next_step_source_filter
+
+
+def matches_summary_source_filter(
+    *,
+    summary_source_filter: str | None,
+    summary_source: str,
+) -> bool:
+    return summary_source_filter is None or summary_source == summary_source_filter
 
 
 def filter_local_inbox_payload_records(
@@ -5388,9 +5408,11 @@ def build_triage_report_record(
         target_limit=target_limit,
     )
     headline = f"Federated CI triage report: {brief.attention_family_count} attention families"
+    headline_source = "triage_snapshot"
     attention_summary = (
         f"active={brief.active_family_count}, lagging={brief.lagging_family_count}, clear={brief.clear_family_count}"
     )
+    attention_summary_source = "triage_snapshot"
     newest_failing_summary = (
         f"{brief.newest_failing_family or 'none'} / {brief.newest_failing_run_id or 'none'} / "
         f"{brief.newest_failing_triage_status or 'none'}"
@@ -5404,6 +5426,8 @@ def build_triage_report_record(
         "### Snapshot",
         f"- source_kind: `{brief.source_kind}`",
         f"- top target window: `{brief.target_limit}`",
+        f"- headline source: `{headline_source}`",
+        f"- attention summary source: `{attention_summary_source}`",
         f"- attention families: `{brief.attention_family_count}` ({attention_summary})",
         f"- newest failing pointer: `{brief.newest_failing_family or ''}` / `{brief.newest_failing_run_id or ''}` ({brief.newest_failing_triage_status or 'none'})",
     ]
@@ -5494,7 +5518,9 @@ def build_triage_report_record(
         source_kind=brief.source_kind,
         target_limit=brief.target_limit,
         headline=headline,
+        headline_source=headline_source,
         attention_summary=attention_summary,
+        attention_summary_source=attention_summary_source,
         newest_failing_summary=newest_failing_summary,
         newest_recovered_summary=newest_recovered_summary,
         local_operator_record=brief.local_operator_record,
@@ -5531,9 +5557,11 @@ def build_triage_report_record(
 def render_triage_report_table(record: TriageReportRecord) -> str:
     sections = [
         f"headline\t{record.headline}",
+        f"headline_source\t{record.headline_source}",
         f"source_kind\t{record.source_kind}",
         f"target_limit\t{record.target_limit}",
         f"attention_summary\t{record.attention_summary}",
+        f"attention_summary_source\t{record.attention_summary_source}",
         f"newest_failing\t{record.newest_failing_summary}",
     ]
     if record.newest_recovered_summary is not None:
@@ -5677,6 +5705,8 @@ def build_handoff_report_record(
             cross_repo_validation_packet_report_id = packet_record.report_id
             cross_repo_validation_packet_path = packet_record.report_path
     headline = f"Operator handoff report: {triage_report.headline.removeprefix('Federated CI triage report: ')}"
+    headline_source = triage_report.headline_source
+    attention_summary_source = triage_report.attention_summary_source
     selected_next_step_source, selected_next_step = build_selected_downstream_next_step(
         local_operator_next_step=triage_report.local_operator_next_step,
         local_validation_action_line=None if not local_validation_action_lines else local_validation_action_lines[0],
@@ -5715,6 +5745,8 @@ def build_handoff_report_record(
         f"- headline: {headline}",
         f"- source_kind: `{triage_report.source_kind}`",
         f"- top target window: `{triage_report.target_limit}`",
+        f"- headline source: `{headline_source}`",
+        f"- attention summary source: `{attention_summary_source}`",
         f"- attention families: `{triage_report.attention_summary}`",
         f"- newest failing pointer: {triage_report.newest_failing_summary}",
     ]
@@ -5838,7 +5870,9 @@ def build_handoff_report_record(
         source_kind=triage_report.source_kind,
         target_limit=triage_report.target_limit,
         headline=headline,
+        headline_source=headline_source,
         attention_summary=triage_report.attention_summary,
+        attention_summary_source=attention_summary_source,
         newest_failing_summary=triage_report.newest_failing_summary,
         newest_recovered_summary=triage_report.newest_recovered_summary,
         local_operator_record=triage_report.local_operator_record,
@@ -5888,9 +5922,11 @@ def build_handoff_report_record(
 def render_handoff_report_table(record: HandoffReportRecord) -> str:
     sections = [
         f"headline\t{record.headline}",
+        f"headline_source\t{record.headline_source}",
         f"source_kind\t{record.source_kind}",
         f"target_limit\t{record.target_limit}",
         f"attention_summary\t{record.attention_summary}",
+        f"attention_summary_source\t{record.attention_summary_source}",
         f"newest_failing\t{record.newest_failing_summary}",
     ]
     if record.newest_recovered_summary is not None:
@@ -7201,6 +7237,8 @@ def parse_args() -> argparse.Namespace:
         choices=SELECTED_NEXT_STEP_SOURCE_CHOICES,
         default=None,
     )
+    triage_report_parser.add_argument("--headline-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    triage_report_parser.add_argument("--attention-summary-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
     triage_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     triage_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -7226,6 +7264,8 @@ def parse_args() -> argparse.Namespace:
         choices=SELECTED_NEXT_STEP_SOURCE_CHOICES,
         default=None,
     )
+    handoff_report_parser.add_argument("--headline-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    handoff_report_parser.add_argument("--attention-summary-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
     handoff_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     handoff_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     handoff_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -8002,6 +8042,16 @@ def main() -> int:
             selected_next_step_source=record.selected_next_step_source,
         ):
             record = None
+        if record is not None and not matches_summary_source_filter(
+            summary_source_filter=args.headline_source,
+            summary_source=record.headline_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_source_filter(
+            summary_source_filter=args.attention_summary_source,
+            summary_source=record.attention_summary_source,
+        ):
+            record = None
         if args.format == "json":
             print(json.dumps({"record": None if record is None else asdict(record)}, ensure_ascii=True, indent=2))
             return 0
@@ -8041,6 +8091,16 @@ def main() -> int:
         if record is not None and not matches_selected_next_step_source_filter(
             selected_next_step_source_filter=args.selected_next_step_source,
             selected_next_step_source=record.selected_next_step_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_source_filter(
+            summary_source_filter=args.headline_source,
+            summary_source=record.headline_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_source_filter(
+            summary_source_filter=args.attention_summary_source,
+            summary_source=record.attention_summary_source,
         ):
             record = None
         if args.format == "json":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1786,7 +1786,9 @@ record = doc["record"]
 assert record["source_kind"] == "stamped", record
 assert record["target_limit"] == 3, record
 assert record["headline"] == "Federated CI triage report: 2 attention families", record
+assert record["headline_source"] == "triage_snapshot", record
 assert record["attention_summary"] == "active=1, lagging=1, clear=0", record
+assert record["attention_summary_source"] == "triage_snapshot", record
 assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun30 / lagging", record
 assert record["newest_recovered_summary"] is None, record
 assert record["local_operator_record"]["run_id"] == "monday-local-operator-stack-20260401T060524Z", record
@@ -1813,6 +1815,8 @@ assert record["target_lines"] == [
     "[lagging/latest-alert-follow-up] federated-ci-runtime-gates -> federated-ci-runtime-gates-20260319-rerun29 domains=checkpoint,readiness,reconcile",
 ], record
 assert "## Federated CI Triage Report" in record["markdown"], record
+assert "headline source: `triage_snapshot`" in record["markdown"], record
+assert "attention summary source: `triage_snapshot`" in record["markdown"], record
 assert "### Local Operator Stack" not in record["markdown"], record
 assert "local operator:" in record["markdown"], record
 assert "local operator next step:" in record["markdown"], record
@@ -2474,7 +2478,9 @@ record = doc["record"]
 assert record["source_kind"] == "stamped", record
 assert record["target_limit"] == 3, record
 assert record["headline"] == "Operator handoff report: 2 attention families", record
+assert record["headline_source"] == "triage_snapshot", record
 assert record["attention_summary"] == "active=1, lagging=1, clear=0", record
+assert record["attention_summary_source"] == "triage_snapshot", record
 assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun30 / lagging", record
 assert record["local_operator_summary"] == (
     "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
@@ -5140,6 +5146,8 @@ assert (
     "selected next step: local-validation: repair monday_local_inbox_runtime_report "
     "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
 ) in record["markdown"], record
+assert "headline source: `triage_snapshot`" in record["markdown"], record
+assert "attention summary source: `triage_snapshot`" in record["markdown"], record
 PY
 
 TRIAGE_REPORT_SELECTED_NEXT_STEP_FILTER_OUTPUT=$(mktemp)
@@ -5162,6 +5170,50 @@ doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
 assert record is not None, doc
 assert record["selected_next_step_source"] == "cross_repo_validation", record
+PY
+
+TRIAGE_REPORT_HEADLINE_SOURCE_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --headline-source triage_snapshot \
+  --attention-summary-source triage_snapshot >"$TRIAGE_REPORT_HEADLINE_SOURCE_FILTER_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_HEADLINE_SOURCE_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["headline_source"] == "triage_snapshot", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+PY
+
+TRIAGE_REPORT_HEADLINE_SOURCE_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --headline-source cross_repo_validation >"$TRIAGE_REPORT_HEADLINE_SOURCE_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_HEADLINE_SOURCE_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
 PY
 
 HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_OUTPUT=$(mktemp)
@@ -5188,6 +5240,8 @@ assert record["selected_next_step"] == (
     "local-validation: repair operator_handoff_report "
     "(freshness=stale, promotability=blocked, reasons=stamped_missing)"
 ), record
+assert record["headline_source"] == "triage_snapshot", record
+assert record["attention_summary_source"] == "triage_snapshot", record
 PY
 
 HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT=$(mktemp)
@@ -5202,6 +5256,50 @@ python3 "$QUERY_PATH" handoff-report \
   --selected-next-step-source cross_repo_validation >"$HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT"
 
 python3 - <<'PY' "$HANDOFF_REPORT_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
+PY
+
+HANDOFF_REPORT_SUMMARY_SOURCE_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --headline-source triage_snapshot \
+  --attention-summary-source triage_snapshot >"$HANDOFF_REPORT_SUMMARY_SOURCE_FILTER_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_SUMMARY_SOURCE_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["headline_source"] == "triage_snapshot", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+PY
+
+HANDOFF_REPORT_SUMMARY_SOURCE_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --attention-summary-source cross_repo_validation >"$HANDOFF_REPORT_SUMMARY_SOURCE_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_SUMMARY_SOURCE_FILTER_MISS_OUTPUT"
 import json
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Scope
- expose explicit `headline_source` and `attention_summary_source` metadata on downstream summary surfaces
- add summary-source filters to `triage-report` and `handoff-report`
- keep headline and attention summary composition fail-closed and triage-snapshot-owned

## Summary
- add `headline_source` and `attention_summary_source` fields to `triage-report` and `handoff-report` JSON, table, and markdown outputs
- introduce `--headline-source` and `--attention-summary-source` filters so operators can isolate the current summary-source ceiling from query surfaces
- extend regression coverage for both matching `triage_snapshot` filters and no-match cases that should return `record: null`

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1020

## Risks
- downstream summary-source filters now depend on `triage_snapshot` remaining the explicit ceiling for headline and attention-summary composition
- this packet does not change headline or attention-summary ranking precedence; it only exposes and filters the current source metadata

## Review Checklist
- [x] `triage-report` and `handoff-report` now emit summary source metadata in JSON and human-readable output
- [x] summary-source filters return `record: null` / no-match when the current surface does not satisfy the requested source
- [x] regression coverage covers both matching and miss cases without widening steering behavior

## Post-Deploy Monitoring & Validation
- confirm `template-and-link-check`, `docs-check`, `contract-conformance`, `federated-conformance`, and `o11y-replay` stay green
- verify only the inherited red lanes remain before merge
