### PR TITLE
feat(query-engine): mirror summary ceilings on triage feed

### DIFF
--- a/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
+++ b/docs/workbench/unified-personal-agent-platform/plans/2026-04-01-monday-local-codex-runtime-rollout-plan.md
@@ -212,6 +212,7 @@ Current deliverables:
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now also expose explicit `summary_steering_scope=selected_next_step_only` metadata and accept `--summary-steering-scope`, making the policy boundary itself query-visible while still leaving `headline` and `attention_summary` owned by `triage_snapshot`
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-report|handoff-report` now also expose explicit `headline_steering_scope=none` and `attention_summary_steering_scope=none` metadata with matching filters, making it query-visible that top-line summary components are still fail-closed and not steering-aware even while `selected_next_step` remains policy-steerable
 - `planningops/scripts/federation/query_federated_ci_artifacts.py triage-brief` now mirrors the same `headline_source`, `headline_steering_scope`, `attention_summary_source`, `attention_summary_steering_scope`, and `summary_steering_scope` metadata with matching filters so compact summary-first reads can audit the same fail-closed policy boundary without reopening `triage-report`
+- `planningops/scripts/federation/query_federated_ci_artifacts.py triage-feed` now mirrors the same summary ceiling metadata and matching filters as `triage-brief`, making the most compact operator overview surface itself an auditable fail-closed summary policy read
 
 ### Phase 2. Codex-to-monday handoff packet
 
@@ -274,4 +275,4 @@ bash scripts/litellm_stack_launcher.sh --mode start
 ## Next Natural Packets
 
 1. revisit operator-facing override promotion only if the new override audit signal shows repeated reviewed usage beyond regression coverage
-2. decide whether `triage-brief` is now the right compact audit ceiling for summary steering policy, or whether any further operator surface should mirror the same summary component ceiling metadata beyond `triage-brief|triage-report|handoff-report`
+2. with `triage-feed|triage-brief|triage-report|handoff-report` all mirroring explicit summary component ceiling metadata, decide whether that set is now the operator-facing audit ceiling or whether any other compact surface still needs the same fail-closed summary policy markers

--- a/planningops/scripts/federation/query_federated_ci_artifacts.py
+++ b/planningops/scripts/federation/query_federated_ci_artifacts.py
@@ -288,6 +288,11 @@ class TriageFeedRecord:
     overview: TriageOverviewRecord
     queue_records: list[TriageQueueRecord]
     target_records: list[TriageTargetRecord]
+    headline_source: str
+    headline_steering_scope: str
+    attention_summary_source: str
+    attention_summary_steering_scope: str
+    summary_steering_scope: str
     local_operator_record: LocalOperatorStackRecord | None
     mission_packet_cross_repo_validation_steering_scope: str | None
     mission_packet_cross_repo_validation_primary_action_promoted: bool | None
@@ -4879,6 +4884,11 @@ def build_triage_feed_record(
     source_kind: str,
     target_limit: int,
 ) -> TriageFeedRecord:
+    headline_source = "triage_snapshot"
+    headline_steering_scope = "none"
+    attention_summary_source = "triage_snapshot"
+    attention_summary_steering_scope = "none"
+    summary_steering_scope = "selected_next_step_only"
     overview = build_triage_overview_record(
         records=records,
         family=family,
@@ -4965,6 +4975,11 @@ def build_triage_feed_record(
         overview=overview,
         queue_records=queue_records,
         target_records=target_records,
+        headline_source=headline_source,
+        headline_steering_scope=headline_steering_scope,
+        attention_summary_source=attention_summary_source,
+        attention_summary_steering_scope=attention_summary_steering_scope,
+        summary_steering_scope=summary_steering_scope,
         local_operator_record=local_operator_record,
         mission_packet_cross_repo_validation_steering_scope=mission_packet_cross_repo_validation_steering_scope,
         mission_packet_cross_repo_validation_primary_action_promoted=(
@@ -4991,6 +5006,11 @@ def render_triage_feed_table(record: TriageFeedRecord) -> str:
     sections = [
         f"source_kind\t{record.source_kind}",
         f"target_limit\t{record.target_limit}",
+        f"headline_source\t{record.headline_source}",
+        f"headline_steering_scope\t{record.headline_steering_scope}",
+        f"attention_summary_source\t{record.attention_summary_source}",
+        f"attention_summary_steering_scope\t{record.attention_summary_steering_scope}",
+        f"summary_steering_scope\t{record.summary_steering_scope}",
         "overview",
         render_triage_overview_table(record.overview),
     ]
@@ -5066,7 +5086,22 @@ def render_triage_feed_table(record: TriageFeedRecord) -> str:
 
 def render_triage_feed_markdown(record: TriageFeedRecord) -> str:
     sections = [
-        f"## Triage Feed\n\n- source_kind: `{record.source_kind}`\n- target_limit: `{record.target_limit}`",
+        (
+            "## Triage Feed\n\n"
+            f"- source_kind: `{record.source_kind}`\n"
+            f"- target_limit: `{record.target_limit}`"
+        ),
+        "\n".join(
+            [
+                "### Summary Steering Policy",
+                "",
+                f"- headline source: `{record.headline_source}`",
+                f"- headline steering scope: `{record.headline_steering_scope}`",
+                f"- attention summary source: `{record.attention_summary_source}`",
+                f"- attention summary steering scope: `{record.attention_summary_steering_scope}`",
+                f"- summary steering scope: `{record.summary_steering_scope}`",
+            ]
+        ),
         "### Overview\n\n" + render_triage_overview_markdown(record.overview),
     ]
     if record.cross_repo_validation_snapshot_status is not None:
@@ -7261,6 +7296,23 @@ def parse_args() -> argparse.Namespace:
     triage_feed_parser.add_argument("--mission-packet-primary-action-promoted", choices=["yes", "no"], default=None)
     triage_feed_parser.add_argument("--day-packet-steering-scope", choices=STEERING_SCOPE_CHOICES, default=None)
     triage_feed_parser.add_argument("--day-packet-primary-action-promoted", choices=["yes", "no"], default=None)
+    triage_feed_parser.add_argument(
+        "--summary-steering-scope",
+        choices=SUMMARY_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
+    triage_feed_parser.add_argument("--headline-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    triage_feed_parser.add_argument(
+        "--headline-steering-scope",
+        choices=SUMMARY_COMPONENT_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
+    triage_feed_parser.add_argument("--attention-summary-source", choices=SUMMARY_SOURCE_CHOICES, default=None)
+    triage_feed_parser.add_argument(
+        "--attention-summary-steering-scope",
+        choices=SUMMARY_COMPONENT_STEERING_SCOPE_CHOICES,
+        default=None,
+    )
     triage_feed_parser.add_argument("--format", choices=["table", "json", "markdown"], default="table")
     triage_feed_parser.add_argument("--ci-root", default=str(DEFAULT_CI_ROOT))
     triage_feed_parser.add_argument("--validation-root", default=str(DEFAULT_VALIDATION_ROOT))
@@ -8079,6 +8131,31 @@ def main() -> int:
             mission_packet_primary_action_promoted=record.mission_packet_cross_repo_validation_primary_action_promoted,
             day_packet_steering_scope=record.day_packet_cross_repo_validation_steering_scope,
             day_packet_primary_action_promoted=record.day_packet_cross_repo_validation_primary_action_promoted,
+        ):
+            record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.summary_steering_scope,
+            summary_steering_scope=record.summary_steering_scope,
+        ):
+            record = None
+        if record is not None and not matches_summary_source_filter(
+            summary_source_filter=args.headline_source,
+            summary_source=record.headline_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.headline_steering_scope,
+            summary_steering_scope=record.headline_steering_scope,
+        ):
+            record = None
+        if record is not None and not matches_summary_source_filter(
+            summary_source_filter=args.attention_summary_source,
+            summary_source=record.attention_summary_source,
+        ):
+            record = None
+        if record is not None and not matches_summary_steering_scope_filter(
+            summary_steering_scope_filter=args.attention_summary_steering_scope,
+            summary_steering_scope=record.attention_summary_steering_scope,
         ):
             record = None
         if args.format == "json":

--- a/planningops/scripts/test_query_federated_ci_artifacts.sh
+++ b/planningops/scripts/test_query_federated_ci_artifacts.sh
@@ -1606,6 +1606,11 @@ doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
 assert record["source_kind"] == "stamped", record
 assert record["target_limit"] == 3, record
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["overview"]["triage_status_counts"] == {"active": 1, "lagging": 1}, record
 assert [queue["priority_bucket"] for queue in record["queue_records"]] == ["active", "lagging"], record
 assert [target["family"] for target in record["target_records"]] == [
@@ -1648,6 +1653,11 @@ doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
 assert record["source_kind"] == "all", record
 assert record["target_limit"] == 1, record
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["overview"]["triage_status_counts"] == {"active": 2}, record
 assert len(record["queue_records"]) == 1, record
 queue = record["queue_records"][0]
@@ -4465,6 +4475,11 @@ from pathlib import Path
 
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
 assert record["mission_packet_cross_repo_validation_primary_action_promoted"] is False, record
 assert record["day_packet_cross_repo_validation_steering_scope"] == "none", record
@@ -4989,8 +5004,63 @@ from pathlib import Path
 doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 record = doc["record"]
 assert record is not None, doc
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+assert record["summary_steering_scope"] == "selected_next_step_only", record
 assert record["mission_packet_cross_repo_validation_steering_scope"] == "none", record
 assert record["day_packet_cross_repo_validation_primary_action_promoted"] is False, record
+PY
+
+TRIAGE_FEED_SUMMARY_COMPONENT_FILTER_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-feed \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --summary-steering-scope selected_next_step_only \
+  --headline-source triage_snapshot \
+  --headline-steering-scope none \
+  --attention-summary-source triage_snapshot \
+  --attention-summary-steering-scope none >"$TRIAGE_FEED_SUMMARY_COMPONENT_FILTER_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_FEED_SUMMARY_COMPONENT_FILTER_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+record = doc["record"]
+assert record is not None, doc
+assert record["summary_steering_scope"] == "selected_next_step_only", record
+assert record["headline_source"] == "triage_snapshot", record
+assert record["headline_steering_scope"] == "none", record
+assert record["attention_summary_source"] == "triage_snapshot", record
+assert record["attention_summary_steering_scope"] == "none", record
+PY
+
+TRIAGE_FEED_SUMMARY_COMPONENT_FILTER_MISS_OUTPUT=$(mktemp)
+python3 "$QUERY_PATH" triage-feed \
+  --format json \
+  --ci-root "$CI_DIR" \
+  --validation-root "$VALIDATION_DIR" \
+  --conformance-root "$CONFORMANCE_DIR" \
+  --local-root "$LOCAL_OPERATOR_DIR" \
+  --consumer-root "$MONDAY_CONSUMER_DIR" \
+  --monday-validation-root "$MONDAY_VALIDATION_DIR" \
+  --headline-steering-scope steering_aware >"$TRIAGE_FEED_SUMMARY_COMPONENT_FILTER_MISS_OUTPUT"
+
+python3 - <<'PY' "$TRIAGE_FEED_SUMMARY_COMPONENT_FILTER_MISS_OUTPUT"
+import json
+import sys
+from pathlib import Path
+
+doc = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert doc["record"] is None, doc
 PY
 
 TRIAGE_BRIEF_STEERING_FILTER_MISS_OUTPUT=$(mktemp)


### PR DESCRIPTION
## Scope
- mirror explicit summary ceiling metadata onto `triage-feed`
- add matching filters so the compact feed surface can audit the same fail-closed summary policy as the richer summary surfaces
- preserve `triage_snapshot` ownership for headline and attention-summary composition without widening behavior

## Summary
- add `headline_source`, `headline_steering_scope`, `attention_summary_source`, `attention_summary_steering_scope`, and `summary_steering_scope` to `triage-feed`
- expose matching filter flags so compact overview reads can isolate the same summary policy boundary already query-visible on `triage-brief|triage-report|handoff-report`
- extend regressions and rollout plan notes to treat `triage-feed` as part of the operator-facing summary ceiling audit path

## Validation
- `python3 -m py_compile planningops/scripts/federation/query_federated_ci_artifacts.py`
- `bash planningops/scripts/test_query_federated_ci_artifacts.sh`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile workbench`
- `bash docs/initiatives/unified-personal-agent-platform/00-governance/scripts/uap-docs.sh check --profile all`

## Linked Issues
- Closes #1028

## Risks
- Low: this packet mirrors already-established summary policy metadata onto an existing compact overview surface without changing selection precedence

## Review Checklist
- [x] `triage-feed` emits the same summary ceiling metadata as the other summary audit surfaces
- [x] summary ceiling filters return correct match/no-match behavior on `triage-feed`
- [x] docs and regressions reflect `triage-feed` parity without widening summary ownership

## Post-Deploy Monitoring & Validation
- confirm operators can audit summary ceiling policy directly from `triage-feed` without reopening richer report surfaces
- keep any future widening of headline or attention-summary steering gated behind a separate audited packet