### PR TITLE
feat(query-engine): mirror summary ceilings on triage brief

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -211,6 +211,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now expose explicit `headline_source` and `attention_summary_source` metadata and accept matching filters, making the current `triage_snapshot`-owned summary ceiling query-visible without actually letting cross-repo steering rewrite headline or attention-summary composition
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now also expose explicit `summary_steering_scope=selected_next_step_only` metadata and accept `--summary-steering-scope`, making the policy boundary itself query-visible while still leaving `headline` and `attention_summary` owned by `triage_snapshot`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now also expose explicit `headline_steering_scope=none` and `attention_summary_steering_scope=none` metadata with matching filters, making it query-visible that top-line summary components are still fail-closed and not steering-aware even while `selected_next_step` remains policy-steerable
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief` now mirrors the same `headline_source`, `headline_steering_scope`, `attention_summary_source`, `attention_summary_steering_scope`, and `summary_steering_scope` metadata with matching filters so compact summary-first reads can audit the same fail-closed policy boundary without reopening `triage-report`
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -273,4 +274,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. keep `headline_steering_scope=none`, `attention_summary_steering_scope=none`, and `summary_steering_scope=selected_next_step_only` as the explicit operator-facing ceiling unless repeated audited usage justifies widening actual summary selection beyond the current `triage_snapshot` ownership boundary
+2. decide whether `triage-brief` is now the right compact audit ceiling for summary steering policy, or whether any further operator surface should mirror the same summary component ceiling metadata beyond `triage-brief|triage-report|handoff-report`

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -309,6 +309,11 @@ class TriageFeedRecord:
 class TriageBriefRecord:
     source_kind: str
     target_limit: int
+    headline_source: str
+    headline_steering_scope: str
+    attention_summary_source: str
+    attention_summary_steering_scope: str
+    summary_steering_scope: str
     attention_family_count: int
     active_family_count: int
     lagging_family_count: int
@@ -5205,9 +5210,19 @@ def build_triage_brief_record(
         day_packet_steering_scope=feed.day_packet_cross_repo_validation_steering_scope,
         day_packet_primary_action_promoted=feed.day_packet_cross_repo_validation_primary_action_promoted,
     )
+    headline_source = "triage_snapshot"
+    headline_steering_scope = "none"
+    attention_summary_source = "triage_snapshot"
+    attention_summary_steering_scope = "none"
+    summary_steering_scope = "selected_next_step_only"
     return TriageBriefRecord(
         source_kind=source_kind,
         target_limit=target_limit,
+        headline_source=headline_source,
+        headline_steering_scope=headline_steering_scope,
+        attention_summary_source=attention_summary_source,
+        attention_summary_steering_scope=attention_summary_steering_scope,
+        summary_steering_scope=summary_steering_scope,
         attention_family_count=overview.triage_status_counts.get("active", 0) + overview.triage_status_counts.get("lagging", 0),
         active_family_count=overview.triage_status_counts.get("active", 0),
         lagging_family_count=overview.triage_status_counts.get("lagging", 0),
@@ -5251,6 +5266,11 @@ def render_triage_brief_table(record: TriageBriefRecord) -> str:
     sections = [
         f"source_kind\t{record.source_kind}",
         f"target_limit\t{record.target_limit}",
+        f"headline_source\t{record.headline_source}",
+        f"headline_steering_scope\t{record.headline_steering_scope}",
+        f"attention_summary_source\t{record.attention_summary_source}",
+        f"attention_summary_steering_scope\t{record.attention_summary_steering_scope}",
+        f"summary_steering_scope\t{record.summary_steering_scope}",
         (
             f"attention\tfamilies={record.attention_family_count},active={record.active_family_count},"
             f"lagging={record.lagging_family_count},clear={record.clear_family_count}"
@@ -5320,6 +5340,11 @@ def render_triage_brief_markdown(record: TriageBriefRecord) -> str:
         "## Triage Brief",
         f"- source_kind: `{record.source_kind}`",
         f"- top target window: `{record.target_limit}`",
+        f"- headline source: `{record.headline_source}`",
+        f"- headline steering scope: `{record.headline_steering_scope}`",
+        f"- attention summary source: `{record.attention_summary_source}`",
+        f"- attention summary steering scope: `{record.attention_summary_steering_scope}`",
+        f"- summary steering scope: `{record.summary_steering_scope}`",
         (
             f"- attention families: `{record.attention_family_count}` "
             f"(`active={record.active_family_count}`, `lagging={record.lagging_family_count}`, `clear={record.clear_family_count}`)"
@@ -7261,6 +7286,23 @@ def parse_args() -> argparse.Namespace:
         choices=SELECTED_NEXT_STEP_SOURCE_CHOICES,
         default=None,
     )
+    triage_brief_parser.add_argument(
+        "--summary-steering-scope",
+        choices=SUMMARY_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
+    triage_brief_parser.add_argument("--headline-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    triage_brief_parser.add_argument(
+        "--headline-steering-scope",
+        choices=SUMMARY_COMPONENT_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
+    triage_brief_parser.add_argument("--attention-summary-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    triage_brief_parser.add_argument(
+        "--attention-summary-steering-scope",
+        choices=SUMMARY_COMPONENT_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
     triage_brief_parser.add_argument("--format", choices=["table", "json", "markdown"], default="markdown")
     triage_brief_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_brief_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -8078,6 +8120,31 @@ def main() -> int:
         if record is not None and not matches_selected_next_step_source_filter(
             selected_next_step_source_filter=args.selected_next_step_source,
             selected_next_step_source=record.selected_next_step_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.summary_steering_scope,
+            summary_steering_scope=record.summary_steering_scope,
+        ):
+            record = None
+        if record is not None and not matches_summary_source_filter(
+            summary_source_filter=args.headline_source,
+            summary_source=record.headline_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.headline_steering_scope,
+            summary_steering_scope=record.headline_steering_scope,
+        ):
+            record = None
+        if record is not None and not matches_summary_source_filter(
+            summary_source_filter=args.attention_summary_source,
+            summary_source=record.attention_summary_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.attention_summary_steering_scope,
+            summary_steering_scope=record.attention_summary_steering_scope,
         ):
             record = None
         if args.format == "json":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1687,6 +1687,11 @@ doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
 assert record["source_kind"] == "stamped", record
 assert record["target_limit"] == 3, record
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["attention_family_count"] == 2, record
 assert record["active_family_count"] == 1, record
 assert record["lagging_family_count"] == 1, record
@@ -1739,6 +1744,11 @@ doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
 assert record["source_kind"] == "all", record
 assert record["target_limit"] == 1, record
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["attention_family_count"] == 2, record
 assert record["active_family_count"] == 2, record
 assert record["lagging_family_count"] == 0, record
@@ -5069,6 +5079,11 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["mission_packet_cross_repo_validation_steering_scope"] == "primary_action_only", record
 assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is True, record
 assert record["day_packet_cross_repo_validation_steering_scope"] == "primary_action_only", record
@@ -5100,6 +5115,11 @@ from pathlib import Path
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
 assert record is not None, doc
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["selected_next_step_source"] == "cross_repo_validation", record
 PY
 
@@ -5115,6 +5135,56 @@ python3 "$QUERY_PATH" triage-brief \
   --selected-next-step-source local_runtime >"$TRIAGE_BRIEF_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT"
 
 python3 - <<'PY' "$TRIAGE_BRIEF_SELECTED_NEXT_STEP_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
+PY
+
+TRIAGE_BRIEF_SUMMARY_COMPONENT_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-brief \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --summary-steering-scope selected_next_step_only \
+  --headline-source triage_snapshot \
+  --headline-steering-scope none \
+  --attention-summary-source triage_snapshot \
+  --attention-summary-steering-scope none >"$TRIAGE_BRIEF_SUMMARY_COMPONENT_FILTER_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_BRIEF_SUMMARY_COMPONENT_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["summary_steering_scope"] == "selected_next_step_only", record
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+PY
+
+TRIAGE_BRIEF_SUMMARY_COMPONENT_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-brief \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --headline-steering-scope steering_aware >"$TRIAGE_BRIEF_SUMMARY_COMPONENT_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_BRIEF_SUMMARY_COMPONENT_FILTER_MISS_OUTPUT"
 import json
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Scope
- mirror explicit summary ceiling metadata onto the compact `triage-brief` surface
- keep `triage-brief` fail-closed and query-friendly without widening summary behavior
- preserve `triage_snapshot` ownership for top-line summary components

## Summary
- add `headline_source`, `headline_steering_scope`, `attention_summary_source`, `attention_summary_steering_scope`, and `summary_steering_scope` to `triage-brief`
- add matching filter flags so compact summary reads can isolate the same policy boundary already exposed by `triage-report` and `handoff-report`
- extend regressions and rollout plan notes to treat `triage-brief` as part of the same summary-steering audit surface

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1026

## Risks
- Low: this packet only mirrors already-established summary ceiling metadata onto the compact brief surface

## Review Checklist
- [x] `triage-brief` emits the same summary ceiling metadata as the richer summary surfaces
- [x] compact summary filters return correct match/no-match behavior
- [x] docs and regressions reflect `triage-brief` parity without widening summary ownership

## Post-Deploy Monitoring & Validation
- confirm operators can audit the fail-closed summary ceiling from `triage-brief` without reopening `triage-report`
- keep any future widening of headline or attention-summary selection gated behind a separate audited packet