### PR TITLE
feat(query-engine): encode summary steering policy

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -209,6 +209,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief|triage-report|handoff-report` now expose an explicit downstream `selected_next_step` and `selected_next_step_source`, using the existing fail-closed precedence `local-runtime -> local-validation -> promoted cross-repo validation -> triage-target` so promoted cross-repo validation can steer summary-level next-step selection without changing mission objective or target ranking
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief|triage-report|handoff-report` now also accept `--selected-next-step-source` so operators can isolate summary surfaces where the currently selected next step is `local_runtime`, `local_validation`, `cross_repo_validation`, `triage_target`, or `none` without reopening packet-local views
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now expose explicit `headline_source` and `attention_summary_source` metadata and accept matching filters, making the current `triage_snapshot`-owned summary ceiling query-visible without actually letting cross-repo steering rewrite headline or attention-summary composition
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now also expose explicit `summary_steering_scope=selected_next_step_only` metadata and accept `--summary-steering-scope`, making the policy boundary itself query-visible while still leaving `headline` and `attention_summary` owned by `triage_snapshot`
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -271,4 +272,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether explicit `headline_source` / `attention_summary_source` metadata is the right operator-facing ceiling, or whether headline/attention summary selection should ever become steering-aware without crossing the current packet-local policy boundary
+2. keep `summary_steering_scope=selected_next_step_only` as the operator-facing ceiling unless repeated audited usage justifies widening actual `headline` / `attention_summary` selection beyond the current `triage_snapshot` ownership boundary

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -74,6 +74,10 @@ SUMMARY_SOURCE_CHOICES = (
     "cross_repo_validation",
     "triage_target",
 )
+SUMMARY_STEERING_SCOPE_CHOICES = (
+    "none",
+    "selected_next_step_only",
+)
 LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_operator_stack_report",
     "operator_handoff_report",
@@ -341,6 +345,7 @@ class TriageReportRecord:
     headline_source: str
     attention_summary: str
     attention_summary_source: str
+    summary_steering_scope: str
     newest_failing_summary: str
     newest_recovered_summary: str | None
     local_operator_record: LocalOperatorStackRecord | None
@@ -375,6 +380,7 @@ class HandoffReportRecord:
     headline_source: str
     attention_summary: str
     attention_summary_source: str
+    summary_steering_scope: str
     newest_failing_summary: str
     newest_recovered_summary: str | None
     local_operator_record: LocalOperatorStackRecord | None
@@ -1585,6 +1591,17 @@ def matches_summary_source_filter(
     summary_source: str,
 ) -> bool:
     return summary_source_filter is None or summary_source == summary_source_filter
+
+
+def matches_summary_steering_scope_filter(
+    *,
+    summary_steering_scope_filter: str | None,
+    summary_steering_scope: str,
+) -> bool:
+    return (
+        summary_steering_scope_filter is None
+        or summary_steering_scope == summary_steering_scope_filter
+    )
 
 
 def filter_local_inbox_payload_records(
@@ -5413,6 +5430,7 @@ def build_triage_report_record(
         f"active={brief.active_family_count}, lagging={brief.lagging_family_count}, clear={brief.clear_family_count}"
     )
     attention_summary_source = "triage_snapshot"
+    summary_steering_scope = "selected_next_step_only"
     newest_failing_summary = (
         f"{brief.newest_failing_family or 'none'} / {brief.newest_failing_run_id or 'none'} / "
         f"{brief.newest_failing_triage_status or 'none'}"
@@ -5428,6 +5446,7 @@ def build_triage_report_record(
         f"- top target window: `{brief.target_limit}`",
         f"- headline source: `{headline_source}`",
         f"- attention summary source: `{attention_summary_source}`",
+        f"- summary steering scope: `{summary_steering_scope}`",
         f"- attention families: `{brief.attention_family_count}` ({attention_summary})",
         f"- newest failing pointer: `{brief.newest_failing_family or ''}` / `{brief.newest_failing_run_id or ''}` ({brief.newest_failing_triage_status or 'none'})",
     ]
@@ -5521,6 +5540,7 @@ def build_triage_report_record(
         headline_source=headline_source,
         attention_summary=attention_summary,
         attention_summary_source=attention_summary_source,
+        summary_steering_scope=summary_steering_scope,
         newest_failing_summary=newest_failing_summary,
         newest_recovered_summary=newest_recovered_summary,
         local_operator_record=brief.local_operator_record,
@@ -5562,6 +5582,7 @@ def render_triage_report_table(record: TriageReportRecord) -> str:
         f"target_limit\t{record.target_limit}",
         f"attention_summary\t{record.attention_summary}",
         f"attention_summary_source\t{record.attention_summary_source}",
+        f"summary_steering_scope\t{record.summary_steering_scope}",
         f"newest_failing\t{record.newest_failing_summary}",
     ]
     if record.newest_recovered_summary is not None:
@@ -5707,6 +5728,7 @@ def build_handoff_report_record(
     headline = f"Operator handoff report: {triage_report.headline.removeprefix('Federated CI triage report: ')}"
     headline_source = triage_report.headline_source
     attention_summary_source = triage_report.attention_summary_source
+    summary_steering_scope = triage_report.summary_steering_scope
     selected_next_step_source, selected_next_step = build_selected_downstream_next_step(
         local_operator_next_step=triage_report.local_operator_next_step,
         local_validation_action_line=None if not local_validation_action_lines else local_validation_action_lines[0],
@@ -5747,6 +5769,7 @@ def build_handoff_report_record(
         f"- top target window: `{triage_report.target_limit}`",
         f"- headline source: `{headline_source}`",
         f"- attention summary source: `{attention_summary_source}`",
+        f"- summary steering scope: `{summary_steering_scope}`",
         f"- attention families: `{triage_report.attention_summary}`",
         f"- newest failing pointer: {triage_report.newest_failing_summary}",
     ]
@@ -5873,6 +5896,7 @@ def build_handoff_report_record(
         headline_source=headline_source,
         attention_summary=triage_report.attention_summary,
         attention_summary_source=attention_summary_source,
+        summary_steering_scope=summary_steering_scope,
         newest_failing_summary=triage_report.newest_failing_summary,
         newest_recovered_summary=triage_report.newest_recovered_summary,
         local_operator_record=triage_report.local_operator_record,
@@ -5927,6 +5951,7 @@ def render_handoff_report_table(record: HandoffReportRecord) -> str:
         f"target_limit\t{record.target_limit}",
         f"attention_summary\t{record.attention_summary}",
         f"attention_summary_source\t{record.attention_summary_source}",
+        f"summary_steering_scope\t{record.summary_steering_scope}",
         f"newest_failing\t{record.newest_failing_summary}",
     ]
     if record.newest_recovered_summary is not None:
@@ -7237,6 +7262,11 @@ def parse_args() -> argparse.Namespace:
         choices=SELECTED_NEXT_STEP_SOURCE_CHOICES,
         default=None,
     )
+    triage_report_parser.add_argument(
+        "--summary-steering-scope",
+        choices=SUMMARY_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
     triage_report_parser.add_argument("--headline-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
     triage_report_parser.add_argument("--attention-summary-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
     triage_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
@@ -7262,6 +7292,11 @@ def parse_args() -> argparse.Namespace:
     handoff_report_parser.add_argument(
         "--selected-next-step-source",
         choices=SELECTED_NEXT_STEP_SOURCE_CHOICES,
+        default=None,
+    )
+    handoff_report_parser.add_argument(
+        "--summary-steering-scope",
+        choices=SUMMARY_STEERING_SCOPE_CHOICES,
         default=None,
     )
     handoff_report_parser.add_argument("--headline-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
@@ -8042,6 +8077,11 @@ def main() -> int:
             selected_next_step_source=record.selected_next_step_source,
         ):
             record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.summary_steering_scope,
+            summary_steering_scope=record.summary_steering_scope,
+        ):
+            record = None
         if record is not None and not matches_summary_source_filter(
             summary_source_filter=args.headline_source,
             summary_source=record.headline_source,
@@ -8091,6 +8131,11 @@ def main() -> int:
         if record is not None and not matches_selected_next_step_source_filter(
             selected_next_step_source_filter=args.selected_next_step_source,
             selected_next_step_source=record.selected_next_step_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.summary_steering_scope,
+            summary_steering_scope=record.summary_steering_scope,
         ):
             record = None
         if record is not None and not matches_summary_source_filter(

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1789,6 +1789,7 @@ assert record["headline"] == "Federated CI triage report: 2 attention families",
 assert record["headline_source"] == "triage_snapshot", record
 assert record["attention_summary"] == "active=1, lagging=1, clear=0", record
 assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun30 / lagging", record
 assert record["newest_recovered_summary"] is None, record
 assert record["local_operator_record"]["run_id"] == "monday-local-operator-stack-20260401T060524Z", record
@@ -1817,6 +1818,7 @@ assert record["target_lines"] == [
 assert "## Federated CI Triage Report" in record["markdown"], record
 assert "headline source: `triage_snapshot`" in record["markdown"], record
 assert "attention summary source: `triage_snapshot`" in record["markdown"], record
+assert "summary steering scope: `selected_next_step_only`" in record["markdown"], record
 assert "### Local Operator Stack" not in record["markdown"], record
 assert "local operator:" in record["markdown"], record
 assert "local operator next step:" in record["markdown"], record
@@ -2481,6 +2483,7 @@ assert record["headline"] == "Operator handoff report: 2 attention families", re
 assert record["headline_source"] == "triage_snapshot", record
 assert record["attention_summary"] == "active=1, lagging=1, clear=0", record
 assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun30 / lagging", record
 assert record["local_operator_summary"] == (
     "monday-local-operator-stack-20260401T060524Z verdict=fail readiness=blocked "
@@ -5148,6 +5151,7 @@ assert (
 ) in record["markdown"], record
 assert "headline source: `triage_snapshot`" in record["markdown"], record
 assert "attention summary source: `triage_snapshot`" in record["markdown"], record
+assert "summary steering scope: `selected_next_step_only`" in record["markdown"], record
 PY
 
 TRIAGE_REPORT_SELECTED_NEXT_STEP_FILTER_OUTPUT=$(mktemp)
@@ -5194,6 +5198,48 @@ record = doc["record"]
 assert record is not None, doc
 assert record["headline_source"] == "triage_snapshot", record
 assert record["attention_summary_source"] == "triage_snapshot", record
+PY
+
+TRIAGE_REPORT_SUMMARY_STEERING_SCOPE_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --summary-steering-scope selected_next_step_only >"$TRIAGE_REPORT_SUMMARY_STEERING_SCOPE_FILTER_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_SUMMARY_STEERING_SCOPE_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["summary_steering_scope"] == "selected_next_step_only", record
+PY
+
+TRIAGE_REPORT_SUMMARY_STEERING_SCOPE_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --summary-steering-scope none >"$TRIAGE_REPORT_SUMMARY_STEERING_SCOPE_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_SUMMARY_STEERING_SCOPE_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
 PY
 
 TRIAGE_REPORT_HEADLINE_SOURCE_FILTER_MISS_OUTPUT=$(mktemp)
@@ -5286,6 +5332,49 @@ record = doc["record"]
 assert record is not None, doc
 assert record["headline_source"] == "triage_snapshot", record
 assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
+PY
+
+HANDOFF_REPORT_SUMMARY_STEERING_SCOPE_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --summary-steering-scope selected_next_step_only >"$HANDOFF_REPORT_SUMMARY_STEERING_SCOPE_FILTER_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_SUMMARY_STEERING_SCOPE_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["summary_steering_scope"] == "selected_next_step_only", record
+PY
+
+HANDOFF_REPORT_SUMMARY_STEERING_SCOPE_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --summary-steering-scope none >"$HANDOFF_REPORT_SUMMARY_STEERING_SCOPE_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_SUMMARY_STEERING_SCOPE_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
 PY
 
 HANDOFF_REPORT_SUMMARY_SOURCE_FILTER_MISS_OUTPUT=$(mktemp)


### PR DESCRIPTION
## Scope
- encode the current summary steering ceiling directly on summary surfaces
- expose a filterable summary steering scope without widening headline or attention-summary ownership
- keep cross-repo steering limited to selected next-step selection

## Summary
- add explicit `summary_steering_scope=selected_next_step_only` metadata to `triage-report` and `handoff-report`
- add `--summary-steering-scope` filters for both query surfaces
- extend regressions and rollout plan notes to reflect the explicit operator-facing policy boundary

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1022

## Risks
- Low: this packet only adds explicit metadata and filtering around the existing summary steering ceiling

## Review Checklist
- [x] summary steering scope is emitted in triage and handoff JSON/table/markdown
- [x] `--summary-steering-scope` returns match/no-match behavior without widening summary ownership
- [x] docs and regressions describe the explicit selected-next-step-only policy boundary

## Post-Deploy Monitoring & Validation
- confirm triage/handoff query users can isolate `selected_next_step_only` surfaces without reopening packet-local records
- keep `headline_source` and `attention_summary_source` at `triage_snapshot` until separate audited demand justifies widening that boundary