### PR TITLE
feat(query-engine): encode summary component steering ceilings

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -210,6 +210,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief|triage-report|handoff-report` now also accept `--selected-next-step-source` so operators can isolate summary surfaces where the currently selected next step is `local_runtime`, `local_validation`, `cross_repo_validation`, `triage_target`, or `none` without reopening packet-local views
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now expose explicit `headline_source` and `attention_summary_source` metadata and accept matching filters, making the current `triage_snapshot`-owned summary ceiling query-visible without actually letting cross-repo steering rewrite headline or attention-summary composition
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now also expose explicit `summary_steering_scope=selected_next_step_only` metadata and accept `--summary-steering-scope`, making the policy boundary itself query-visible while still leaving `headline` and `attention_summary` owned by `triage_snapshot`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now also expose explicit `headline_steering_scope=none` and `attention_summary_steering_scope=none` metadata with matching filters, making it query-visible that top-line summary components are still fail-closed and not steering-aware even while `selected_next_step` remains policy-steerable
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -272,4 +273,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. keep `summary_steering_scope=selected_next_step_only` as the operator-facing ceiling unless repeated audited usage justifies widening actual `headline` / `attention_summary` selection beyond the current `triage_snapshot` ownership boundary
+2. keep `headline_steering_scope=none`, `attention_summary_steering_scope=none`, and `summary_steering_scope=selected_next_step_only` as the explicit operator-facing ceiling unless repeated audited usage justifies widening actual summary selection beyond the current `triage_snapshot` ownership boundary

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -78,6 +78,10 @@ SUMMARY_STEERING_SCOPE_CHOICES = (
     "none",
     "selected_next_step_only",
 )
+SUMMARY_COMPONENT_STEERING_SCOPE_CHOICES = (
+    "none",
+    "steering_aware",
+)
 LOCAL_VALIDATION_FAMILY_CHOICES = (
     "monday_local_operator_stack_report",
     "operator_handoff_report",
@@ -343,8 +347,10 @@ class TriageReportRecord:
     target_limit: int
     headline: str
     headline_source: str
+    headline_steering_scope: str
     attention_summary: str
     attention_summary_source: str
+    attention_summary_steering_scope: str
     summary_steering_scope: str
     newest_failing_summary: str
     newest_recovered_summary: str | None
@@ -378,8 +384,10 @@ class HandoffReportRecord:
     target_limit: int
     headline: str
     headline_source: str
+    headline_steering_scope: str
     attention_summary: str
     attention_summary_source: str
+    attention_summary_steering_scope: str
     summary_steering_scope: str
     newest_failing_summary: str
     newest_recovered_summary: str | None
@@ -5426,10 +5434,12 @@ def build_triage_report_record(
     )
     headline = f"Federated CI triage report: {brief.attention_family_count} attention families"
     headline_source = "triage_snapshot"
+    headline_steering_scope = "none"
     attention_summary = (
         f"active={brief.active_family_count}, lagging={brief.lagging_family_count}, clear={brief.clear_family_count}"
     )
     attention_summary_source = "triage_snapshot"
+    attention_summary_steering_scope = "none"
     summary_steering_scope = "selected_next_step_only"
     newest_failing_summary = (
         f"{brief.newest_failing_family or 'none'} / {brief.newest_failing_run_id or 'none'} / "
@@ -5445,7 +5455,9 @@ def build_triage_report_record(
         f"- source_kind: `{brief.source_kind}`",
         f"- top target window: `{brief.target_limit}`",
         f"- headline source: `{headline_source}`",
+        f"- headline steering scope: `{headline_steering_scope}`",
         f"- attention summary source: `{attention_summary_source}`",
+        f"- attention summary steering scope: `{attention_summary_steering_scope}`",
         f"- summary steering scope: `{summary_steering_scope}`",
         f"- attention families: `{brief.attention_family_count}` ({attention_summary})",
         f"- newest failing pointer: `{brief.newest_failing_family or ''}` / `{brief.newest_failing_run_id or ''}` ({brief.newest_failing_triage_status or 'none'})",
@@ -5538,8 +5550,10 @@ def build_triage_report_record(
         target_limit=brief.target_limit,
         headline=headline,
         headline_source=headline_source,
+        headline_steering_scope=headline_steering_scope,
         attention_summary=attention_summary,
         attention_summary_source=attention_summary_source,
+        attention_summary_steering_scope=attention_summary_steering_scope,
         summary_steering_scope=summary_steering_scope,
         newest_failing_summary=newest_failing_summary,
         newest_recovered_summary=newest_recovered_summary,
@@ -5578,10 +5592,12 @@ def render_triage_report_table(record: TriageReportRecord) -> str:
     sections = [
         f"headline\t{record.headline}",
         f"headline_source\t{record.headline_source}",
+        f"headline_steering_scope\t{record.headline_steering_scope}",
         f"source_kind\t{record.source_kind}",
         f"target_limit\t{record.target_limit}",
         f"attention_summary\t{record.attention_summary}",
         f"attention_summary_source\t{record.attention_summary_source}",
+        f"attention_summary_steering_scope\t{record.attention_summary_steering_scope}",
         f"summary_steering_scope\t{record.summary_steering_scope}",
         f"newest_failing\t{record.newest_failing_summary}",
     ]
@@ -5727,7 +5743,9 @@ def build_handoff_report_record(
             cross_repo_validation_packet_path = packet_record.report_path
     headline = f"Operator handoff report: {triage_report.headline.removeprefix('Federated CI triage report: ')}"
     headline_source = triage_report.headline_source
+    headline_steering_scope = triage_report.headline_steering_scope
     attention_summary_source = triage_report.attention_summary_source
+    attention_summary_steering_scope = triage_report.attention_summary_steering_scope
     summary_steering_scope = triage_report.summary_steering_scope
     selected_next_step_source, selected_next_step = build_selected_downstream_next_step(
         local_operator_next_step=triage_report.local_operator_next_step,
@@ -5768,7 +5786,9 @@ def build_handoff_report_record(
         f"- source_kind: `{triage_report.source_kind}`",
         f"- top target window: `{triage_report.target_limit}`",
         f"- headline source: `{headline_source}`",
+        f"- headline steering scope: `{headline_steering_scope}`",
         f"- attention summary source: `{attention_summary_source}`",
+        f"- attention summary steering scope: `{attention_summary_steering_scope}`",
         f"- summary steering scope: `{summary_steering_scope}`",
         f"- attention families: `{triage_report.attention_summary}`",
         f"- newest failing pointer: {triage_report.newest_failing_summary}",
@@ -5894,8 +5914,10 @@ def build_handoff_report_record(
         target_limit=triage_report.target_limit,
         headline=headline,
         headline_source=headline_source,
+        headline_steering_scope=headline_steering_scope,
         attention_summary=triage_report.attention_summary,
         attention_summary_source=attention_summary_source,
+        attention_summary_steering_scope=attention_summary_steering_scope,
         summary_steering_scope=summary_steering_scope,
         newest_failing_summary=triage_report.newest_failing_summary,
         newest_recovered_summary=triage_report.newest_recovered_summary,
@@ -5947,10 +5969,12 @@ def render_handoff_report_table(record: HandoffReportRecord) -> str:
     sections = [
         f"headline\t{record.headline}",
         f"headline_source\t{record.headline_source}",
+        f"headline_steering_scope\t{record.headline_steering_scope}",
         f"source_kind\t{record.source_kind}",
         f"target_limit\t{record.target_limit}",
         f"attention_summary\t{record.attention_summary}",
         f"attention_summary_source\t{record.attention_summary_source}",
+        f"attention_summary_steering_scope\t{record.attention_summary_steering_scope}",
         f"summary_steering_scope\t{record.summary_steering_scope}",
         f"newest_failing\t{record.newest_failing_summary}",
     ]
@@ -7268,7 +7292,17 @@ def parse_args() -> argparse.Namespace:
         default=None,
     )
     triage_report_parser.add_argument("--headline-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    triage_report_parser.add_argument(
+        "--headline-steering-scope",
+        choices=SUMMARY_COMPONENT_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
     triage_report_parser.add_argument("--attention-summary-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    triage_report_parser.add_argument(
+        "--attention-summary-steering-scope",
+        choices=SUMMARY_COMPONENT_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
     triage_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     triage_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -7300,7 +7334,17 @@ def parse_args() -> argparse.Namespace:
         default=None,
     )
     handoff_report_parser.add_argument("--headline-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    handoff_report_parser.add_argument(
+        "--headline-steering-scope",
+        choices=SUMMARY_COMPONENT_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
     handoff_report_parser.add_argument("--attention-summary-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    handoff_report_parser.add_argument(
+        "--attention-summary-steering-scope",
+        choices=SUMMARY_COMPONENT_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
     handoff_report_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     handoff_report_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     handoff_report_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -8087,9 +8131,19 @@ def main() -> int:
             summary_source=record.headline_source,
         ):
             record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.headline_steering_scope,
+            summary_steering_scope=record.headline_steering_scope,
+        ):
+            record = None
         if record is not None and not matches_summary_source_filter(
             summary_source_filter=args.attention_summary_source,
             summary_source=record.attention_summary_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.attention_summary_steering_scope,
+            summary_steering_scope=record.attention_summary_steering_scope,
         ):
             record = None
         if args.format == "json":
@@ -8143,9 +8197,19 @@ def main() -> int:
             summary_source=record.headline_source,
         ):
             record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.headline_steering_scope,
+            summary_steering_scope=record.headline_steering_scope,
+        ):
+            record = None
         if record is not None and not matches_summary_source_filter(
             summary_source_filter=args.attention_summary_source,
             summary_source=record.attention_summary_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.attention_summary_steering_scope,
+            summary_steering_scope=record.attention_summary_steering_scope,
         ):
             record = None
         if args.format == "json":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1787,8 +1787,10 @@ assert record["source_kind"] == "stamped", record
 assert record["target_limit"] == 3, record
 assert record["headline"] == "Federated CI triage report: 2 attention families", record
 assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
 assert record["attention_summary"] == "active=1, lagging=1, clear=0", record
 assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
 assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun30 / lagging", record
 assert record["newest_recovered_summary"] is None, record
@@ -1817,7 +1819,9 @@ assert record["target_lines"] == [
 ], record
 assert "## Federated CI Triage Report" in record["markdown"], record
 assert "headline source: `triage_snapshot`" in record["markdown"], record
+assert "headline steering scope: `none`" in record["markdown"], record
 assert "attention summary source: `triage_snapshot`" in record["markdown"], record
+assert "attention summary steering scope: `none`" in record["markdown"], record
 assert "summary steering scope: `selected_next_step_only`" in record["markdown"], record
 assert "### Local Operator Stack" not in record["markdown"], record
 assert "local operator:" in record["markdown"], record
@@ -2481,8 +2485,10 @@ assert record["source_kind"] == "stamped", record
 assert record["target_limit"] == 3, record
 assert record["headline"] == "Operator handoff report: 2 attention families", record
 assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
 assert record["attention_summary"] == "active=1, lagging=1, clear=0", record
 assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
 assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["newest_failing_summary"] == "federated-ci-runtime-gates / federated-ci-runtime-gates-20260319-rerun30 / lagging", record
 assert record["local_operator_summary"] == (
@@ -5150,7 +5156,9 @@ assert (
     "(freshness=fresh, promotability=blocked, reasons=source_artifact_missing)"
 ) in record["markdown"], record
 assert "headline source: `triage_snapshot`" in record["markdown"], record
+assert "headline steering scope: `none`" in record["markdown"], record
 assert "attention summary source: `triage_snapshot`" in record["markdown"], record
+assert "attention summary steering scope: `none`" in record["markdown"], record
 assert "summary steering scope: `selected_next_step_only`" in record["markdown"], record
 PY
 
@@ -5198,6 +5206,52 @@ record = doc["record"]
 assert record is not None, doc
 assert record["headline_source"] == "triage_snapshot", record
 assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_steering_scope"] == "none", record
+PY
+
+TRIAGE_REPORT_COMPONENT_STEERING_SCOPE_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --headline-steering-scope none \
+  --attention-summary-steering-scope none >"$TRIAGE_REPORT_COMPONENT_STEERING_SCOPE_FILTER_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_COMPONENT_STEERING_SCOPE_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_steering_scope"] == "none", record
+PY
+
+TRIAGE_REPORT_COMPONENT_STEERING_SCOPE_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --headline-steering-scope steering_aware >"$TRIAGE_REPORT_COMPONENT_STEERING_SCOPE_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_REPORT_COMPONENT_STEERING_SCOPE_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
 PY
 
 TRIAGE_REPORT_SUMMARY_STEERING_SCOPE_FILTER_OUTPUT=$(mktemp)
@@ -5332,7 +5386,53 @@ record = doc["record"]
 assert record is not None, doc
 assert record["headline_source"] == "triage_snapshot", record
 assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_steering_scope"] == "none", record
 assert record["summary_steering_scope"] == "selected_next_step_only", record
+PY
+
+HANDOFF_REPORT_COMPONENT_STEERING_SCOPE_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --headline-steering-scope none \
+  --attention-summary-steering-scope none >"$HANDOFF_REPORT_COMPONENT_STEERING_SCOPE_FILTER_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_COMPONENT_STEERING_SCOPE_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_steering_scope"] == "none", record
+PY
+
+HANDOFF_REPORT_COMPONENT_STEERING_SCOPE_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" handoff-report \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --attention-summary-steering-scope steering_aware >"$HANDOFF_REPORT_COMPONENT_STEERING_SCOPE_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$HANDOFF_REPORT_COMPONENT_STEERING_SCOPE_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
 PY
 
 HANDOFF_REPORT_SUMMARY_STEERING_SCOPE_FILTER_OUTPUT=$(mktemp)


### PR DESCRIPTION
## Scope
- encode the current headline and attention-summary steering ceilings directly on operator summary surfaces
- keep top-line summary ownership with `triage_snapshot`
- make the non-steered policy boundary queryable without widening summary behavior

## Summary
- add explicit `headline_steering_scope=none` and `attention_summary_steering_scope=none` metadata to `triage-report` and `handoff-report`
- add matching `--headline-steering-scope` and `--attention-summary-steering-scope` filters
- extend regressions and rollout plan notes to reflect the explicit fail-closed component ceiling

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1024

## Risks
- Low: this packet only encodes and filters the already-existing fail-closed summary component ceiling

## Review Checklist
- [x] headline and attention-summary steering ceilings are emitted in triage and handoff JSON/table/markdown
- [x] component steering filters return correct match/no-match behavior
- [x] docs and regressions describe the explicit fail-closed component ceiling without widening summary ownership

## Post-Deploy Monitoring & Validation
- confirm operators can isolate `headline_steering_scope=none` and `attention_summary_steering_scope=none` surfaces directly from query outputs
- keep actual headline and attention-summary selection owned by `triage_snapshot` unless audited demand justifies a separate widening packet